### PR TITLE
New instruction format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,19 @@ a single file, all images are expected to be created under a different tag.
 
 ### Instruction format
 
-Each line represents a build instruction.
-There are different formats that Stackbrew is able to parse.
+Note: there is no backwards compatibility with the old format. This is part
+of our effort to create strict, unambiguous references to build images upon.
 
-	<git-url>
-	git://github.com/dotcloud/hipache
-	https://github.com/dotcloud/docker.git
+	<docker-tag>:	<git-url>@<git-tag>
+	2.4.0: 	git://github.com/dotcloud/docker-redis@2.4.0
+	<docker-tag>:	<git-url>@<git-commit-id>
+	2.2.0: 	git://github.com/dotcloud/docker-redis@a4bf8923ee4ec566d3ddc212
 
-The simplest format. Stackbrew will fetch data from the provided git
-repository from the `HEAD`of its `master` branch. Generated image will be
-tagged as `latest`. Use of this format is discouraged because there is no
-way to ensure stability.
-
-	<docker-tag> <git-url>
-	bleeding-edge git://github.com/dotcloud/docker
-	unstable https://github.com/dotcloud/docker-redis.git
-
-A more advanced format. Stackbrew will fetch data from the provided git
-repository from the `HEAD`of its `master` branch. Generated image will be
-tagged as `<docker-tag>`. Recommended if we always want to provide a snapshot
-of the latest development. Again, no way to ensure stability.
-
-	<docker-tag>	<git-url>	T:<git-tag>
-	2.4.0 	git://github.com/dotcloud/docker-redis	T:2.4.0
-	<docker-tag>	<git-url>	B:<git-branch>
-	zfs		https://github.com/dotcloud/docker.git	B:zfs-support
-	<docker-tag>	<git-url>	C:<git-commit-id>
-	2.2.0 	git://github.com/dotcloud/docker-redis C:a4bf8923ee4ec566d3ddc212
-
-The most complete format. Stackbrew will fetch data from the provided git
-repository from the provided reference (if it's a branch, Stackbrew will fetch its
-`HEAD`). Generated image will be tagged as `<docker-tag>`. Recommended whenever
-possible.
+Stackbrew will fetch data from the provided git repository from the
+provided reference. Generated image will be tagged as `<docker-tag>`.
+If a git tag is removed and added to another commit,
+**you should not expect the image to be rebuilt.** Create a new tag and submit
+a pull request instead.
 
 ## Contributing to the standard library
 

--- a/library/busybox
+++ b/library/busybox
@@ -1,1 +1,1 @@
-latest git://github.com/dotcloud/docker-busybox
+latest: git://github.com/dotcloud/docker-busybox@31097284232f1c8be4c06af0c75a97d699f719ed

--- a/library/debian
+++ b/library/debian
@@ -1,10 +1,10 @@
-latest	git://github.com/tianon/docker-brew-debian	C:8cca9c1bba4aa246ca71b8967700623bb63735fa
-wheezy	git://github.com/tianon/docker-brew-debian	C:8cca9c1bba4aa246ca71b8967700623bb63735fa
-7.2		git://github.com/tianon/docker-brew-debian	C:8cca9c1bba4aa246ca71b8967700623bb63735fa
+latest: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
+wheezy: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
+7.2: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
 
-jessie	git://github.com/tianon/docker-brew-debian	C:51bf81b164ec5e788099136cbe9dd9e141140d4c
+jessie: git://github.com/tianon/docker-brew-debian@51bf81b164ec5e788099136cbe9dd9e141140d4c
 
-sid		git://github.com/tianon/docker-brew-debian	C:d532462cfbae0d9809c3c24f9855291bf1142c1a
+sid: git://github.com/tianon/docker-brew-debian@d532462cfbae0d9809c3c24f9855291bf1142c1a
 
-squeeze	git://github.com/tianon/docker-brew-debian	C:af59cb2f4237f07713a369ee7def53bad7e46506
-6.0.8	git://github.com/tianon/docker-brew-debian	C:af59cb2f4237f07713a369ee7def53bad7e46506
+squeeze: git://github.com/tianon/docker-brew-debian@af59cb2f4237f07713a369ee7def53bad7e46506
+6.0.8: git://github.com/tianon/docker-brew-debian@af59cb2f4237f07713a369ee7def53bad7e46506

--- a/library/hipache
+++ b/library/hipache
@@ -1,2 +1,2 @@
-latest	git://github.com/dotcloud/hipache C:7362ff5b812f93eceafbdbf5e5959f676f731f80
-0.2.4	git://github.com/dotcloud/hipache C:7362ff5b812f93eceafbdbf5e5959f676f731f80
+latest: git://github.com/dotcloud/hipache@7362ff5b812f93eceafbdbf5e5959f676f731f80
+0.2.4: git://github.com/dotcloud/hipache@7362ff5b812f93eceafbdbf5e5959f676f731f80

--- a/library/registry
+++ b/library/registry
@@ -1,3 +1,3 @@
-latest	git://github.com/dotcloud/docker-registry	C:2854126e601aeb9d684cfc99a2d83afc4cc1a03b
-0.5.9	git://github.com/dotcloud/docker-registry	C:debd567e95df51f8ac91d0bb69ca35037d957ee6
-0.6.0	git://github.com/dotcloud/docker-registry	C:ab2a346ae246b65eecc4e68bb91a2ec25ea7756e
+latest: git://github.com/dotcloud/docker-registry@2854126e601aeb9d684cfc99a2d83afc4cc1a03b
+0.5.9: git://github.com/dotcloud/docker-registry@debd567e95df51f8ac91d0bb69ca35037d957ee6
+0.6.0: git://github.com/dotcloud/docker-registry@ab2a346ae246b65eecc4e68bb91a2ec25ea7756e

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,12 +1,12 @@
-latest	git://github.com/tianon/docker-brew-ubuntu	C:96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
-precise	git://github.com/tianon/docker-brew-ubuntu	C:96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
-12.04	git://github.com/tianon/docker-brew-ubuntu	C:96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
+latest: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
+precise: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
+12.04: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
 
-quantal	git://github.com/tianon/docker-brew-ubuntu	C:c4e5dee217efe78bb773223b9f4a2ebbe1226caf
-12.10	git://github.com/tianon/docker-brew-ubuntu	C:c4e5dee217efe78bb773223b9f4a2ebbe1226caf
+quantal: git://github.com/tianon/docker-brew-ubuntu@c4e5dee217efe78bb773223b9f4a2ebbe1226caf
+12.10: git://github.com/tianon/docker-brew-ubuntu@c4e5dee217efe78bb773223b9f4a2ebbe1226caf
 
-raring	git://github.com/tianon/docker-brew-ubuntu	C:80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
-13.04	git://github.com/tianon/docker-brew-ubuntu	C:80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
+raring: git://github.com/tianon/docker-brew-ubuntu@80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
+13.04: git://github.com/tianon/docker-brew-ubuntu@80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
 
-saucy	git://github.com/tianon/docker-brew-ubuntu	C:c8ba2f1f5883b528a92cfa705e670dea8ddeaf0d
-13.10	git://github.com/tianon/docker-brew-ubuntu	C:c8ba2f1f5883b528a92cfa705e670dea8ddeaf0d
+saucy: git://github.com/tianon/docker-brew-ubuntu@c8ba2f1f5883b528a92cfa705e670dea8ddeaf0d
+13.10: git://github.com/tianon/docker-brew-ubuntu@c8ba2f1f5883b528a92cfa705e670dea8ddeaf0d


### PR DESCRIPTION
As per discussion with @shykes and @tianon 

```
8:11 PM shykes 
There's this one thread about the syntax
I kind of agree with the people saying it might be confusing
I wanted to discuss that with you
If we do decide we want to change it, it's better to change it early
since it affects file formats, which stick around and need to be supported for a long time
how do you like the unique syntax "<docker_tag>: <url>[@<version>]"
where <version> could be a git branch, tag or commit
8:13 PM joffrey
what if a tag and a branch share the same name in one repo ?
8:15 PM shykes
mmm
git has the same problem
when you 'checkout <tag_or_branch>'
you may get a warning about ambiguous refname
and then it chooses one
I think the tag gets precedence
might make sense to mimic that
8:16 PM joffrey
okay
8:16 PM shykes
*or* we could just never use branches
since their use is discouraged anyway
and using them would probably not yield the intended result for upstream contributors
8:17 PM joffrey
and then if a tag replicates a commit ID, the commit ID would take precedence?
8:17 PM shykes
yeah
which is what git does also
(just checked)
what do you think?
8:18 PM tianon 
sounding tasty to me
8:19 PM joffrey
sure, works for me. while we're at it, let's make the @<version> mandatory
```
