### PR TITLE
Update MAINTAINERS syntax to match what Gordon will expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Thank you for your interest in the stackbrew project! We strive to make these in
 * Create a new file in the library folder. Its name will be the name of your repository.
 * Add your tag definitions using the provided syntax (see above).
 * Add the following line to the MAINTAINERS file:
-`repo: Your Name (github.name) <you@email.com>`
+`repo: Your Name <you@email.com> (@github.name)`
 * Create a pull request from your git repository to this one. Don't hesitate to add details as to what your repository does.
 
 ### New tag in existing repository.


### PR DESCRIPTION
I think it might even be more worthwhile to have these as comments in the file directly.

```
14:53:04  tianon:> joffrey: what do you think about adding a convention of putting a "maintainer" comment at the top of all the library files?
14:53:36  tianon:> (shykes's comment made me think we probably ought to have some quick and easy way to identify the maintainer of an image or group of images, even if only manually so like a comment)
14:53:59  tianon:> and the plus of a comment is that a single tag could even have a different maintainer pretty easily
14:57:02  tianon:> joffrey: I'm thinking something like we have in MAINTAINERS, like so: # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
14:57:17  tianon:> followed by a blank line, so that it's obvious that's for the whole file, not for just the first tag
```

As an example:

```
# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)

latest: git://github.com/dotcloud/docker@v0.6.5
...

# maintainer: John Smith <jsmith@example.com> (@example)
v0.5.3: git://github.com/dotcloud/docker@v0.5.3
```

(Assuming that "John Smith" cares/knows more about the v0.5.3 image than I do.)
