### PR TITLE
Add new docker-dev image

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,0 +1,10 @@
+# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+
+latest: git://github.com/dotcloud/docker@v0.6.5
+v0.6.5: git://github.com/dotcloud/docker@v0.6.5
+v0.6.4: git://github.com/dotcloud/docker@v0.6.4
+v0.6.3: git://github.com/dotcloud/docker@v0.6.3
+v0.6.2: git://github.com/dotcloud/docker@v0.6.2
+v0.6.1: git://github.com/dotcloud/docker@v0.6.1
+v0.6.0: git://github.com/dotcloud/docker@v0.6.0
+v0.5.3: git://github.com/dotcloud/docker@v0.5.3


### PR DESCRIPTION
This has the `# maintainer: ...` line I proposed in #6, as an example.  If that idea isn't something we want or like, I'll be happy to remove it. :+1:
