### PR TITLE
Update debian images to use http.debian.net instead of being hard-coded ...

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,10 +1,10 @@
-latest: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
-wheezy: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
-7.2: git://github.com/tianon/docker-brew-debian@8cca9c1bba4aa246ca71b8967700623bb63735fa
+latest: git://github.com/tianon/docker-brew-debian@149fa8a40b5742846243e0edd2bd641a68873144
+wheezy: git://github.com/tianon/docker-brew-debian@149fa8a40b5742846243e0edd2bd641a68873144
+7.2: git://github.com/tianon/docker-brew-debian@149fa8a40b5742846243e0edd2bd641a68873144
 
-jessie: git://github.com/tianon/docker-brew-debian@51bf81b164ec5e788099136cbe9dd9e141140d4c
+jessie: git://github.com/tianon/docker-brew-debian@6b80be230090cd2373047ee3408a8285f33d88c3
 
-sid: git://github.com/tianon/docker-brew-debian@d532462cfbae0d9809c3c24f9855291bf1142c1a
+sid: git://github.com/tianon/docker-brew-debian@ad54ef16a1c44ed0b8874c1a4090019aff609284
 
-squeeze: git://github.com/tianon/docker-brew-debian@af59cb2f4237f07713a369ee7def53bad7e46506
-6.0.8: git://github.com/tianon/docker-brew-debian@af59cb2f4237f07713a369ee7def53bad7e46506
+squeeze: git://github.com/tianon/docker-brew-debian@e9519637347231a80822fe49e2369739647822b2
+6.0.8: git://github.com/tianon/docker-brew-debian@e9519637347231a80822fe49e2369739647822b2


### PR DESCRIPTION
...with a US mirror (which is slow and sub-optimal for just about everybody, including those in the US).

(This was by recommendation from @paultag, who tells me this will probably eventually become the default mirror for debootstrap.)

Also, inside the images, I've added to the end of the `MAINTAINER` line the exact command and arguments used to generate it (which is also included as the commit message for the images themselves now).  Hopefully this makes them slightly more "transparent" than they've been in the past.
