### PR TITLE
Update ubuntu images with ubuntu-minimal and apt-cache translations exclusion

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,12 +1,12 @@
-latest: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
-precise: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
-12.04: git://github.com/tianon/docker-brew-ubuntu@96fb1a4775743da97ef914f9bd91ac5d59eaf3d6
+latest: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
+precise: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
+12.04: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
 
-quantal: git://github.com/tianon/docker-brew-ubuntu@c4e5dee217efe78bb773223b9f4a2ebbe1226caf
-12.10: git://github.com/tianon/docker-brew-ubuntu@c4e5dee217efe78bb773223b9f4a2ebbe1226caf
+quantal: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
+12.10: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
 
-raring: git://github.com/tianon/docker-brew-ubuntu@80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
-13.04: git://github.com/tianon/docker-brew-ubuntu@80e86d8bb6ff135805de6f1f56d3998b9aabe1ff
+raring: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
+13.04: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
 
-saucy: git://github.com/tianon/docker-brew-ubuntu@f66fc3e7496312aaeff35f894897246a54bf709e
-13.10: git://github.com/tianon/docker-brew-ubuntu@f66fc3e7496312aaeff35f894897246a54bf709e
+saucy: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc
+13.10: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc


### PR DESCRIPTION
So this update is actually two-fold.  It includes the same new "Translations" exclusions from the debian images (and the fix to keep us from growing 40MB on the first "apt-get update"), but it also includes ubuntu-minimal, since we're legally required to include that metapackage and its deps to call this image "ubuntu".  It moves our image size to be around 120-140 MB (from the sparse roughly 100 MB it is now), but that's a necessary evil since we'd like to have Ubuntu. :)
