### PR TITLE
Add new "lucid" image and note EOL dates for all suites

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,14 +1,26 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
+# see also https://wiki.ubuntu.com/Releases#Current
+
 latest: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
 precise: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
 12.04: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
+# EOL: Apr 2017
+
+lucid: git://github.com/tianon/docker-brew-ubuntu@577bec59f4ad94e247571944dcb4adb187c5bc2e
+10.04: git://github.com/tianon/docker-brew-ubuntu@577bec59f4ad94e247571944dcb4adb187c5bc2e
+# EOL: Apr 2015
+
+# ---
 
 quantal: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
 12.10: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
+# EOL: Apr 2014
 
 raring: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
 13.04: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
+# EOL: Jan 2014
 
 saucy: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc
 13.10: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc
+# EOL: Jul 2014


### PR DESCRIPTION
``` console
$ ./brew-cli -n stackbrew --targets ubuntu -b lucid git://github.com/tianon/brew
2014-01-03 11:29:00,527 INFO Cloning docker repo from git://github.com/tianon/brew, branch: lucid
2014-01-03 11:29:04,585 INFO Cloning git://github.com/tianon/docker-brew-ubuntu (ref: ba833691e33f5b671adb90a4c53676ad16ba8302)
2014-01-03 11:30:14,927 INFO Building using dockerfile...
2014-01-03 11:30:25,948 INFO Committing to stackbrew/ubuntu:latest
2014-01-03 11:30:28,411 INFO This ref has already been built, reusing image ID
2014-01-03 11:30:28,411 INFO Committing to stackbrew/ubuntu:precise
2014-01-03 11:30:31,537 INFO This ref has already been built, reusing image ID
2014-01-03 11:30:31,537 INFO Committing to stackbrew/ubuntu:12.04
2014-01-03 11:30:33,997 INFO Cloning git://github.com/tianon/docker-brew-ubuntu (ref: 577bec59f4ad94e247571944dcb4adb187c5bc2e)
2014-01-03 11:30:34,393 INFO Building using dockerfile...
2014-01-03 11:30:44,764 INFO Committing to stackbrew/ubuntu:lucid
2014-01-03 11:30:46,969 INFO This ref has already been built, reusing image ID
2014-01-03 11:30:46,970 INFO Committing to stackbrew/ubuntu:10.04
2014-01-03 11:30:49,015 INFO Cloning git://github.com/tianon/docker-brew-ubuntu (ref: 2f3eca8ff6f9d40603812cd141d4240d9f32e54c)
2014-01-03 11:30:49,341 INFO Building using dockerfile...
2014-01-03 11:31:01,734 INFO Committing to stackbrew/ubuntu:quantal
2014-01-03 11:31:04,083 INFO This ref has already been built, reusing image ID
2014-01-03 11:31:04,083 INFO Committing to stackbrew/ubuntu:12.10
2014-01-03 11:31:07,258 INFO Cloning git://github.com/tianon/docker-brew-ubuntu (ref: d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a)
2014-01-03 11:31:07,602 INFO Building using dockerfile...
2014-01-03 11:31:18,572 INFO Committing to stackbrew/ubuntu:raring
2014-01-03 11:31:20,661 INFO This ref has already been built, reusing image ID
2014-01-03 11:31:20,661 INFO Committing to stackbrew/ubuntu:13.04
2014-01-03 11:31:22,950 INFO Cloning git://github.com/tianon/docker-brew-ubuntu (ref: c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc)
2014-01-03 11:31:23,272 INFO Building using dockerfile...
2014-01-03 11:31:34,357 INFO Committing to stackbrew/ubuntu:saucy
2014-01-03 11:31:37,323 INFO This ref has already been built, reusing image ID
2014-01-03 11:31:37,323 INFO Committing to stackbrew/ubuntu:13.10
2014-01-03 11:31:37,346 INFO BREW BUILD SUMMARY
-------------------------------------------------------------
OVERALL SUCCESS: True
-------------------------------------------------------------
ubuntu
-------------------------------------------------------------
 6 | OK | 688401b9a9d7                                      
24 | OK | dc08df84179d                                      
25 | OK | dc08df84179d                                      
21 | OK | 656182c1cfb9                                      
20 | OK | 656182c1cfb9                                      
11 | OK | a8304bf571c2                                      
16 | OK | 6c621cd7f810                                      
17 | OK | 6c621cd7f810                                      
 5 | OK | 688401b9a9d7                                      
10 | OK | a8304bf571c2                                      
 7 | OK | 688401b9a9d7                                      
-------------------------------------------------------------
```
