### PR TITLE
Update docker-dev to 0.7.6, remove old versions

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,7 +1,5 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-latest: git://github.com/dotcloud/docker@v0.7.4
-v0.7.4: git://github.com/dotcloud/docker@v0.7.4
-v0.7.3: git://github.com/dotcloud/docker@v0.7.3
-v0.7.2: git://github.com/dotcloud/docker@v0.7.2
+latest: git://github.com/dotcloud/docker@v0.7.6
+v0.7.6: git://github.com/dotcloud/docker@v0.7.6
 v0.6.7: git://github.com/dotcloud/docker@v0.6.7


### PR DESCRIPTION
I've decided to only keep the latest copy of each major version up-to-date (so 0.6.7 and 0.7.6 currently).
