### PR TITLE
Update all the debian and ubuntu images with the newer debootstrap script

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,12 +1,29 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-latest: git://github.com/tianon/docker-brew-debian@e1b9de169b8e9c9fccd07a8c11ba1e4dbf832500
-wheezy: git://github.com/tianon/docker-brew-debian@e1b9de169b8e9c9fccd07a8c11ba1e4dbf832500
-7.3: git://github.com/tianon/docker-brew-debian@e1b9de169b8e9c9fccd07a8c11ba1e4dbf832500
+# stable
+latest: git://github.com/tianon/docker-brew-debian@b306b9af3af44fdd33e2b3e2930277c8b5f60cb3
+wheezy: git://github.com/tianon/docker-brew-debian@b306b9af3af44fdd33e2b3e2930277c8b5f60cb3
+7.3: git://github.com/tianon/docker-brew-debian@b306b9af3af44fdd33e2b3e2930277c8b5f60cb3
+#
+stable: git://github.com/tianon/docker-brew-debian@2df5cf53c831143d889c16d2574906282b52cd38
 
-jessie: git://github.com/tianon/docker-brew-debian@6b80be230090cd2373047ee3408a8285f33d88c3
+# testing
+jessie: git://github.com/tianon/docker-brew-debian@d604cabf8285f85fb9e09d01f17c3ea5f65bf604
+#
+testing: git://github.com/tianon/docker-brew-debian@cd0894727a3697c15b64301f21037a5c62f063d2
 
-sid: git://github.com/tianon/docker-brew-debian@ad54ef16a1c44ed0b8874c1a4090019aff609284
+# unstable
+sid: git://github.com/tianon/docker-brew-debian@38e4c51c5cb44b358d1306c776c24a07b6954ed2
+#
+unstable: git://github.com/tianon/docker-brew-debian@47b51c796249fdfcd455e0fb6467bed8811e95ec
 
-squeeze: git://github.com/tianon/docker-brew-debian@e9519637347231a80822fe49e2369739647822b2
-6.0.8: git://github.com/tianon/docker-brew-debian@e9519637347231a80822fe49e2369739647822b2
+# oldstable
+squeeze: git://github.com/tianon/docker-brew-debian@c3aca1de4709d531761c673c5ea623dd2e5e67a0
+6.0.8: git://github.com/tianon/docker-brew-debian@c3aca1de4709d531761c673c5ea623dd2e5e67a0
+#
+oldstable: git://github.com/tianon/docker-brew-debian@7c432310a1ec6eefcc3f0d3ac3ff2d75db0cec17
+
+# experimental
+rc-buggy: git://github.com/tianon/dockerfiles@8548eebce2c11cc5b4de37c75c44b0c03c1fbab2 debian/rc-buggy
+#
+experimental: git://github.com/tianon/dockerfiles@8548eebce2c11cc5b4de37c75c44b0c03c1fbab2 debian/experimental

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -2,25 +2,25 @@
 
 # see also https://wiki.ubuntu.com/Releases#Current
 
-latest: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
-precise: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
-12.04: git://github.com/tianon/docker-brew-ubuntu@ba833691e33f5b671adb90a4c53676ad16ba8302
+latest: git://github.com/tianon/docker-brew-ubuntu@bb19e4ec7bd4b00c0d333b80654da80764ea109d
+precise: git://github.com/tianon/docker-brew-ubuntu@bb19e4ec7bd4b00c0d333b80654da80764ea109d
+12.04: git://github.com/tianon/docker-brew-ubuntu@bb19e4ec7bd4b00c0d333b80654da80764ea109d
 # EOL: Apr 2017
 
-lucid: git://github.com/tianon/docker-brew-ubuntu@577bec59f4ad94e247571944dcb4adb187c5bc2e
-10.04: git://github.com/tianon/docker-brew-ubuntu@577bec59f4ad94e247571944dcb4adb187c5bc2e
+lucid: git://github.com/tianon/docker-brew-ubuntu@8c8d60abf5999986e8d6ca55f0703eb1e3cb83ec
+10.04: git://github.com/tianon/docker-brew-ubuntu@8c8d60abf5999986e8d6ca55f0703eb1e3cb83ec
 # EOL: Apr 2015
 
 # ---
 
-quantal: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
-12.10: git://github.com/tianon/docker-brew-ubuntu@2f3eca8ff6f9d40603812cd141d4240d9f32e54c
+quantal: git://github.com/tianon/docker-brew-ubuntu@a6f44431cb178050bf86db5069740b38900d94f2
+12.10: git://github.com/tianon/docker-brew-ubuntu@a6f44431cb178050bf86db5069740b38900d94f2
 # EOL: Apr 2014
 
-raring: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
-13.04: git://github.com/tianon/docker-brew-ubuntu@d71d3f2b1bebbdde9ee4a538bc4a0fdd564b304a
+raring: git://github.com/tianon/docker-brew-ubuntu@214633ffb6a5871dd9309ac2352c36da71b62567
+13.04: git://github.com/tianon/docker-brew-ubuntu@214633ffb6a5871dd9309ac2352c36da71b62567
 # EOL: Jan 2014
 
-saucy: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc
-13.10: git://github.com/tianon/docker-brew-ubuntu@c6343e95cc7543f10ed8cb9d1b3cff4ccba372cc
+saucy: git://github.com/tianon/docker-brew-ubuntu@4c06b3e8849af10679224a154dd9866a3926720f
+13.10: git://github.com/tianon/docker-brew-ubuntu@4c06b3e8849af10679224a154dd9866a3926720f
 # EOL: Jul 2014


### PR DESCRIPTION
This includes running "apt-get update" as the last step of each image, and fixes some problems that were specific to the ubuntu:lucid image.

Finally, I've added more debian images:
- debian:stable, debian:testing, debian:unstable are all tagged to the "release" in /etc/apt/sources.list
- debian:experimental and debian:rc-buggy include the "experimental" repository on top of sid/unstable
