### PR TITLE
Add CirrOS Docker Image

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -1,0 +1,4 @@
+# maintainer: Eric Windisch <ewindisch@docker.com> (@ewindisch)
+
+latest: git://github.com/ewindisch/docker-cirros@d3c144f98beed34a1f3c815072e2c5de07aec1ae
+0.3.0: git://github.com/ewindisch/docker-cirros@d3c144f98beed34a1f3c815072e2c5de07aec1ae


### PR DESCRIPTION
"CirrOS is a Tiny OS that specializes in running on a cloud."

This stackbrew image is maintained by Eric Windisch,
while CirrOS itself is maintained by Scott Moser.

More on CirrOS may be found on its launchpad page:
    https://launchpad.net/cirros
