### PR TITLE
Added tag 3.0 for current CRUX release

### DIFF
--- a/library/crux
+++ b/library/crux
@@ -1,3 +1,4 @@
 # maintainer: James Mills <prologic@shortcircuit.net.au> (@therealprologic)
 
 latest: git://github.com/therealprologic/docker-crux@fb55041ef9dc8de9405f8589487f245a11861ed0
+3.0: git://github.com/therealprologic/docker-crux@fb55041ef9dc8de9405f8589487f245a11861ed0


### PR DESCRIPTION
My intention is to maintain two versions. Current and Previous of the CRUX base image.

/cc @tianon
