### PR TITLE
Update ubuntu-upstart references to use the updated image

### DIFF
--- a/library/ubuntu-upstart
+++ b/library/ubuntu-upstart
@@ -2,26 +2,26 @@
 
 # see also https://wiki.ubuntu.com/Releases#Current
 
-latest: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/12.04
-precise: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/12.04
-12.04: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/12.04
+latest: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/12.04
+precise: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/12.04
+12.04: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/12.04
 # EOL: Apr 2017
 
 # TODO lucid/10.04 support
-#lucid: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/10.04
-#10.04: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/10.04
+#lucid: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/10.04
+#10.04: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/10.04
 # EOL: Apr 2015
 
 # ---
 
-quantal: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/12.10
-12.10: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/12.10
+quantal: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/12.10
+12.10: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/12.10
 # EOL: Apr 2014
 
-raring: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/13.04
-13.04: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/13.04
+raring: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/13.04
+13.04: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/13.04
 # EOL: Jan 2014
 
-saucy: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/13.10
-13.10: git://github.com/tianon/dockerfiles@0f90322cdcba865c131a9ca4c568aa7ba4e7b80c sbin-init/ubuntu/13.10
+saucy: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/13.10
+13.10: git://github.com/tianon/dockerfiles@e6a5cd2e84c8b28efb8b4ea9346d3d94f6af2c3a sbin-init/ubuntu/upstart/13.10
 # EOL: Jul 2014


### PR DESCRIPTION
... where "/etc/init/lxc.conf" has been renamed to "/etc/init/fake-container-events.conf" to avoid conflicts with the "lxc" package inside the container
