### PR TITLE
Registry now builds off ubuntu:13.10

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -1,6 +1,5 @@
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
-latest: git://github.com/dotcloud/docker-registry@abea91b858d5ddfbfdd5701c2fd7faa6798d60bd
-0.6.5: git://github.com/dotcloud/docker-registry@b912de08ef936b0efb4e8ce15e16d13f055c599c
-0.6.6: git://github.com/dotcloud/docker-registry@570c35b7c624e7c3d7a76333231ad4893df57b79
-0.6.7: git://github.com/dotcloud/docker-registry@abea91b858d5ddfbfdd5701c2fd7faa6798d60bd
+latest: git://github.com/dotcloud/docker-registry@36c4b8283b8598a7c3c969c04f1b81cf55e42d54
+0.6.6: git://github.com/dotcloud/docker-registry@c3c2ee2bfa934948158e96cd08403a22a269ad47
+0.6.7: git://github.com/dotcloud/docker-registry@36c4b8283b8598a7c3c969c04f1b81cf55e42d54


### PR DESCRIPTION
Backported to 2 latest releases.
