### PR TITLE
Update ubuntu images for heartbleed

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,5 +1,11 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
+# notable changelog: (only up to 4 most recent entries)
+# 2014-04-09 - heartbleed.com RUN patches
+# 2014-01-29 - general update and "apt-get update" for up-to-date archive
+# 2014-01-03 - "lucid"
+# 2013-12-20 - ubuntu-minimal and exclude apt-cache translations
+
 # see also https://wiki.ubuntu.com/Releases#Current
 
 latest: git://github.com/tianon/docker-brew-ubuntu@2df0498891eda98e15e9564e808ce52a2c348982


### PR DESCRIPTION
`RUN apt-get update && apt-get install -y $(dpkg-query -W '*ssl*' | awk '{ print $1 }')` hackpatch for now
