### PR TITLE
Fix hipache

### DIFF
--- a/library/hipache
+++ b/library/hipache
@@ -1,4 +1,4 @@
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
-latest: git://github.com/dotcloud/hipache@7362ff5b812f93eceafbdbf5e5959f676f731f80
-0.2.4: git://github.com/dotcloud/hipache@7362ff5b812f93eceafbdbf5e5959f676f731f80
+latest: git://github.com/dotcloud/hipache@0.2.8
+0.2.8: git://github.com/dotcloud/hipache@0.2.8


### PR DESCRIPTION
Hi,

See https://github.com/dotcloud/hipache/issues/133 for reference.

0.2.4 is no longer working - so, I'm updating it to the latest stable Hipache release on the 0.2 branch - before we release 0.3 which contains important changes.
