### PR TITLE
Update hipache

### DIFF
--- a/library/hipache
+++ b/library/hipache
@@ -1,4 +1,5 @@
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
+# maintainer: Olivier Gambier <olivier@webitup.fr> (@dmp42)
 
 latest: git://github.com/dotcloud/hipache@0.3.1
 0.3.1: git://github.com/dotcloud/hipache@0.3.1


### PR DESCRIPTION
Hi @shin-,

Can we get this in?

This is the first Hipache image that doesn't pull hipache from npm (which means it's the first one we are sure what version of hipache actually is in) - which is the reason why I'm not keeping references to 0.2.x versions (though the images will still lie around).

As this is (now) the strongly recommended version to use, I would love to see this in ASAP. I don't list 0.3.0 in there, as it had a minor problem fixed by 0.3.1. 

Thanks!
