### PR TITLE
Update docker-dev image for 0.11.1

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,6 +1,7 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-latest: git://github.com/dotcloud/docker@v0.10.0
+latest: git://github.com/dotcloud/docker@v0.11.1
+v0.11.1: git://github.com/dotcloud/docker@v0.11.1
 v0.10.0: git://github.com/dotcloud/docker@v0.10.0
 v0.9.1: git://github.com/dotcloud/docker@v0.9.1
 v0.8.1: git://github.com/dotcloud/docker@v0.8.1


### PR DESCRIPTION
``` console
root@ee37004b7ceb:/stackbrew/stackbrew# ./brew-cli -b update-docker --targets docker-dev --debug git://github.com/tianon/stackbrew
2014-05-12 22:15:37,413 INFO Cloning docker repo from git://github.com/tianon/stackbrew, branch: update-docker
2014-05-12 22:15:38,169 DEBUG docker-dev ---> latest: git://github.com/dotcloud/docker@v0.11.1

2014-05-12 22:15:38,169 DEBUG Pulling docker-dev from official repository (cache fill)
2014-05-12 22:30:43,201 INFO [cache miss] 09e4df6b775e4dadca6c9517b8f73ed3
2014-05-12 22:30:43,201 INFO Cloning git://github.com/dotcloud/docker (ref: v0.11.1)

2014-05-12 22:31:45,420 INFO Building using dockerfile...
2014-05-12 22:31:58,312 INFO Committing to library/docker-dev:latest
2014-05-12 22:31:58,315 INFO Registering as processed: 09e4df6b775e4dadca6c9517b8f73ed3
2014-05-12 22:31:58,316 DEBUG docker-dev ---> v0.11.1: git://github.com/dotcloud/docker@v0.11.1

2014-05-12 22:31:58,316 DEBUG Pulling docker-dev from official repository (cache fill)
2014-05-12 22:32:22,801 INFO [cache hit] 09e4df6b775e4dadca6c9517b8f73ed3
2014-05-12 22:32:22,802 INFO This ref has already been built, reusing image ID
2014-05-12 22:32:22,802 INFO Committing to library/docker-dev:v0.11.1
2014-05-12 22:32:22,817 INFO Registering as processed: 09e4df6b775e4dadca6c9517b8f73ed3
2014-05-12 22:32:22,817 DEBUG docker-dev ---> v0.10.0: git://github.com/dotcloud/docker@v0.10.0

2014-05-12 22:32:22,817 DEBUG Pulling docker-dev from official repository (cache fill)
2014-05-12 22:32:31,887 INFO [cache miss] b4f427e1e7847d1ce8c9cc57a1b6227c
2014-05-12 22:32:31,887 INFO Cloning git://github.com/dotcloud/docker (ref: v0.10.0)
2014-05-12 22:32:32,105 INFO Building using dockerfile...
2014-05-12 22:43:11,195 INFO Committing to library/docker-dev:v0.10.0
2014-05-12 22:43:11,199 INFO Registering as processed: b4f427e1e7847d1ce8c9cc57a1b6227c
2014-05-12 22:43:11,199 DEBUG docker-dev ---> v0.9.1: git://github.com/dotcloud/docker@v0.9.1

2014-05-12 22:43:11,199 DEBUG Pulling docker-dev from official repository (cache fill)
2014-05-12 22:43:24,970 INFO [cache miss] 8d6bfa38dfbb9fa69b03ce1f44f17176
2014-05-12 22:43:24,970 INFO Cloning git://github.com/dotcloud/docker (ref: v0.9.1)
2014-05-12 22:43:25,161 INFO Building using dockerfile...
...
```

I stopped the build there since it had already succeeded at building the new v0.11.1. :)
