### PR TITLE
Update busybox + provide tags for variants

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,3 +1,8 @@
 # maintainer: Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 
-latest: git://github.com/jpetazzo/docker-busybox@02a13fddf5fa8e1c0e1427526dd89f63be918234
+buildroot-2013.08.1: git://github.com/jpetazzo/docker-busybox@02a13fddf5fa8e1c0e1427526dd89f63be918234
+buildroot-2014.02: git://github.com/jpetazzo/docker-busybox@d595e94020a3a420a05d4531cf8f75b71a3fd8e8
+latest: git://github.com/jpetazzo/docker-busybox@d595e94020a3a420a05d4531cf8f75b71a3fd8e8
+ubuntu-12.04: git://github.com/jpetazzo/docker-busybox@b03e2e24dfca86b2223a6e493a649b699c460e99
+ubuntu-14.04: git://github.com/jpetazzo/docker-busybox@93811b9206948a2bc38679ffff4af8a2267aa8c7
+


### PR DESCRIPTION
"Latest" now points to a version built with buildroot 2014.02, and includes netcat.

I also added tags for the old version, and for versions built using the alternate Ubuntu tarmaker (which includes a full libc etc.)
