### PR TITLE
Update Debian images to fix minor cache typo that caused 50%+ increase in image sizes

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,32 +1,33 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-05-25 - fix minor cache typo that caused 50%+ increase in image sizes
 # 2014-05-21 - 7.5 and newer apt in jessie to fix "Hash Sum Mismatch" errors
 # 2014-04-09 - heartbleed.com
 # 2014-03-14 - 7.4 and 6.0.9
 
 # stable
-latest: git://github.com/tianon/docker-brew-debian@1920570d209e76dcd8da032c13619944f45aedbc
-wheezy: git://github.com/tianon/docker-brew-debian@1920570d209e76dcd8da032c13619944f45aedbc
-7.5: git://github.com/tianon/docker-brew-debian@1920570d209e76dcd8da032c13619944f45aedbc
+latest: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
+wheezy: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
+7.5: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
 #
-stable: git://github.com/tianon/docker-brew-debian@47c6c8082586f105f17ff769c8a3efd5be25b2b6
+stable: git://github.com/tianon/docker-brew-debian@de5f165852f3d167842da1536b78e5fa52111b8a
 
 # testing
-jessie: git://github.com/tianon/docker-brew-debian@a15f79b278c058c03607690f45871e47fe36e476
+jessie: git://github.com/tianon/docker-brew-debian@db44e9e6fd68f8a90093e4a7a022a79711f90b51
 #
-testing: git://github.com/tianon/docker-brew-debian@a633f5cd9b888094a8f931e13c48fde6cf73f676
+testing: git://github.com/tianon/docker-brew-debian@1e244709dffe6778c0cf095dcff3f1b6e6d168ab
 
 # unstable
-sid: git://github.com/tianon/docker-brew-debian@141eeb502203bb43cf27f0c56ba47d4ed15df73d
+sid: git://github.com/tianon/docker-brew-debian@7311f0ed495937ce42fe03a0d2e966d1bde3adb1
 #
-unstable: git://github.com/tianon/docker-brew-debian@8f7b110630e4514fce2530fe0ac1f23e88172257
+unstable: git://github.com/tianon/docker-brew-debian@f52d02bfadb3c903d74494cb731173be171cddeb
 
 # oldstable
-squeeze: git://github.com/tianon/docker-brew-debian@57e19963798952d76c3895eab1de59ad6bba59ef
-6.0.9: git://github.com/tianon/docker-brew-debian@57e19963798952d76c3895eab1de59ad6bba59ef
+squeeze: git://github.com/tianon/docker-brew-debian@b528893003cbfe6594e8aefc382d1473cc9b1467
+6.0.9: git://github.com/tianon/docker-brew-debian@b528893003cbfe6594e8aefc382d1473cc9b1467
 #
-oldstable: git://github.com/tianon/docker-brew-debian@8ad7ea54024ab07fd42d2a4758c4849f2465c656
+oldstable: git://github.com/tianon/docker-brew-debian@5c568007758721a147d07a264acd7ab90765c975
 
 # experimental
 rc-buggy: git://github.com/tianon/dockerfiles@8548eebce2c11cc5b4de37c75c44b0c03c1fbab2 debian/rc-buggy


### PR DESCRIPTION
See also dotcloud/docker#6037.
