### PR TITLE
Updated registry libfile

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -1,7 +1,7 @@
 # maintainer: Joffrey F <joffrey@docker.com> (@shin-)
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
-latest: git://github.com/dotcloud/docker-registry@d30962d4a8f8ed1b6001a04e0d9e1ddc3b064eba
-0.6.7: git://github.com/dotcloud/docker-registry@36c4b8283b8598a7c3c969c04f1b81cf55e42d54
-0.6.8: git://github.com/dotcloud/docker-registry@46d75775055efa618e89abfe6a87f1d8767d05eb
-0.6.9: git://github.com/dotcloud/docker-registry@d30962d4a8f8ed1b6001a04e0d9e1ddc3b064eba
+latest: git://github.com/dotcloud/docker-registry@0.7.0
+0.6.8: git://github.com/dotcloud/docker-registry@0.6.8
+0.6.9: git://github.com/dotcloud/docker-registry@0.6.9
+0.7.0: git://github.com/dotcloud/docker-registry@0.7.0


### PR DESCRIPTION
Use tags instead of commit IDs. Added 0.7.0
