### PR TITLE
Fix CVE-2014-0224 in Ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,6 +1,7 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-06-18 - removed EOL images, CVE-2014-0224 fix
 # 2014-04-22 - new, official Ubuntu Core images
 # 2014-04-09 - heartbleed.com RUN patches
 # 2014-01-29 - general update and "apt-get update" for up-to-date archive
@@ -9,25 +10,17 @@
 # see https://wiki.ubuntu.com/Core#Current_Releases
 # see also https://wiki.ubuntu.com/Releases#Current
 
-latest: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 14.04
-# EOL: TBD
+latest: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04
+trusty: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04
+14.04: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04
+# EOL: Apr 2019
 
-precise: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 12.04.4
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 12.04.4
+precise: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 12.04.4
+12.04: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 12.04.4
 # EOL: Apr 2017
 
 # ---
 
-quantal: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 12.10
-12.10: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 12.10
-# EOL: Apr 2014
-
-raring: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 13.04
-13.04: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 13.04
-# EOL: Jan 2014
-
-saucy: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 13.10
-13.10: git://github.com/tianon/docker-brew-ubuntu-core@8c85eb1f0adfbcb99ac60402461d465f136ad441 13.10
+saucy: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 13.10
+13.10: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 13.10
 # EOL: Jul 2014


### PR DESCRIPTION
- Removed images that are past their EOL
- Moved ubuntu source repo to docker-library namespace
- Added hotfix for CVE-2014-0224 (pending update of the ubuntu-core tarballs)

```
$ ./brew-cli --debug --targets ubuntu .. 
2014-06-18 21:00:19,483 INFO Repository provided assumed to be a local path
2014-06-18 21:00:19,488 DEBUG latest: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04

2014-06-18 21:00:19,489 DEBUG trusty: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04

2014-06-18 21:00:19,489 DEBUG 14.04: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 14.04

2014-06-18 21:00:19,489 DEBUG precise: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 12.04.4

2014-06-18 21:00:19,490 DEBUG 12.04: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 12.04.4

2014-06-18 21:00:19,490 DEBUG saucy: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 13.10

2014-06-18 21:00:19,490 DEBUG 13.10: git://github.com/docker-library/docker-brew-ubuntu-core@6.18.14 13.10

2014-06-18 21:00:19,490 DEBUG ubuntu: latest,trusty,14.04
2014-06-18 21:00:19,491 DEBUG ubuntu: saucy,13.10
2014-06-18 21:00:19,491 DEBUG ubuntu: precise,12.04
2014-06-18 21:00:19,491 DEBUG Cloning repo_url=git://github.com/docker-library/docker-brew-ubuntu-core, ref=6.18.14
2014-06-18 21:00:19,491 DEBUG folder = /tmp/tmpDtykDo
2014-06-18 21:00:19,491 DEBUG Cloning git://github.com/docker-library/docker-brew-ubuntu-core into /tmp/tmpDtykDo
2014-06-18 21:00:19,492 DEBUG Executing "git clone git://github.com/docker-library/docker-brew-ubuntu-core ." in /tmp/tmpDtykDo
Cloning into '.'...
remote: Reusing existing pack: 71, done.
remote: Counting objects: 8, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 79 (delta 3), reused 4 (delta 3)
Receiving objects: 100% (79/79), 211.21 MiB | 726.00 KiB/s, done.
Resolving deltas: 100% (20/20), done.
Checking connectivity... done.
2014-06-18 21:04:05,510 DEBUG Checkout ref:6.18.14 in /tmp/tmpDtykDo
2014-06-18 21:04:05,510 DEBUG Executing "git checkout 6.18.14" in /tmp/tmpDtykDo
Note: checking out '6.18.14'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at c0aaa95... Fix CVE-2014-0224
2014-06-18 21:04:05,940 INFO Build start: ubuntu ('git://github.com/docker-library/docker-brew-ubuntu-core', '6.18.14', '14.04')
2014-06-18 21:05:13,741 INFO Build success: 51a7362b35b1 (ubuntu:latest)
2014-06-18 21:05:13,746 INFO Build success: 51a7362b35b1 (ubuntu:trusty)
2014-06-18 21:05:13,751 INFO Build success: 51a7362b35b1 (ubuntu:14.04)
2014-06-18 21:05:13,756 DEBUG Checkout ref:6.18.14 in /tmp/tmpDtykDo
2014-06-18 21:05:13,756 DEBUG Executing "git checkout 6.18.14" in /tmp/tmpDtykDo
HEAD is now at c0aaa95... Fix CVE-2014-0224
2014-06-18 21:05:14,210 INFO Build start: ubuntu ('git://github.com/docker-library/docker-brew-ubuntu-core', '6.18.14', '13.10')
2014-06-18 21:05:51,838 INFO Build success: 246f4b4a64e6 (ubuntu:saucy)
2014-06-18 21:05:51,840 INFO Build success: 246f4b4a64e6 (ubuntu:13.10)
2014-06-18 21:05:51,844 DEBUG Checkout ref:6.18.14 in /tmp/tmpDtykDo
2014-06-18 21:05:51,844 DEBUG Executing "git checkout 6.18.14" in /tmp/tmpDtykDo
HEAD is now at c0aaa95... Fix CVE-2014-0224
2014-06-18 21:05:51,849 INFO Build start: ubuntu ('git://github.com/docker-library/docker-brew-ubuntu-core', '6.18.14', '12.04.4')
2014-06-18 21:06:45,234 INFO Build success: 7078d5b74139 (ubuntu:precise)
2014-06-18 21:06:45,239 INFO Build success: 7078d5b74139 (ubuntu:12.04)
```

cc @tianon @ewindisch @discordianfish @samalba 
