### PR TITLE
Fix registry 0.6.x dependencies

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -2,8 +2,8 @@
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
 latest: git://github.com/dotcloud/docker-registry@0.7.3
-0.6.8: git://github.com/dotcloud/docker-registry@0.6.8
-0.6.9: git://github.com/dotcloud/docker-registry@0.6.9
+0.6.8: git://github.com/dotcloud/docker-registry@0.6.8-fixed
+0.6.9: git://github.com/dotcloud/docker-registry@0.6.9-fixed
 0.7.0: git://github.com/dotcloud/docker-registry@0.7.0
 0.7.1: git://github.com/dotcloud/docker-registry@0.7.1
 0.7.2: git://github.com/dotcloud/docker-registry@0.7.2


### PR DESCRIPTION
cc @dmp42 @samalba 
Related: https://github.com/dotcloud/docker-registry/issues/441
