### PR TITLE
Add initial ubuntu-debootstrap

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,0 +1,25 @@
+# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+
+# notable changelog: (only up to 4 most recent entries)
+# 2014-06-20 - initial version
+
+# see https://wiki.ubuntu.com/Releases#Current
+
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04
+# EOL: Apr 2019
+
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 12.04
+# EOL: Apr 2017
+
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 10.04
+# EOL: Apr 2015
+
+# ---
+
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.10
+# EOL: TBD


### PR DESCRIPTION
Fixes #38

I don't know why `--targets ubuntu-debootstrap` builds both "ubuntu" and "ubuntu-debootstrap" (probably some minor bug in the `--targets` option parsing), but it works and both are built successfully (as seen below).

``` console
root@04e904c4bfe2:/stackbrew/stackbrew# ./brew-cli --debug -b ubuntu-debootstrap --targets ubuntu-debootstrap git://github.com/tianon/stackbrew
2014-06-21 05:48:24,069 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew, ref=ubuntu-debootstrap
2014-06-21 05:48:24,071 DEBUG folder = /tmp/tmpgee_e_
2014-06-21 05:48:24,071 DEBUG Cloning git://github.com/tianon/stackbrew into /tmp/tmpgee_e_
2014-06-21 05:48:24,071 DEBUG Executing "git clone git://github.com/tianon/stackbrew ." in /tmp/tmpgee_e_
Cloning into '.'...
remote: Counting objects: 787, done.
remote: Compressing objects: 100% (353/353), done.
remote: Total 787 (delta 428), reused 776 (delta 423)
Receiving objects: 100% (787/787), 118.98 KiB | 0 bytes/s, done.
Resolving deltas: 100% (428/428), done.
Checking connectivity... done.
2014-06-21 05:48:24,843 DEBUG Checkout ref:ubuntu-debootstrap in /tmp/tmpgee_e_
2014-06-21 05:48:24,843 DEBUG Executing "git checkout ubuntu-debootstrap" in /tmp/tmpgee_e_
Branch ubuntu-debootstrap set up to track remote branch ubuntu-debootstrap from origin.
Switched to a new branch 'ubuntu-debootstrap'
2014-06-21 05:48:24,849 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04

2014-06-21 05:48:24,850 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04

2014-06-21 05:48:24,850 DEBUG 14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.04

2014-06-21 05:48:24,850 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 12.04

2014-06-21 05:48:24,850 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 12.04

2014-06-21 05:48:24,850 DEBUG lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 10.04

2014-06-21 05:48:24,850 DEBUG 10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 10.04

2014-06-21 05:48:24,850 DEBUG utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.10

2014-06-21 05:48:24,850 DEBUG 14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b47b5e58354faa274dd71cb84cea29aed65dbda9 14.10

2014-06-21 05:48:24,850 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04

2014-06-21 05:48:24,850 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04

2014-06-21 05:48:24,851 DEBUG 14.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04

2014-06-21 05:48:24,851 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.04.4

2014-06-21 05:48:24,851 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.04.4

2014-06-21 05:48:24,851 DEBUG quantal: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.10

2014-06-21 05:48:24,851 DEBUG 12.10: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.10

2014-06-21 05:48:24,851 DEBUG raring: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.04

2014-06-21 05:48:24,851 DEBUG 13.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.04

2014-06-21 05:48:24,851 DEBUG saucy: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.10

2014-06-21 05:48:24,851 DEBUG 13.10: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.10

2014-06-21 05:48:24,851 DEBUG ubuntu-debootstrap: latest,trusty,14.04
2014-06-21 05:48:24,851 DEBUG ubuntu-debootstrap: lucid,10.04
2014-06-21 05:48:24,851 DEBUG ubuntu-debootstrap: utopic,14.10
2014-06-21 05:48:24,851 DEBUG ubuntu-debootstrap: precise,12.04
2014-06-21 05:48:24,851 DEBUG ubuntu: latest,trusty,14.04
2014-06-21 05:48:24,852 DEBUG ubuntu: precise,12.04
2014-06-21 05:48:24,852 DEBUG ubuntu: saucy,13.10
2014-06-21 05:48:24,852 DEBUG ubuntu: raring,13.04
2014-06-21 05:48:24,852 DEBUG ubuntu: quantal,12.10
2014-06-21 05:48:24,852 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-debootstrap, ref=b47b5e58354faa274dd71cb84cea29aed65dbda9
2014-06-21 05:48:24,852 DEBUG folder = /tmp/tmpKM5TsY
2014-06-21 05:48:24,852 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-debootstrap into /tmp/tmpKM5TsY
2014-06-21 05:48:24,852 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-debootstrap ." in /tmp/tmpKM5TsY
Cloning into '.'...
remote: Counting objects: 37, done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 37 (delta 6), reused 19 (delta 0)
Receiving objects: 100% (37/37), 92.71 MiB | 1.56 MiB/s, done.
Resolving deltas: 100% (6/6), done.
Checking connectivity... done.
2014-06-21 05:49:29,900 DEBUG Checkout ref:b47b5e58354faa274dd71cb84cea29aed65dbda9 in /tmp/tmpKM5TsY
2014-06-21 05:49:29,901 DEBUG Executing "git checkout b47b5e58354faa274dd71cb84cea29aed65dbda9" in /tmp/tmpKM5TsY
Note: checking out 'b47b5e58354faa274dd71cb84cea29aed65dbda9'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at b47b5e5... Gnasty Tarballs
2014-06-21 05:49:30,146 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', 'b47b5e58354faa274dd71cb84cea29aed65dbda9', '14.04')
2014-06-21 05:49:36,953 INFO Build success: b7eef20af6df (ubuntu-debootstrap:latest)
2014-06-21 05:49:36,958 INFO Build success: b7eef20af6df (ubuntu-debootstrap:trusty)
2014-06-21 05:49:36,962 INFO Build success: b7eef20af6df (ubuntu-debootstrap:14.04)
2014-06-21 05:49:36,965 DEBUG Checkout ref:b47b5e58354faa274dd71cb84cea29aed65dbda9 in /tmp/tmpKM5TsY
2014-06-21 05:49:36,965 DEBUG Executing "git checkout b47b5e58354faa274dd71cb84cea29aed65dbda9" in /tmp/tmpKM5TsY
HEAD is now at b47b5e5... Gnasty Tarballs
2014-06-21 05:49:37,328 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', 'b47b5e58354faa274dd71cb84cea29aed65dbda9', '10.04')
2014-06-21 05:49:44,033 INFO Build success: 71decc9d20b5 (ubuntu-debootstrap:lucid)
2014-06-21 05:49:44,038 INFO Build success: 71decc9d20b5 (ubuntu-debootstrap:10.04)
2014-06-21 05:49:44,042 DEBUG Checkout ref:b47b5e58354faa274dd71cb84cea29aed65dbda9 in /tmp/tmpKM5TsY
2014-06-21 05:49:44,042 DEBUG Executing "git checkout b47b5e58354faa274dd71cb84cea29aed65dbda9" in /tmp/tmpKM5TsY
HEAD is now at b47b5e5... Gnasty Tarballs
2014-06-21 05:49:44,046 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', 'b47b5e58354faa274dd71cb84cea29aed65dbda9', '14.10')
2014-06-21 05:49:51,843 INFO Build success: f8b30a68c0d3 (ubuntu-debootstrap:utopic)
2014-06-21 05:49:51,847 INFO Build success: f8b30a68c0d3 (ubuntu-debootstrap:14.10)
2014-06-21 05:49:51,851 DEBUG Checkout ref:b47b5e58354faa274dd71cb84cea29aed65dbda9 in /tmp/tmpKM5TsY
2014-06-21 05:49:51,851 DEBUG Executing "git checkout b47b5e58354faa274dd71cb84cea29aed65dbda9" in /tmp/tmpKM5TsY
HEAD is now at b47b5e5... Gnasty Tarballs
2014-06-21 05:49:51,855 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', 'b47b5e58354faa274dd71cb84cea29aed65dbda9', '12.04')
2014-06-21 05:50:06,630 INFO Build success: a1496256819e (ubuntu-debootstrap:precise)
2014-06-21 05:50:06,726 INFO Build success: a1496256819e (ubuntu-debootstrap:12.04)
2014-06-21 05:50:07,805 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-core, ref=487c2e834faee181ff5c15d15f57842a610f56da
2014-06-21 05:50:07,805 DEBUG folder = /tmp/tmpTbcBX9
2014-06-21 05:50:07,805 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-core into /tmp/tmpTbcBX9
2014-06-21 05:50:07,805 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-core ." in /tmp/tmpTbcBX9
Cloning into '.'...
remote: Counting objects: 83, done.
remote: Compressing objects: 100% (65/65), done.
remote: Total 83 (delta 28), reused 69 (delta 17)
Receiving objects: 100% (83/83), 211.21 MiB | 1.56 MiB/s, done.
Resolving deltas: 100% (28/28), done.
Checking connectivity... done.
2014-06-21 05:52:26,439 DEBUG Checkout ref:487c2e834faee181ff5c15d15f57842a610f56da in /tmp/tmpTbcBX9
2014-06-21 05:52:26,440 DEBUG Executing "git checkout 487c2e834faee181ff5c15d15f57842a610f56da" in /tmp/tmpTbcBX9
Note: checking out '487c2e834faee181ff5c15d15f57842a610f56da'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 487c2e8... CVE-2014-0224
2014-06-21 05:52:27,135 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '487c2e834faee181ff5c15d15f57842a610f56da', '14.04')
2014-06-21 05:53:15,957 INFO Build success: 9be7c30650ff (ubuntu:latest)
2014-06-21 05:53:16,201 INFO Build success: 9be7c30650ff (ubuntu:trusty)
2014-06-21 05:53:16,463 INFO Build success: 9be7c30650ff (ubuntu:14.04)
2014-06-21 05:53:16,720 DEBUG Checkout ref:487c2e834faee181ff5c15d15f57842a610f56da in /tmp/tmpTbcBX9
2014-06-21 05:53:16,721 DEBUG Executing "git checkout 487c2e834faee181ff5c15d15f57842a610f56da" in /tmp/tmpTbcBX9
HEAD is now at 487c2e8... CVE-2014-0224
2014-06-21 05:53:16,724 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '487c2e834faee181ff5c15d15f57842a610f56da', '12.04.4')
2014-06-21 05:53:55,751 INFO Build success: ce390c75fd65 (ubuntu:precise)
2014-06-21 05:53:55,756 INFO Build success: ce390c75fd65 (ubuntu:12.04)
2014-06-21 05:53:55,760 DEBUG Checkout ref:487c2e834faee181ff5c15d15f57842a610f56da in /tmp/tmpTbcBX9
2014-06-21 05:53:55,760 DEBUG Executing "git checkout 487c2e834faee181ff5c15d15f57842a610f56da" in /tmp/tmpTbcBX9
HEAD is now at 487c2e8... CVE-2014-0224
2014-06-21 05:53:55,764 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '487c2e834faee181ff5c15d15f57842a610f56da', '13.10')
2014-06-21 05:54:44,442 INFO Build success: 55dae92dcd81 (ubuntu:saucy)
2014-06-21 05:54:44,447 INFO Build success: 55dae92dcd81 (ubuntu:13.10)
2014-06-21 05:54:44,452 DEBUG Checkout ref:487c2e834faee181ff5c15d15f57842a610f56da in /tmp/tmpTbcBX9
2014-06-21 05:54:44,452 DEBUG Executing "git checkout 487c2e834faee181ff5c15d15f57842a610f56da" in /tmp/tmpTbcBX9
HEAD is now at 487c2e8... CVE-2014-0224
2014-06-21 05:54:44,456 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '487c2e834faee181ff5c15d15f57842a610f56da', '13.04')
2014-06-21 05:55:09,812 INFO Build success: af34ab48fb33 (ubuntu:raring)
2014-06-21 05:55:09,816 INFO Build success: af34ab48fb33 (ubuntu:13.04)
2014-06-21 05:55:09,820 DEBUG Checkout ref:487c2e834faee181ff5c15d15f57842a610f56da in /tmp/tmpTbcBX9
2014-06-21 05:55:09,820 DEBUG Executing "git checkout 487c2e834faee181ff5c15d15f57842a610f56da" in /tmp/tmpTbcBX9
HEAD is now at 487c2e8... CVE-2014-0224
2014-06-21 05:55:09,824 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '487c2e834faee181ff5c15d15f57842a610f56da', '12.10')
2014-06-21 05:55:38,497 INFO Build success: 6bec1e612bad (ubuntu:quantal)
2014-06-21 05:55:38,501 INFO Build success: 6bec1e612bad (ubuntu:12.10)
```
