### PR TITLE
Update wordpress to allow specifying values like AUTH_KEY via WORDPRESS_AUTH_KEY

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/wordpress@c08407d4b61b403e5892c87b0a5e3dbe1c8bec16
-3: git://github.com/docker-library/wordpress@c08407d4b61b403e5892c87b0a5e3dbe1c8bec16
-3.9: git://github.com/docker-library/wordpress@c08407d4b61b403e5892c87b0a5e3dbe1c8bec16
-3.9.1: git://github.com/docker-library/wordpress@c08407d4b61b403e5892c87b0a5e3dbe1c8bec16
+latest: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
+3: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
+3.9: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
+3.9.1: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de


### PR DESCRIPTION
Also, if they're unspecified, this new code will randomize them.  This improves the security of the authentication cookies WordPress uses.

``` console
root@ea58faa9e241:/stackbrew/stackbrew# ./brew-cli --debug -b wordpress --targets wordpress git://github.com/infosiftr/stackbrew
2014-06-23 22:27:48,587 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=wordpress
2014-06-23 22:27:48,589 DEBUG folder = /tmp/tmpqbo64I
2014-06-23 22:27:48,589 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmpqbo64I
2014-06-23 22:27:48,589 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmpqbo64I
Cloning into '.'...
remote: Counting objects: 804, done.
remote: Compressing objects: 100% (364/364), done.
remote: Total 804 (delta 438), reused 787 (delta 429)
Receiving objects: 100% (804/804), 120.90 KiB | 0 bytes/s, done.
Resolving deltas: 100% (438/438), done.
Checking connectivity... done.
2014-06-23 22:27:49,428 DEBUG Checkout ref:wordpress in /tmp/tmpqbo64I
2014-06-23 22:27:49,429 DEBUG Executing "git checkout wordpress" in /tmp/tmpqbo64I
Branch wordpress set up to track remote branch wordpress from origin.
Switched to a new branch 'wordpress'
2014-06-23 22:27:49,434 DEBUG latest: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de

2014-06-23 22:27:49,434 DEBUG 3: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de

2014-06-23 22:27:49,434 DEBUG 3.9: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de

2014-06-23 22:27:49,434 DEBUG 3.9.1: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de

2014-06-23 22:27:49,434 DEBUG wordpress: latest,3,3.9,3.9.1
2014-06-23 22:27:49,434 DEBUG Cloning repo_url=git://github.com/docker-library/wordpress, ref=e33e55b17adf897e14384e5177fcf7f98accc2de
2014-06-23 22:27:49,434 DEBUG folder = /tmp/tmpt2wCSJ
2014-06-23 22:27:49,435 DEBUG Cloning git://github.com/docker-library/wordpress into /tmp/tmpt2wCSJ
2014-06-23 22:27:49,435 DEBUG Executing "git clone git://github.com/docker-library/wordpress ." in /tmp/tmpt2wCSJ
Cloning into '.'...
remote: Counting objects: 162669, done.
remote: Compressing objects: 100% (33733/33733), done.
remote: Total 162669 (delta 128211), reused 162661 (delta 128209)
Receiving objects: 100% (162669/162669), 85.02 MiB | 1.56 MiB/s, done.
Resolving deltas: 100% (128211/128211), done.
Checking connectivity... done.
2014-06-23 22:28:51,204 DEBUG Checkout ref:e33e55b17adf897e14384e5177fcf7f98accc2de in /tmp/tmpt2wCSJ
2014-06-23 22:28:51,205 DEBUG Executing "git checkout e33e55b17adf897e14384e5177fcf7f98accc2de" in /tmp/tmpt2wCSJ
Note: checking out 'e33e55b17adf897e14384e5177fcf7f98accc2de'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at e33e55b... Allow specifying values like AUTH_KEY via WORDPRESS_AUTH_KEY, and default them to random values if unspecified
2014-06-23 22:28:51,316 INFO Build start: wordpress ('git://github.com/docker-library/wordpress', 'e33e55b17adf897e14384e5177fcf7f98accc2de', '.')
2014-06-23 22:29:06,244 INFO Build success: 927b115ac5f0 (wordpress:latest)
2014-06-23 22:29:06,248 INFO Build success: 927b115ac5f0 (wordpress:3)
2014-06-23 22:29:06,271 INFO Build success: 927b115ac5f0 (wordpress:3.9)
2014-06-23 22:29:06,276 INFO Build success: 927b115ac5f0 (wordpress:3.9.1)
```
