### PR TITLE
Update wordpress to allow special characters in parameters to wp-config

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
-3: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
-3.9: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
-3.9.1: git://github.com/docker-library/wordpress@e33e55b17adf897e14384e5177fcf7f98accc2de
+latest: git://github.com/docker-library/wordpress@9b0c78d065901cb1ce2379df5bcec4eed243a52a
+3: git://github.com/docker-library/wordpress@9b0c78d065901cb1ce2379df5bcec4eed243a52a
+3.9: git://github.com/docker-library/wordpress@9b0c78d065901cb1ce2379df5bcec4eed243a52a
+3.9.1: git://github.com/docker-library/wordpress@9b0c78d065901cb1ce2379df5bcec4eed243a52a


### PR DESCRIPTION
This way, things like `-e WORDPRESS_NONCE_SALT="lol
'wut'yousay\"haha\\"` actually work properly and create `define('NONCE_SALT',       'lol\'wut\'yousay"haha\\');` (properly escaped for use within the PHP code).
