### PR TITLE
Update ubuntu from new Core tarballs

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,33 +1,20 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-06-24 - new "daily" Core tarballs
 # 2014-04-22 - CVE-2014-0224 RUN patches
 # 2014-04-22 - new, official Ubuntu Core images
 # 2014-04-09 - heartbleed.com RUN patches
-# 2014-01-29 - general update and "apt-get update" for up-to-date archive
 
 # see https://wiki.ubuntu.com/Core#Current_Releases
 # see also https://wiki.ubuntu.com/Releases#Current
+# see also http://cdimage.ubuntu.com/ubuntu-core/
 
-latest: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 14.04
-# EOL: TBD
+latest: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
+# EOL: Apr 2019
 
-precise: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.04.4
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.04.4
+precise: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
 # EOL: Apr 2017
-
-# ---
-
-quantal: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.10
-12.10: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 12.10
-# EOL: Apr 2014
-
-raring: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.04
-13.04: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.04
-# EOL: Jan 2014
-
-saucy: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.10
-13.10: git://github.com/tianon/docker-brew-ubuntu-core@487c2e834faee181ff5c15d15f57842a610f56da 13.10
-# EOL: Jul 2014


### PR DESCRIPTION
``` console
root@eff9d2228db4:/stackbrew/stackbrew# ./brew-cli --debug -b ubuntu --targets ubuntu git://github.com/tianon/stackbrew 
2014-06-24 17:10:15,941 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew, ref=ubuntu
2014-06-24 17:10:15,943 DEBUG folder = /tmp/tmpJVeJWt
2014-06-24 17:10:15,943 DEBUG Cloning git://github.com/tianon/stackbrew into /tmp/tmpJVeJWt
2014-06-24 17:10:15,943 DEBUG Executing "git clone git://github.com/tianon/stackbrew ." in /tmp/tmpJVeJWt
Cloning into '.'...
remote: Counting objects: 821, done.
remote: Compressing objects: 100% (381/381), done.
remote: Total 821 (delta 449), reused 786 (delta 429)
Receiving objects: 100% (821/821), 122.95 KiB | 0 bytes/s, done.
Resolving deltas: 100% (449/449), done.
Checking connectivity... done.
2014-06-24 17:10:17,572 DEBUG Checkout ref:ubuntu in /tmp/tmpJVeJWt
2014-06-24 17:10:17,572 DEBUG Executing "git checkout ubuntu" in /tmp/tmpJVeJWt
Branch ubuntu set up to track remote branch ubuntu from origin.
Switched to a new branch 'ubuntu'
2014-06-24 17:10:17,579 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-24 17:10:17,579 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-24 17:10:17,579 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-24 17:10:17,579 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise

2014-06-24 17:10:17,579 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise

2014-06-24 17:10:17,579 DEBUG ubuntu: latest,trusty,trusty
2014-06-24 17:10:17,579 DEBUG ubuntu: precise,12.04
2014-06-24 17:10:17,579 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-core, ref=e95176d335ced8a314bd664cffedb51e145e3848
2014-06-24 17:10:17,580 DEBUG folder = /tmp/tmpDeAQEA
2014-06-24 17:10:17,580 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-core into /tmp/tmpDeAQEA
2014-06-24 17:10:17,580 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-core ." in /tmp/tmpDeAQEA
Cloning into '.'...
remote: Counting objects: 25, done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 25 (delta 3), reused 1 (delta 0)
Receiving objects: 100% (25/25), 102.60 MiB | 1.12 MiB/s, done.
Resolving deltas: 100% (3/3), done.
Checking connectivity... done.
2014-06-24 17:12:04,252 DEBUG Checkout ref:e95176d335ced8a314bd664cffedb51e145e3848 in /tmp/tmpDeAQEA
2014-06-24 17:12:04,252 DEBUG Executing "git checkout e95176d335ced8a314bd664cffedb51e145e3848" in /tmp/tmpDeAQEA
Note: checking out 'e95176d335ced8a314bd664cffedb51e145e3848'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at e95176d... 24-Jun-2014
2014-06-24 17:12:04,653 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'e95176d335ced8a314bd664cffedb51e145e3848', 'trusty')
2014-06-24 17:12:17,981 INFO Build success: ec82b5df91a7 (ubuntu:latest)
2014-06-24 17:12:17,986 INFO Build success: ec82b5df91a7 (ubuntu:trusty)
2014-06-24 17:12:18,009 INFO Build success: ec82b5df91a7 (ubuntu:trusty)
2014-06-24 17:12:18,014 DEBUG Checkout ref:e95176d335ced8a314bd664cffedb51e145e3848 in /tmp/tmpDeAQEA
2014-06-24 17:12:18,014 DEBUG Executing "git checkout e95176d335ced8a314bd664cffedb51e145e3848" in /tmp/tmpDeAQEA
HEAD is now at e95176d... 24-Jun-2014
2014-06-24 17:12:18,649 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'e95176d335ced8a314bd664cffedb51e145e3848', 'precise')
2014-06-24 17:12:32,690 INFO Build success: e8d2fc83213b (ubuntu:precise)
2014-06-24 17:12:32,694 INFO Build success: e8d2fc83213b (ubuntu:12.04)
```
