### PR TITLE
Update the CirrOS image

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -1,4 +1,4 @@
 # maintainer: Eric Windisch <ewindisch@docker.com> (@ewindisch)
 
-latest: git://github.com/ewindisch/docker-cirros@d3c144f98beed34a1f3c815072e2c5de07aec1ae
-0.3.0: git://github.com/ewindisch/docker-cirros@d3c144f98beed34a1f3c815072e2c5de07aec1ae
+latest: git://github.com/ewindisch/docker-cirros@1cded459668e8b9dbf4ef976c94c05add9bbd8e9
+0.3.0: git://github.com/ewindisch/docker-cirros@1cded459668e8b9dbf4ef976c94c05add9bbd8e9


### PR DESCRIPTION
We've updated the CirrOS image with several bugfixes.

The latest image fixes network configuration disabling
lxc_netdown in rc.sysinit.

The newest image also has a major behavioral change of
running init by default. Running init is the generally
expected method of running CirrOS, which is largely used
for testing OpenStack deployments, SSH connectivity,
and connections to metadata service APIs.

Users will remain able to override CMD to point
to /bin/sh and use this image to run microservices.
