### PR TITLE
Update debian for new gnupg CVE, updated packages, and removed /var/lib/apt/lists

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,35 +1,35 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-06-27 - new gnupg CVE, updated packages, and removed /var/lib/apt/lists
 # 2014-05-25 - fix minor cache typo that caused 50%+ increase in image sizes
 # 2014-05-21 - 7.5 and newer apt in jessie to fix "Hash Sum Mismatch" errors
 # 2014-04-09 - heartbleed.com
-# 2014-03-14 - 7.4 and 6.0.9
 
 # stable
-latest: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
-wheezy: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
-7.5: git://github.com/tianon/docker-brew-debian@8b8fb72a27a68d7969983b0c6c58d0e13f78e66a
+latest: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy
+7.5: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy
 #
-stable: git://github.com/tianon/docker-brew-debian@de5f165852f3d167842da1536b78e5fa52111b8a
+stable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd stable
 
 # testing
-jessie: git://github.com/tianon/docker-brew-debian@db44e9e6fd68f8a90093e4a7a022a79711f90b51
+jessie: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd jessie
 #
-testing: git://github.com/tianon/docker-brew-debian@1e244709dffe6778c0cf095dcff3f1b6e6d168ab
+testing: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd testing
 
 # unstable
-sid: git://github.com/tianon/docker-brew-debian@7311f0ed495937ce42fe03a0d2e966d1bde3adb1
+sid: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd sid
 #
-unstable: git://github.com/tianon/docker-brew-debian@f52d02bfadb3c903d74494cb731173be171cddeb
+unstable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd unstable
 
 # oldstable
-squeeze: git://github.com/tianon/docker-brew-debian@b528893003cbfe6594e8aefc382d1473cc9b1467
-6.0.9: git://github.com/tianon/docker-brew-debian@b528893003cbfe6594e8aefc382d1473cc9b1467
+squeeze: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd squeeze
+6.0.9: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd squeeze
 #
-oldstable: git://github.com/tianon/docker-brew-debian@5c568007758721a147d07a264acd7ab90765c975
+oldstable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd oldstable
 
 # experimental
-rc-buggy: git://github.com/tianon/dockerfiles@8548eebce2c11cc5b4de37c75c44b0c03c1fbab2 debian/rc-buggy
+rc-buggy: git://github.com/tianon/dockerfiles@caa1407e7c59a314ab5ea989bb6c718de0c83f78 debian/rc-buggy
 #
-experimental: git://github.com/tianon/dockerfiles@8548eebce2c11cc5b4de37c75c44b0c03c1fbab2 debian/experimental
+experimental: git://github.com/tianon/dockerfiles@caa1407e7c59a314ab5ea989bb6c718de0c83f78 debian/experimental


### PR DESCRIPTION
Fixes #81
Fixes #96

``` console
root@f752aa6da802:/stackbrew/stackbrew# ./brew-cli --debug -b debian --targets debian git://github.com/tianon/stackbrew
2014-06-27 16:13:31,257 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew, ref=debian
2014-06-27 16:13:31,259 DEBUG folder = /tmp/tmpg2ASXh
2014-06-27 16:13:31,259 DEBUG Cloning git://github.com/tianon/stackbrew into /tmp/tmpg2ASXh
2014-06-27 16:13:31,259 DEBUG Executing "git clone git://github.com/tianon/stackbrew ." in /tmp/tmpg2ASXh
Cloning into '.'...
remote: Counting objects: 839, done.
remote: Compressing objects: 100% (399/399), done.
remote: Total 839 (delta 460), reused 784 (delta 429)
Receiving objects: 100% (839/839), 125.42 KiB | 0 bytes/s, done.
Resolving deltas: 100% (460/460), done.
Checking connectivity... done.
2014-06-27 16:13:32,267 DEBUG Checkout ref:debian in /tmp/tmpg2ASXh
2014-06-27 16:13:32,268 DEBUG Executing "git checkout debian" in /tmp/tmpg2ASXh
Branch debian set up to track remote branch debian from origin.
Switched to a new branch 'debian'
2014-06-27 16:13:32,274 DEBUG latest: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy

2014-06-27 16:13:32,274 DEBUG wheezy: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy

2014-06-27 16:13:32,274 DEBUG 7.5: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd wheezy

2014-06-27 16:13:32,275 DEBUG stable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd stable

2014-06-27 16:13:32,275 DEBUG jessie: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd jessie

2014-06-27 16:13:32,275 DEBUG testing: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd testing

2014-06-27 16:13:32,275 DEBUG sid: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd sid

2014-06-27 16:13:32,275 DEBUG unstable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd unstable

2014-06-27 16:13:32,275 DEBUG squeeze: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd squeeze

2014-06-27 16:13:32,275 DEBUG 6.0.9: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd squeeze

2014-06-27 16:13:32,275 DEBUG oldstable: git://github.com/tianon/docker-brew-debian@d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd oldstable

2014-06-27 16:13:32,275 DEBUG rc-buggy: git://github.com/tianon/dockerfiles@caa1407e7c59a314ab5ea989bb6c718de0c83f78 debian/rc-buggy

2014-06-27 16:13:32,275 DEBUG experimental: git://github.com/tianon/dockerfiles@caa1407e7c59a314ab5ea989bb6c718de0c83f78 debian/experimental

2014-06-27 16:13:32,275 DEBUG debian: squeeze,6.0.9
2014-06-27 16:13:32,275 DEBUG debian: oldstable
2014-06-27 16:13:32,275 DEBUG debian: rc-buggy
2014-06-27 16:13:32,275 DEBUG debian: latest,wheezy,7.5
2014-06-27 16:13:32,275 DEBUG debian: unstable
2014-06-27 16:13:32,275 DEBUG debian: experimental
2014-06-27 16:13:32,275 DEBUG debian: testing
2014-06-27 16:13:32,276 DEBUG debian: sid
2014-06-27 16:13:32,276 DEBUG debian: stable
2014-06-27 16:13:32,276 DEBUG debian: jessie
2014-06-27 16:13:32,276 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-debian, ref=d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd
2014-06-27 16:13:32,276 DEBUG folder = /tmp/tmpwseFtj
2014-06-27 16:13:32,276 DEBUG Cloning git://github.com/tianon/docker-brew-debian into /tmp/tmpwseFtj
2014-06-27 16:13:32,276 DEBUG Executing "git clone git://github.com/tianon/docker-brew-debian ." in /tmp/tmpwseFtj
Cloning into '.'...
remote: Counting objects: 68, done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 68 (delta 15), reused 31 (delta 0)
Receiving objects: 100% (68/68), 168.78 MiB | 1.04 MiB/s, done.
Resolving deltas: 100% (15/15), done.
Checking connectivity... done.
2014-06-27 16:16:46,456 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:16:46,456 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
Note: checking out 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:16:46,851 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'squeeze')
2014-06-27 16:17:13,398 INFO Build success: a0beb870bcc0 (debian:squeeze)
2014-06-27 16:17:13,435 INFO Build success: a0beb870bcc0 (debian:6.0.9)
2014-06-27 16:17:13,508 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:17:13,508 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:17:14,401 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'oldstable')
2014-06-27 16:17:40,687 INFO Build success: 272c80af2d55 (debian:oldstable)
2014-06-27 16:17:40,726 DEBUG Cloning repo_url=git://github.com/tianon/dockerfiles, ref=caa1407e7c59a314ab5ea989bb6c718de0c83f78
2014-06-27 16:17:40,726 DEBUG folder = /tmp/tmpXk3ZEm
2014-06-27 16:17:40,726 DEBUG Cloning git://github.com/tianon/dockerfiles into /tmp/tmpXk3ZEm
2014-06-27 16:17:40,726 DEBUG Executing "git clone git://github.com/tianon/dockerfiles ." in /tmp/tmpXk3ZEm
Cloning into '.'...
remote: Reusing existing pack: 530, done.
remote: Counting objects: 15, done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 545 (delta 3), reused 0 (delta 0)
Receiving objects: 100% (545/545), 241.85 KiB | 277.00 KiB/s, done.
Resolving deltas: 100% (214/214), done.
Checking connectivity... done.
2014-06-27 16:17:42,050 DEBUG Checkout ref:caa1407e7c59a314ab5ea989bb6c718de0c83f78 in /tmp/tmpXk3ZEm
2014-06-27 16:17:42,051 DEBUG Executing "git checkout caa1407e7c59a314ab5ea989bb6c718de0c83f78" in /tmp/tmpXk3ZEm
Note: checking out 'caa1407e7c59a314ab5ea989bb6c718de0c83f78'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at caa1407... SMALLER BASE IMAGES
2014-06-27 16:17:42,057 INFO Build start: debian ('git://github.com/tianon/dockerfiles', 'caa1407e7c59a314ab5ea989bb6c718de0c83f78', 'debian/rc-buggy')
2014-06-27 16:17:48,502 INFO Build success: ed7f3155a54c (debian:rc-buggy)
2014-06-27 16:17:48,553 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:17:48,553 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:17:48,558 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'wheezy')
2014-06-27 16:18:14,856 INFO Build success: 753348355da3 (debian:latest)
2014-06-27 16:18:14,896 INFO Build success: 753348355da3 (debian:wheezy)
2014-06-27 16:18:14,950 INFO Build success: 753348355da3 (debian:7.5)
2014-06-27 16:18:15,006 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:18:15,006 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:18:15,011 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'unstable')
2014-06-27 16:19:01,029 INFO Build success: 935f9cb08ef7 (debian:unstable)
2014-06-27 16:19:01,054 DEBUG Checkout ref:caa1407e7c59a314ab5ea989bb6c718de0c83f78 in /tmp/tmpXk3ZEm
2014-06-27 16:19:01,054 DEBUG Executing "git checkout caa1407e7c59a314ab5ea989bb6c718de0c83f78" in /tmp/tmpXk3ZEm
HEAD is now at caa1407... SMALLER BASE IMAGES
2014-06-27 16:19:01,059 INFO Build start: debian ('git://github.com/tianon/dockerfiles', 'caa1407e7c59a314ab5ea989bb6c718de0c83f78', 'debian/experimental')
2014-06-27 16:19:02,842 INFO Build success: 8ea11a86f88e (debian:experimental)
2014-06-27 16:19:02,875 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:19:02,876 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:19:02,880 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'testing')
2014-06-27 16:19:49,965 INFO Build success: 2625a8ac90e8 (debian:testing)
2014-06-27 16:19:50,148 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:19:50,148 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:19:50,153 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'sid')
2014-06-27 16:20:28,289 INFO Build success: c27f03fe0028 (debian:sid)
2014-06-27 16:20:28,361 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:20:28,361 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:20:28,366 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'stable')
2014-06-27 16:21:01,877 INFO Build success: dcd99a7a6e5e (debian:stable)
2014-06-27 16:21:01,945 DEBUG Checkout ref:d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd in /tmp/tmpwseFtj
2014-06-27 16:21:01,945 DEBUG Executing "git checkout d17c7161f4db1f2f12a4b09a77f76ead4a9da6cd" in /tmp/tmpwseFtj
HEAD is now at d17c716... 2014-06-27 debootstraps
2014-06-27 16:21:01,950 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'd17c7161f4db1f2f12a4b09a77f76ead4a9da6cd', 'jessie')
2014-06-27 16:21:24,792 INFO Build success: 4bf50e5fa15c (debian:jessie)
```

``` console
$ docker images library/debian
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
library/debian      jessie              4bf50e5fa15c        23 seconds ago       89.41 MB
library/debian      stable              dcd99a7a6e5e        49 seconds ago       85.18 MB
library/debian      sid                 c27f03fe0028        About a minute ago   89.84 MB
library/debian      testing             2625a8ac90e8        About a minute ago   89.41 MB
library/debian      experimental        8ea11a86f88e        2 minutes ago        123.6 MB
library/debian      unstable            935f9cb08ef7        2 minutes ago        89.84 MB
library/debian      latest              753348355da3        3 minutes ago        85.18 MB
library/debian      7.5                 753348355da3        3 minutes ago        85.18 MB
library/debian      wheezy              753348355da3        3 minutes ago        85.18 MB
library/debian      rc-buggy            ed7f3155a54c        4 minutes ago        123.6 MB
library/debian      oldstable           272c80af2d55        4 minutes ago        78.48 MB
library/debian      6.0.9               a0beb870bcc0        4 minutes ago        78.48 MB
library/debian      squeeze             a0beb870bcc0        4 minutes ago        78.48 MB
```
