### PR TITLE
Add "utopic"/"14.10" (and fix the "14.04" tag)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,10 +1,10 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-06-27 - fix "14.04" tag and add "utopic"/"14.10"
 # 2014-06-24 - new "daily" Core tarballs
 # 2014-04-22 - CVE-2014-0224 RUN patches
 # 2014-04-22 - new, official Ubuntu Core images
-# 2014-04-09 - heartbleed.com RUN patches
 
 # see https://wiki.ubuntu.com/Core#Current_Releases
 # see also https://wiki.ubuntu.com/Releases#Current
@@ -12,9 +12,13 @@
 
 latest: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
 trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
 # EOL: Apr 2019
 
 precise: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
 12.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
 # EOL: Apr 2017
+
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic
+# EOL: sometime after BOL ;) (not officially released just yet)


### PR DESCRIPTION
My bad on 14.04 typo. :)

Also, Utopic with not only Ubuntu's blessing, but their strong endorsement. :D

``` console
root@cff4602c5f72:/stackbrew/stackbrew# ./brew-cli --debug -b ubuntu-utopic --targets ubuntu git://github.com/tianon/stackbrew  
2014-06-27 18:08:23,607 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew, ref=ubuntu-utopic
2014-06-27 18:08:23,608 DEBUG folder = /tmp/tmplM1aE8
2014-06-27 18:08:23,609 DEBUG Cloning git://github.com/tianon/stackbrew into /tmp/tmplM1aE8
2014-06-27 18:08:23,609 DEBUG Executing "git clone git://github.com/tianon/stackbrew ." in /tmp/tmplM1aE8
Cloning into '.'...
remote: Counting objects: 843, done.
remote: Compressing objects: 100% (372/372), done.
remote: Total 843 (delta 461), reused 838 (delta 460)
Receiving objects: 100% (843/843), 126.67 KiB | 0 bytes/s, done.
Resolving deltas: 100% (461/461), done.
Checking connectivity... done.
2014-06-27 18:08:24,645 DEBUG Checkout ref:ubuntu-utopic in /tmp/tmplM1aE8
2014-06-27 18:08:24,645 DEBUG Executing "git checkout ubuntu-utopic" in /tmp/tmplM1aE8
Branch ubuntu-utopic set up to track remote branch ubuntu-utopic from origin.
Switched to a new branch 'ubuntu-utopic'
2014-06-27 18:08:24,651 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-27 18:08:24,652 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-27 18:08:24,652 DEBUG 14.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty

2014-06-27 18:08:24,652 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise

2014-06-27 18:08:24,652 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise

2014-06-27 18:08:24,652 DEBUG utopic: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic

2014-06-27 18:08:24,652 DEBUG 14.10: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic

2014-06-27 18:08:24,652 DEBUG ubuntu: latest,trusty,14.04
2014-06-27 18:08:24,652 DEBUG ubuntu: precise,12.04
2014-06-27 18:08:24,652 DEBUG ubuntu: utopic,14.10
2014-06-27 18:08:24,652 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-core, ref=e95176d335ced8a314bd664cffedb51e145e3848
2014-06-27 18:08:24,652 DEBUG folder = /tmp/tmpCbvqan
2014-06-27 18:08:24,652 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-core into /tmp/tmpCbvqan
2014-06-27 18:08:24,653 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-core ." in /tmp/tmpCbvqan
Cloning into '.'...
remote: Counting objects: 41, done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 41 (delta 9), reused 22 (delta 3)
Receiving objects: 100% (41/41), 165.25 MiB | 874.00 KiB/s, done.
Resolving deltas: 100% (9/9), done.
Checking connectivity... done.
2014-06-27 18:11:15,360 DEBUG Checkout ref:e95176d335ced8a314bd664cffedb51e145e3848 in /tmp/tmpCbvqan
2014-06-27 18:11:15,361 DEBUG Executing "git checkout e95176d335ced8a314bd664cffedb51e145e3848" in /tmp/tmpCbvqan
Note: checking out 'e95176d335ced8a314bd664cffedb51e145e3848'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at e95176d... 24-Jun-2014
2014-06-27 18:11:15,798 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'e95176d335ced8a314bd664cffedb51e145e3848', 'trusty')
2014-06-27 18:11:28,779 INFO Build success: 002f5a866e54 (ubuntu:latest)
2014-06-27 18:11:28,783 INFO Build success: 002f5a866e54 (ubuntu:trusty)
2014-06-27 18:11:28,787 INFO Build success: 002f5a866e54 (ubuntu:14.04)
2014-06-27 18:11:28,791 DEBUG Checkout ref:e95176d335ced8a314bd664cffedb51e145e3848 in /tmp/tmpCbvqan
2014-06-27 18:11:28,791 DEBUG Executing "git checkout e95176d335ced8a314bd664cffedb51e145e3848" in /tmp/tmpCbvqan
HEAD is now at e95176d... 24-Jun-2014
2014-06-27 18:11:29,308 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'e95176d335ced8a314bd664cffedb51e145e3848', 'precise')
2014-06-27 18:11:39,314 INFO Build success: b063a1e775d9 (ubuntu:precise)
2014-06-27 18:11:39,318 INFO Build success: b063a1e775d9 (ubuntu:12.04)
2014-06-27 18:11:39,321 DEBUG Checkout ref:5ababebbfb2c9a7d93f876c324faaee44758a9f0 in /tmp/tmpCbvqan
2014-06-27 18:11:39,321 DEBUG Executing "git checkout 5ababebbfb2c9a7d93f876c324faaee44758a9f0" in /tmp/tmpCbvqan
Previous HEAD position was e95176d... 24-Jun-2014
HEAD is now at 5ababeb... 27-Jun-2014 utopic! \o/
2014-06-27 18:11:39,606 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', '5ababebbfb2c9a7d93f876c324faaee44758a9f0', 'utopic')
2014-06-27 18:11:54,960 INFO Build success: 7fcfb5895368 (ubuntu:utopic)
2014-06-27 18:11:54,964 INFO Build success: 7fcfb5895368 (ubuntu:14.10)
```
