### PR TITLE
Adding a file for Perl (5.20.0 and 5.18.2)

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,21 +1,21 @@
-# Maintainer: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
+# maintainer: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
 
-latest: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit
+latest: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
 
-5: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit
+5: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
 
-5.20: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit
-5.20.0: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit
+5.20: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
+5.20.0: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
 
-5.18: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.018.002-64bit
-5.18.2: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.018.002-64bit
+5.18: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit
+5.18.2: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit
 
-latest-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit,threaded
+latest-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
 
-5-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit,threaded
+5-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
 
-5.20-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit,threaded
-5.20.0-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.020.000-64bit,threaded
+5.20-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
+5.20.0-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
 
-5.18-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.018.002-64bit,threaded
-5.18.2-threaded: git://github.com/petermartini/docker-perl@a2e267efb9943a7695dadfe7a152c4c1620710ea 5.018.002-64bit,threaded
+5.18-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit,threaded
+5.18.2-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit,threaded


### PR DESCRIPTION
The referenced repo has 4 directories right now, 2 for
each version of Perl.  One has command line options
just for 64-bit compilation (which would actually be turned
on by default anyway, but I wanted to be explicit about it),
and the other will also enable threads.  Threads are generally
discouraged, so they specifically need to be opted into.

(I'm not sure how to properly test this file format, though I have done basic testing of the Dockerfiles themselves)
