### PR TITLE
Remove obsolete docker-dev@0.6.7

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -8,6 +8,5 @@ v0.10.0: git://github.com/dotcloud/docker@v0.10.0
 v0.9.1: git://github.com/dotcloud/docker@v0.9.1
 v0.8.1: git://github.com/dotcloud/docker@v0.8.1
 v0.7.6: git://github.com/dotcloud/docker@v0.7.6
-v0.6.7: git://github.com/dotcloud/docker@v0.6.7
 
 # one tag per major version


### PR DESCRIPTION
@tianon 
Essentially the Dockerfile is broken anyway and I don't think there's any value in fixing it.

```
# cat docker-dev.v0.6.7.error.log 
# Skipping unknown instruction DOCKER-VERSION

Step 1 : from ubuntu:12.04

 ---> db7fb3df454e

Step 2 : maintainer Solomon Hykes <solomon@dotcloud.com>

 ---> Using cache

 ---> 451399c6e924

Step 3 : run echo 'deb http://archive.ubuntu.com/ubuntu precise main universe' > /etc/apt/sources.list

 ---> Using cache

 ---> 8b4c24a8fcd0

Step 4 : run apt-get update

 ---> Using cache

 ---> 9281e98e0316

Step 5 : run apt-get install -y -q curl

 ---> Using cache

 ---> c67cbd9a68fe

Step 6 : run apt-get install -y -q git

 ---> Running in f2085260f1e3

Reading package lists...


Building dependency tree...

Reading state information...


Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:

 git : Depends: perl-modules but it is not going to be installed
       Depends: liberror-perl but it is not going to be installed

E: Unable to correct problems, you have held broken packages.
```
