### PR TITLE
Add in a Hylang stackbrew image

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,0 +1,6 @@
+# maintainer: Paul Tagliamonte <paultag@hylang.org> (@paultag)
+
+latest: git://github.com/hylang/hy@1265f546d1fbcfa9c62b51f3e455c0709be7acc8
+0: git://github.com/hylang/hy@1265f546d1fbcfa9c62b51f3e455c0709be7acc8
+0.10: git://github.com/hylang/hy@1265f546d1fbcfa9c62b51f3e455c0709be7acc8
+0.10.0: git://github.com/hylang/hy@1265f546d1fbcfa9c62b51f3e455c0709be7acc8


### PR DESCRIPTION
Hy is a dialect of Lisp that’s embedded in / compiles to Python.

Since Hy transforms its Lisp code into the Python Abstract Syntax Tree, you have the whole beautiful world of Python at your fingertips, in Lisp form!

https://github.com/hylang/hy

``` hylang
(print "Thanks!")
```
