### PR TITLE
fedora image updates

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,6 +1,7 @@
 # maintainer: Lokesh Mandvekar <lsm5@fedoraproject.org> (@lsm5)
 
-latest: git://github.com/lsm5/docker-brew-fedora@63ea5c6226124051995fbe7f0c4edbc5e1499615
-20: git://github.com/lsm5/docker-brew-fedora@63ea5c6226124051995fbe7f0c4edbc5e1499615
-heisenbug: git://github.com/lsm5/docker-brew-fedora@63ea5c6226124051995fbe7f0c4edbc5e1499615
-rawhide: git://github.com/lsm5/docker-brew-fedora@58eb7d0b6774ed0697333b4edaf55e239a4a98ce
+latest: git://github.com/lsm5/docker-brew-fedora@f85f2975c9391b58df3dd8bb9fa95b274f01a310
+20: git://github.com/lsm5/docker-brew-fedora@f85f2975c9391b58df3dd8bb9fa95b274f01a310
+heisenbug: git://github.com/lsm5/docker-brew-fedora@f85f2975c9391b58df3dd8bb9fa95b274f01a310
+21: git://github.com/lsm5/docker-brew-fedora@5b0e7742b2e98f105375fd054cc1f546711e6c58
+rawhide: git://github.com/lsm5/docker-brew-fedora@0d4daabcb4de7c469776205ffaa92aba3b1b0dec


### PR DESCRIPTION
rebuilt 20/heisenbug/latest
new branch: 21
rebuilt rawhide (now moved to 22 since 21 branch)

```
modified:   library/fedora
```
