### PR TITLE
Update python:2 to include "pip" by default

### DIFF
--- a/library/python
+++ b/library/python
@@ -5,6 +5,6 @@ latest: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9
 3.4: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3
 3: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3
 
-2.7.7: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 2
-2.7: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 2
-2: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 2
+2.7.7: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2
+2.7: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2
+2: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2


### PR DESCRIPTION
``` console
root@0212e958890f:/stackbrew/stackbrew# ./brew-cli --debug -b python2-pip --targets python git://github.com/infosiftr/stackbrew
2014-07-16 00:32:01,121 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=python2-pip
2014-07-16 00:32:01,123 DEBUG folder = /tmp/tmp3UhYD5
2014-07-16 00:32:01,123 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmp3UhYD5
2014-07-16 00:32:01,123 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmp3UhYD5
Cloning into '.'...
remote: Counting objects: 912, done.
remote: Compressing objects: 100% (404/404), done.
remote: Total 912 (delta 501), reused 902 (delta 497)
Receiving objects: 100% (912/912), 136.11 KiB | 0 bytes/s, done.
Resolving deltas: 100% (501/501), done.
Checking connectivity... done.
2014-07-16 00:32:02,117 DEBUG Checkout ref:python2-pip in /tmp/tmp3UhYD5
2014-07-16 00:32:02,117 DEBUG Executing "git checkout python2-pip" in /tmp/tmp3UhYD5
Branch python2-pip set up to track remote branch python2-pip from origin.
Switched to a new branch 'python2-pip'
2014-07-16 00:32:02,123 DEBUG latest: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3

2014-07-16 00:32:02,123 DEBUG 3.4.1: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3

2014-07-16 00:32:02,123 DEBUG 3.4: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3

2014-07-16 00:32:02,123 DEBUG 3: git://github.com/docker-library/docker-python@10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 3

2014-07-16 00:32:02,123 DEBUG 2.7.7: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2

2014-07-16 00:32:02,123 DEBUG 2.7: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2

2014-07-16 00:32:02,123 DEBUG 2: git://github.com/docker-library/docker-python@771cb8f39dee0850092b978346a8c95ba0d9c273 2

2014-07-16 00:32:02,124 DEBUG python: latest,3.4.1,3.4,3
2014-07-16 00:32:02,124 DEBUG python: 2.7.7,2.7,2
2014-07-16 00:32:02,124 DEBUG Cloning repo_url=git://github.com/docker-library/docker-python, ref=10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362
2014-07-16 00:32:02,124 DEBUG folder = /tmp/tmpwmIz15
2014-07-16 00:32:02,124 DEBUG Cloning git://github.com/docker-library/docker-python into /tmp/tmpwmIz15
2014-07-16 00:32:02,124 DEBUG Executing "git clone git://github.com/docker-library/docker-python ." in /tmp/tmpwmIz15
Cloning into '.'...
remote: Reusing existing pack: 37, done.
remote: Counting objects: 4, done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 41 (delta 0), reused 3 (delta 0)
Receiving objects: 100% (41/41), 4.51 KiB | 0 bytes/s, done.
Resolving deltas: 100% (8/8), done.
Checking connectivity... done.
2014-07-16 00:32:02,604 DEBUG Checkout ref:10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362 in /tmp/tmpwmIz15
2014-07-16 00:32:02,604 DEBUG Executing "git checkout 10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362" in /tmp/tmpwmIz15
Note: checking out '10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 10eb8b1... Put "curl | tar" in a separate RUN since we keep the source around at the end of the build anyways
2014-07-16 00:32:02,609 INFO Build start: python ('git://github.com/docker-library/docker-python', '10eb8b1bac2bfbc6d1fdf1dad9c1ecae1d607362', '3')
2014-07-16 00:38:45,422 INFO Build success: b1a5708c0aab (python:latest)
2014-07-16 00:38:45,426 INFO Build success: b1a5708c0aab (python:3.4.1)
2014-07-16 00:38:45,444 INFO Build success: b1a5708c0aab (python:3.4)
2014-07-16 00:38:45,448 INFO Build success: b1a5708c0aab (python:3)
2014-07-16 00:38:45,452 DEBUG Checkout ref:771cb8f39dee0850092b978346a8c95ba0d9c273 in /tmp/tmpwmIz15
2014-07-16 00:38:45,452 DEBUG Executing "git checkout 771cb8f39dee0850092b978346a8c95ba0d9c273" in /tmp/tmpwmIz15
Previous HEAD position was 10eb8b1... Put "curl | tar" in a separate RUN since we keep the source around at the end of the build anyways
HEAD is now at 771cb8f... Merge pull request #2 from infosiftr/pip
2014-07-16 00:38:45,458 INFO Build start: python ('git://github.com/docker-library/docker-python', '771cb8f39dee0850092b978346a8c95ba0d9c273', '2')
2014-07-16 00:38:47,409 INFO Build success: 9130fa0b17c8 (python:2.7.7)
2014-07-16 00:38:47,427 INFO Build success: 9130fa0b17c8 (python:2.7)
2014-07-16 00:38:47,461 INFO Build success: 9130fa0b17c8 (python:2)
```
