### PR TITLE
Update ruby to have onbuild triggers as a separate image

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,6 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/ruby@15a75728df122ca5e0210c296095285facda11d4
-2: git://github.com/docker-library/ruby@15a75728df122ca5e0210c296095285facda11d4
-2.1: git://github.com/docker-library/ruby@15a75728df122ca5e0210c296095285facda11d4
-2.1.2: git://github.com/docker-library/ruby@15a75728df122ca5e0210c296095285facda11d4
+latest: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
+2: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
+2.1: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
+2.1.2: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
+
+onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
+2-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
+2.1-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
+2.1.2-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild


### PR DESCRIPTION
This will break many users' current builds so we will need to update the hub long description.
