### PR TITLE
Update ubuntu images to 17-Jul-2014

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,24 +1,24 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # notable changelog: (only up to 4 most recent entries)
+# 2014-07-17 - "17-Jul-2014" images (solves some "apt-get update" issues)
 # 2014-06-27 - fix "14.04" tag and add "utopic"/"14.10"
 # 2014-06-24 - new "daily" Core tarballs
 # 2014-04-22 - CVE-2014-0224 RUN patches
-# 2014-04-22 - new, official Ubuntu Core images
 
 # see https://wiki.ubuntu.com/Core#Current_Releases
 # see also https://wiki.ubuntu.com/Releases#Current
 # see also http://cdimage.ubuntu.com/ubuntu-core/
 
-latest: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce trusty
 # EOL: Apr 2019
 
-precise: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@e95176d335ced8a314bd664cffedb51e145e3848 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce precise
 # EOL: Apr 2017
 
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@5ababebbfb2c9a7d93f876c324faaee44758a9f0 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce utopic
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@4d9284074f3712e4a35357b1d7e5ffca6c9027ce utopic
 # EOL: sometime after BOL ;) (not officially released just yet)


### PR DESCRIPTION
See also https://github.com/tianon/docker-brew-ubuntu-core/issues/9 (`apt-get update` woes)

I also did a resync of our minor tweaks to match our contrib/mkimage/debootstrap script more closely again.
