### PR TITLE
Jenkins LTS based official image

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -1,4 +1,5 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
 latest: git://github.com/cloudbees/jenkins-ci.org-docker@2627b96534028614f718315d7f84eb49362e445d
+1.554: git://github.com/cloudbees/jenkins-ci.org-docker@2627b96534028614f718315d7f84eb49362e445d
 1.554.3: git://github.com/cloudbees/jenkins-ci.org-docker@2627b96534028614f718315d7f84eb49362e445d


### PR DESCRIPTION
As discussed with Brian Goff - here is the official Jenkins repo for inclusion. 

Jenkins has a weekly non long-term-support release schedule - but we thought for the purposes of stackbrew we should stick to the LTS versions of Jenkins - which are infrequent enough that a pull request is feasible. 

For a logo, here is the official one in png form: https://camo.githubusercontent.com/73aa2e5efdce9c86a20922bc04f9c2bde852be4f/687474703a2f2f6a656e6b696e732d63692e6f72672f73697465732f64656661756c742f66696c65732f6a656e6b696e735f6c6f676f2e706e67 
