### PR TITLE
Update docker.Client to default to DOCKER_HOST so that it "just works" more often

### DIFF
--- a/stackbrew/brew/brew.py
+++ b/stackbrew/brew/brew.py
@@ -264,7 +264,8 @@ class LocalBuilder(StackbrewBuilder):
         super(LocalBuilder, self).__init__(
             library, namespaces, targetlist, repo_cache
         )
-        self.client = docker.Client(version='1.9', timeout=10000)
+        self.client = docker.Client(version='1.9', timeout=10000,
+                                    base_url=os.getenv('DOCKER_HOST'))
         self.build_success_re = r'^Successfully built ([a-f0-9]+)\n$'
 
     def do_build(self, repo, version, dockerfile_location, callback=None):

--- a/stackbrew/requirements.txt
+++ b/stackbrew/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.9
 SQLAlchemy==0.8.2
-docker-py==0.3.1
+docker-py==0.4.0


### PR DESCRIPTION
See also https://github.com/dotcloud/docker-py/pull/204 (especially the discussion there).
