### PR TITLE
Added openSUSE to the library

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,0 +1,5 @@
+# maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
+
+latest: git://github.com/openSUSE/docker-containers-build@7c5bb0ec448b66dea489e4430b9b154284797681 docker
+13.1: git://github.com/openSUSE/docker-containers-build@7c5bb0ec448b66dea489e4430b9b154284797681 docker
+bottle: git://github.com/openSUSE/docker-containers-build@7c5bb0ec448b66dea489e4430b9b154284797681 docker


### PR DESCRIPTION
This PR adds openSUSE to the list of official images. It also helps solving [this](https://github.com/docker/docker/pull/6765) issue.
