### PR TITLE
Update to have many versions of postgres pulling from upstream packaging

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,6 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/postgres@09530ea5ee45272907f5a203bdd3d6929a18dd91
-9: git://github.com/docker-library/postgres@09530ea5ee45272907f5a203bdd3d6929a18dd91
-9.3: git://github.com/docker-library/postgres@09530ea5ee45272907f5a203bdd3d6929a18dd91
-9.3.4: git://github.com/docker-library/postgres@09530ea5ee45272907f5a203bdd3d6929a18dd91
+latest: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+
+9: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+9.3: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+9.3.5: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+
+9.2: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.2
+9.2.9: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.2
+
+9.1: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.1
+9.1.14: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.1
+
+9.0: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.0
+9.0.18: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.0
+
+8.4: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 8.4
+8.4.22: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 8.4
+
+9.4: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.4
+9.4-beta2: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.4


### PR DESCRIPTION
Also reduces size as a bonus.

From about 800MB to around 240MB.
