### PR TITLE
Update postgres with fix for /var/run/postgresql issue

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+8.4.22: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
+8.4: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
+8: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
 
-9: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
-9.3: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
-9.3.5: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.3
+9.0.18: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.0
+9.0: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.0
 
-9.2: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.2
-9.2.9: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.2
+9.1.14: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.1
+9.1: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.1
 
-9.1: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.1
-9.1.14: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.1
+9.2.9: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.2
+9.2: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.2
 
-9.0: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.0
-9.0.18: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.0
+9.3.5: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
+9.3: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
+9: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
+latest: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
 
-8.4: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 8.4
-8.4.22: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 8.4
-
-9.4: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.4
-9.4-beta2: git://github.com/docker-library/postgres@6abeb8590f35c5251b9f100a667024febaeee06b 9.4
+9.4-beta2: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.4
+9.4: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.4


### PR DESCRIPTION
Sorry for the order change in the file - we've got this file being generated more consistently by a script now (https://github.com/docker-library/postgres/blob/docker/generate-stackbrew-library.sh) so that we don't forget anything (like the "postgres:8" tag we forgot on the previous PR).
