### PR TITLE
Updated version of library/perl to bundle cpanm

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,21 +1,21 @@
 # maintainer: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
 
-latest: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
+latest: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit
 
-5: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
+5: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit
 
-5.20: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
-5.20.0: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit
+5.20: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit
+5.20.0: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit
 
-5.18: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit
-5.18.2: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit
+5.18: git://github.com/perl/docker-perl@r20140804.0 5.018.002-64bit
+5.18.2: git://github.com/perl/docker-perl@r20140804.0 5.018.002-64bit
 
-latest-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
+latest-threaded: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit,threaded
 
-5-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
+5-threaded: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit,threaded
 
-5.20-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
-5.20.0-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.020.000-64bit,threaded
+5.20-threaded: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit,threaded
+5.20.0-threaded: git://github.com/perl/docker-perl@r20140804.0 5.020.000-64bit,threaded
 
-5.18-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit,threaded
-5.18.2-threaded: git://github.com/perl/docker-perl@34796bd21f9f48816e0dbb2e5126593d83588f78 5.018.002-64bit,threaded
+5.18-threaded: git://github.com/perl/docker-perl@r20140804.0 5.018.002-64bit,threaded
+5.18.2-threaded: git://github.com/perl/docker-perl@r20140804.0 5.018.002-64bit,threaded


### PR DESCRIPTION
The tagged version of docker-perl includes cpanm on top of the Perl 5 core.  I'm not sure if it makes sense to do that or not, but my gut feeling, for cpanm, was to go for it.  I'm happy to hear arguments on either side.

I also used a date+version tag instead of the SHA for clarity's sake, tested with brew-cli.
