### PR TITLE
Latest Jenkins LTS is available

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -3,6 +3,4 @@
 latest: git://github.com/cloudbees/jenkins-ci.org-docker@a5bfd41e00d0df91a35dd6a252b8c4a831d00743
 1.574: git://github.com/cloudbees/jenkins-ci.org-docker@a5bfd41e00d0df91a35dd6a252b8c4a831d00743
 
-1.554: git://github.com/cloudbees/jenkins-ci.org-docker@2627b96534028614f718315d7f84eb49362e445d
-1.554.3: git://github.com/cloudbees/jenkins-ci.org-docker@2627b96534028614f718315d7f84eb49362e445d
 


### PR DESCRIPTION
New Jenkins LTS version is available. 
