### PR TITLE
Update WordPress to use wheezy, and fix SSL proxy

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/wordpress@862b8b5bf2aa0e8542605f5f513d737a10b17d46
-3: git://github.com/docker-library/wordpress@862b8b5bf2aa0e8542605f5f513d737a10b17d46
-3.9: git://github.com/docker-library/wordpress@862b8b5bf2aa0e8542605f5f513d737a10b17d46
-3.9.1: git://github.com/docker-library/wordpress@862b8b5bf2aa0e8542605f5f513d737a10b17d46
+latest: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
+3: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
+3.9: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
+3.9.1: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f


### PR DESCRIPTION
By changing to wheezy, this also fixes the strange issue with the `RUN rm -rf /var/www/html && mkdir /var/www/html` not actually changing anything. See https://github.com/docker-library/wordpress/issues/4
