### PR TITLE
Update wordpress, especially to remove upstream artifacts and simplify the build (~374.2MB down to ~203.8MB)

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
-3: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
-3.9: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
-3.9.1: git://github.com/docker-library/wordpress@91154405010f2009a4972c64a6aad594fef3474f
+3.9.2: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
+3.9: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
+3: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
+latest: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b


### PR DESCRIPTION
This also bumps us from 0.9.1 to 0.9.2, which is a security bump.

``` console
root@5f1002e49017:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b wordpress --targets wordpress git://github.com/infosiftr/stackbrew
2014-08-11 23:07:25,558 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=wordpress
2014-08-11 23:07:25,560 DEBUG folder = /tmp/tmpRg_kLk
2014-08-11 23:07:25,560 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmpRg_kLk
2014-08-11 23:07:25,560 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmpRg_kLk
Cloning into '.'...
remote: Counting objects: 1127, done.
remote: Compressing objects: 100% (515/515), done.
remote: Total 1127 (delta 631), reused 1077 (delta 600)
Receiving objects: 100% (1127/1127), 166.06 KiB | 0 bytes/s, done.
Resolving deltas: 100% (631/631), done.
Checking connectivity... done.
2014-08-11 23:07:26,504 DEBUG Checkout ref:wordpress in /tmp/tmpRg_kLk
2014-08-11 23:07:26,504 DEBUG Executing "git checkout wordpress" in /tmp/tmpRg_kLk
Branch wordpress set up to track remote branch wordpress from origin.
Switched to a new branch 'wordpress'
2014-08-11 23:07:26,510 DEBUG 3.9.2: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b

2014-08-11 23:07:26,510 DEBUG 3.9: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b

2014-08-11 23:07:26,510 DEBUG 3: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b

2014-08-11 23:07:26,510 DEBUG latest: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b

2014-08-11 23:07:26,510 DEBUG wordpress: 3.9.2,3.9,3,latest
2014-08-11 23:07:26,510 DEBUG Cloning repo_url=git://github.com/docker-library/wordpress, ref=69c6d14ae81392b39d1ded401da617ece7c10c5b
2014-08-11 23:07:26,510 DEBUG folder = /tmp/tmpsOSVf4
2014-08-11 23:07:26,510 DEBUG Cloning git://github.com/docker-library/wordpress into /tmp/tmpsOSVf4
2014-08-11 23:07:26,511 DEBUG Executing "git clone git://github.com/docker-library/wordpress ." in /tmp/tmpsOSVf4
Cloning into '.'...
remote: Counting objects: 14, done.
remote: Compressing objects: 100% (14/14), done.
Receiving objects: 100% (14/14), 4.23 KiB | 0 bytes/s, done.
Resolving deltas: 100% (4/4), done.
remote: Total 14 (delta 4), reused 1 (delta 0)
Checking connectivity... done.
2014-08-11 23:07:26,969 DEBUG Checkout ref:69c6d14ae81392b39d1ded401da617ece7c10c5b in /tmp/tmpsOSVf4
2014-08-11 23:07:26,970 DEBUG Executing "git checkout 69c6d14ae81392b39d1ded401da617ece7c10c5b" in /tmp/tmpsOSVf4
Note: checking out '69c6d14ae81392b39d1ded401da617ece7c10c5b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 69c6d14... Remove extraneous leftover " $version" on our generate-stackbrew-library.sh echo
2014-08-11 23:07:26,974 INFO Build start: wordpress ('git://github.com/docker-library/wordpress', '69c6d14ae81392b39d1ded401da617ece7c10c5b', '.')
2014-08-11 23:07:35,241 INFO Build success: ea377c29ae9b (wordpress:3.9.2)
2014-08-11 23:07:35,254 INFO Build success: ea377c29ae9b (wordpress:3.9)
2014-08-11 23:07:35,266 INFO Build success: ea377c29ae9b (wordpress:3)
2014-08-11 23:07:35,278 INFO Build success: ea377c29ae9b (wordpress:latest)
```
