### PR TITLE
Update mysql with the 5.7.4-m14 development release

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -1,6 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/docker-mysql@a63bd99cbf39d5965d7e59e362aea330fcfe014a
-5: git://github.com/docker-library/docker-mysql@a63bd99cbf39d5965d7e59e362aea330fcfe014a
-5.6: git://github.com/docker-library/docker-mysql@a63bd99cbf39d5965d7e59e362aea330fcfe014a
-5.6.17: git://github.com/docker-library/docker-mysql@a63bd99cbf39d5965d7e59e362aea330fcfe014a
+5.6.20: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
+5.6: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
+5: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
+latest: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
+
+5.7.4-m14: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7
+5.7.4: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7
+5.7: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7


### PR DESCRIPTION
``` console
root@ef4cd39707c5:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b mysql --targets mysql git://github.com/infosiftr/stackbrew
2014-08-11 23:11:32,623 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=mysql
2014-08-11 23:11:32,625 DEBUG folder = /tmp/tmpyRlxgF
2014-08-11 23:11:32,625 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmpyRlxgF
2014-08-11 23:11:32,625 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmpyRlxgF
Cloning into '.'...
remote: Counting objects: 1131, done.
remote: Compressing objects: 100% (519/519), done.
remote: Total 1131 (delta 633), reused 1077 (delta 600)
Receiving objects: 100% (1131/1131), 166.52 KiB | 0 bytes/s, done.
Resolving deltas: 100% (633/633), done.
Checking connectivity... done.
2014-08-11 23:11:33,537 DEBUG Checkout ref:mysql in /tmp/tmpyRlxgF
2014-08-11 23:11:33,537 DEBUG Executing "git checkout mysql" in /tmp/tmpyRlxgF
Branch mysql set up to track remote branch mysql from origin.
Switched to a new branch 'mysql'
2014-08-11 23:11:33,543 DEBUG 5.6.20: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6

2014-08-11 23:11:33,543 DEBUG 5.6: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6

2014-08-11 23:11:33,543 DEBUG 5: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6

2014-08-11 23:11:33,543 DEBUG latest: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6

2014-08-11 23:11:33,543 DEBUG 5.7.4-m14: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7

2014-08-11 23:11:33,543 DEBUG 5.7.4: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7

2014-08-11 23:11:33,543 DEBUG 5.7: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7

2014-08-11 23:11:33,543 DEBUG mysql: 5.6.20,5.6,5,latest
2014-08-11 23:11:33,543 DEBUG mysql: 5.7.4-m14,5.7.4,5.7
2014-08-11 23:11:33,543 DEBUG Cloning repo_url=git://github.com/docker-library/docker-mysql, ref=fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12
2014-08-11 23:11:33,544 DEBUG folder = /tmp/tmpe7ZPEb
2014-08-11 23:11:33,544 DEBUG Cloning git://github.com/docker-library/docker-mysql into /tmp/tmpe7ZPEb
2014-08-11 23:11:33,544 DEBUG Executing "git clone git://github.com/docker-library/docker-mysql ." in /tmp/tmpe7ZPEb
Cloning into '.'...
remote: Counting objects: 72, done.
remote: Compressing objects: 100% (56/56), done.
remote: Total 72 (delta 25), reused 43 (delta 16)
Receiving objects: 100% (72/72), 10.31 KiB | 0 bytes/s, done.
Resolving deltas: 100% (25/25), done.
Checking connectivity... done.
2014-08-11 23:11:34,065 DEBUG Checkout ref:fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 in /tmp/tmpe7ZPEb
2014-08-11 23:11:34,065 DEBUG Executing "git checkout fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12" in /tmp/tmpe7ZPEb
Note: checking out 'fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at fd3bd50... Create our default root@% user with CREATE USER / GRANT especially to fix our "expired password" issues in the 5.7 development version
2014-08-11 23:11:34,070 INFO Build start: mysql ('git://github.com/docker-library/docker-mysql', 'fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12', '5.6')
2014-08-11 23:15:12,443 INFO Build success: f1732efad800 (mysql:5.6.20)
2014-08-11 23:15:12,454 INFO Build success: f1732efad800 (mysql:5.6)
2014-08-11 23:15:12,466 INFO Build success: f1732efad800 (mysql:5)
2014-08-11 23:15:12,476 INFO Build success: f1732efad800 (mysql:latest)
2014-08-11 23:15:12,487 DEBUG Checkout ref:fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 in /tmp/tmpe7ZPEb
2014-08-11 23:15:12,487 DEBUG Executing "git checkout fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12" in /tmp/tmpe7ZPEb
HEAD is now at fd3bd50... Create our default root@% user with CREATE USER / GRANT especially to fix our "expired password" issues in the 5.7 development version
2014-08-11 23:15:12,491 INFO Build start: mysql ('git://github.com/docker-library/docker-mysql', 'fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12', '5.7')
2014-08-11 23:15:18,960 INFO Build success: e4a08f4b4a82 (mysql:5.7.4-m14)
2014-08-11 23:15:19,174 INFO Build success: e4a08f4b4a82 (mysql:5.7.4)
2014-08-11 23:15:19,495 INFO Build success: e4a08f4b4a82 (mysql:5.7)
```

This also bumps our 5.6 track to 5.6.20.
