### PR TITLE
Introduce NeuroDebian to library

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,31 +1,23 @@
 # maintainer: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 
-lucid: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/lucid
-nd10.04: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/lucid
+lucid: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/lucid
+nd10.04: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/lucid
 
-precise: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/precise
-nd12.04: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/precise
+precise: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/precise
+nd12.04: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/precise
 
-quantal: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/quantal
-nd12.10: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/quantal
+trusty: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/trusty
+nd14.04: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/trusty
 
-raring: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/raring
-nd13.04: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/raring
+squeeze: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/squeeze
+nd60: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/squeeze
 
-saucy: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/saucy
-nd13.10: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/saucy
+wheezy: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/wheezy
+nd70: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/wheezy
+latest: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/wheezy
 
-trusty: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/trusty
-nd14.04: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/trusty
+jessie: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/jessie
+nd80: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/jessie
 
-squeeze: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/squeeze
-nd60: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/squeeze
-
-wheezy: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/wheezy
-nd70: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/wheezy
-
-jessie: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/jessie
-nd80: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/jessie
-
-sid: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/sid
-nd: git://github.com/neurodebian/dockerfiles@d2c388b72859a79cfaecc77eb118b3365bb0b135 dockerfiles/sid
+sid: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/sid
+nd: git://github.com/neurodebian/dockerfiles@6ee7033cb630b4a72fa3a4a56ad6046405efacdf dockerfiles/sid


### PR DESCRIPTION
Corresponding Dockerfiles generated using
https://github.com/neurodebian/dockerfiles/blob/master/gen_dockerfiles
and simply add few RUN commands to add neurodebian repository into the stock Debian and Ubuntu images.  No apt-get update was RAN
