### PR TITLE
Update ubuntu-debootstrap:lucid to fix missing gnupg and /var/lib/apt/lists/partial

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@76b24379e24c96f0b1bc7129f2dcde60365530a5 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@76b24379e24c96f0b1bc7129f2dcde60365530a5 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@76b24379e24c96f0b1bc7129f2dcde60365530a5 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b0c4c43cc0c727cd2a4483714fd9b9d96a98cf24 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b0c4c43cc0c727cd2a4483714fd9b9d96a98cf24 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b0c4c43cc0c727cd2a4483714fd9b9d96a98cf24 10.04
 
 12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@76b24379e24c96f0b1bc7129f2dcde60365530a5 12.04
 12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@76b24379e24c96f0b1bc7129f2dcde60365530a5 12.04


### PR DESCRIPTION
This is as mentioned on #152 (see also https://github.com/docker/docker/pull/7545, which this necessarily includes).
