### PR TITLE
Fix `--targets` by converting the argument to an actual list instead of relying on string handling

### DIFF
--- a/stackbrew/brew-cli
+++ b/stackbrew/brew-cli
@@ -65,8 +65,9 @@ if __name__ == '__main__':
     namespaces = args.n.split(',')
     if args.no_namespace:
         namespaces.append('')
+    targets = args.targets.split(',')
     sb_library = brew.StackbrewLibrary(args.repository, args.b)
-    builder = brew.LocalBuilder(sb_library, namespaces, args.targets)
+    builder = brew.LocalBuilder(sb_library, namespaces, targets)
     builder.build_repo_list()
     builder.build_all()
     if args.push:


### PR DESCRIPTION
Fixes  #147

The problem was that we were doing `xyz in abc` where `abc` is a string, so it did substring matching (ie, `"ubuntu" in "ubuntu-debootstrap"`).  Converting it to a list (so that it becomes `"ubuntu" in ["ubuntu-debootstrap"]`) makes it function properly. :smile:
