### PR TITLE
Add ruby 1.9, reduce ruby image size

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,11 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
-2: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
-2.1: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
-2.1.2: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f
+1.9.3-p547: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9
+1.9.3: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9
+1.9: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9
+1: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9
 
-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
-2-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
-2.1-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
-2.1.2-onbuild: git://github.com/docker-library/ruby@3c212166381cf64eb3a084dd9634a90955cc323f docker-onbuild
+1.9.3-p547-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
+1.9.3-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
+1.9-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
+1-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
+
+2.1.2: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1
+2.1: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1
+2: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1
+latest: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1
+
+2.1.2-onbuild: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1/onbuild
+2.1-onbuild: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1/onbuild
+2-onbuild: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1/onbuild
+onbuild: git://github.com/docker-library/ruby@950a673e59df846608f624ee55321d36ba1f89ba 2.1/onbuild


### PR DESCRIPTION
916.7 MB for Ruby 2.1 from 1.555 GB
616.2 MB for Ruby 1.9
