### PR TITLE
Update mysql to be smaller, based on the official binary releases, and to do GPG signature verification of the downloads

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.6.20: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
-5.6: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
-5: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
-latest: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.6
+5.6.20: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
+5.6: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
+5: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
+latest: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
 
-5.7.4-m14: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7
-5.7.4: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7
-5.7: git://github.com/docker-library/docker-mysql@fd3bd505c6c7ae5b17cae7abe63311c8b8bb6d12 5.7
+5.7.4-m14: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7
+5.7.4: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7
+5.7: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7


### PR DESCRIPTION
``` console
root@708b54f302ae:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b mysql --targets mysql git://github.com/infosiftr/stackbrew
2014-08-15 20:43:19,231 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=mysql
2014-08-15 20:43:19,233 DEBUG folder = /tmp/tmpVz3uUv
2014-08-15 20:43:19,233 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmpVz3uUv
2014-08-15 20:43:19,234 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmpVz3uUv
Cloning into '.'...
remote: Counting objects: 1196, done.
remote: Compressing objects: 100% (521/521), done.
remote: Total 1196 (delta 670), reused 1179 (delta 663)
Receiving objects: 100% (1196/1196), 176.55 KiB | 266.00 KiB/s, done.
Resolving deltas: 100% (670/670), done.
Checking connectivity... done.
2014-08-15 20:43:20,438 DEBUG Checkout ref:mysql in /tmp/tmpVz3uUv
2014-08-15 20:43:20,439 DEBUG Executing "git checkout mysql" in /tmp/tmpVz3uUv
Branch mysql set up to track remote branch mysql from origin.
Switched to a new branch 'mysql'
2014-08-15 20:43:20,445 DEBUG 5.6.20: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6

2014-08-15 20:43:20,445 DEBUG 5.6: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6

2014-08-15 20:43:20,445 DEBUG 5: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6

2014-08-15 20:43:20,445 DEBUG latest: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6

2014-08-15 20:43:20,445 DEBUG 5.7.4-m14: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7

2014-08-15 20:43:20,445 DEBUG 5.7.4: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7

2014-08-15 20:43:20,445 DEBUG 5.7: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7

2014-08-15 20:43:20,445 DEBUG mysql: 5.6.20,5.6,5,latest
2014-08-15 20:43:20,445 DEBUG mysql: 5.7.4-m14,5.7.4,5.7
2014-08-15 20:43:20,445 DEBUG Cloning repo_url=git://github.com/docker-library/docker-mysql, ref=8f83313be73c8c294109d038aa2f921f6886b21c
2014-08-15 20:43:20,446 DEBUG folder = /tmp/tmpnq9TQy
2014-08-15 20:43:20,446 DEBUG Cloning git://github.com/docker-library/docker-mysql into /tmp/tmpnq9TQy
2014-08-15 20:43:20,446 DEBUG Executing "git clone git://github.com/docker-library/docker-mysql ." in /tmp/tmpnq9TQy
Cloning into '.'...
remote: Counting objects: 84, done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 84 (delta 29), reused 68 (delta 23)
Receiving objects: 100% (84/84), 13.34 KiB | 0 bytes/s, done.
Resolving deltas: 100% (29/29), done.
Checking connectivity... done.
2014-08-15 20:43:21,019 DEBUG Checkout ref:8f83313be73c8c294109d038aa2f921f6886b21c in /tmp/tmpnq9TQy
2014-08-15 20:43:21,020 DEBUG Executing "git checkout 8f83313be73c8c294109d038aa2f921f6886b21c" in /tmp/tmpnq9TQy
Note: checking out '8f83313be73c8c294109d038aa2f921f6886b21c'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 8f83313... Switch to sourcing from the Oracle-compiled binaries instead of compiling from source
2014-08-15 20:43:21,024 INFO Build start: mysql ('git://github.com/docker-library/docker-mysql', '8f83313be73c8c294109d038aa2f921f6886b21c', '5.6')
2014-08-15 20:43:29,990 INFO Build success: 1c8e5add3cea (mysql:5.6.20)
2014-08-15 20:43:30,007 INFO Build success: 1c8e5add3cea (mysql:5.6)
2014-08-15 20:43:30,028 INFO Build success: 1c8e5add3cea (mysql:5)
2014-08-15 20:43:30,049 INFO Build success: 1c8e5add3cea (mysql:latest)
2014-08-15 20:43:30,064 DEBUG Checkout ref:8f83313be73c8c294109d038aa2f921f6886b21c in /tmp/tmpnq9TQy
2014-08-15 20:43:30,064 DEBUG Executing "git checkout 8f83313be73c8c294109d038aa2f921f6886b21c" in /tmp/tmpnq9TQy
HEAD is now at 8f83313... Switch to sourcing from the Oracle-compiled binaries instead of compiling from source
2014-08-15 20:43:30,069 INFO Build start: mysql ('git://github.com/docker-library/docker-mysql', '8f83313be73c8c294109d038aa2f921f6886b21c', '5.7')
2014-08-15 20:43:36,578 INFO Build success: 5d89732a398e (mysql:5.7.4-m14)
2014-08-15 20:43:36,595 INFO Build success: 5d89732a398e (mysql:5.7.4)
2014-08-15 20:43:36,628 INFO Build success: 5d89732a398e (mysql:5.7)
```

``` console
root@708b54f302ae:/stackbrew/stackbrew# docker images mysql
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
mysql               5.7                 5d89732a398e        8 seconds ago       252.7 MB
mysql               5.7.4               5d89732a398e        8 seconds ago       252.7 MB
mysql               5.7.4-m14           5d89732a398e        8 seconds ago       252.7 MB
mysql               5                   1c8e5add3cea        15 seconds ago      236 MB
mysql               5.6                 1c8e5add3cea        15 seconds ago      236 MB
mysql               5.6.20              1c8e5add3cea        15 seconds ago      236 MB
mysql               latest              1c8e5add3cea        15 seconds ago      236 MB
```
