### PR TITLE
Update postgres with proper UTF-8 locale (thus enabling UTF-8 defaults),...

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
-8.4: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
-8: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 8.4
+8.4.22: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
+8.4: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
+8: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
 
-9.0.18: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.0
-9.0: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.0
+9.0.18: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.0
+9.0: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.0
 
-9.1.14: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.1
-9.1: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.1
+9.1.14: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.1
+9.1: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.1
 
-9.2.9: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.2
-9.2: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.2
+9.2.9: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.2
+9.2: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.2
 
-9.3.5: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
-9.3: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
-9: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
-latest: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.3
+9.3.5: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
+9.3: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
+9: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
+latest: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
 
-9.4-beta2: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.4
-9.4: git://github.com/docker-library/postgres@c6484bf22f5a0f72a49658ae9e5569bc01785eff 9.4
+9.4-beta2: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.4
+9.4: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.4


### PR DESCRIPTION
... and shrink each image from ~244 MB down to ~214 MB
