### PR TITLE
Update rails with separate "onbuild" tag and smaller main image size

### DIFF
--- a/library/rails
+++ b/library/rails
@@ -1,5 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/rails@8a540d2ca1d042aec81fee02cf5e584d3af1aeda
-4.1: git://github.com/docker-library/rails@8a540d2ca1d042aec81fee02cf5e584d3af1aeda
-4.1.1: git://github.com/docker-library/rails@8a540d2ca1d042aec81fee02cf5e584d3af1aeda
+4.1.4: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb
+4.1: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb
+4: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb
+latest: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb
+
+onbuild: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb onbuild


### PR DESCRIPTION
Replaces #120

``` console
root@bbb3ad212414:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b rails --targets rails git://github.com/infosiftr/stackbrew
2014-08-16 01:11:57,837 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=rails
2014-08-16 01:11:57,839 DEBUG folder = /tmp/tmp3LI39o
2014-08-16 01:11:57,839 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmp3LI39o
2014-08-16 01:11:57,839 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmp3LI39o
Cloning into '.'...
remote: Counting objects: 1204, done.
remote: Compressing objects: 100% (529/529), done.
remote: Total 1204 (delta 674), reused 1179 (delta 663)
Receiving objects: 100% (1204/1204), 177.53 KiB | 0 bytes/s, done.
Resolving deltas: 100% (674/674), done.
Checking connectivity... done.
2014-08-16 01:11:58,799 DEBUG Checkout ref:rails in /tmp/tmp3LI39o
2014-08-16 01:11:58,799 DEBUG Executing "git checkout rails" in /tmp/tmp3LI39o
Branch rails set up to track remote branch rails from origin.
Switched to a new branch 'rails'
2014-08-16 01:11:58,805 DEBUG 4.1.4: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb

2014-08-16 01:11:58,805 DEBUG 4.1: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb

2014-08-16 01:11:58,805 DEBUG 4: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb

2014-08-16 01:11:58,805 DEBUG latest: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb

2014-08-16 01:11:58,805 DEBUG onbuild: git://github.com/docker-library/rails@7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb onbuild

2014-08-16 01:11:58,805 DEBUG rails: 4.1.4,4.1,4,latest
2014-08-16 01:11:58,806 DEBUG rails: onbuild
2014-08-16 01:11:58,806 DEBUG Cloning repo_url=git://github.com/docker-library/rails, ref=7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb
2014-08-16 01:11:58,806 DEBUG folder = /tmp/tmpAKOB4y
2014-08-16 01:11:58,806 DEBUG Cloning git://github.com/docker-library/rails into /tmp/tmpAKOB4y
2014-08-16 01:11:58,806 DEBUG Executing "git clone git://github.com/docker-library/rails ." in /tmp/tmpAKOB4y
Cloning into '.'...
remote: Counting objects: 22, done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 22 (delta 3), reused 22 (delta 3)
Receiving objects: 100% (22/22), done.
Resolving deltas: 100% (3/3), done.
Checking connectivity... done.
2014-08-16 01:11:59,369 DEBUG Checkout ref:7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb in /tmp/tmpAKOB4y
2014-08-16 01:11:59,369 DEBUG Executing "git checkout 7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb" in /tmp/tmpAKOB4y
Note: checking out '7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 7bb6ade... Change the ONBUILD to be as special of a snowflake as Ruby itself is
2014-08-16 01:11:59,374 INFO Build start: rails ('git://github.com/docker-library/rails', '7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb', '.')
2014-08-16 01:12:00,386 INFO Build success: ff0088a6c74c (rails:4.1.4)
2014-08-16 01:12:00,426 INFO Build success: ff0088a6c74c (rails:4.1)
2014-08-16 01:12:00,446 INFO Build success: ff0088a6c74c (rails:4)
2014-08-16 01:12:00,474 INFO Build success: ff0088a6c74c (rails:latest)
2014-08-16 01:12:00,488 DEBUG Checkout ref:7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb in /tmp/tmpAKOB4y
2014-08-16 01:12:00,489 DEBUG Executing "git checkout 7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb" in /tmp/tmpAKOB4y
HEAD is now at 7bb6ade... Change the ONBUILD to be as special of a snowflake as Ruby itself is
2014-08-16 01:12:00,493 INFO Build start: rails ('git://github.com/docker-library/rails', '7bb6ade7f97129cc58967d7d0ae17f4b62ae52eb', 'onbuild')
2014-08-16 01:12:03,438 INFO Build success: b7d43af688cd (rails:onbuild)
```

``` console
root@bbb3ad212414:/stackbrew/stackbrew# docker images rails
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
rails               onbuild             b7d43af688cd        3 hours ago         877.6 MB
rails               4.1.4               ff0088a6c74c        3 hours ago         903.6 MB
rails               latest              ff0088a6c74c        3 hours ago         903.6 MB
rails               4                   ff0088a6c74c        3 hours ago         903.6 MB
rails               4.1                 ff0088a6c74c        3 hours ago         903.6 MB
```
