### PR TITLE
Update mongo with more versions and smaller size (from ~747.9 MB down to ~391.3 MB for 2.6)

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,5 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/mongo@f3327851aa89d923465a1b361f5d5a3d4139342c
-2.6: git://github.com/docker-library/mongo@f3327851aa89d923465a1b361f5d5a3d4139342c
-2.6.1: git://github.com/docker-library/mongo@f3327851aa89d923465a1b361f5d5a3d4139342c
+2.2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2
+2.2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2
+
+2.4.10: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4
+2.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4
+
+2.6.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
+2.6: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
+2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
+latest: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
+
+2.7.5: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7
+2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7


### PR DESCRIPTION
``` console
root@05ff67a8505a:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b mongo --targets mongo git://github.com/infosiftr/stackbrew
2014-08-18 22:57:50,625 DEBUG Cloning repo_url=git://github.com/infosiftr/stackbrew, ref=mongo
2014-08-18 22:57:50,627 DEBUG folder = /tmp/tmp46F0Ff
2014-08-18 22:57:50,627 DEBUG Cloning git://github.com/infosiftr/stackbrew into /tmp/tmp46F0Ff
2014-08-18 22:57:50,627 DEBUG Executing "git clone git://github.com/infosiftr/stackbrew ." in /tmp/tmp46F0Ff
Cloning into '.'...
remote: Counting objects: 1218, done.
remote: Compressing objects: 100% (543/543), done.
remote: Total 1218 (delta 682), reused 1180 (delta 663)
Receiving objects: 100% (1218/1218), 179.73 KiB | 0 bytes/s, done.
Resolving deltas: 100% (682/682), done.
Checking connectivity... done.
2014-08-18 22:57:51,694 DEBUG Checkout ref:mongo in /tmp/tmp46F0Ff
2014-08-18 22:57:51,695 DEBUG Executing "git checkout mongo" in /tmp/tmp46F0Ff
Branch mongo set up to track remote branch mongo from origin.
Switched to a new branch 'mongo'
2014-08-18 22:57:51,700 DEBUG 2.2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2

2014-08-18 22:57:51,700 DEBUG 2.2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2

2014-08-18 22:57:51,700 DEBUG 2.4.10: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4

2014-08-18 22:57:51,700 DEBUG 2.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4

2014-08-18 22:57:51,700 DEBUG 2.6.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6

2014-08-18 22:57:51,700 DEBUG 2.6: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6

2014-08-18 22:57:51,701 DEBUG 2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6

2014-08-18 22:57:51,701 DEBUG latest: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6

2014-08-18 22:57:51,701 DEBUG 2.7.5: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7

2014-08-18 22:57:51,701 DEBUG 2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7

2014-08-18 22:57:51,701 DEBUG mongo: 2.7.5,2.7
2014-08-18 22:57:51,701 DEBUG mongo: 2.4.10,2.4
2014-08-18 22:57:51,701 DEBUG mongo: 2.2.7,2.2
2014-08-18 22:57:51,701 DEBUG mongo: 2.6.4,2.6,2,latest
2014-08-18 22:57:51,701 DEBUG Cloning repo_url=git://github.com/docker-library/mongo, ref=274cd39430c54babaec47225f5d2e77c8952d8d0
2014-08-18 22:57:51,701 DEBUG folder = /tmp/tmpKup7d4
2014-08-18 22:57:51,701 DEBUG Cloning git://github.com/docker-library/mongo into /tmp/tmpKup7d4
2014-08-18 22:57:51,701 DEBUG Executing "git clone git://github.com/docker-library/mongo ." in /tmp/tmpKup7d4
Cloning into '.'...
remote: Counting objects: 17, done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 17 (delta 5), reused 3 (delta 0)
Receiving objects: 100% (17/17), done.
Resolving deltas: 100% (5/5), done.
Checking connectivity... done.
2014-08-18 22:57:52,208 DEBUG Checkout ref:274cd39430c54babaec47225f5d2e77c8952d8d0 in /tmp/tmpKup7d4
2014-08-18 22:57:52,209 DEBUG Executing "git checkout 274cd39430c54babaec47225f5d2e77c8952d8d0" in /tmp/tmpKup7d4
Note: checking out '274cd39430c54babaec47225f5d2e77c8952d8d0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 274cd39... Add multiple versions, an update.sh script, and a generate-stackbrew-library.sh script
2014-08-18 22:57:52,213 INFO Build start: mongo ('git://github.com/docker-library/mongo', '274cd39430c54babaec47225f5d2e77c8952d8d0', '2.7')
2014-08-18 22:58:00,252 INFO Build success: 3c9f182b9ac1 (mongo:2.7.5)
2014-08-18 22:58:00,337 INFO Build success: 3c9f182b9ac1 (mongo:2.7)
2014-08-18 22:58:00,369 DEBUG Checkout ref:274cd39430c54babaec47225f5d2e77c8952d8d0 in /tmp/tmpKup7d4
2014-08-18 22:58:00,370 DEBUG Executing "git checkout 274cd39430c54babaec47225f5d2e77c8952d8d0" in /tmp/tmpKup7d4
HEAD is now at 274cd39... Add multiple versions, an update.sh script, and a generate-stackbrew-library.sh script
2014-08-18 22:58:00,374 INFO Build start: mongo ('git://github.com/docker-library/mongo', '274cd39430c54babaec47225f5d2e77c8952d8d0', '2.4')
2014-08-18 22:58:06,039 INFO Build success: cee2c6d30d48 (mongo:2.4.10)
2014-08-18 22:58:06,056 INFO Build success: cee2c6d30d48 (mongo:2.4)
2014-08-18 22:58:06,076 DEBUG Checkout ref:274cd39430c54babaec47225f5d2e77c8952d8d0 in /tmp/tmpKup7d4
2014-08-18 22:58:06,076 DEBUG Executing "git checkout 274cd39430c54babaec47225f5d2e77c8952d8d0" in /tmp/tmpKup7d4
HEAD is now at 274cd39... Add multiple versions, an update.sh script, and a generate-stackbrew-library.sh script
2014-08-18 22:58:06,080 INFO Build start: mongo ('git://github.com/docker-library/mongo', '274cd39430c54babaec47225f5d2e77c8952d8d0', '2.2')
2014-08-18 22:58:12,761 INFO Build success: 6cc1dfd3651a (mongo:2.2.7)
2014-08-18 22:58:12,778 INFO Build success: 6cc1dfd3651a (mongo:2.2)
2014-08-18 22:58:12,844 DEBUG Checkout ref:274cd39430c54babaec47225f5d2e77c8952d8d0 in /tmp/tmpKup7d4
2014-08-18 22:58:12,844 DEBUG Executing "git checkout 274cd39430c54babaec47225f5d2e77c8952d8d0" in /tmp/tmpKup7d4
HEAD is now at 274cd39... Add multiple versions, an update.sh script, and a generate-stackbrew-library.sh script
2014-08-18 22:58:12,849 INFO Build start: mongo ('git://github.com/docker-library/mongo', '274cd39430c54babaec47225f5d2e77c8952d8d0', '2.6')
2014-08-18 22:58:22,757 INFO Build success: 93c6985061e7 (mongo:2.6.4)
2014-08-18 22:58:22,778 INFO Build success: 93c6985061e7 (mongo:2.6)
2014-08-18 22:58:22,820 INFO Build success: 93c6985061e7 (mongo:2)
2014-08-18 22:58:22,851 INFO Build success: 93c6985061e7 (mongo:latest)
```

``` console
root@05ff67a8505a:/stackbrew/stackbrew# docker images mongo
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
mongo               2.6.4               93c6985061e7        About a minute ago   391.3 MB
mongo               2.6                 93c6985061e7        About a minute ago   391.3 MB
mongo               latest              93c6985061e7        About a minute ago   391.3 MB
mongo               2                   93c6985061e7        About a minute ago   391.3 MB
mongo               2.2.7               6cc1dfd3651a        About a minute ago   240.1 MB
mongo               2.2                 6cc1dfd3651a        About a minute ago   240.1 MB
mongo               2.4                 cee2c6d30d48        About a minute ago   345.3 MB
mongo               2.4.10              cee2c6d30d48        About a minute ago   345.3 MB
mongo               2.7.5               3c9f182b9ac1        About a minute ago   378.9 MB
mongo               2.7                 3c9f182b9ac1        About a minute ago   378.9 MB
```
