### PR TITLE
Shrink redis again, add more versions from src tars

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,5 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/redis@9fcab2d41ba06d2a581e7ccfee856e86dbb91d3f
-2.8.13: git://github.com/docker-library/redis@9fcab2d41ba06d2a581e7ccfee856e86dbb91d3f
-2.8:    git://github.com/docker-library/redis@9fcab2d41ba06d2a581e7ccfee856e86dbb91d3f
+2.6.17: git://github.com/docker-library/redis@02d9cd887a4e0d50db4bb085eab7235115a6fe4a 2.6.17
+2.6: git://github.com/docker-library/redis@02d9cd887a4e0d50db4bb085eab7235115a6fe4a 2.6.17
+
+2.8.10: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.10
+
+2.8.11: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.11
+
+2.8.12: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.12
+
+2.8.13: git://github.com/docker-library/redis@d0665bb1bbddd4cc035dbc1fc774695fa534d648 2.8.13
+2.8: git://github.com/docker-library/redis@d0665bb1bbddd4cc035dbc1fc774695fa534d648 2.8.13
+latest: git://github.com/docker-library/redis@d0665bb1bbddd4cc035dbc1fc774695fa534d648 2.8.13
+
+2.8.6: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.6
+
+2.8.7: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.7
+
+2.8.8: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.8
+
+2.8.9: git://github.com/docker-library/redis@ffb29617e5dcfe71adf67842d18063c410beede7 2.8.9


### PR DESCRIPTION
This pulls the source tars from download.redis.io.  The size change is down to ~98mb from 175mb.
