### PR TITLE
update to 1.576 LTS

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -1,6 +1,6 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
-latest: git://github.com/cloudbees/jenkins-ci.org-docker@a5bfd41e00d0df91a35dd6a252b8c4a831d00743
-1.574: git://github.com/cloudbees/jenkins-ci.org-docker@a5bfd41e00d0df91a35dd6a252b8c4a831d00743
+latest: git://github.com/cloudbees/jenkins-ci.org-docker@3c32be0054f326090d6577fcae2035aac0906e3d
+1.576: git://github.com/cloudbees/jenkins-ci.org-docker@3c32be0054f326090d6577fcae2035aac0906e3d
 
 


### PR DESCRIPTION
Jenkins LTSes are monthly (at least minor ones). 
