### PR TITLE
Fix to use actual LTS numbers

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -1,6 +1,7 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
-latest: git://github.com/cloudbees/jenkins-ci.org-docker@3c32be0054f326090d6577fcae2035aac0906e3d
-1.576: git://github.com/cloudbees/jenkins-ci.org-docker@3c32be0054f326090d6577fcae2035aac0906e3d
+latest: git://github.com/cloudbees/jenkins-ci.org-docker@1b45c449d295ee1da4b751929fda466a74bde039
+1.565: git://github.com/cloudbees/jenkins-ci.org-docker@1b45c449d295ee1da4b751929fda466a74bde039
+1.565.1: git://github.com/cloudbees/jenkins-ci.org-docker@1b45c449d295ee1da4b751929fda466a74bde039
 
 


### PR DESCRIPTION
Additionally, can I request that tags: 

1.574, 1.576 be removed from the repo? they are incorrectly tagged (and are non LTS numbers) - my stupid mistake.
