### PR TITLE
update for new centos base images

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -1,5 +1,5 @@
 # maintainer: The CentOS Project <cloud-ops@centos.org> (@CentOS)
-
+# Build date 20140902_1805
 latest: git://github.com/CentOS/sig-cloud-instance-images@f7732ef53029d6adfbadb7069c6666528e5c6d0e docker
 centos7: git://github.com/CentOS/sig-cloud-instance-images@f7732ef53029d6adfbadb7069c6666528e5c6d0e docker
 centos6: git://github.com/CentOS/sig-cloud-instance-images@e1ea1c01abea5f402c650caf12049a711373b27a docker


### PR DESCRIPTION
Adds a centos5 base image, removes systemd and replaces it with a fakesystemd package to fix some container breakage. 
