### PR TITLE
Slim golang images; add @proppy as maintainer

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,32 +1,33 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.2: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2
+1.2: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2
 
-1.2-onbuild: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2/onbuild
+1.2-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2/onbuild
 
-1.2-cross: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2/cross
+1.2-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2/cross
 
-1.2.1: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2.1
+1.2.1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2.1
 
-1.2.1-onbuild: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2.1/onbuild
+1.2.1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.1/onbuild
 
-1.2.1-cross: git://github.com/docker-library/golang@bd73eec2ea81b4f107400c8d99e33e3b3fd93c00 1.2.1/cross
+1.2.1-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.1/cross
 
-1.2.2: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.2
+1.2.2: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2.2
 
 1.2.2-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.2/onbuild
 
 1.2.2-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.2/cross
 
-1.3: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3
+1.3: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3
 
 1.3-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3/onbuild
 
 1.3-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3/cross
 
-1.3.1: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1
-1: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1
-latest: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1
+1.3.1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
+1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
+latest: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
 
 1.3.1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/onbuild
 1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/onbuild


### PR DESCRIPTION
On go1.3.1, from 413.8 MB to 386.4MB
