### PR TITLE
Update debian, especially for CVE-2014-5119

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,26 +1,26 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-jessie: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 jessie
+jessie: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 sid
+sid: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 squeeze
-6: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze
+6: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 stable
+stable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 stable
 
-testing: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 testing
+testing: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 unstable
+unstable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 unstable
 
-7.6: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 wheezy
-7: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 wheezy
-latest: git://github.com/tianon/docker-brew-debian@2966c17d1ce5351fd314dd407559603b5d823355 wheezy
+7.6: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy
+7: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy
+latest: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@8bfa99bb8e6a6d6dcba3b6fe8f80ce04dcd36b0d debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@8bfa99bb8e6a6d6dcba3b6fe8f80ce04dcd36b0d debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@38243e35bd04e17a6232da8948971020840b31cc debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@38243e35bd04e17a6232da8948971020840b31cc debian/experimental


### PR DESCRIPTION
``` console
root@329de5ee7290:/stackbrew/stackbrew# ./brew-cli --debug --no-namespace -b debian --targets debian git://github.com/tianon/stackbrew
2014-09-04 15:51:28,370 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew, ref=debian
2014-09-04 15:51:28,372 DEBUG folder = /tmp/tmpNoTzlN
2014-09-04 15:51:28,372 DEBUG Cloning git://github.com/tianon/stackbrew into /tmp/tmpNoTzlN
2014-09-04 15:51:28,372 DEBUG Executing "git clone git://github.com/tianon/stackbrew ." in /tmp/tmpNoTzlN
Cloning into '.'...
remote: Counting objects: 1295, done.
remote: Compressing objects: 100% (573/573), done.
remote: Total 1295 (delta 731), reused 1259 (delta 710)
Receiving objects: 100% (1295/1295), 188.34 KiB | 156.00 KiB/s, done.
Resolving deltas: 100% (731/731), done.
Checking connectivity... done.
2014-09-04 15:51:30,139 DEBUG Checkout ref:debian in /tmp/tmpNoTzlN
2014-09-04 15:51:30,139 DEBUG Executing "git checkout debian" in /tmp/tmpNoTzlN
Branch debian set up to track remote branch debian from origin.
Switched to a new branch 'debian'
2014-09-04 15:51:30,145 DEBUG jessie: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 jessie

2014-09-04 15:51:30,146 DEBUG oldstable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 oldstable

2014-09-04 15:51:30,146 DEBUG sid: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 sid

2014-09-04 15:51:30,146 DEBUG 6.0.10: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze

2014-09-04 15:51:30,146 DEBUG 6.0: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze

2014-09-04 15:51:30,146 DEBUG 6: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze

2014-09-04 15:51:30,146 DEBUG squeeze: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 squeeze

2014-09-04 15:51:30,146 DEBUG stable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 stable

2014-09-04 15:51:30,146 DEBUG testing: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 testing

2014-09-04 15:51:30,146 DEBUG unstable: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 unstable

2014-09-04 15:51:30,146 DEBUG 7.6: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy

2014-09-04 15:51:30,146 DEBUG 7: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy

2014-09-04 15:51:30,146 DEBUG wheezy: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy

2014-09-04 15:51:30,147 DEBUG latest: git://github.com/tianon/docker-brew-debian@5e42a86948cda806f2ec07693b9750789d1a55b6 wheezy

2014-09-04 15:51:30,147 DEBUG rc-buggy: git://github.com/tianon/dockerfiles@38243e35bd04e17a6232da8948971020840b31cc debian/rc-buggy

2014-09-04 15:51:30,147 DEBUG experimental: git://github.com/tianon/dockerfiles@38243e35bd04e17a6232da8948971020840b31cc debian/experimental

2014-09-04 15:51:30,147 DEBUG debian: jessie
2014-09-04 15:51:30,147 DEBUG debian: oldstable
2014-09-04 15:51:30,147 DEBUG debian: sid
2014-09-04 15:51:30,147 DEBUG debian: 6.0.10,6.0,6,squeeze
2014-09-04 15:51:30,147 DEBUG debian: stable
2014-09-04 15:51:30,147 DEBUG debian: testing
2014-09-04 15:51:30,147 DEBUG debian: unstable
2014-09-04 15:51:30,147 DEBUG debian: 7.6,7,wheezy,latest
2014-09-04 15:51:30,147 DEBUG debian: rc-buggy
2014-09-04 15:51:30,147 DEBUG debian: experimental
2014-09-04 15:51:30,147 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-debian, ref=5e42a86948cda806f2ec07693b9750789d1a55b6
2014-09-04 15:51:30,147 DEBUG folder = /tmp/tmpMrLnvD
2014-09-04 15:51:30,148 DEBUG Cloning git://github.com/tianon/docker-brew-debian into /tmp/tmpMrLnvD
2014-09-04 15:51:30,148 DEBUG Executing "git clone git://github.com/tianon/docker-brew-debian ." in /tmp/tmpMrLnvD
Cloning into '.'...
remote: Counting objects: 80, done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 80 (delta 21), reused 53 (delta 13)
Receiving objects: 100% (80/80), 187.74 MiB | 1.46 MiB/s, done.
Resolving deltas: 100% (21/21), done.
Checking connectivity... done.
2014-09-04 15:55:07,823 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:07,823 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
Note: checking out '5e42a86948cda806f2ec07693b9750789d1a55b6'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:08,262 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'jessie')
2014-09-04 15:55:15,380 INFO Build success: 413e301e1af5 (debian:jessie)
2014-09-04 15:55:15,432 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:15,432 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:16,003 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'oldstable')
2014-09-04 15:55:21,093 INFO Build success: 14b341d46826 (debian:oldstable)
2014-09-04 15:55:21,109 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:21,109 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:21,114 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'sid')
2014-09-04 15:55:27,258 INFO Build success: 86fb6898f970 (debian:sid)
2014-09-04 15:55:27,271 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:27,271 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:27,276 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'squeeze')
2014-09-04 15:55:32,184 INFO Build success: 84173e3276c5 (debian:6.0.10)
2014-09-04 15:55:32,200 INFO Build success: 84173e3276c5 (debian:6.0)
2014-09-04 15:55:32,213 INFO Build success: 84173e3276c5 (debian:6)
2014-09-04 15:55:32,255 INFO Build success: 84173e3276c5 (debian:squeeze)
2014-09-04 15:55:32,266 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:32,266 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:32,271 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'stable')
2014-09-04 15:55:40,459 INFO Build success: 3e5aed8a602a (debian:stable)
2014-09-04 15:55:40,475 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:40,475 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:40,479 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'testing')
2014-09-04 15:55:53,063 INFO Build success: 03d716d1fbee (debian:testing)
2014-09-04 15:55:53,347 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:55:53,348 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:55:53,352 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'unstable')
2014-09-04 15:56:08,081 INFO Build success: 53ec492999c5 (debian:unstable)
2014-09-04 15:56:08,766 DEBUG Checkout ref:5e42a86948cda806f2ec07693b9750789d1a55b6 in /tmp/tmpMrLnvD
2014-09-04 15:56:08,767 DEBUG Executing "git checkout 5e42a86948cda806f2ec07693b9750789d1a55b6" in /tmp/tmpMrLnvD
HEAD is now at 5e42a86... Add 2014-09-03 debootstraps (especially for CVE-2014-5119)
2014-09-04 15:56:08,771 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '5e42a86948cda806f2ec07693b9750789d1a55b6', 'wheezy')
2014-09-04 15:56:22,491 INFO Build success: 7131cd454000 (debian:7.6)
2014-09-04 15:56:23,105 INFO Build success: 7131cd454000 (debian:7)
2014-09-04 15:56:24,636 INFO Build success: 7131cd454000 (debian:wheezy)
2014-09-04 15:56:25,690 INFO Build success: 7131cd454000 (debian:latest)
2014-09-04 15:56:27,966 DEBUG Cloning repo_url=git://github.com/tianon/dockerfiles, ref=38243e35bd04e17a6232da8948971020840b31cc
2014-09-04 15:56:27,966 DEBUG folder = /tmp/tmpcuKJuA
2014-09-04 15:56:27,966 DEBUG Cloning git://github.com/tianon/dockerfiles into /tmp/tmpcuKJuA
2014-09-04 15:56:27,966 DEBUG Executing "git clone git://github.com/tianon/dockerfiles ." in /tmp/tmpcuKJuA
Cloning into '.'...
remote: Counting objects: 674, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 674 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (674/674), 261.19 KiB | 0 bytes/s, done.
Resolving deltas: 100% (273/273), done.
Checking connectivity... done.
2014-09-04 15:56:28,881 DEBUG Checkout ref:38243e35bd04e17a6232da8948971020840b31cc in /tmp/tmpcuKJuA
2014-09-04 15:56:28,882 DEBUG Executing "git checkout 38243e35bd04e17a6232da8948971020840b31cc" in /tmp/tmpcuKJuA
Note: checking out '38243e35bd04e17a6232da8948971020840b31cc'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 38243e3... add "-y" to "apt-get install -f"
2014-09-04 15:56:28,888 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '38243e35bd04e17a6232da8948971020840b31cc', 'debian/rc-buggy')
2014-09-04 15:56:35,191 INFO Build success: dc2ed79a4c73 (debian:rc-buggy)
2014-09-04 15:56:36,695 DEBUG Checkout ref:38243e35bd04e17a6232da8948971020840b31cc in /tmp/tmpcuKJuA
2014-09-04 15:56:36,695 DEBUG Executing "git checkout 38243e35bd04e17a6232da8948971020840b31cc" in /tmp/tmpcuKJuA
HEAD is now at 38243e3... add "-y" to "apt-get install -f"
2014-09-04 15:56:36,701 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '38243e35bd04e17a6232da8948971020840b31cc', 'debian/experimental')
2014-09-04 15:56:38,324 INFO Build success: e92dd5f319e9 (debian:experimental)
```

``` console
root@329de5ee7290:/stackbrew/stackbrew# docker images debian
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
debian              experimental        e92dd5f319e9        About a minute ago   114.9 MB
debian              rc-buggy            dc2ed79a4c73        About a minute ago   114.9 MB
debian              latest              7131cd454000        About a minute ago   85.18 MB
debian              7.6                 7131cd454000        About a minute ago   85.18 MB
debian              wheezy              7131cd454000        About a minute ago   85.18 MB
debian              7                   7131cd454000        About a minute ago   85.18 MB
debian              unstable            53ec492999c5        About a minute ago   114.9 MB
debian              testing             03d716d1fbee        2 minutes ago        114 MB
debian              stable              3e5aed8a602a        2 minutes ago        85.18 MB
debian              6.0                 84173e3276c5        2 minutes ago        78.48 MB
debian              squeeze             84173e3276c5        2 minutes ago        78.48 MB
debian              6.0.10              84173e3276c5        2 minutes ago        78.48 MB
debian              6                   84173e3276c5        2 minutes ago        78.48 MB
debian              sid                 86fb6898f970        2 minutes ago        114.9 MB
debian              oldstable           14b341d46826        2 minutes ago        78.48 MB
debian              jessie              413e301e1af5        2 minutes ago        114 MB
```
