### PR TITLE
fix for --excludedocs build errors in C5

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -3,4 +3,4 @@
 latest: git://github.com/CentOS/sig-cloud-instance-images@f7732ef53029d6adfbadb7069c6666528e5c6d0e docker
 centos7: git://github.com/CentOS/sig-cloud-instance-images@f7732ef53029d6adfbadb7069c6666528e5c6d0e docker
 centos6: git://github.com/CentOS/sig-cloud-instance-images@e1ea1c01abea5f402c650caf12049a711373b27a docker
-centos5: git://github.com/CentOS/sig-cloud-instance-images@7773d2785aff413e67ba525ba117c05ffe1d85dc docker
+centos5: git://github.com/CentOS/sig-cloud-instance-images@7d888ae1b0d55a893129a1039d946e42c3573afa docker


### PR DESCRIPTION
CentOS5 images have an issue building with --excludedocs. This updated image resolves the issue.  
