### PR TITLE
Create ubuntu-core

### DIFF
--- a/library/ubuntu-core
+++ b/library/ubuntu-core
@@ -1,4 +1,15 @@
 # maintainer:
 # Direkt SPEED <frank@dspeed.eu> (irc://SP33D@freenode.org#docker)
-latest: git://github.com/dockerimages/ubuntu-core@master
-14.04: git://github.com/dockerimages/ubuntu-core@14.04 
+14.04: git://github.com/dockerimages/ubuntu-core@14.04
+14.04.1: git://github.com/dockerimages/ubuntu-core@14.04.1 
+latest: git://github.com/dockerimages/ubuntu-core@14.04.1
+trusty: git://github.com/dockerimages/ubuntu-core@14.04.1
+14.10: git://github.com/dockerimages/ubuntu-core@14.10
+utopic: git://github.com/dockerimages/ubuntu-core@14.10
+13.10: git://github.com/dockerimages/ubuntu-core@13.10
+saucy: git://github.com/dockerimages/ubuntu-core@13.10
+12.04: git://github.com/dockerimages/ubuntu-core@12.04.5
+12.04.5: git://github.com/dockerimages/ubuntu-core@12.04.5
+precise: git://github.com/dockerimages/ubuntu-core@12.04.5
+
+


### PR DESCRIPTION
Adding Ubuntu-Core to baseimage list to use it as _ubuntu-core in the registry
