### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.2: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2
+1.2: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2
 
-1.2-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2/onbuild
+1.2-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2/onbuild
 
 1.2-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2/cross
 
-1.2.1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2.1
+1.2.1: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.1
 
-1.2.1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.1/onbuild
+1.2.1-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.1/onbuild
 
 1.2.1-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.1/cross
 
-1.2.2: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.2.2
+1.2.2: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.2
 
-1.2.2-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.2/onbuild
+1.2.2-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.2/onbuild
 
 1.2.2-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.2.2/cross
 
-1.3: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3
+1.3: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3
 
-1.3-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3/onbuild
+1.3-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3/onbuild
 
 1.3-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3/cross
 
-1.3.1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
-1: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
-latest: git://github.com/docker-library/golang@887b0816c9480f83eb715350a32b6a3b4d331b1b 1.3.1
+1.3.1: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1
+1: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1
+latest: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1
 
-1.3.1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/onbuild
-1-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/onbuild
-onbuild: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/onbuild
+1.3.1-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1/onbuild
+1-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1/onbuild
+onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1/onbuild
 
 1.3.1-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/cross
 1-cross: git://github.com/docker-library/golang@40bd84e4bcc278281595174a60e7b4451d972dee 1.3.1/cross

--- a/library/mongo
+++ b/library/mongo
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2
-2.2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.2
+2.2.7: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.2
+2.2: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.2
 
-2.4.10: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4
-2.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.4
+2.4.11: git://github.com/docker-library/mongo@807078cb7b5f0289f6dabf9f6875d5318122bc30 2.4
+2.4: git://github.com/docker-library/mongo@807078cb7b5f0289f6dabf9f6875d5318122bc30 2.4
 
-2.6.4: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
-2.6: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
-2: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
-latest: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.6
+2.6.4: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.6
+2.6: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.6
+2: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.6
+latest: git://github.com/docker-library/mongo@77c841472ccb6cc87fea1218269d097405edc6cb 2.6
 
-2.7.5: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7
-2.7: git://github.com/docker-library/mongo@274cd39430c54babaec47225f5d2e77c8952d8d0 2.7
+2.7.6: git://github.com/docker-library/mongo@807078cb7b5f0289f6dabf9f6875d5318122bc30 2.7
+2.7: git://github.com/docker-library/mongo@807078cb7b5f0289f6dabf9f6875d5318122bc30 2.7

--- a/library/mysql
+++ b/library/mysql
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.6.20: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
-5.6: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
-5: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
-latest: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.6
+5.6.20: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.6
+5.6: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.6
+5: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.6
+latest: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.6
 
-5.7.4-m14: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7
-5.7.4: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7
-5.7: git://github.com/docker-library/docker-mysql@8f83313be73c8c294109d038aa2f921f6886b21c 5.7
+5.7.4-m14: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.7
+5.7.4: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.7
+5.7: git://github.com/docker-library/docker-mysql@7461a52b43f06839a4d8723ae8841f4cb616b3d0 5.7

--- a/library/node
+++ b/library/node
@@ -1,14 +1,14 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.31: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10
-0.10: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10
-0: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10
-latest: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10
+0.10.32: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10
+0.10: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10
+0: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10
+latest: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10
 
-0.10.31-onbuild: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10/onbuild
-0.10-onbuild: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10/onbuild
-0-onbuild: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10/onbuild
-onbuild: git://github.com/docker-library/node@9cb7597ec2e5e4885e29bff9b2ab0a9cfb9c6b83 0.10/onbuild
+0.10.32-onbuild: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10/onbuild
+0.10-onbuild: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10/onbuild
+0-onbuild: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10/onbuild
+onbuild: git://github.com/docker-library/node@913a225f2fda34d6a811fac1466e4f09f075fcf6 0.10/onbuild
 
 0.11.13: git://github.com/docker-library/node@d017d679e92e84a810c580cdb29fcdbba23c2bb9 0.11
 0.11: git://github.com/docker-library/node@d017d679e92e84a810c580cdb29fcdbba23c2bb9 0.11

--- a/library/php
+++ b/library/php
@@ -1,29 +1,29 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.3.29-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.3
-5.3-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.3
+5.3.29-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
+5.3-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
 
-5.3.29-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.3/apache
-5.3-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.3/apache
+5.3.29-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache
+5.3-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache
 
-5.4.32-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.4
-5.4-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.4
+5.4.33-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
+5.4-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
 
-5.4.32-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.4/apache
-5.4-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.4/apache
+5.4.33-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache
+5.4-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache
 
-5.5.16-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.5
-5.5-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.5
+5.5.17-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
+5.5-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
 
-5.5.16-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.5/apache
-5.5-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.5/apache
+5.5.17-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache
+5.5-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache
 
-5.6.0-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6
-5.6-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6
-5-cli: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6
-latest: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6
+5.6.0-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
+5.6-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
+5-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
+latest: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
 
-5.6.0-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6/apache
-5.6-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6/apache
-5-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6/apache
-apache: git://github.com/docker-library/php@e19f15271b1cbe9d3e5c9f0c552beca9579f0677 5.6/apache
+5.6.0-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
+5.6-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
+5-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
+apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
-8.4: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
-8: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 8.4
+8.4.22: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 8.4
+8.4: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 8.4
+8: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 8.4
 
-9.0.18: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.0
-9.0: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.0
+9.0.18: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.0
+9.0: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.0
 
-9.1.14: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.1
-9.1: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.1
+9.1.14: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.1
+9.1: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.1
 
-9.2.9: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.2
-9.2: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.2
+9.2.9: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.2
+9.2: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.2
 
-9.3.5: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
-9.3: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
-9: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
-latest: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.3
+9.3.5: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.3
+9.3: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.3
+9: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.3
+latest: git://github.com/docker-library/postgres@33b8046b5f68b465a3c04fcc428e8923bcb7cd12 9.3
 
-9.4-beta2: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.4
-9.4: git://github.com/docker-library/postgres@d74b69598c835fe15eac39a26b5c61058f99c3db 9.4
+9.4-beta2: git://github.com/docker-library/postgres@94aee2022d2014230fad3d054c048678137281d1 9.4
+9.4: git://github.com/docker-library/postgres@94aee2022d2014230fad3d054c048678137281d1 9.4

--- a/library/python
+++ b/library/python
@@ -1,19 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.8: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2
-2.7: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2
-2: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2
+2.7.8: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7
+2.7: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7
+2: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7
 
-2.7.8-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2/onbuild
-2.7-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2/onbuild
-2-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 2/onbuild
+2.7.8-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
+2.7-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
+2-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 
-3.4.1: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3
-3.4: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3
-3: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3
-latest: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3
+3.3.5: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3
+3.3: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3
 
-3.4.1-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3/onbuild
-3.4-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3/onbuild
-3-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3/onbuild
-onbuild: git://github.com/docker-library/python@660bda5ddf057e5cbcd130a75dd4ae935eba4e8d 3/onbuild
+3.3.5-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
+3.3-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
+
+3.4.1: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4
+3.4: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4
+3: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4
+latest: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4
+
+3.4.1-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4/onbuild
+3.4-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4/onbuild
+3-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4/onbuild
+onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.4/onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -1,21 +1,29 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.3-p547: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 1.9
-1.9.3: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 1.9
-1.9: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 1.9
-1: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 1.9
+1.9.3-p547: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
+1.9.3: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
+1.9: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
+1: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
 
 1.9.3-p547-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
 1.9.3-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
 1.9-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
 1-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
 
-2.1.2: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 2.1
-2.1: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 2.1
-2: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 2.1
-latest: git://github.com/docker-library/ruby@2701609004b336feff4e88e73ef32e8700d1c668 2.1
+2.0.0-p576: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
+2.0.0: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
+2.0: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
 
-2.1.2-onbuild: git://github.com/docker-library/ruby@4e94b39f5b76645819639e22d8de471c8fbd9855 2.1/onbuild
-2.1-onbuild: git://github.com/docker-library/ruby@4e94b39f5b76645819639e22d8de471c8fbd9855 2.1/onbuild
-2-onbuild: git://github.com/docker-library/ruby@4e94b39f5b76645819639e22d8de471c8fbd9855 2.1/onbuild
-onbuild: git://github.com/docker-library/ruby@4e94b39f5b76645819639e22d8de471c8fbd9855 2.1/onbuild
+2.0.0-p576-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
+2.0.0-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
+2.0-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
+
+2.1.3: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
+2.1: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
+2: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
+latest: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
+
+2.1.3-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
+2.1-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
+2-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
+onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.9.2: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
-3.9: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
-3: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
-latest: git://github.com/docker-library/wordpress@69c6d14ae81392b39d1ded401da617ece7c10c5b
+4.0.0: git://github.com/docker-library/wordpress@aee00669e7c43f435f021cb02871bffd63d5677a
+4.0: git://github.com/docker-library/wordpress@aee00669e7c43f435f021cb02871bffd63d5677a
+4: git://github.com/docker-library/wordpress@aee00669e7c43f435f021cb02871bffd63d5677a
+latest: git://github.com/docker-library/wordpress@aee00669e7c43f435f021cb02871bffd63d5677a


### PR DESCRIPTION
Highlights include:
- fixed golang onbuild images (via `go-wrapper`)
- added python 3.3
- added ruby 2.0
