### PR TITLE
Add ruby altname

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -1,8 +1,8 @@
 # maintainer: Brian Goff <cpuguy83@gmail.com> (@cpuguy83)
 
-1.7: git://github.com/cpuguy83/docker-jruby@da39f6ba4489618cb1bc2004dcc63912d430c310 1.7
-1.7.15: git://github.com/cpuguy83/docker-jruby@da39f6ba4489618cb1bc2004dcc63912d430c310 1.7
-latest: git://github.com/cpuguy83/docker-jruby@da39f6ba4489618cb1bc2004dcc63912d430c310 1.7
+1.7: git://github.com/cpuguy83/docker-jruby@9d4071a485dc1e0688dabaa7b6baaf679180d55b 1.7
+1.7.15: git://github.com/cpuguy83/docker-jruby@9d4071a485dc1e0688dabaa7b6baaf679180d55b 1.7
+latest: git://github.com/cpuguy83/docker-jruby@9d4071a485dc1e0688dabaa7b6baaf679180d55b 1.7
 
 1.7-onbuild: git://github.com/cpuguy83/docker-jruby@53d1d6ec2bc99ef884d60aa756861234710f2bbc 1.7/onbuild
 1.7.15-onbuild: git://github.com/cpuguy83/docker-jruby@53d1d6ec2bc99ef884d60aa756861234710f2bbc 1.7/onbuild


### PR DESCRIPTION
Image was missing alt name for `ruby`, so someone couldn't do `ruby some_script.rb`
