### PR TITLE
Update ubuntu-upstart to include all and only the supported versions of ubuntu

### DIFF
--- a/library/ubuntu-upstart
+++ b/library/ubuntu-upstart
@@ -1,31 +1,11 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-# see also https://wiki.ubuntu.com/Releases#Current
+12.04: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/12.04
+precise: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/12.04
 
-latest: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/14.04
-trusty: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/14.04
-14.04: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/14.04
-# EOL: Apr 2019
+14.04: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04
+trusty: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04
+latest: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04
 
-precise: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/12.04
-12.04: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/12.04
-# EOL: Apr 2017
-
-# TODO lucid/10.04 support
-#lucid: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/10.04
-#10.04: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/10.04
-# EOL: Apr 2015
-
-# ---
-
-quantal: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/12.10
-12.10: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/12.10
-# EOL: Apr 2014
-
-raring: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/13.04
-13.04: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/13.04
-# EOL: Jan 2014
-
-saucy: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/13.10
-13.10: git://github.com/tianon/dockerfiles@c4f86111caa8c8eab8e1b3a58cdebcf86807169c sbin-init/ubuntu/upstart/13.10
-# EOL: Jul 2014
+14.10: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.10
+utopic: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.10


### PR DESCRIPTION
``` console
root@04de6f74c6d3:/usr/src/stackbrew# ./brew-cli --debug --no-namespace -b ubuntu-upstart --targets ubuntu-upstart git://github.com/tianon/stackbrew.git
2014-09-25 04:08:36,657 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew.git, ref=ubuntu-upstart
2014-09-25 04:08:36,659 DEBUG folder = /tmp/tmpS5d8LD
2014-09-25 04:08:36,659 DEBUG Cloning git://github.com/tianon/stackbrew.git into /tmp/tmpS5d8LD
2014-09-25 04:08:36,659 DEBUG Executing "git clone git://github.com/tianon/stackbrew.git ." in /tmp/tmpS5d8LD
Cloning into '.'...
remote: Counting objects: 1427, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 1427 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (1427/1427), 214.72 KiB | 243.00 KiB/s, done.
Resolving deltas: 100% (802/802), done.
Checking connectivity... done.
2014-09-25 04:08:38,157 DEBUG Checkout ref:ubuntu-upstart in /tmp/tmpS5d8LD
2014-09-25 04:08:38,157 DEBUG Executing "git checkout ubuntu-upstart" in /tmp/tmpS5d8LD
Branch ubuntu-upstart set up to track remote branch ubuntu-upstart from origin.
Switched to a new branch 'ubuntu-upstart'
2014-09-25 04:08:38,171 DEBUG 12.04: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/12.04

2014-09-25 04:08:38,171 DEBUG precise: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/12.04

2014-09-25 04:08:38,172 DEBUG 14.04: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04

2014-09-25 04:08:38,172 DEBUG trusty: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04

2014-09-25 04:08:38,172 DEBUG latest: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.04

2014-09-25 04:08:38,172 DEBUG 14.10: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.10

2014-09-25 04:08:38,172 DEBUG utopic: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 sbin-init/ubuntu/upstart/14.10

2014-09-25 04:08:38,172 DEBUG ubuntu-upstart: 12.04,precise
2014-09-25 04:08:38,172 DEBUG ubuntu-upstart: 14.04,trusty,latest
2014-09-25 04:08:38,172 DEBUG ubuntu-upstart: 14.10,utopic
2014-09-25 04:08:38,172 DEBUG Cloning repo_url=git://github.com/tianon/dockerfiles, ref=4d24a12b54b75b3e0904d8a285900d88d3326361
2014-09-25 04:08:38,172 DEBUG folder = /tmp/tmppjBitN
2014-09-25 04:08:38,172 DEBUG Cloning git://github.com/tianon/dockerfiles into /tmp/tmppjBitN
2014-09-25 04:08:38,172 DEBUG Executing "git clone git://github.com/tianon/dockerfiles ." in /tmp/tmppjBitN
Cloning into '.'...
remote: Counting objects: 722, done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 722 (delta 3), reused 0 (delta 0)
Receiving objects: 100% (722/722), 268.82 KiB | 223.00 KiB/s, done.
Resolving deltas: 100% (289/289), done.
Checking connectivity... done.
2014-09-25 04:08:39,640 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmppjBitN
2014-09-25 04:08:39,640 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmppjBitN
Note: checking out '4d24a12b54b75b3e0904d8a285900d88d3326361'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-25 04:08:39,654 INFO Build start: ubuntu-upstart ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'sbin-init/ubuntu/upstart/12.04')
2014-09-25 04:09:23,245 INFO Build success: 91e8bc8005b8 (ubuntu-upstart:12.04)
2014-09-25 04:09:23,258 INFO Build success: 91e8bc8005b8 (ubuntu-upstart:precise)
2014-09-25 04:09:23,271 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmppjBitN
2014-09-25 04:09:23,271 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmppjBitN
HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-25 04:09:23,276 INFO Build start: ubuntu-upstart ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'sbin-init/ubuntu/upstart/14.04')
2014-09-25 04:10:19,068 INFO Build success: b2e7eaea8237 (ubuntu-upstart:14.04)
2014-09-25 04:10:19,080 INFO Build success: b2e7eaea8237 (ubuntu-upstart:trusty)
2014-09-25 04:10:19,092 INFO Build success: b2e7eaea8237 (ubuntu-upstart:latest)
2014-09-25 04:10:19,102 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmppjBitN
2014-09-25 04:10:19,103 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmppjBitN
HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-25 04:10:19,108 INFO Build start: ubuntu-upstart ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'sbin-init/ubuntu/upstart/14.10')
2014-09-25 04:13:51,411 INFO Build success: 48fb3889a0b7 (ubuntu-upstart:14.10)
2014-09-25 04:13:51,427 INFO Build success: 48fb3889a0b7 (ubuntu-upstart:utopic)
```
