### PR TITLE
Update debian:oldstable, debian:squeeze, debian:unstable, debian:sid, ubuntu:precise, and ubuntu:trusty with the actual CVE-2014-6271 fix

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,26 +1,26 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-jessie: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 jessie
+jessie: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 sid
+sid: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 squeeze
-6: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
+6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 stable
+stable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 stable
 
-testing: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 testing
+testing: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 unstable
+unstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 unstable
 
-7.6: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 wheezy
-7: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 wheezy
-latest: git://github.com/tianon/docker-brew-debian@e702577ca66f0672c3a6baaebfcdab8dec157fc3 wheezy
+7.6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
+7: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
+latest: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@c59a0145f300cc4ff07395dd03fabf47f209bb7c debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@c59a0145f300cc4ff07395dd03fabf47f209bb7c debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/experimental

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -4,14 +4,14 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 # see also http://cdimage.ubuntu.com/ubuntu-core/
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 trusty
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@b24589ba87fadefcf2a326df614af77b93472375 utopic
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 utopic


### PR DESCRIPTION
Fixes #213

``` console
root@c199b25d3b17:/usr/src/stackbrew# ./brew-cli --debug --no-namespace -b CVE-2014-6271 --targets debian,ubuntu git://github.com/tianon/stackbrew.git
2014-09-25 18:00:55,051 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew.git, ref=CVE-2014-6271
2014-09-25 18:00:55,053 DEBUG folder = /tmp/tmp2jj9Ud
2014-09-25 18:00:55,053 DEBUG Cloning git://github.com/tianon/stackbrew.git into /tmp/tmp2jj9Ud
2014-09-25 18:00:55,053 DEBUG Executing "git clone git://github.com/tianon/stackbrew.git ." in /tmp/tmp2jj9Ud
Cloning into '.'...
remote: Counting objects: 1437, done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 1437 (delta 4), reused 0 (delta 0)
Receiving objects: 100% (1437/1437), 216.33 KiB | 164.00 KiB/s, done.
Resolving deltas: 100% (806/806), done.
Checking connectivity... done.
2014-09-25 18:00:56,828 DEBUG Checkout ref:CVE-2014-6271 in /tmp/tmp2jj9Ud
2014-09-25 18:00:56,829 DEBUG Executing "git checkout CVE-2014-6271" in /tmp/tmp2jj9Ud
Branch CVE-2014-6271 set up to track remote branch CVE-2014-6271 from origin.
Switched to a new branch 'CVE-2014-6271'
2014-09-25 18:00:56,836 DEBUG 12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise

2014-09-25 18:00:56,836 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise

2014-09-25 18:00:56,836 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 precise

2014-09-25 18:00:56,836 DEBUG 14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty

2014-09-25 18:00:56,836 DEBUG 14.04: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty

2014-09-25 18:00:56,836 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty

2014-09-25 18:00:56,836 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 trusty

2014-09-25 18:00:56,836 DEBUG 14.10: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 utopic

2014-09-25 18:00:56,836 DEBUG utopic: git://github.com/tianon/docker-brew-ubuntu-core@a905242b4ae2f7a4d1a59fc253af6052680e12e9 utopic

2014-09-25 18:00:56,837 DEBUG jessie: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 jessie

2014-09-25 18:00:56,837 DEBUG oldstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 oldstable

2014-09-25 18:00:56,837 DEBUG sid: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 sid

2014-09-25 18:00:56,837 DEBUG 6.0.10: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze

2014-09-25 18:00:56,837 DEBUG 6.0: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze

2014-09-25 18:00:56,837 DEBUG 6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze

2014-09-25 18:00:56,837 DEBUG squeeze: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze

2014-09-25 18:00:56,837 DEBUG stable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 stable

2014-09-25 18:00:56,837 DEBUG testing: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 testing

2014-09-25 18:00:56,837 DEBUG unstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 unstable

2014-09-25 18:00:56,837 DEBUG 7.6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy

2014-09-25 18:00:56,838 DEBUG 7: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy

2014-09-25 18:00:56,838 DEBUG wheezy: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy

2014-09-25 18:00:56,838 DEBUG latest: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy

2014-09-25 18:00:56,838 DEBUG rc-buggy: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/rc-buggy

2014-09-25 18:00:56,838 DEBUG experimental: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/experimental

2014-09-25 18:00:56,838 DEBUG ubuntu: 12.04.5,12.04,precise
2014-09-25 18:00:56,838 DEBUG ubuntu: 14.04.1,14.04,trusty,latest
2014-09-25 18:00:56,838 DEBUG ubuntu: 14.10,utopic
2014-09-25 18:00:56,838 DEBUG debian: jessie
2014-09-25 18:00:56,838 DEBUG debian: oldstable
2014-09-25 18:00:56,838 DEBUG debian: sid
2014-09-25 18:00:56,838 DEBUG debian: 6.0.10,6.0,6,squeeze
2014-09-25 18:00:56,838 DEBUG debian: stable
2014-09-25 18:00:56,839 DEBUG debian: testing
2014-09-25 18:00:56,839 DEBUG debian: unstable
2014-09-25 18:00:56,839 DEBUG debian: 7.6,7,wheezy,latest
2014-09-25 18:00:56,839 DEBUG debian: rc-buggy
2014-09-25 18:00:56,839 DEBUG debian: experimental
2014-09-25 18:00:56,839 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-core, ref=a905242b4ae2f7a4d1a59fc253af6052680e12e9
2014-09-25 18:00:56,839 DEBUG folder = /tmp/tmps4xbov
2014-09-25 18:00:56,839 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-core into /tmp/tmps4xbov
2014-09-25 18:00:56,839 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-core ." in /tmp/tmps4xbov
Cloning into '.'...
remote: Counting objects: 59, done.
remote: Compressing objects: 100% (42/42), done.
remote: Total 59 (delta 16), reused 46 (delta 14)
Receiving objects: 100% (59/59), 163.28 MiB | 534.00 KiB/s, done.
Resolving deltas: 100% (16/16), done.
Checking connectivity... done.
2014-09-25 18:05:53,534 DEBUG Checkout ref:a905242b4ae2f7a4d1a59fc253af6052680e12e9 in /tmp/tmps4xbov
2014-09-25 18:05:53,535 DEBUG Executing "git checkout a905242b4ae2f7a4d1a59fc253af6052680e12e9" in /tmp/tmps4xbov
Note: checking out 'a905242b4ae2f7a4d1a59fc253af6052680e12e9'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at a905242... 20140925 tarballs; especially for CVE-2014-6271
2014-09-25 18:05:54,259 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'a905242b4ae2f7a4d1a59fc253af6052680e12e9', 'precise')
2014-09-25 18:07:05,205 INFO Build success: 26a8fcfc6043 (ubuntu:12.04.5)
2014-09-25 18:07:05,243 INFO Build success: 26a8fcfc6043 (ubuntu:12.04)
2014-09-25 18:07:05,279 INFO Build success: 26a8fcfc6043 (ubuntu:precise)
2014-09-25 18:07:05,313 DEBUG Checkout ref:a905242b4ae2f7a4d1a59fc253af6052680e12e9 in /tmp/tmps4xbov
2014-09-25 18:07:05,313 DEBUG Executing "git checkout a905242b4ae2f7a4d1a59fc253af6052680e12e9" in /tmp/tmps4xbov
HEAD is now at a905242... 20140925 tarballs; especially for CVE-2014-6271
2014-09-25 18:07:05,568 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'a905242b4ae2f7a4d1a59fc253af6052680e12e9', 'trusty')
2014-09-25 18:08:18,130 INFO Build success: 9dcc58e06ed8 (ubuntu:14.04.1)
2014-09-25 18:08:18,259 INFO Build success: 9dcc58e06ed8 (ubuntu:14.04)
2014-09-25 18:08:18,298 INFO Build success: 9dcc58e06ed8 (ubuntu:trusty)
2014-09-25 18:08:18,332 INFO Build success: 9dcc58e06ed8 (ubuntu:latest)
2014-09-25 18:08:18,383 DEBUG Checkout ref:a905242b4ae2f7a4d1a59fc253af6052680e12e9 in /tmp/tmps4xbov
2014-09-25 18:08:18,383 DEBUG Executing "git checkout a905242b4ae2f7a4d1a59fc253af6052680e12e9" in /tmp/tmps4xbov
HEAD is now at a905242... 20140925 tarballs; especially for CVE-2014-6271
2014-09-25 18:08:18,387 INFO Build start: ubuntu ('git://github.com/tianon/docker-brew-ubuntu-core', 'a905242b4ae2f7a4d1a59fc253af6052680e12e9', 'utopic')
2014-09-25 18:09:28,982 INFO Build success: f629dcec207b (ubuntu:14.10)
2014-09-25 18:09:29,022 INFO Build success: f629dcec207b (ubuntu:utopic)
2014-09-25 18:09:29,060 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-debian, ref=eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5
2014-09-25 18:09:29,060 DEBUG folder = /tmp/tmp92Ot8F
2014-09-25 18:09:29,060 DEBUG Cloning git://github.com/tianon/docker-brew-debian into /tmp/tmp92Ot8F
2014-09-25 18:09:29,060 DEBUG Executing "git clone git://github.com/tianon/docker-brew-debian ." in /tmp/tmp92Ot8F
Cloning into '.'...
remote: Counting objects: 80, done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 80 (delta 21), reused 54 (delta 13)
Receiving objects: 100% (80/80), 190.45 MiB | 314.00 KiB/s, done.
Resolving deltas: 100% (21/21), done.
Checking connectivity... done.
2014-09-25 18:16:10,419 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:10,419 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
Note: checking out 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:10,905 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'jessie')
2014-09-25 18:16:18,568 INFO Build success: 8f593ec48d74 (debian:jessie)
2014-09-25 18:16:18,605 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:18,605 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:19,330 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'oldstable')
2014-09-25 18:16:31,143 INFO Build success: 1c38bd2a3f56 (debian:oldstable)
2014-09-25 18:16:31,656 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:31,656 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:31,660 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'sid')
2014-09-25 18:16:39,076 INFO Build success: 93acee78a7c9 (debian:sid)
2014-09-25 18:16:39,103 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:39,103 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:39,109 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'squeeze')
2014-09-25 18:16:44,645 INFO Build success: c57f4635c077 (debian:6.0.10)
2014-09-25 18:16:44,682 INFO Build success: c57f4635c077 (debian:6.0)
2014-09-25 18:16:44,724 INFO Build success: c57f4635c077 (debian:6)
2014-09-25 18:16:44,760 INFO Build success: c57f4635c077 (debian:squeeze)
2014-09-25 18:16:44,795 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:44,795 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:44,800 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'stable')
2014-09-25 18:16:50,585 INFO Build success: d6ca13bad958 (debian:stable)
2014-09-25 18:16:50,622 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:16:50,622 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:16:50,626 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'testing')
2014-09-25 18:17:00,735 INFO Build success: 4e85da777b95 (debian:testing)
2014-09-25 18:17:00,761 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:17:00,762 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:17:00,766 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'unstable')
2014-09-25 18:17:15,911 INFO Build success: 4e256a709b6f (debian:unstable)
2014-09-25 18:17:17,161 DEBUG Checkout ref:eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 in /tmp/tmp92Ot8F
2014-09-25 18:17:17,161 DEBUG Executing "git checkout eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5" in /tmp/tmp92Ot8F
HEAD is now at eee2af7... 2014-09-25 debootstraps; especially for CVE-2014-6271
2014-09-25 18:17:17,166 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', 'eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5', 'wheezy')
2014-09-25 18:17:31,556 INFO Build success: ea76169510c6 (debian:7.6)
2014-09-25 18:17:32,925 INFO Build success: ea76169510c6 (debian:7)
2014-09-25 18:17:36,909 INFO Build success: ea76169510c6 (debian:wheezy)
2014-09-25 18:17:38,227 INFO Build success: ea76169510c6 (debian:latest)
2014-09-25 18:17:39,515 DEBUG Cloning repo_url=git://github.com/tianon/dockerfiles, ref=4d24a12b54b75b3e0904d8a285900d88d3326361
2014-09-25 18:17:39,515 DEBUG folder = /tmp/tmpYkOrnm
2014-09-25 18:17:39,516 DEBUG Cloning git://github.com/tianon/dockerfiles into /tmp/tmpYkOrnm
2014-09-25 18:17:39,516 DEBUG Executing "git clone git://github.com/tianon/dockerfiles ." in /tmp/tmpYkOrnm
Cloning into '.'...
remote: Counting objects: 722, done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 722 (delta 3), reused 0 (delta 0)
Receiving objects: 100% (722/722), 268.82 KiB | 0 bytes/s, done.
Resolving deltas: 100% (289/289), done.
Checking connectivity... done.
2014-09-25 18:17:40,590 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmpYkOrnm
2014-09-25 18:17:40,591 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmpYkOrnm
Note: checking out '4d24a12b54b75b3e0904d8a285900d88d3326361'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-25 18:17:40,597 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'debian/rc-buggy')
2014-09-25 18:17:46,177 INFO Build success: df2c5bb8adea (debian:rc-buggy)
2014-09-25 18:17:46,400 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmpYkOrnm
2014-09-25 18:17:46,400 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmpYkOrnm
HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-25 18:17:46,406 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'debian/experimental')
2014-09-25 18:17:47,395 INFO Build success: c85874747dc0 (debian:experimental)
```
