### PR TITLE
Update ubuntu-debootstrap for CVE-2014-7169

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,19 +1,19 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.04
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@2b23f16c335219338c51a3faa292655414939a70 devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 devel


### PR DESCRIPTION
``` console
root@996c49383319:/usr/src/stackbrew# ./brew-cli --debug --no-namespace -b ubuntu-debootstrap --targets ubuntu-debootstrap git://github.com/tianon/stackbrew.git
2014-09-26 16:40:20,780 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew.git, ref=ubuntu-debootstrap
2014-09-26 16:40:20,782 DEBUG folder = /tmp/tmprwxQCE
2014-09-26 16:40:20,782 DEBUG Cloning git://github.com/tianon/stackbrew.git into /tmp/tmprwxQCE
2014-09-26 16:40:20,782 DEBUG Executing "git clone git://github.com/tianon/stackbrew.git ." in /tmp/tmprwxQCE
Cloning into '.'...
remote: Counting objects: 1474, done.
remote: Compressing objects: 100% (51/51), done.
remote: Total 1474 (delta 27), reused 0 (delta 0)
Receiving objects: 100% (1474/1474), 220.42 KiB | 253.00 KiB/s, done.
Resolving deltas: 100% (829/829), done.
Checking connectivity... done.
2014-09-26 16:40:22,215 DEBUG Checkout ref:ubuntu-debootstrap in /tmp/tmprwxQCE
2014-09-26 16:40:22,215 DEBUG Executing "git checkout ubuntu-debootstrap" in /tmp/tmprwxQCE
Branch ubuntu-debootstrap set up to track remote branch ubuntu-debootstrap from origin.
Switched to a new branch 'ubuntu-debootstrap'
2014-09-26 16:40:22,222 DEBUG 10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04

2014-09-26 16:40:22,223 DEBUG 10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04

2014-09-26 16:40:22,223 DEBUG lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04

2014-09-26 16:40:22,223 DEBUG 12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04

2014-09-26 16:40:22,223 DEBUG 12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04

2014-09-26 16:40:22,223 DEBUG precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04

2014-09-26 16:40:22,223 DEBUG 14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04

2014-09-26 16:40:22,223 DEBUG 14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04

2014-09-26 16:40:22,223 DEBUG trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04

2014-09-26 16:40:22,223 DEBUG latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04

2014-09-26 16:40:22,223 DEBUG 14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10

2014-09-26 16:40:22,223 DEBUG utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10

2014-09-26 16:40:22,224 DEBUG devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 devel

2014-09-26 16:40:22,224 DEBUG ubuntu-debootstrap: 10.04.4,10.04,lucid
2014-09-26 16:40:22,224 DEBUG ubuntu-debootstrap: 12.04.5,12.04,precise
2014-09-26 16:40:22,224 DEBUG ubuntu-debootstrap: 14.04.1,14.04,trusty,latest
2014-09-26 16:40:22,224 DEBUG ubuntu-debootstrap: 14.10,utopic
2014-09-26 16:40:22,224 DEBUG ubuntu-debootstrap: devel
2014-09-26 16:40:22,224 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-ubuntu-debootstrap, ref=95554c91ed7f013d5a55d7d8a7372da13396a922
2014-09-26 16:40:22,224 DEBUG folder = /tmp/tmpAiTMCT
2014-09-26 16:40:22,224 DEBUG Cloning git://github.com/tianon/docker-brew-ubuntu-debootstrap into /tmp/tmpAiTMCT
2014-09-26 16:40:22,224 DEBUG Executing "git clone git://github.com/tianon/docker-brew-ubuntu-debootstrap ." in /tmp/tmpAiTMCT
Cloning into '.'...
remote: Counting objects: 67, done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 67 (delta 20), reused 57 (delta 16)
Receiving objects: 100% (67/67), 122.08 MiB | 517.00 KiB/s, done.
Resolving deltas: 100% (20/20), done.
Checking connectivity... done.
2014-09-26 16:43:20,608 DEBUG Checkout ref:95554c91ed7f013d5a55d7d8a7372da13396a922 in /tmp/tmpAiTMCT
2014-09-26 16:43:20,608 DEBUG Executing "git checkout 95554c91ed7f013d5a55d7d8a7372da13396a922" in /tmp/tmpAiTMCT
Note: checking out '95554c91ed7f013d5a55d7d8a7372da13396a922'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 95554c9... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:43:20,952 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', '95554c91ed7f013d5a55d7d8a7372da13396a922', '10.04')
2014-09-26 16:43:27,380 INFO Build success: 0370908dcfa4 (ubuntu-debootstrap:10.04.4)
2014-09-26 16:43:27,418 INFO Build success: 0370908dcfa4 (ubuntu-debootstrap:10.04)
2014-09-26 16:43:27,462 INFO Build success: 0370908dcfa4 (ubuntu-debootstrap:lucid)
2014-09-26 16:43:27,496 DEBUG Checkout ref:95554c91ed7f013d5a55d7d8a7372da13396a922 in /tmp/tmpAiTMCT
2014-09-26 16:43:27,496 DEBUG Executing "git checkout 95554c91ed7f013d5a55d7d8a7372da13396a922" in /tmp/tmpAiTMCT
HEAD is now at 95554c9... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:43:27,975 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', '95554c91ed7f013d5a55d7d8a7372da13396a922', '12.04')
2014-09-26 16:43:35,276 INFO Build success: aba2d0397b17 (ubuntu-debootstrap:12.04.5)
2014-09-26 16:43:35,315 INFO Build success: aba2d0397b17 (ubuntu-debootstrap:12.04)
2014-09-26 16:43:35,358 INFO Build success: aba2d0397b17 (ubuntu-debootstrap:precise)
2014-09-26 16:43:35,411 DEBUG Checkout ref:95554c91ed7f013d5a55d7d8a7372da13396a922 in /tmp/tmpAiTMCT
2014-09-26 16:43:35,411 DEBUG Executing "git checkout 95554c91ed7f013d5a55d7d8a7372da13396a922" in /tmp/tmpAiTMCT
HEAD is now at 95554c9... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:43:35,415 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', '95554c91ed7f013d5a55d7d8a7372da13396a922', '14.04')
2014-09-26 16:43:44,836 INFO Build success: 74263671842d (ubuntu-debootstrap:14.04.1)
2014-09-26 16:43:44,928 INFO Build success: 74263671842d (ubuntu-debootstrap:14.04)
2014-09-26 16:43:44,966 INFO Build success: 74263671842d (ubuntu-debootstrap:trusty)
2014-09-26 16:43:45,004 INFO Build success: 74263671842d (ubuntu-debootstrap:latest)
2014-09-26 16:43:45,039 DEBUG Checkout ref:95554c91ed7f013d5a55d7d8a7372da13396a922 in /tmp/tmpAiTMCT
2014-09-26 16:43:45,040 DEBUG Executing "git checkout 95554c91ed7f013d5a55d7d8a7372da13396a922" in /tmp/tmpAiTMCT
HEAD is now at 95554c9... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:43:45,045 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', '95554c91ed7f013d5a55d7d8a7372da13396a922', '14.10')
2014-09-26 16:43:52,657 INFO Build success: 80a9133a01b3 (ubuntu-debootstrap:14.10)
2014-09-26 16:43:52,696 INFO Build success: 80a9133a01b3 (ubuntu-debootstrap:utopic)
2014-09-26 16:43:52,739 DEBUG Checkout ref:95554c91ed7f013d5a55d7d8a7372da13396a922 in /tmp/tmpAiTMCT
2014-09-26 16:43:52,740 DEBUG Executing "git checkout 95554c91ed7f013d5a55d7d8a7372da13396a922" in /tmp/tmpAiTMCT
HEAD is now at 95554c9... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:43:52,744 INFO Build start: ubuntu-debootstrap ('git://github.com/tianon/docker-brew-ubuntu-debootstrap', '95554c91ed7f013d5a55d7d8a7372da13396a922', 'devel')
2014-09-26 16:44:03,822 INFO Build success: ed72ca990c29 (ubuntu-debootstrap:devel)
```
