### PR TITLE
Update debian for CVE-2014-7169

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,26 +1,26 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-jessie: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 jessie
+jessie: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 sid
+sid: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
-6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
+6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 stable
+stable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 stable
 
-testing: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 testing
+testing: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 unstable
+unstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 unstable
 
-7.6: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
-7: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
-latest: git://github.com/tianon/docker-brew-debian@eee2af79d16f8a9f9db76b0e7df054f1e5ca94c5 wheezy
+7.6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
+7: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
+latest: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
 
 rc-buggy: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/rc-buggy
 experimental: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/experimental


### PR DESCRIPTION
This includes the following patch to `debian:jessie` and `debian:testing` because _testing is not supported for security updates_: (see also https://wiki.debian.org/DebianTesting https://www.debian.org/security/faq#testing https://www.debian.org/doc/manuals/securing-debian-howto/ch10.en.html#s-security-support-testing)

``` Dockerfile
# CVE-2014-7169 (upstream testing is not security supported)
RUN echo 'deb http://http.debian.net/debian sid main' > /etc/apt/sources.list.d/unstable.list \
    && apt-get update \
    && apt-get install -y bash \
    && rm -rf /var/lib/apt/lists/* \
    && rm /etc/apt/sources.list.d/unstable.list
```

``` console
root@fc58fec40fed:/usr/src/stackbrew# ./brew-cli --debug --no-namespace -b debian --targets debian git://github.com/tianon/stackbrew.git
2014-09-26 16:40:20,454 DEBUG Cloning repo_url=git://github.com/tianon/stackbrew.git, ref=debian
2014-09-26 16:40:20,456 DEBUG folder = /tmp/tmpPyLueI
2014-09-26 16:40:20,456 DEBUG Cloning git://github.com/tianon/stackbrew.git into /tmp/tmpPyLueI
2014-09-26 16:40:20,456 DEBUG Executing "git clone git://github.com/tianon/stackbrew.git ." in /tmp/tmpPyLueI
Cloning into '.'...
remote: Counting objects: 1474, done.
remote: Compressing objects: 100% (51/51), done.
remote: Total 1474 (delta 27), reused 0 (delta 0)
Receiving objects: 100% (1474/1474), 220.42 KiB | 310.00 KiB/s, done.
Resolving deltas: 100% (829/829), done.
Checking connectivity... done.
2014-09-26 16:40:21,659 DEBUG Checkout ref:debian in /tmp/tmpPyLueI
2014-09-26 16:40:21,660 DEBUG Executing "git checkout debian" in /tmp/tmpPyLueI
Branch debian set up to track remote branch debian from origin.
Switched to a new branch 'debian'
2014-09-26 16:40:21,667 DEBUG jessie: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 jessie

2014-09-26 16:40:21,667 DEBUG oldstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 oldstable

2014-09-26 16:40:21,667 DEBUG sid: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 sid

2014-09-26 16:40:21,667 DEBUG 6.0.10: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze

2014-09-26 16:40:21,667 DEBUG 6.0: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze

2014-09-26 16:40:21,667 DEBUG 6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze

2014-09-26 16:40:21,667 DEBUG squeeze: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze

2014-09-26 16:40:21,667 DEBUG stable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 stable

2014-09-26 16:40:21,667 DEBUG testing: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 testing

2014-09-26 16:40:21,667 DEBUG unstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 unstable

2014-09-26 16:40:21,667 DEBUG 7.6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy

2014-09-26 16:40:21,667 DEBUG 7: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy

2014-09-26 16:40:21,668 DEBUG wheezy: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy

2014-09-26 16:40:21,668 DEBUG latest: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy

2014-09-26 16:40:21,668 DEBUG rc-buggy: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/rc-buggy

2014-09-26 16:40:21,668 DEBUG experimental: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/experimental

2014-09-26 16:40:21,668 DEBUG debian: jessie
2014-09-26 16:40:21,668 DEBUG debian: oldstable
2014-09-26 16:40:21,668 DEBUG debian: sid
2014-09-26 16:40:21,668 DEBUG debian: 6.0.10,6.0,6,squeeze
2014-09-26 16:40:21,668 DEBUG debian: stable
2014-09-26 16:40:21,668 DEBUG debian: testing
2014-09-26 16:40:21,668 DEBUG debian: unstable
2014-09-26 16:40:21,668 DEBUG debian: 7.6,7,wheezy,latest
2014-09-26 16:40:21,668 DEBUG debian: rc-buggy
2014-09-26 16:40:21,668 DEBUG debian: experimental
2014-09-26 16:40:21,668 DEBUG Cloning repo_url=git://github.com/tianon/docker-brew-debian, ref=73d0c4920f55de7c2e6299197fdf97d69ed2cb02
2014-09-26 16:40:21,669 DEBUG folder = /tmp/tmpcI9mbO
2014-09-26 16:40:21,669 DEBUG Cloning git://github.com/tianon/docker-brew-debian into /tmp/tmpcI9mbO
2014-09-26 16:40:21,669 DEBUG Executing "git clone git://github.com/tianon/docker-brew-debian ." in /tmp/tmpcI9mbO
Cloning into '.'...
remote: Counting objects: 81, done.
remote: Compressing objects: 100% (45/45), done.
remote: Total 81 (delta 21), reused 54 (delta 13)
Receiving objects: 100% (81/81), 190.44 MiB | 985.00 KiB/s, done.
Resolving deltas: 100% (21/21), done.
Checking connectivity... done.
2014-09-26 16:46:34,478 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:46:34,478 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
Note: checking out '73d0c4920f55de7c2e6299197fdf97d69ed2cb02'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:46:34,977 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'jessie')
2014-09-26 16:47:26,894 INFO Build success: edcc938a748c (debian:jessie)
2014-09-26 16:47:26,942 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:47:26,942 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:47:27,689 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'oldstable')
2014-09-26 16:47:33,407 INFO Build success: b96d9edead62 (debian:oldstable)
2014-09-26 16:47:33,432 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:47:33,432 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:47:33,437 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'sid')
2014-09-26 16:47:40,748 INFO Build success: 3e025e2e3b87 (debian:sid)
2014-09-26 16:47:40,785 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:47:40,786 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:47:40,790 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'squeeze')
2014-09-26 16:47:46,418 INFO Build success: 28bbe9ae213d (debian:6.0.10)
2014-09-26 16:47:46,458 INFO Build success: 28bbe9ae213d (debian:6.0)
2014-09-26 16:47:46,496 INFO Build success: 28bbe9ae213d (debian:6)
2014-09-26 16:47:46,591 INFO Build success: 28bbe9ae213d (debian:squeeze)
2014-09-26 16:47:46,635 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:47:46,636 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:47:46,641 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'stable')
2014-09-26 16:47:55,839 INFO Build success: fe43d6ca524c (debian:stable)
2014-09-26 16:47:55,951 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:47:55,951 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:47:55,972 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'testing')
2014-09-26 16:48:50,016 INFO Build success: 4ae1900e32c5 (debian:testing)
2014-09-26 16:48:50,054 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:48:50,054 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:48:50,058 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'unstable')
2014-09-26 16:48:57,206 INFO Build success: 7964442b82f0 (debian:unstable)
2014-09-26 16:48:57,243 DEBUG Checkout ref:73d0c4920f55de7c2e6299197fdf97d69ed2cb02 in /tmp/tmpcI9mbO
2014-09-26 16:48:57,243 DEBUG Executing "git checkout 73d0c4920f55de7c2e6299197fdf97d69ed2cb02" in /tmp/tmpcI9mbO
HEAD is now at 73d0c49... 2014-09-26 debootstraps; especially for CVE-2014-7169
2014-09-26 16:48:57,247 INFO Build start: debian ('git://github.com/tianon/docker-brew-debian', '73d0c4920f55de7c2e6299197fdf97d69ed2cb02', 'wheezy')
2014-09-26 16:49:07,898 INFO Build success: 68c0a34e58fb (debian:7.6)
2014-09-26 16:49:07,923 INFO Build success: 68c0a34e58fb (debian:7)
2014-09-26 16:49:07,965 INFO Build success: 68c0a34e58fb (debian:wheezy)
2014-09-26 16:49:08,000 INFO Build success: 68c0a34e58fb (debian:latest)
2014-09-26 16:49:08,034 DEBUG Cloning repo_url=git://github.com/tianon/dockerfiles, ref=4d24a12b54b75b3e0904d8a285900d88d3326361
2014-09-26 16:49:08,034 DEBUG folder = /tmp/tmpDrkDCH
2014-09-26 16:49:08,035 DEBUG Cloning git://github.com/tianon/dockerfiles into /tmp/tmpDrkDCH
2014-09-26 16:49:08,035 DEBUG Executing "git clone git://github.com/tianon/dockerfiles ." in /tmp/tmpDrkDCH
Cloning into '.'...
remote: Counting objects: 722, done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 722 (delta 3), reused 0 (delta 0)
Receiving objects: 100% (722/722), 268.82 KiB | 177.00 KiB/s, done.
Resolving deltas: 100% (289/289), done.
Checking connectivity... done.
2014-09-26 16:49:10,134 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmpDrkDCH
2014-09-26 16:49:10,134 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmpDrkDCH
Note: checking out '4d24a12b54b75b3e0904d8a285900d88d3326361'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-26 16:49:10,140 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'debian/rc-buggy')
2014-09-26 16:49:11,235 INFO Build success: ba94f670974a (debian:rc-buggy)
2014-09-26 16:49:11,259 DEBUG Checkout ref:4d24a12b54b75b3e0904d8a285900d88d3326361 in /tmp/tmpDrkDCH
2014-09-26 16:49:11,260 DEBUG Executing "git checkout 4d24a12b54b75b3e0904d8a285900d88d3326361" in /tmp/tmpDrkDCH
HEAD is now at 4d24a12... update ubuntu-init to only include the supported versions of ubuntu and a new script to generate the stackbrew library file
2014-09-26 16:49:11,265 INFO Build start: debian ('git://github.com/tianon/dockerfiles', '4d24a12b54b75b3e0904d8a285900d88d3326361', 'debian/experimental')
2014-09-26 16:49:12,232 INFO Build success: 8119b3428de5 (debian:experimental)
```
