### PR TITLE
Fix bug where lowercase FROM instruction was ignored

### DIFF
--- a/bashbrew/build.sh
+++ b/bashbrew/build.sh
@@ -243,7 +243,7 @@ while [ "$#" -gt 0 ]; do
 	fi
 	
 	IFS=$'\n'
-	froms=( $(grep '^FROM[[:space:]]' "$gitRepo/$gitDir/Dockerfile" | awk -F '[[:space:]]+' '{ print $2 ~ /:/ ? $2 : $2":latest" }') )
+	froms=( $(grep -i '^FROM[[:space:]]' "$gitRepo/$gitDir/Dockerfile" | awk '{ print $2 ~ /:/ ? $2 : $2":latest" }') )
 	unset IFS
 	
 	for from in "${froms[@]}"; do


### PR DESCRIPTION
I forgot that Dockerfile instructions are case-insensitive, especially because lowercase looks so silly, but this makes "hipache" build when it should be deferred to only build after "ubuntu".

Also, awk's default is to split on any number of whitespace-chars, so no need for the explicit "-F" there.
