### PR TITLE
Update Perl to 5.18.4, fix gcc 4.9 build issue

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,21 +1,21 @@
 # maintainer: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
 
-latest:          git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit
+latest:          git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit
 
-5:               git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit
+5:               git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit
 
-5.20:            git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit
-5.20.1:          git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit
+5.20:            git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit
+5.20.1:          git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit
 
-5.18:            git://github.com/perl/docker-perl@r20141002.0 5.018.004-64bit
-5.18.4:          git://github.com/perl/docker-perl@r20141002.0 5.018.004-64bit
+5.18:            git://github.com/perl/docker-perl@r20141003.0 5.018.004-64bit
+5.18.4:          git://github.com/perl/docker-perl@r20141003.0 5.018.004-64bit
 
-latest-threaded: git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit,threaded
+latest-threaded: git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit,threaded
 
-5-threaded:      git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit,threaded
+5-threaded:      git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit,threaded
 
-5.20-threaded:   git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit,threaded
-5.20.1-threaded: git://github.com/perl/docker-perl@r20141002.0 5.020.001-64bit,threaded
+5.20-threaded:   git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit,threaded
+5.20.1-threaded: git://github.com/perl/docker-perl@r20141003.0 5.020.001-64bit,threaded
 
-5.18-threaded:   git://github.com/perl/docker-perl@r20141002.0 5.018.004-64bit,threaded
-5.18.4-threaded: git://github.com/perl/docker-perl@r20141002.0 5.018.004-64bit,threaded
+5.18-threaded:   git://github.com/perl/docker-perl@r20141003.0 5.018.004-64bit,threaded
+5.18.4-threaded: git://github.com/perl/docker-perl@r20141003.0 5.018.004-64bit,threaded


### PR DESCRIPTION
perl r20141002.0 changes:
- support for 5.18.4 (just released)
- download via https / sha1sum of download (https://github.com/Perl/docker-perl/issues/4)
- Fixed failing tests in 5.18 (https://github.com/Perl/docker-perl/issues/5)
