### PR TITLE
Update jenkins for LTS 1.565.3

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -2,11 +2,11 @@
 # maintainer: Nicolas De Loof <ndeloof@cloudbees.com> (@ndeloof)
 
 # "latest" is latest _stable_, i.e. latest LTS release
-latest: git://github.com/cloudbees/jenkins-ci.org-docker@b32f552ce052433e53f915c6f40102e2975877b6
-1.565.3: git://github.com/cloudbees/jenkins-ci.org-docker@b32f552ce052433e53f915c6f40102e2975877b6
+latest: git://github.com/cloudbees/jenkins-ci.org-docker@b2b442e360cf92317326fa4e325a81ab1f11a422
+1.565.3: git://github.com/cloudbees/jenkins-ci.org-docker@b2b442e360cf92317326fa4e325a81ab1f11a422
 
 # weekly releases
-weekly: git://github.com/cloudbees/jenkins-ci.org-docker@d317de7bc7cb6f3c4cb2ca4180d9e4674a59e27a
-1.583: git://github.com/cloudbees/jenkins-ci.org-docker@d317de7bc7cb6f3c4cb2ca4180d9e4674a59e27a
+weekly: git://github.com/cloudbees/jenkins-ci.org-docker@f969422940ce4b2cd0bbbdcf31ea96fa2485e86c
+1.583: git://github.com/cloudbees/jenkins-ci.org-docker@f969422940ce4b2cd0bbbdcf31ea96fa2485e86c
 
 


### PR DESCRIPTION
Also includes weekly release 1.583

I wonder if "latest" should point to actual latest (weekly) and we should define a "lts" alias for "latest lts"
