### PR TITLE
Haskell Platform Docker library file

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,6 +1,6 @@
 # maintainer: Satnam Singh <satnam6502@gmail.com> (@satnam6502)
 
-# A Docker library file for a build of the Haskell Platform on Debian.
+# A Docker library file for a build of the Haskell Platform on Ubuntu 14.04
 
-latest: git://github.com/satnam6502/haskell-docker@7bd6e9fb52ae599a500a89336ecb938a6d8835c1
-2014.2.0.0: git://github.com/satnam6502/haskell-docker@7bd6e9fb52ae599a500a89336ecb938a6d8835c1
+latest: git://github.com/satnam6502/haskell-docker@fb3e550faf28dbd606ec1111c41a46025e19937d
+2014.2.0.0: git://github.com/satnam6502/haskell-docker@fb3e550faf28dbd606ec1111c41a46025e19937d


### PR DESCRIPTION
This is a sister proposal to the "ghc" library proposal.
This is for the "Haskell Platform" which contains the GHC Haskell compiler along with commonly used tools which will be the preferred way of using Haskell for most users.
