### PR TITLE
Update several docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,56 +1,26 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.2.0: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.2.0
+1.2.2: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2
+1.2: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2
 
-1.2.0-onbuild: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.2.0/onbuild
+1.2.2-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/onbuild
+1.2-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/onbuild
 
-1.2.0-cross: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.2.0/cross
+1.2.2-cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/cross
+1.2-cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/cross
 
-1.2.1: git://github.com/docker-library/golang@435956495be76fd3c756240b7d147f507d36b22b 1.2.1
+1.3.3: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3
+1.3: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3
+1: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3
+latest: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3
 
-1.2.1-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.1/onbuild
+1.3.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
+1.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
+1-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
+onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
 
-1.2.1-cross: git://github.com/docker-library/golang@8055f75d6b50483fb570b96cbcf10edf2fbde749 1.2.1/cross
-
-1.2.2: git://github.com/docker-library/golang@435956495be76fd3c756240b7d147f507d36b22b 1.2.2
-1.2: git://github.com/docker-library/golang@435956495be76fd3c756240b7d147f507d36b22b 1.2.2
-
-1.2.2-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.2/onbuild
-1.2-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.2.2/onbuild
-
-1.2.2-cross: git://github.com/docker-library/golang@8055f75d6b50483fb570b96cbcf10edf2fbde749 1.2.2/cross
-1.2-cross: git://github.com/docker-library/golang@8055f75d6b50483fb570b96cbcf10edf2fbde749 1.2.2/cross
-
-1.3.0: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.0
-
-1.3.0-onbuild: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.0/onbuild
-
-1.3.0-cross: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.0/cross
-
-1.3.1: git://github.com/docker-library/golang@435956495be76fd3c756240b7d147f507d36b22b 1.3.1
-
-1.3.1-onbuild: git://github.com/docker-library/golang@9ff2ccca569f9525b023080540f1bb55f6b59d7f 1.3.1/onbuild
-
-1.3.1-cross: git://github.com/docker-library/golang@8055f75d6b50483fb570b96cbcf10edf2fbde749 1.3.1/cross
-
-1.3.2: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.2
-
-1.3.2-onbuild: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.2/onbuild
-
-1.3.2-cross: git://github.com/docker-library/golang@83d3f38479896f8fe550300d6fd58134246bf071 1.3.2/cross
-
-1.3.3: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3
-1.3: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3
-1: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3
-latest: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3
-
-1.3.3-onbuild: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/onbuild
-1.3-onbuild: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/onbuild
-1-onbuild: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/onbuild
-onbuild: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/onbuild
-
-1.3.3-cross: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/cross
-1.3-cross: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/cross
-1-cross: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/cross
-cross: git://github.com/docker-library/golang@30f0b1517c8df30f74ad9dde46cac0cfffb2c2b9 1.3.3/cross
+1.3.3-cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/cross
+1.3-cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/cross
+1-cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/cross
+cross: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/cross

--- a/library/php
+++ b/library/php
@@ -1,29 +1,39 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.3.29-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
-5.3-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
+5.3.29-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3
+5.3-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3
+5.3.29: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3
+5.3: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3
 
-5.3.29-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache
-5.3-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache
+5.3.29-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3/apache
+5.3-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.3/apache
 
-5.4.33-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
-5.4-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
+5.4.33-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4
+5.4-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4
+5.4.33: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4
+5.4: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4
 
-5.4.33-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache
-5.4-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache
+5.4.33-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4/apache
+5.4-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.4/apache
 
-5.5.17-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
-5.5-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
+5.5.17-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5
+5.5-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5
+5.5.17: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5
+5.5: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5
 
-5.5.17-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache
-5.5-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache
+5.5.17-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5/apache
+5.5-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.5/apache
 
-5.6.1-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
-5.6-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
-5-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
-latest: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6
+5.6.1-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+5.6-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+5-cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+cli: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+5.6.1: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+5.6: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+5: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
+latest: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6
 
-5.6.1-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
-5.6-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
-5-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.6/apache
+5.6.1-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6/apache
+5.6-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6/apache
+5-apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6/apache
+apache: git://github.com/docker-library/php@6b0affa0c5a8cc1cbbd8b1110f239a226a137c97 5.6/apache

--- a/library/python
+++ b/library/python
@@ -8,18 +8,18 @@
 2.7-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 
-3.3.5: git://github.com/docker-library/python@dbe3e241f4c3263a81a888896f5126861807b3db 3.3
-3.3: git://github.com/docker-library/python@dbe3e241f4c3263a81a888896f5126861807b3db 3.3
+3.3.5: git://github.com/docker-library/python@5da3b09cc56f1a431c912dcb1dc1d72efbd17409 3.3
+3.3: git://github.com/docker-library/python@5da3b09cc56f1a431c912dcb1dc1d72efbd17409 3.3
 
 3.3.5-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
 
-3.4.1: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4
-3.4: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4
-3: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4
-latest: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4
+3.4.2: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
+3.4: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
+3: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
+latest: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
 
-3.4.1-onbuild: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4/onbuild
-3.4-onbuild: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4/onbuild
-3-onbuild: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4/onbuild
-onbuild: git://github.com/docker-library/python@9cdb6eeb857908d3817cdd46f63e3b954f3072ae 3.4/onbuild
+3.4.2-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
+3.4-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
+3-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
+onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild

--- a/library/redis
+++ b/library/redis
@@ -1,30 +1,30 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.6.17
-2.6: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.6.17
+2.6.17: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.6.17
+2.6: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.6.17
 
-2.8.10: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.10
+2.8.10: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.10
 
-2.8.11: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.11
+2.8.11: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.11
 
-2.8.12: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.12
+2.8.12: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.12
 
-2.8.13: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.13
+2.8.13: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.13
 
-2.8.14: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.14
+2.8.14: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.14
 
-2.8.15: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.15
+2.8.15: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.15
 
-2.8.16: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.16
+2.8.16: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.16
 
-2.8.17: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.17
-2.8: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.17
-latest: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.17
+2.8.17: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
+2.8: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
+latest: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
 
-2.8.6: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.6
+2.8.6: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.6
 
-2.8.7: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.7
+2.8.7: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.7
 
-2.8.8: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.8
+2.8.8: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.8
 
-2.8.9: git://github.com/docker-library/redis@d9ec31cfa11cfaa9bf3db6b26a59b8b7402f81dc 2.8.9
+2.8.9: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.9


### PR DESCRIPTION
- `golang`: removed most of the tags now (only the latest patch release of each of the two major versions now; 1.2 and 1.3)
- `php`: update and add a ton of tags that were missing (`php:cli` to match `php:apache`, `php:5.6`, etc.)
- `python`: update several versions, especially to make sure 3.3 has pip
- `redis`: chown of volume data and redis-sentinel symlink
