### PR TITLE
Update debian, especially for CVE-2014-7206

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,26 +1,26 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-jessie: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 jessie
+jessie: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 sid
+sid: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
-6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec squeeze
+6.0: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec squeeze
+6: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 stable
+stable: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec stable
 
-testing: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 testing
+testing: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec testing
 
-unstable: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 unstable
+unstable: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec unstable
 
-7.6: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
-7: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
-latest: git://github.com/tianon/docker-brew-debian@73d0c4920f55de7c2e6299197fdf97d69ed2cb02 wheezy
+7.6: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec wheezy
+7: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec wheezy
+latest: git://github.com/tianon/docker-brew-debian@c126f932c08746c6be9b287d2f16d1257b6187ec wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@4d24a12b54b75b3e0904d8a285900d88d3326361 debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@8c304e884f4b5b418dfdae524099ca6081a9c09a debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@8c304e884f4b5b418dfdae524099ca6081a9c09a debian/experimental


### PR DESCRIPTION
Just for reference, Ubuntu 14.10 isn't updated yet (which is why Ubuntu isn't included here).  Be sure to follow http://people.canonical.com/~ubuntu-security/cve/2014/CVE-2014-7206.html and https://bugs.launchpad.net/ubuntu/%2Bsource/apt/%2Bbug/1378680 for the latest on that.
