### PR TITLE
Switch Travis to "language: bash" (which will actually avoid all the "ruby" output once they deploy the change)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# just pick a random language so we don't get funky "bundle" ruby stuff
-language: c
+language: bash
 
 # allow for use of Docker-based workers
 sudo: false


### PR DESCRIPTION
See also https://github.com/travis-ci/travis-ci/issues/2856 and https://github.com/travis-ci/travis-build/pull/306
