### PR TITLE
Update ubuntu and ubuntu-debootstrap for CVE-2014-7206

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -4,14 +4,14 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 # see also http://cdimage.ubuntu.com/ubuntu-core/
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f precise
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 trusty
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f trusty
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@2b105575647a7e2030ff344d427c3920b89e17a9 utopic
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@ec15aea17b31eda47dc22f0c6ebbfebbe6094c1f utopic

--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,19 +1,19 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 10.04
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 12.04
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.04
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df 14.10
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@95554c91ed7f013d5a55d7d8a7372da13396a922 devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@b8758eac0f9c23c3b81e475c8b79ce8b469429df devel


### PR DESCRIPTION
Note that for ubuntu-debootstrap, this only includes a regeneration of 12.04 and 14.04 because 10.04 is not affected and 14.10/devel does not have the fix yet.

See https://bugs.launchpad.net/ubuntu/%2Bsource/apt/%2Bbug/1378680 to track Utopic's status.
