### PR TITLE
Add Travis badge to README and disable cache use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: bash
 # allow for use of Docker-based workers
 sudo: false
 
-# cache those huge source repos, if possible (since build.sh handles existing repos intelligently)
-cache:
-    directories:
-        - bashbrew/src
-
 # --no-build because we has no Docker in Travis :)
 script:
     - ./bashbrew/build.sh --no-build --all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Docker Official Images
 
+[![Build Status](https://travis-ci.org/docker-library/official-images.svg?branch=master)](https://travis-ci.org/docker-library/official-images)
+
 ## Contributing to the standard library
 
 Thank you for your interest in the Docker official images project! We


### PR DESCRIPTION
The cache takes about as long to copy into the build system as cloning the repos takes anyhow, so the benefits of using it are dubious at best.
