### PR TITLE
Clean up the clone/fetch output

### DIFF
--- a/bashbrew/build.sh
+++ b/bashbrew/build.sh
@@ -178,15 +178,15 @@ for repoTag in "${repos[@]}"; do
 		else
 			if [ ! -d "$gitRepo" ]; then
 				mkdir -p "$(dirname "$gitRepo")"
-				echo "Cloning '$gitUrl' into '$gitRepo' ..."
+				echo "Cloning $repo ($gitUrl) ..."
 				git clone -q "$gitUrl" "$gitRepo"
-				echo 'Cloned successfully!'
 			else
 				# if we don't have the "ref" specified, "git fetch" in the hopes that we get it
 				if ! (
 					cd "$gitRepo"
 					git rev-parse --verify "${gitRef}^{commit}" &> /dev/null
 				); then
+					echo "Fetching $repo ($gitUrl) ..."
 					(
 						cd "$gitRepo"
 						git fetch -q --all


### PR DESCRIPTION
This makes it match the other output we've got:

``` console
$ ./bashbrew/build.sh --no-build --all
Fetching java (git://github.com/docker-library/java) ...
Fetching node (git://github.com/docker-library/node) ...
Processing buildpack-deps:jessie ...
- deferred; FROM debian:jessie
Processing buildpack-deps:latest ...
- deferred; FROM debian:jessie
Processing buildpack-deps:wheezy ...
- deferred; FROM debian:wheezy
Processing busybox:buildroot-2013.08.1 ...
Processing busybox:buildroot-2014.02 ...
Processing busybox:latest ...
Processing busybox:ubuntu-12.04 ...
Processing busybox:ubuntu-14.04 ...
Processing centos:latest ...
Processing centos:centos7 ...
Processing centos:centos6 ...
Processing centos:centos5 ...
Processing cirros:latest ...
Processing cirros:0.3.0 ...
Processing clojure:latest ...
- deferred; FROM java:7
Processing clojure:lein-2.5.0 ...
- deferred; FROM java:7
Processing clojure:lein-2.4.3 ...
- deferred; FROM java:7
Processing crux:latest ...
Processing crux:3.0 ...
Processing debian:jessie ...
Processing debian:oldstable ...
Processing debian:sid ...
....
```
