### PR TITLE
Add a Mono image

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -1,0 +1,4 @@
+# maintainer: James Ottaway <docker@james.ottaway.io> (@jamesottaway)
+
+latest: git://github.com/jamesottaway/mono-docker@3.6.0
+3.6.0: git://github.com/jamesottaway/mono-docker@3.6.0


### PR DESCRIPTION
I've attempted to mimic the Ruby and Golang language packs to create one for Mono.

I've (hopefully only temporarily) added it to the public Docker Index under my account as a sanity check: https://registry.hub.docker.com/u/jamesottaway/mono/

The repo is currently hosted under my GitHub account (https://github.com/jamesottaway/mono-docker), but is there a way to move it under @docker-library?

The `README.md` also contains a reference to `jamesottaway/mono` as the image name, which I'm guessing I should change if this is merged.

Is there anything I've missed?
