### PR TITLE
An attempt at an official Haskell image

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,0 +1,4 @@
+# maintainer: Deni Bertovic <deni@denibertovic.com> (@denibertovic)
+
+latest: git://github.com/denibertovic/haskell@ccc95160285b25812ef8cf590ed2493a321882c7
+


### PR DESCRIPTION
It would be great if we had an official haskell image.

I'm making this PR as an attempt to get things rolling at least. 

A few notes. The way I envision the official haskell image is with only ghc and cabal inside. I see no reason one would need to install haskell platform in the image itself. If the users needs the platform they can inherit from this image and install whatever else is need, but it is my strong opinion that the base image should only have ghc and cabal in there. So the users can install the required libraries they need and build their code.

Currently there's on one tag `latest` but we can add others based on the ghc version we want to add. 

I'm happy to hear any thoughts and opinions on this matter.
