### PR TITLE
Update mongo, node, php, python, rails, ruby

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -3,8 +3,8 @@
 2.2.7: git://github.com/docker-library/mongo@2881be3e0d85b3600bda8d45050a2ceb3f7bb12b 2.2
 2.2: git://github.com/docker-library/mongo@2881be3e0d85b3600bda8d45050a2ceb3f7bb12b 2.2
 
-2.4.11: git://github.com/docker-library/mongo@2881be3e0d85b3600bda8d45050a2ceb3f7bb12b 2.4
-2.4: git://github.com/docker-library/mongo@2881be3e0d85b3600bda8d45050a2ceb3f7bb12b 2.4
+2.4.12: git://github.com/docker-library/mongo@6fcf234e0bd9b50cfbac267ccb451cb8500c8dfc 2.4
+2.4: git://github.com/docker-library/mongo@6fcf234e0bd9b50cfbac267ccb451cb8500c8dfc 2.4
 
 2.6.5: git://github.com/docker-library/mongo@bebabb72a2785d7b78309bf6be6c82bab882574b 2.6
 2.6: git://github.com/docker-library/mongo@bebabb72a2785d7b78309bf6be6c82bab882574b 2.6

--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.32: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10
-0.10: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10
-0: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10
-latest: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10
+0.10.32: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10
+0.10: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10
+0: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10
+latest: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10
 
 0.10.32-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.10/onbuild
 0.10-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.10/onbuild
 0-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.10/onbuild
 onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.10/onbuild
 
-0.10.32-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10/slim
-0.10-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10/slim
-0-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10/slim
-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.10/slim
+0.10.32-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10/slim
+0.10-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10/slim
+0-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10/slim
+slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.11
-0.11: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.11
+0.11.14: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.11
+0.11: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.11
 
 0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.11/slim
-0.11-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.11/slim
+0.11.14-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.11/slim
+0.11-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.8
-0.8: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.8
+0.8.28: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.8
+0.8: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.8
 
 0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.8/slim
-0.8-slim: git://github.com/docker-library/node@824c3161f9a7fa393cb60582edbbd713a0d08ceb 0.8/slim
+0.8.28-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.8/slim
+0.8-slim: git://github.com/docker-library/node@907d2001dc2d6d592f9ff5432ecd2f7e6cdca6ec 0.8/slim

--- a/library/php
+++ b/library/php
@@ -1,31 +1,31 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.33-cli: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4
-5.4-cli: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4
-5.4.33: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4
-5.4: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4
+5.4.34-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.4
+5.4-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.4
+5.4.34: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.4
+5.4: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.4
 
-5.4.33-apache: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4/apache
+5.4.34-apache: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4/apache
 5.4-apache: git://github.com/docker-library/php@9fc452451b227d1d20b77183cacc26906c9f669d 5.4/apache
 
-5.5.17-cli: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5
-5.5-cli: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5
-5.5.17: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5
-5.5: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5
+5.5.18-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.5
+5.5-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.5
+5.5.18: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.5
+5.5: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.5
 
-5.5.17-apache: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5/apache
+5.5.18-apache: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5/apache
 5.5-apache: git://github.com/docker-library/php@6527e41240379ce1112b629a505ef9752f42a64f 5.5/apache
 
-5.6.1-cli: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-5.6-cli: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-5-cli: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-cli: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-5.6.1: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-5.6: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-5: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
-latest: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6
+5.6.2-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+5.6-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+5-cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+cli: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+5.6.2: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+5.6: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+5: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
+latest: git://github.com/docker-library/php@f8a3ea57872453063f6416d1a1e92011daa19a0e 5.6
 
-5.6.1-apache: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6/apache
+5.6.2-apache: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6/apache
 5.6-apache: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6/apache
 5-apache: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6/apache
 apache: git://github.com/docker-library/php@524908779e1de87ab8fbd50f544c798782d8fc06 5.6/apache

--- a/library/python
+++ b/library/python
@@ -8,11 +8,11 @@
 2.7-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 
-3.3.5: git://github.com/docker-library/python@5da3b09cc56f1a431c912dcb1dc1d72efbd17409 3.3
-3.3: git://github.com/docker-library/python@5da3b09cc56f1a431c912dcb1dc1d72efbd17409 3.3
+3.3.6: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3
+3.3: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3
 
-3.3.5-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
-3.3-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 3.3/onbuild
+3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
+3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
 3.4.2: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
 3.4: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.6: git://github.com/docker-library/rails@7e32ae82ec83b21bffe89ae2b13fb4ad6ca60435
-4.1: git://github.com/docker-library/rails@7e32ae82ec83b21bffe89ae2b13fb4ad6ca60435
-4: git://github.com/docker-library/rails@7e32ae82ec83b21bffe89ae2b13fb4ad6ca60435
-latest: git://github.com/docker-library/rails@7e32ae82ec83b21bffe89ae2b13fb4ad6ca60435
+4.1.6: git://github.com/docker-library/rails@c5eaefb3e9e3ba382ff94241aedfe96a3635535c
+4.1: git://github.com/docker-library/rails@c5eaefb3e9e3ba382ff94241aedfe96a3635535c
+4: git://github.com/docker-library/rails@c5eaefb3e9e3ba382ff94241aedfe96a3635535c
+latest: git://github.com/docker-library/rails@c5eaefb3e9e3ba382ff94241aedfe96a3635535c
 
-onbuild: git://github.com/docker-library/rails@7e32ae82ec83b21bffe89ae2b13fb4ad6ca60435 onbuild
+onbuild: git://github.com/docker-library/rails@c5eaefb3e9e3ba382ff94241aedfe96a3635535c onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -1,29 +1,29 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.3-p547: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
-1.9.3: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
-1.9: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
-1: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 1.9
+1.9.3-p547: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9
+1.9.3: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9
+1.9: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9
+1: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9
 
-1.9.3-p547-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
-1.9.3-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
-1.9-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
-1-onbuild: git://github.com/docker-library/ruby@4938a7b4b5b62c90b5d387c9c286fd7749d9499e 1.9/onbuild
+1.9.3-p547-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9/onbuild
+1.9.3-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9/onbuild
+1.9-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9/onbuild
+1-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 1.9/onbuild
 
-2.0.0-p576: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
-2.0.0: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
-2.0: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0
+2.0.0-p576: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0
+2.0.0: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0
+2.0: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0
 
-2.0.0-p576-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
-2.0.0-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
-2.0-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.0/onbuild
+2.0.0-p576-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0/onbuild
+2.0.0-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0/onbuild
+2.0-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.0/onbuild
 
-2.1.3: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
-2.1: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
-2: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
-latest: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1
+2.1.3: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1
+2.1: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1
+2: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1
+latest: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1
 
-2.1.3-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
-2.1-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
-2-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
-onbuild: git://github.com/docker-library/ruby@50295f3a139273601b5f2df29060ee2788f067d3 2.1/onbuild
+2.1.3-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1/onbuild
+2.1-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1/onbuild
+2-onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1/onbuild
+onbuild: git://github.com/docker-library/ruby@f9a2625e38d17238b61b3eb084d84da2a1a4ea66 2.1/onbuild


### PR DESCRIPTION
For details of the ruby and rails changes, see https://github.com/docker-library/ruby/pull/21 and https://github.com/docker-library/rails/pull/12.
