### PR TITLE
updated crate repository to 0.44.7

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -2,6 +2,6 @@
 
 # see also https://crate.io
 
-latest: git://github.com/crate/docker-crate@0.44.6
-0.44: git://github.com/crate/docker-crate@0.44.6
-0.44.6: git://github.com/crate/docker-crate@0.44.6
+latest: git://github.com/crate/docker-crate@0.44.7
+0.44: git://github.com/crate/docker-crate@0.44.7
+0.44.7: git://github.com/crate/docker-crate@0.44.7


### PR DESCRIPTION
0.44.7 is the latest hotfix release for the CrateIO data store

changes: https://github.com/crate/crate/blob/0.44.7/CHANGES.txt
