### PR TITLE
Add httpd with upstream defaults and no php

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -1,0 +1,9 @@
+# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+
+2.2.29: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.2
+2.2: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.2
+
+2.4.10: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
+2.4: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
+2: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
+latest: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4


### PR DESCRIPTION
This repo still needs docs in docker-library/docs.  Also anything else in httpd itself?
