### PR TITLE
Added new openSUSE 13.2 image

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,5 +1,6 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
-latest: git://github.com/openSUSE/docker-containers-build@fc6453ff4ce5d67ed77aad572acbf311214b41dc docker
+latest: git://github.com/openSUSE/docker-containers-build@4a69fad7e0ce58bca406092938bd295c3c885858 docker
 13.1: git://github.com/openSUSE/docker-containers-build@fc6453ff4ce5d67ed77aad572acbf311214b41dc docker
+13.2: git://github.com/openSUSE/docker-containers-build@4a69fad7e0ce58bca406092938bd295c3c885858 docker
 bottle: git://github.com/openSUSE/docker-containers-build@fc6453ff4ce5d67ed77aad572acbf311214b41dc docker


### PR DESCRIPTION
It would be nice to have that merged by tomorrow (4th of November) because that's the release date of openSUSE 13.2.

Thanks
