### PR TITLE
Bump registry version

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -1,7 +1,8 @@
 # maintainer: Joffrey F <joffrey@docker.com> (@shin-)
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
-latest: git://github.com/docker/docker-registry@0.8.1
+latest: git://github.com/docker/docker-registry@0.9.0
 0.6.9: git://github.com/docker/docker-registry@0.6.9-fixed
 0.7.3: git://github.com/docker/docker-registry@0.7.3
 0.8.1: git://github.com/docker/docker-registry@0.8.1
+0.9.0: git://github.com/docker/docker-registry@0.9.0


### PR DESCRIPTION
0.9.0 is out.
