### PR TITLE
New registry version

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -1,7 +1,6 @@
 # maintainer: Joffrey F <joffrey@docker.com> (@shin-)
 # maintainer: Sam Alba <sam@dotcloud.com> (@samalba)
 
-latest: git://github.com/docker/docker-registry@0.8.1
-0.6.9: git://github.com/docker/docker-registry@0.6.9-fixed
-0.7.3: git://github.com/docker/docker-registry@0.7.3
+latest: git://github.com/docker/docker-registry@0.9.0
 0.8.1: git://github.com/docker/docker-registry@0.8.1
+0.9.0: git://github.com/docker/docker-registry@0.9.0


### PR DESCRIPTION
Added the latest (0.9) - 0.8 will receive active support for the time being, but older versions are not to receive any specific attention and users should really migrate to one of the two latest releases.
