### PR TITLE
Update docker-library images

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.33: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10
-0.10: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10
-0: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10
-latest: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10
+0.10.33: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10
+0.10: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10
+0: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10
+latest: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10
 
 0.10.33-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 0.10-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 0-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 
-0.10.33-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/slim
-0.10-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/slim
-0-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/slim
-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/slim
+0.10.33-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10/slim
+0.10-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10/slim
+0-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10/slim
+slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.11
-0.11: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.11
+0.11.14: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.11
+0.11: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.11
 
 0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.11/slim
-0.11-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.11/slim
+0.11.14-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.11/slim
+0.11-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.8
-0.8: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.8
+0.8.28: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.8
+0.8: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.8
 
 0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.8/slim
-0.8-slim: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.8/slim
+0.8.28-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.8/slim
+0.8-slim: git://github.com/docker-library/node@9078df001cc3de2713050d89bd9ba3c539845c6f 0.8/slim

--- a/library/php
+++ b/library/php
@@ -1,31 +1,31 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.34-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4
-5.4-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4
-5.4.34: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4
-5.4: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4
+5.4.34-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
+5.4-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
+5.4.34: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
+5.4: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
 
-5.4.34-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4/apache
-5.4-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.4/apache
+5.4.34-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4/apache
+5.4-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4/apache
 
-5.5.18-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5
-5.5-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5
-5.5.18: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5
-5.5: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5
+5.5.18-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
+5.5-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
+5.5.18: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
+5.5: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
 
-5.5.18-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5/apache
-5.5-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.5/apache
+5.5.18-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5/apache
+5.5-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5/apache
 
-5.6.2-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-5.6-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-5-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-cli: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-5.6.2: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-5.6: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-5: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
-latest: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6
+5.6.2-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5.6-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5.6.2: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5.6: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+latest: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
 
-5.6.2-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6/apache
-5.6-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6/apache
-5-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6/apache
-apache: git://github.com/docker-library/php@c1fe2a2c01a6fd31fc9c03315939229ab06a80e5 5.6/apache
+5.6.2-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
+5.6-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
+5-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
+apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache

--- a/library/redis
+++ b/library/redis
@@ -1,30 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.6.17
-2.6: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.6.17
+2.6.17: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.6
+2.6: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.6
 
-2.8.10: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.10
-
-2.8.11: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.11
-
-2.8.12: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.12
-
-2.8.13: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.13
-
-2.8.14: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.14
-
-2.8.15: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.15
-
-2.8.16: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.16
-
-2.8.17: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
-2.8: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
-latest: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.17
-
-2.8.6: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.6
-
-2.8.7: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.7
-
-2.8.8: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.8
-
-2.8.9: git://github.com/docker-library/redis@99c172e82ed81af441e13dd48dda2729e19493bc 2.8.9
+2.8.17: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.8
+2.8: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.8
+2: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.8
+latest: git://github.com/docker-library/redis@9e5054fef2e6d1fdd7035ecb4ed0ae68e10bd6d6 2.8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.0: git://github.com/docker-library/wordpress@850c1431664030da37e3054ba3679ca6f6c51fc9
-4.0: git://github.com/docker-library/wordpress@850c1431664030da37e3054ba3679ca6f6c51fc9
-4: git://github.com/docker-library/wordpress@850c1431664030da37e3054ba3679ca6f6c51fc9
-latest: git://github.com/docker-library/wordpress@850c1431664030da37e3054ba3679ca6f6c51fc9
+4.0.0: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
+4.0: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
+4: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
+latest: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c


### PR DESCRIPTION
- `node`: NPM 2.1.7
- `php`: cut image sizes roughly in half across the board (docker-library/php#36)
- `redis`: drop official support for versions upstream doesn't support (docker-library/redis#15)
- `wordpress`: fix `chown` issue (docker-library/wordpress#21)
