### PR TITLE
Update docker-dev for consistency with other repos

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,10 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-latest: git://github.com/docker/docker@v1.2.0
-v1.2.0: git://github.com/docker/docker@v1.2.0
-v1.2:   git://github.com/docker/docker@v1.2.0
+1.3.1: git://github.com/docker/docker@v1.3.1
+1.3: git://github.com/docker/docker@v1.3.1
+1: git://github.com/docker/docker@v1.3.1
+latest: git://github.com/docker/docker@v1.3.1
 
-v1.0.1: git://github.com/docker/docker@v1.0.1
-v1.0:   git://github.com/docker/docker@v1.0.1
-
-# "supported": one tag per major, only upstream-supported majors
+# "supported": one tag per major, only upstream-supported majors (which is currently only "latest")


### PR DESCRIPTION
This updates us to 1.3.1 and updates the tag format to bare version numbers instead of having the "v" prefix.
