### PR TITLE
CRUX: Updates to 3.0 and 3.1 packages

### DIFF
--- a/library/crux
+++ b/library/crux
@@ -1,5 +1,5 @@
 # maintainer: James Mills <prologic@shortcircuit.net.au> (@therealprologic)
 
-latest: git://github.com/therealprologic/docker-crux@7426533bc54154a9227bd8c983182c86bd2e319f
-3.1: git://github.com/therealprologic/docker-crux@7426533bc54154a9227bd8c983182c86bd2e319f
-3.0: git://github.com/therealprologic/docker-crux@91a99d9156b30d4af0b624be83042605ce1c91ab
+latest: git://github.com/therealprologic/docker-crux@46c53a82b42907e3954c792adb2f47e436b537ba
+3.1: git://github.com/therealprologic/docker-crux@46c53a82b42907e3954c792adb2f47e436b537ba
+3.0: git://github.com/therealprologic/docker-crux@7442b34f3c47665067abb0e8f724868f2899fc22


### PR DESCRIPTION
Also adds `/bin/bash` as default `CMD` for both 3.0 and 3.1 images.
