### PR TITLE
Update docker-library

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,23 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.8: git://github.com/docker-library/python@dbe3e241f4c3263a81a888896f5126861807b3db 2.7
-2.7: git://github.com/docker-library/python@dbe3e241f4c3263a81a888896f5126861807b3db 2.7
-2: git://github.com/docker-library/python@dbe3e241f4c3263a81a888896f5126861807b3db 2.7
+2.7.8: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
+2.7: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
+2: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
 
 2.7.8-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 
-3.3.6: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3
-3.3: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3
+3.3.6: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.3
+3.3: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
-3.4.2: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
-3.4: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
-3: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
-latest: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4
+3.4.2: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
+3.4: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
+3: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
+latest: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
 
 3.4.2-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -14,11 +14,11 @@
 7.0: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
 7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
 
-8.0.14-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-8.0.14: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-8.0: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-8: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
-latest: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 8-jre7
+8.0.15-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+8.0.15: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+8.0: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+8: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+latest: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7


### PR DESCRIPTION
- `python`: remove source and skip tests (docker-library/python#20)
- `tomcat`: 8.0.15
