### PR TITLE
Update docker-library

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,31 +1,31 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.34-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
-5.4-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
-5.4.34: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
-5.4: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4
+5.4.34-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4
+5.4-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4
+5.4.34: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4
+5.4: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4
 
-5.4.34-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4/apache
-5.4-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.4/apache
+5.4.34-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4/apache
+5.4-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.4/apache
 
-5.5.18-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
-5.5-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
-5.5.18: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
-5.5: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5
+5.5.18-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5
+5.5-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5
+5.5.18: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5
+5.5: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5
 
-5.5.18-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5/apache
-5.5-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.5/apache
+5.5.18-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5/apache
+5.5-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.5/apache
 
-5.6.2-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-5.6-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-5-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-cli: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-5.6.2: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-5.6: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-5: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
-latest: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6
+5.6.2-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+5.6-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+5-cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+cli: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+5.6.2: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+5.6: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+5: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
+latest: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6
 
-5.6.2-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
-5.6-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
-5-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
-apache: git://github.com/docker-library/php@cf2a4bcb5b7044f3db73eef4aa8d8e56e07cdf61 5.6/apache
+5.6.2-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6/apache
+5.6-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6/apache
+5-apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6/apache
+apache: git://github.com/docker-library/php@b2e1b8e2a37db419ae1244b9f63456b86f666ffe 5.6/apache

--- a/library/tomcat
+++ b/library/tomcat
@@ -7,12 +7,12 @@
 6.0: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
 6: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
 
-7.0.56-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
-7.0.56: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
-7.0: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
-7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 7-jre7
+7.0.57-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+7.0.57: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+7.0: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 
 8.0.15-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
 8.0-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.0: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
-4.0: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
-4: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
-latest: git://github.com/docker-library/wordpress@8a3f1826ecd05b20a1e903bf250cc836c7b9657c
+4.0.0: git://github.com/docker-library/wordpress@c1fbc8c0fca1a9c3e2c10aefaa4b205ec916ba56
+4.0: git://github.com/docker-library/wordpress@c1fbc8c0fca1a9c3e2c10aefaa4b205ec916ba56
+4: git://github.com/docker-library/wordpress@c1fbc8c0fca1a9c3e2c10aefaa4b205ec916ba56
+latest: git://github.com/docker-library/wordpress@c1fbc8c0fca1a9c3e2c10aefaa4b205ec916ba56


### PR DESCRIPTION
- `php`: fix some Apache woes (docker-library/php#43), and add `docker-php-ext-install` and `docker-php-ext-configure` (docker-library/php#41)
- `tomcat`: 7.0.57
- `wordpress`: push more of the PHP+Apache logic into `php` where it belongs (docker-library/wordpress#25), and update the image to use the new `docker-php-ext-install` magic for the extra core extensions it needs (docker-library/wordpress#26)
