### PR TITLE
fedora 21 releng-issued image

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -3,5 +3,5 @@
 latest: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
 20: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
 heisenbug: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
-21: git://github.com/lsm5/docker-brew-fedora@897d815f95a4c31d839050b73bf6e87ae1647848
+21: git://github.com/lsm5/docker-brew-fedora@606897f6b35f4e77b4b386135128385018a7412c
 rawhide: git://github.com/lsm5/docker-brew-fedora@c713b5ab5373e80f8e2cecc52390ff7328922417


### PR DESCRIPTION
Image info available here:
http://koji.fedoraproject.org/koji/taskinfo?taskID=7978938

The gz tarball on this page contains the rootfs and metadata.

The xz tarball available at
lsm5/docker-brew-fedora@606897f6b35f4e77b4b386135128385018a7412c
only includes the rootfs.

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org

```
modified:   library/fedora
```
