### PR TITLE
updated crate version to 0.45.4

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -2,8 +2,8 @@
 
 # see also https://crate.io
 
-latest: git://github.com/crate/docker-crate@0.45.2
+latest: git://github.com/crate/docker-crate@0.45.4
 0.44: git://github.com/crate/docker-crate@0.44.8
 0.44.8: git://github.com/crate/docker-crate@0.44.8
-0.45: git://github.com/crate/docker-crate@0.45.2
-0.45.2: git://github.com/crate/docker-crate@0.45.2
+0.45: git://github.com/crate/docker-crate@0.45.4
+0.45.4: git://github.com/crate/docker-crate@0.45.4


### PR DESCRIPTION
regarding supported version see https://github.com/docker-library/official-images/pull/307#issuecomment-63022649
