### PR TITLE
Add Datadog to library

### DIFF
--- a/library/datadog
+++ b/library/datadog
@@ -1,0 +1,4 @@
+# maintainer: Datadog <package@datadoghq.com> (@DataDog)
+
+latest: git://github.com/DataDog/docker-dd-agent@01140d8272c0ceb6c16dbafd724a92b84814b091
+5.0.5: git://github.com/DataDog/docker-dd-agent@01140d8272c0ceb6c16dbafd724a92b84814b091


### PR DESCRIPTION
First official container for the Datadog Agent.
Based on Agent 5.0.5.

I don't know what's the exact tagging policy, but because there is no reason to freeze the Datadog Agent to a specific major or minor version, the tag is there as an "indication" (that's why there is no "5" or "5.0" version).

Corresponding docs PR:
https://github.com/docker-library/docs/pull/104