### PR TITLE
Update docker-library

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,6 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-jessie: git://github.com/docker-library/docker-buildpack-deps@a201b127ddf29f47738a9fd04b2f004eb41b009f jessie
-latest: git://github.com/docker-library/docker-buildpack-deps@a201b127ddf29f47738a9fd04b2f004eb41b009f jessie
+jessie-micro: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad jessie/micro
+micro: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad jessie/micro
 
-wheezy: git://github.com/docker-library/docker-buildpack-deps@a201b127ddf29f47738a9fd04b2f004eb41b009f wheezy
+jessie: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad jessie
+latest: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad jessie
+
+wheezy-micro: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad wheezy/micro
+
+wheezy: git://github.com/docker-library/docker-buildpack-deps@fc4bb937881466a88e408f660ce4d8ad18c11bad wheezy

--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.33: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10
-0.10: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10
-0: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10
-latest: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10
+0.10.33: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10
+0.10: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10
+0: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10
+latest: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10
 
 0.10.33-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 0.10-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 0-onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 onbuild: git://github.com/docker-library/node@806873187edbff36d7fc294a62131f4f28fa681a 0.10/onbuild
 
-0.10.33-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10/slim
-0.10-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10/slim
-0-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10/slim
-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.10/slim
+0.10.33-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10/slim
+0.10-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10/slim
+0-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10/slim
+slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.11
-0.11: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.11
+0.11.14: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.11
+0.11: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.11
 
 0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.11/slim
-0.11-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.11/slim
+0.11.14-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.11/slim
+0.11-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.8
-0.8: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.8
+0.8.28: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.8
+0.8: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.8
 
 0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.8/slim
-0.8-slim: git://github.com/docker-library/node@013858ac35afb9ca7b10102956427b629e7708da 0.8/slim
+0.8.28-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.8/slim
+0.8-slim: git://github.com/docker-library/node@57dd55534374b98309c13cd19e00691f5479ddf0 0.8/slim

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.35-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4
-5.4-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4
-5.4.35: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4
-5.4: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4
+5.4.35-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4
+5.4-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4
+5.4.35: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4
+5.4: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4
 
-5.4.35-apache: git://github.com/docker-library/php@583557dc05de007ee5701d0a92c400fd397c8970 5.4/apache
-5.4-apache: git://github.com/docker-library/php@583557dc05de007ee5701d0a92c400fd397c8970 5.4/apache
+5.4.35-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.4/apache
+5.4-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.4/apache
 
-5.4.35-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.4/fpm
+5.4.35-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.4/fpm
 
-5.5.19-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5
-5.5-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5
-5.5.19: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5
-5.5: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5
+5.5.19-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5
+5.5-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5
+5.5.19: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5
+5.5: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5
 
-5.5.19-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.5/apache
-5.5-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.5/apache
+5.5.19-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.5/apache
+5.5-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.5/apache
 
-5.5.19-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.5/fpm
+5.5.19-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.5/fpm
 
-5.6.3-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-5.6-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-5-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-cli: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-5.6.3: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-5.6: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-5: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
-latest: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6
+5.6.3-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+5.6-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+5-cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+cli: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+5.6.3: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+5.6: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+5: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
+latest: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6
 
-5.6.3-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.6/apache
-5.6-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.6/apache
-5-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.6/apache
-apache: git://github.com/docker-library/php@18b5d0884c45f30d54bd0eca22352df7fc9fb0d8 5.6/apache
+5.6.3-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.6/apache
+5.6-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.6/apache
+5-apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.6/apache
+apache: git://github.com/docker-library/php@58c3fd175cb3ab30633fbc3e86314154ecc38e89 5.6/apache
 
-5.6.3-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6/fpm
-5-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6/fpm
-fpm: git://github.com/docker-library/php@9bb0b224807e03fff64574d0e76ed3e6e7d2ef26 5.6/fpm
+5.6.3-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6/fpm
+5-fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6/fpm
+fpm: git://github.com/docker-library/php@4a5d6cfe6902d86bea3f040c868b64712e94e7c1 5.6/fpm

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.4.4: git://github.com/docker-library/sentry@e369849d190fe69c8d59793eb619258a772664f0
-6.4: git://github.com/docker-library/sentry@e369849d190fe69c8d59793eb619258a772664f0
-6: git://github.com/docker-library/sentry@e369849d190fe69c8d59793eb619258a772664f0
-latest: git://github.com/docker-library/sentry@e369849d190fe69c8d59793eb619258a772664f0
+6.4.4: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
+6.4: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
+6: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
+latest: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.41-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
-6.0.41: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
-6.0: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
-6: git://github.com/docker-library/tomcat@2c7c55c923a12607c527186fad50e6f42c3f9d6b 6-jre7
+6.0.43-jre7: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
+6.0-jre7: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
+6-jre7: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
+6.0.43: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
+6.0: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
+6: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
 
 7.0.57-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7.0-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.0: git://github.com/docker-library/wordpress@79e4e8cb26caf6e5ca071248567bebfcf46c991b
-4.0: git://github.com/docker-library/wordpress@79e4e8cb26caf6e5ca071248567bebfcf46c991b
-4: git://github.com/docker-library/wordpress@79e4e8cb26caf6e5ca071248567bebfcf46c991b
-latest: git://github.com/docker-library/wordpress@79e4e8cb26caf6e5ca071248567bebfcf46c991b
+4.0.1: git://github.com/docker-library/wordpress@0c7d43082446a5a9741ca6812cf1ac92bb6697dd
+4.0: git://github.com/docker-library/wordpress@0c7d43082446a5a9741ca6812cf1ac92bb6697dd
+4: git://github.com/docker-library/wordpress@0c7d43082446a5a9741ca6812cf1ac92bb6697dd
+latest: git://github.com/docker-library/wordpress@0c7d43082446a5a9741ca6812cf1ac92bb6697dd


### PR DESCRIPTION
- `buildpack-deps`: add `micro` variant without development headers
- `node`: NPM 2.1.9
- `php`: `zend_extension` loading in `docker-php-ext-install`, especially for `opcache`
- `sentry`: just `REAMDE.md` stub - figured I'd just update to get it out of the way :)
- `tomcat`: 6.0.43
- `wordpress`: 4.0.1
