### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-1.3.1: git://github.com/docker/docker@v1.3.1
-1.3: git://github.com/docker/docker@v1.3.1
-1: git://github.com/docker/docker@v1.3.1
-latest: git://github.com/docker/docker@v1.3.1
+1.3.2: git://github.com/docker/docker@v1.3.2
+1.3: git://github.com/docker/docker@v1.3.2
+1: git://github.com/docker/docker@v1.3.2
+latest: git://github.com/docker/docker@v1.3.2
 
 # "supported": one tag per major, only upstream-supported majors (which is currently only "latest")

--- a/library/golang
+++ b/library/golang
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.2.2: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.2
-1.2: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.2
+1.2.2: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.2
+1.2: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.2
 
 1.2.2-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/onbuild
 1.2-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.2/onbuild
@@ -10,10 +10,10 @@
 1.2.2-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.2/cross
 1.2-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.2/cross
 
-1.3.3: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3
-1.3: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3
-1: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3
-latest: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3
+1.3.3: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
+1.3: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
+1: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
+latest: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
 
 1.3.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
 1.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
@@ -25,13 +25,13 @@ onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc
 1-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 
-1.3.3-wheezy: git://github.com/docker-library/golang@af4e450a47a99f9a4f56225cdf598f552907d946 1.3/wheezy
-1.3-wheezy: git://github.com/docker-library/golang@af4e450a47a99f9a4f56225cdf598f552907d946 1.3/wheezy
-1-wheezy: git://github.com/docker-library/golang@af4e450a47a99f9a4f56225cdf598f552907d946 1.3/wheezy
-wheezy: git://github.com/docker-library/golang@af4e450a47a99f9a4f56225cdf598f552907d946 1.3/wheezy
+1.3.3-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
+1.3-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
+1-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
+wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
 
-1.4rc1: git://github.com/docker-library/golang@898bf4174e6a575ae311d14a23f96b4f6724ee13 1.4
-1.4: git://github.com/docker-library/golang@898bf4174e6a575ae311d14a23f96b4f6724ee13 1.4
+1.4rc1: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.4
+1.4: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.4
 
 1.4rc1-onbuild: git://github.com/docker-library/golang@1bab172aa5ca0675891ca58411f067a1b95a10d6 1.4/onbuild
 1.4-onbuild: git://github.com/docker-library/golang@1bab172aa5ca0675891ca58411f067a1b95a10d6 1.4/onbuild
@@ -39,5 +39,5 @@ wheezy: git://github.com/docker-library/golang@af4e450a47a99f9a4f56225cdf598f552
 1.4rc1-cross: git://github.com/docker-library/golang@898bf4174e6a575ae311d14a23f96b4f6724ee13 1.4/cross
 1.4-cross: git://github.com/docker-library/golang@898bf4174e6a575ae311d14a23f96b4f6724ee13 1.4/cross
 
-1.4rc1-wheezy: git://github.com/docker-library/golang@1bab172aa5ca0675891ca58411f067a1b95a10d6 1.4/wheezy
-1.4-wheezy: git://github.com/docker-library/golang@1bab172aa5ca0675891ca58411f067a1b95a10d6 1.4/wheezy
+1.4rc1-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.4/wheezy
+1.4-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.4/wheezy

--- a/library/python
+++ b/library/python
@@ -1,25 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.8: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
-2.7: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
-2: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 2.7
+2.7.8: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7
+2.7: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7
+2: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7
 
 2.7.8-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@a30ed3056ee58ca3df4fd5b51e3d30849dcb7e32 2.7/onbuild
 
-3.3.6: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.3
-3.3: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.3
+2.7.8-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7/slim
+2.7-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7/slim
+2-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 2.7/slim
+
+3.3.6: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.3
+3.3: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
-3.4.2: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
-3.4: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
-3: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
-latest: git://github.com/docker-library/python@ce7da0b874784e6b69e3966b5d7ba995e873163e 3.4
+3.3.6-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.3/slim
+3.3-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.3/slim
+
+3.4.2: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4
+3.4: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4
+3: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4
+latest: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4
 
 3.4.2-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
 onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
+
+3.4.2-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4/slim
+3.4-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4/slim
+3-slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4/slim
+slim: git://github.com/docker-library/python@01d97288839cc467b848dc425138a865568fe25c 3.4/slim

--- a/library/tomcat
+++ b/library/tomcat
@@ -7,12 +7,20 @@
 6.0: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
 6: git://github.com/docker-library/tomcat@452e2d4dcb58e3d044a6288befab6d717f94590e 6-jre7
 
+6.0.43-jre8: git://github.com/docker-library/tomcat@e826a7e6953f03f8fa03a9faed70721d6de1d3df 6-jre8
+6.0-jre8: git://github.com/docker-library/tomcat@e826a7e6953f03f8fa03a9faed70721d6de1d3df 6-jre8
+6-jre8: git://github.com/docker-library/tomcat@e826a7e6953f03f8fa03a9faed70721d6de1d3df 6-jre8
+
 7.0.57-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7.0-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7-jre7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7.0.57: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7.0: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
 7: git://github.com/docker-library/tomcat@88b51c6d19c83b689221d5eb2e9489d9d36ed8db 7-jre7
+
+7.0.57-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 7-jre8
 
 8.0.15-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
 8.0-jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
@@ -22,3 +30,8 @@ jre7: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706
 8.0: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
 8: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
 latest: git://github.com/docker-library/tomcat@aff42b3c40f2dff08b421fce66b81983706bfc50 8-jre7
+
+8.0.15-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 8-jre8
+jre8: git://github.com/docker-library/tomcat@9c2fb18446d9e6841997362e575804da73f23eee 8-jre8


### PR DESCRIPTION
- `docker-dev`: `1.3.2`
- `golang`: support for Go 1.4 "Custom Import Paths" (docker-library/golang#32)
- `python`: smaller and `--enable-shared` (docker-library/python#23); slim variants (docker-library/python#24)
- `tomcat`: jre8 versions (docker-library/tomcat#5)
