### PR TITLE
Add thrift

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -1,4 +1,4 @@
-# maintainer: Adam Hwkins <adam@hawkins.io> (@adman65)
+# maintainer: Adam Hawkins <adam@hawkins.io> (@ahawkins)
 
 0.9: git://github.com/ahawkins/docker-thrift@a44afdab68eaf2a930e46809fac1c0a2d4355908 0.9
 0.9.2: git://github.com/ahawkins/docker-thrift@a44afdab68eaf2a930e46809fac1c0a2d4355908 0.9


### PR DESCRIPTION
Corresponding documentation in docker-library/docs#114. I think it's possible to backbuild old versions, but not sure how to accomplish this task in the context of the official images.
