### PR TITLE
Update ubuntu to use the shiny new tarballs from https://partner-images.canonical.com/core/

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,20 +1,22 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-# see https://wiki.ubuntu.com/Core#Current_Releases
+# see https://partner-images.canonical.com/core/
 # see also https://wiki.ubuntu.com/Releases#Current
-# see also http://cdimage.ubuntu.com/ubuntu-core/
 
 # commits: (master..dist)
-#  - b3d5822 20141125 tarballs
+#  - d87d411 20141204 tarballs
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 precise
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 trusty
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 trusty
 
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@b3d5822d7fa42d27cbf32e5fcc0b97b02c007618 vivid
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 utopic
+
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@d87d4118b02bdc65995387b83d6544e90ff55586 vivid


### PR DESCRIPTION
These will be _much_ better supported. :+1: :heart: (and `utopic` is back, :tada:)
