### PR TITLE
Fedora 21 release image, point fedora:latest to 21

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,7 +1,7 @@
 # maintainer: Lokesh Mandvekar <lsm5@fedoraproject.org> (@lsm5)
 
-latest: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
-20: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
-heisenbug: git://github.com/lsm5/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
-21: git://github.com/lsm5/docker-brew-fedora@606897f6b35f4e77b4b386135128385018a7412c
-rawhide: git://github.com/lsm5/docker-brew-fedora@c713b5ab5373e80f8e2cecc52390ff7328922417
+latest: git://github.com/fedora-cloud/docker-brew-fedora@817c0f532d35a4996f04aca58f49cdc8408ed04d
+21: git://github.com/fedora-cloud/docker-brew-fedora@817c0f532d35a4996f04aca58f49cdc8408ed04d
+rawhide: git://github.com/fedora-cloud/docker-brew-fedora@c713b5ab5373e80f8e2cecc52390ff7328922417
+20: git://github.com/fedora-cloud/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9
+heisenbug: git://github.com/fedora-cloud/docker-brew-fedora@f0e71344fcf117e2c2ea8e6aadd7ef16112835f9


### PR DESCRIPTION
The official fedora 21 image koji build can be found here:
http://koji.fedoraproject.org/koji/taskinfo?taskID=8289768

This commit also points fedora:latest to fedora:21

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org
