### PR TITLE
Cosmetics

### DIFF
--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -53,21 +53,6 @@ push options:
 EOUSAGE
 }
 
-# which subcommand
-subcommand="$1"
-case "$subcommand" in
-	build|push)
-		shift
-		;;
-	*)
-		{
-			echo "error: unknown subcommand: $1"
-			usage
-		} >&2
-		exit 1
-		;;
-esac
-
 # arg handling
 opts="$(getopt -o 'h?' --long 'all,docker:,help,library:,logs:,namespaces:,no-build,no-clone,no-push,src:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
@@ -100,6 +85,21 @@ while true; do
 			;;
 	esac
 done
+
+# which subcommand
+subcommand="$1"
+case "$subcommand" in
+	build|push)
+		shift
+		;;
+	*)
+		{
+			echo "error: unknown subcommand: $1"
+			usage
+		} >&2
+		exit 1
+		;;
+esac
 
 repos=()
 if [ "$buildAll" ]; then


### PR DESCRIPTION
PERTY:

``` console
$ bashbrew --help

usage: bashbrew [build|push] [options] [repo[:tag] ...]
   ie: bashbrew build --all
       bashbrew push debian ubuntu:12.04

This script processes the specified Docker images using the corresponding
repository manifest files.

common options:
  --all              Build all repositories specified in library
  --docker="docker"
                     Use a custom Docker binary
  --help, -h, -?     Print this help message
  --library="/home/tianon/docker/stackbrew/library"
                     Where to find repository manifest files
  --logs="/home/tianon/docker/stackbrew/bashbrew/logs"
                     Where to store the build logs
  --namespaces="library stackbrew"
                     Space separated list of namespaces to tag images in after
                     building

build options:
  --no-build         Don't build, print what would build
  --no-clone         Don't pull/clone Git repositories
  --src="/home/tianon/docker/stackbrew/bashbrew/src"
                     Where to store cloned Git repositories (GOPATH style)

push options:
  --no-push          Don't push, print what would push

```
