### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,0 +1,20 @@
+# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+
+1.7.1-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
+1.7-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
+1-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
+python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
+
+python2-onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7/onbuild
+
+1.7.1-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1.7.1: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1.7-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1.7: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+latest: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+
+python3-onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4/onbuild
+onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4/onbuild

--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-1.3.3: git://github.com/docker/docker@v1.3.3
-1.3: git://github.com/docker/docker@v1.3.3
-1: git://github.com/docker/docker@v1.3.3
-latest: git://github.com/docker/docker@v1.3.3
+1.4.1: git://github.com/docker/docker@v1.4.1
+1.4: git://github.com/docker/docker@v1.4.1
+1: git://github.com/docker/docker@v1.4.1
+latest: git://github.com/docker/docker@v1.4.1
 
 # "supported": one tag per major, only upstream-supported majors (which is currently only "latest")

--- a/library/gcc
+++ b/library/gcc
@@ -6,8 +6,8 @@
 4.7.4: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.7
 4.7: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.7
 
-4.8.3: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.8
-4.8: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.8
+4.8.4: git://github.com/docker-library/gcc@fc4dbbf38ef4fa1120036fe9f59504e5ebc70223 4.8
+4.8: git://github.com/docker-library/gcc@fc4dbbf38ef4fa1120036fe9f59504e5ebc70223 4.8
 
 4.9.2: git://github.com/docker-library/gcc@af77dacbf20f2346a98978d0102db0da0670ea76 4.9
 4.9: git://github.com/docker-library/gcc@af77dacbf20f2346a98978d0102db0da0670ea76 4.9

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,6 +8,6 @@ latest: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed
 10.1.2: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.1
 10.1: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.1
 
-5.5.40: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 5.5
-5.5: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 5.5
-5: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 5.5
+5.5.41: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5
+5.5: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5
+5: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -11,6 +11,6 @@
 2: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
 latest: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
 
-2.8.0-rc3: git://github.com/docker-library/mongo@6b7aa64a4a991a3694dfb019865721c6343284c2 2.8
-2.8.0: git://github.com/docker-library/mongo@6b7aa64a4a991a3694dfb019865721c6343284c2 2.8
-2.8: git://github.com/docker-library/mongo@6b7aa64a4a991a3694dfb019865721c6343284c2 2.8
+2.8.0-rc4: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8
+2.8.0: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8
+2.8: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8

--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.34: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10
-0.10: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10
-0: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10
-latest: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10
+0.10.35: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
+0.10: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
+0: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
+latest: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
 
-0.10.34-onbuild: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/onbuild
-0.10-onbuild: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/onbuild
-0-onbuild: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/onbuild
-onbuild: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/onbuild
+0.10.35-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
+0.10-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
+0-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
+onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
 
-0.10.34-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/slim
-0.10-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/slim
-0-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/slim
-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.10/slim
+0.10.35-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
+0.10-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
+0-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
+slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.11
-0.11: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.11
+0.11.14: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11
+0.11: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11
 
 0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.11/slim
-0.11-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.11/slim
+0.11.14-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11/slim
+0.11-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.8
-0.8: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.8
+0.8.28: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8
+0.8: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8
 
 0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.8/slim
-0.8-slim: git://github.com/docker-library/node@70741d88bf688389bfac7b147573f3b761f9ede9 0.8/slim
+0.8.28-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8/slim
+0.8-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8/slim

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 8.4
-8.4: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 8.4
-8: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 8.4
+8.4.22: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
+8.4: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
+8: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
 
-9.0.18: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.0
-9.0: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.0
+9.0.18: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.0
+9.0: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.0
 
-9.1.14: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.1
-9.1: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.1
+9.1.14: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.1
+9.1: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.1
 
-9.2.9: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.2
-9.2: git://github.com/docker-library/postgres@e30347e48b1f1528fccf4d26efea5834ae9b2869 9.2
+9.2.9: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.2
+9.2: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.2
 
-9.3.5: git://github.com/docker-library/postgres@bfa7152926890a27e9fd8925fdffa824c353480a 9.3
-9.3: git://github.com/docker-library/postgres@bfa7152926890a27e9fd8925fdffa824c353480a 9.3
+9.3.5: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.3
+9.3: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.3
 
-9.4.0: git://github.com/docker-library/postgres@5f401753715311752f2346cdbd32bd55e7251ddd 9.4
-9.4: git://github.com/docker-library/postgres@5f401753715311752f2346cdbd32bd55e7251ddd 9.4
-9: git://github.com/docker-library/postgres@5f401753715311752f2346cdbd32bd55e7251ddd 9.4
-latest: git://github.com/docker-library/postgres@5f401753715311752f2346cdbd32bd55e7251ddd 9.4
+9.4.0: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
+9.4: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
+9: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
+latest: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.8: git://github.com/docker-library/rails@4cb183520d97f8bfe1828604397c1af8533a465d
-4.1: git://github.com/docker-library/rails@4cb183520d97f8bfe1828604397c1af8533a465d
-4: git://github.com/docker-library/rails@4cb183520d97f8bfe1828604397c1af8533a465d
-latest: git://github.com/docker-library/rails@4cb183520d97f8bfe1828604397c1af8533a465d
+4.2.0: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
+4.2: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
+4: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
+latest: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
 
-onbuild: git://github.com/docker-library/rails@cedbbc335ac4520c838e2921257ad1809c734c9a onbuild
+onbuild: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814 onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -29,27 +29,24 @@
 
 2.1.5: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1
 2.1: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1
-2: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1
-latest: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1
 
 2.1.5-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
-2-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 
 2.1.5-wheezy: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1/wheezy
 2.1-wheezy: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1/wheezy
-2-wheezy: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1/wheezy
-wheezy: git://github.com/docker-library/ruby@7d72919217b5d99d085d485d57fad273a2a644b8 2.1/wheezy
 
-2.2.0-rc1: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2
-2.2.0: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2
-2.2: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2
+2.2.0: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2
+2.2: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2
+2: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2
+latest: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2
 
-2.2.0-rc1-onbuild: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/onbuild
-2.2.0-onbuild: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/onbuild
-2.2-onbuild: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/onbuild
+2.2.0-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
+2.2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
+2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
+onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
 
-2.2.0-rc1-wheezy: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/wheezy
-2.2.0-wheezy: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/wheezy
-2.2-wheezy: git://github.com/docker-library/ruby@991bdc9cfbf6b1f1bc93dbcc9fc24d3507192afb 2.2/wheezy
+2.2.0-wheezy: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/wheezy
+2.2-wheezy: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/wheezy
+2-wheezy: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/wheezy
+wheezy: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/wheezy


### PR DESCRIPTION
- `django`: brand new image! :tada:
- `docker-dev`: 1.4.1
- `gcc`: 4.8.4
- `mariadb`: 5.5.41
- `node`: 0.10.35 and NPM 2.1.14
- `postgres`: minor formatting/output changes
- `rails`: 4.2.0
