### PR TITLE
Oracle Linux base images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,12 +1,10 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
-
 # Oracle Linux 7
-7: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/7.0
-7.0: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/7.0
-latest: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/7.0
+7: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
+7.0: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/6.6
-6.6: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/6.6
-6.5: git://github.com/oracle/docker-images.git@b06c8e24c6afa8d9f0a00c4ca50a7d7422eae97b OracleLinux/6.5
+6: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/6.6
+6.6: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/6.6


### PR DESCRIPTION
Initial commit of Oracle Linux 6.5, 6.6 and 7.0 to the Docker official library.

Signed-off-by: Avi Miller avi.miller@oracle.com
