### PR TITLE
Update debian to fix duplicated tag

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,33 +1,31 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - a130964 2014-12-31 debootstraps
+#  - 9a6aebe 2014-12-31 debootstraps
 
-8.0: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a jessie
-8: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a jessie
-jessie: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a jessie
+8.0: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 jessie
+8: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 jessie
+jessie: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 oldstable
 
-8.0: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a sid
-8: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a sid
-sid: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a sid
+sid: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a squeeze
-6.0: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a squeeze
-6: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 squeeze
+6: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a stable
+stable: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 stable
 
-testing: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a testing
+testing: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a unstable
+unstable: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 unstable
 
-7.7: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a wheezy
-7: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a wheezy
-latest: git://github.com/tianon/docker-brew-debian@a13096487c65c924e476d86547c1578e711d3d2a wheezy
+7.7: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 wheezy
+7: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 wheezy
+latest: git://github.com/tianon/docker-brew-debian@9a6aebe153f72ffc623a7f692625c2b69b3ccb50 wheezy
 
 rc-buggy: git://github.com/tianon/dockerfiles@4f5e47f39b90308b6aadf115b5469891b4bfbb37 debian/rc-buggy
 experimental: git://github.com/tianon/dockerfiles@4f5e47f39b90308b6aadf115b5469891b4bfbb37 debian/experimental


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/pull/382, which will prevent future occurrances of this problem. :angel: