### PR TITLE
Update thrift images with gofmt fix

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -1,5 +1,5 @@
 # maintainer: Adam Hawkins <adam@hawkins.io> (@ahawkins)
 
-0.9: git://github.com/ahawkins/docker-thrift@a44afdab68eaf2a930e46809fac1c0a2d4355908 0.9
-0.9.2: git://github.com/ahawkins/docker-thrift@a44afdab68eaf2a930e46809fac1c0a2d4355908 0.9
-latest: git://github.com/ahawkins/docker-thrift@a44afdab68eaf2a930e46809fac1c0a2d4355908 0.9
+0.9: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9
+0.9.2: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9
+latest: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9


### PR DESCRIPTION
I'm unsure if it's allowed to update the commit for a previously used tag. The referenced commit adds `gofmt` which is optional when generating go code. The `thrift` command still works, just generated a bunch of warnings. This should be a transparent change for any previous users.