### PR TITLE
Changes for docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.7.1-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
-1.7-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
-1-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
+1.7.2-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
+1.7-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
+1-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
+python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
 
 python2-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7/onbuild
 
-1.7.1-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-1.7.1: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-1.7-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-1.7: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-1-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-1: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
-latest: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1.7.2-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1.7.2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1.7-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1.7: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+latest: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
 
 python3-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild
 onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.7.1-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
-1.7-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
-1-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
-python2: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7
+1.7.1-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
+1.7-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
+1-python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
+python2: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7
 
-python2-onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 2.7/onbuild
+python2-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7/onbuild
 
-1.7.1-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-1.7.1: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-1.7-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-1.7: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-1-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-1: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-python3: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
-latest: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4
+1.7.1-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1.7.1: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1.7-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1.7: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1-python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+1: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+python3: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
+latest: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4
 
-python3-onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4/onbuild
-onbuild: git://github.com/docker-library/django@bb3c2e2bf12906c37330602b70d8b8398bf734b9 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild
+onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild

--- a/library/gcc
+++ b/library/gcc
@@ -1,14 +1,14 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.6.4: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.6
-4.6: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.6
+4.6.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.6
+4.6: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.6
 
-4.7.4: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.7
-4.7: git://github.com/docker-library/gcc@ba6f069df8e6c838d0465b09215e96f8d5d65269 4.7
+4.7.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.7
+4.7: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.7
 
-4.8.4: git://github.com/docker-library/gcc@fc4dbbf38ef4fa1120036fe9f59504e5ebc70223 4.8
-4.8: git://github.com/docker-library/gcc@fc4dbbf38ef4fa1120036fe9f59504e5ebc70223 4.8
+4.8.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.8
+4.8: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.8
 
-4.9.2: git://github.com/docker-library/gcc@af77dacbf20f2346a98978d0102db0da0670ea76 4.9
-4.9: git://github.com/docker-library/gcc@af77dacbf20f2346a98978d0102db0da0670ea76 4.9
-latest: git://github.com/docker-library/gcc@af77dacbf20f2346a98978d0102db0da0670ea76 4.9
+4.9.2: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9
+4.9: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9
+latest: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9

--- a/library/haproxy
+++ b/library/haproxy
@@ -3,7 +3,7 @@
 1.4.25: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.4
 1.4: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.4
 
-1.5.9: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.5
-1.5: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.5
-1: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.5
-latest: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.5
+1.5.10: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
+1.5: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
+1: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
+latest: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.29: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.2
-2.2: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.2
+2.2.29: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.2
+2.2: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.2
 
-2.4.10: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
-2.4: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
-2: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
-latest: git://github.com/docker-library/httpd@79fef78cd5440f55d181cfb5a9ababbc0c01ce4a 2.4
+2.4.10: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
+2.4: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
+2: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
+latest: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.15: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.0
-10.0: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.0
-10: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.0
-latest: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.0
+10.0.15: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.0
+10.0: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.0
+10: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.0
+latest: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.0
 
-10.1.2: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.1
-10.1: git://github.com/docker-library/mariadb@cbcee5a22e2be955f6597486465465ed82185698 10.1
+10.1.2: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.1
+10.1: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.1
 
-5.5.41: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5
-5.5: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5
-5: git://github.com/docker-library/mariadb@1c635c60703014571543ef2c23322fc518243d0d 5.5
+5.5.41: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5
+5.5: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5
+5: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@bb4bf3a053adaebc5c417e42d256940b7a1b3c08 2.2
-2.2: git://github.com/docker-library/mongo@bb4bf3a053adaebc5c417e42d256940b7a1b3c08 2.2
+2.2.7: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.2
+2.2: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.2
 
-2.4.12: git://github.com/docker-library/mongo@bb4bf3a053adaebc5c417e42d256940b7a1b3c08 2.4
-2.4: git://github.com/docker-library/mongo@bb4bf3a053adaebc5c417e42d256940b7a1b3c08 2.4
+2.4.12: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.4
+2.4: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.4
 
-2.6.6: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
-2.6: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
-2: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
-latest: git://github.com/docker-library/mongo@4f7e68ce6ae537999d3577f9df2cb5e1d4e07bfb 2.6
+2.6.6: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
+2.6: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
+2: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
+latest: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
 
-2.8.0-rc4: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8
-2.8.0: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8
-2.8: git://github.com/docker-library/mongo@fb0ecea9030bc02c6264188fceb3e5573e83be70 2.8
+2.8.0-rc4: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8
+2.8.0: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8
+2.8: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8

--- a/library/mongo
+++ b/library/mongo
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.2
-2.2: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.2
+2.2.7: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.2
+2.2: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.2
 
-2.4.12: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.4
-2.4: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.4
+2.4.12: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.4
+2.4: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.4
 
-2.6.6: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
-2.6: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
-2: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
-latest: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.6
+2.6.6: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
+2.6: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
+2: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
+latest: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
 
-2.8.0-rc4: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8
-2.8.0: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8
-2.8: git://github.com/docker-library/mongo@b8c013f63624f65d7e40ef3fed91e66ef3b58dc7 2.8
+2.8.0-rc4: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8
+2.8.0: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8
+2.8: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.41: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.5
-5.5: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.5
+5.5.41: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
+5.5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
 
-5.6.22: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.6
-5.6: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.6
-5: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.6
-latest: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.6
+5.6.22: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5.6: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+latest: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
 
-5.7.5-m15: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.7
-5.7.5: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.7
-5.7: git://github.com/docker-library/docker-mysql@d6268ace61047c74468d7c59b4d8da6be5dec16a 5.7
+5.7.5-m15: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7.5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7

--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.10.35: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
-0.10: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
-0: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
-latest: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10
+0.10.35: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
+0.10: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
+0: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
+latest: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
 
 0.10.35-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
 0.10-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
 0-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
 onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
 
-0.10.35-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
-0.10-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
-0-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.10/slim
+0.10.35-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
+0.10-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
+0-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
+slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11
-0.11: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11
+0.11.14: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11
+0.11: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11
 
 0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11/slim
-0.11-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.11/slim
+0.11.14-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11/slim
+0.11-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8
-0.8: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8
+0.8.28: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8
+0.8: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8
 
 0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8/slim
-0.8-slim: git://github.com/docker-library/node@194500097264a62ef675e2caf6778335cb5d4f7b 0.8/slim
+0.8.28-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8/slim
+0.8-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8/slim

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.36-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4
-5.4-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4
-5.4.36: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4
-5.4: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4
+5.4.36-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
+5.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
+5.4.36: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
+5.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
 
-5.4.36-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4/apache
-5.4-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.4/apache
+5.4.36-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
+5.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
 
-5.4.36-fpm: git://github.com/docker-library/php@61918f0fd60c2b131ab468fe40eec626687ce881 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@61918f0fd60c2b131ab468fe40eec626687ce881 5.4/fpm
+5.4.36-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
 
-5.5.20-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5
-5.5-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5
-5.5.20: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5
-5.5: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5
+5.5.20-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
+5.5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
+5.5.20: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
+5.5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
 
-5.5.20-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5/apache
-5.5-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.5/apache
+5.5.20-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
+5.5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
 
-5.5.20-fpm: git://github.com/docker-library/php@4bb8f8678056630c0322364d080acd585baef95d 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@4bb8f8678056630c0322364d080acd585baef95d 5.5/fpm
+5.5.20-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
 
-5.6.4-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-5.6-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-5-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-cli: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-5.6.4: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-5.6: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-5: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
-latest: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6
+5.6.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5.6-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5.6.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5.6: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+latest: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
 
-5.6.4-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6/apache
-5.6-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6/apache
-5-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6/apache
-apache: git://github.com/docker-library/php@a51c16e5f91be6243452471d1454dca5b168e3d4 5.6/apache
+5.6.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
+5.6-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
+5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
+apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
 
-5.6.4-fpm: git://github.com/docker-library/php@f972d91aac11cf41e5de6d24a45dcb1bb00f221d 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@f972d91aac11cf41e5de6d24a45dcb1bb00f221d 5.6/fpm
-5-fpm: git://github.com/docker-library/php@f972d91aac11cf41e5de6d24a45dcb1bb00f221d 5.6/fpm
-fpm: git://github.com/docker-library/php@f972d91aac11cf41e5de6d24a45dcb1bb00f221d 5.6/fpm
+5.6.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
+5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
+fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
-8.4: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
-8: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 8.4
+8.4.22: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 8.4
+8.4: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 8.4
+8: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 8.4
 
-9.0.18: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.0
-9.0: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.0
+9.0.18: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.0
+9.0: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.0
 
-9.1.14: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.1
-9.1: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.1
+9.1.14: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.1
+9.1: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.1
 
-9.2.9: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.2
-9.2: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.2
+9.2.9: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.2
+9.2: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.2
 
-9.3.5: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.3
-9.3: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.3
+9.3.5: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.3
+9.3: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.3
 
-9.4.0: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
-9.4: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
-9: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
-latest: git://github.com/docker-library/postgres@c9d9f4c1a0d33a161fefda666f041ef0dc4dc9f8 9.4
+9.4.0: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.4
+9.4: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.4
+9: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.4
+latest: git://github.com/docker-library/postgres@51e5166d69320581cb707d6fb102d3ba04803400 9.4

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.2: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df
-3.4: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df
-3: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df
-latest: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df
+3.4.3: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
+3.4: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
+3: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
+latest: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
 
-3.4.2-management: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df management
-3.4-management: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df management
-3-management: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df management
-management: git://github.com/docker-library/rabbitmq@a5446802167ab04b780eef1505fc1ab3c48e24df management
+3.4.3-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
+3.4-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
+3-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
+management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.0: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
-4.2: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
-4: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
-latest: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814
+4.2.0: git://github.com/docker-library/rails@7a7f05408cddabc75ca3c5252097e238021680a8
+4.2: git://github.com/docker-library/rails@7a7f05408cddabc75ca3c5252097e238021680a8
+4: git://github.com/docker-library/rails@7a7f05408cddabc75ca3c5252097e238021680a8
+latest: git://github.com/docker-library/rails@7a7f05408cddabc75ca3c5252097e238021680a8
 
 onbuild: git://github.com/docker-library/rails@940d1a7d0fc11d32aed4eb3b2cb22f62f65c6814 onbuild

--- a/library/redis
+++ b/library/redis
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@109323988b7663bceaf4a01c3353f8934dfc002e 2.6
-2.6: git://github.com/docker-library/redis@109323988b7663bceaf4a01c3353f8934dfc002e 2.6
+2.6.17: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
+2.6: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
 
-2.8.19: git://github.com/docker-library/redis@c0701c47588a90c4487808ebc8b0d078f40fe680 2.8
-2.8: git://github.com/docker-library/redis@c0701c47588a90c4487808ebc8b0d078f40fe680 2.8
-2: git://github.com/docker-library/redis@c0701c47588a90c4487808ebc8b0d078f40fe680 2.8
-latest: git://github.com/docker-library/redis@c0701c47588a90c4487808ebc8b0d078f40fe680 2.8
+2.8.19: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+2.8: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+2: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+latest: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.43-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
-6.0.43: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
-6.0: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
-6: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre7
+6.0.43-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
+6.0-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
+6-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
+6.0.43: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
+6.0: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
+6: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre7
 
-6.0.43-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre8
-6.0-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre8
-6-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 6-jre8
+6.0.43-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre8
+6.0-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre8
+6-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 6-jre8
 
-7.0.57-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
-7.0.57: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
-7.0: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
-7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre7
+7.0.57-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
+7.0.57: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
+7.0: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
+7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre7
 
-7.0.57-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 7-jre8
+7.0.57-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre8
 
-8.0.15-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-jre7: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-8.0.15: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-8.0: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
-latest: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre7
+8.0.15-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+jre7: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+8.0.15: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+8.0: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
+latest: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre7
 
-8.0.15-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre8
-jre8: git://github.com/docker-library/tomcat@6f1c628fa92feea8b28e98e56a990500f2326936 8-jre8
+8.0.15-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre8
+jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 8-jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/wordpress@8dd234753eb20df43ca013c833a964e712297d47
-4.1: git://github.com/docker-library/wordpress@8dd234753eb20df43ca013c833a964e712297d47
-4: git://github.com/docker-library/wordpress@8dd234753eb20df43ca013c833a964e712297d47
-latest: git://github.com/docker-library/wordpress@8dd234753eb20df43ca013c833a964e712297d47
+4.1.0: git://github.com/docker-library/wordpress@990b1b00b8ca4903e11e53e908b1996fbaab3c1a
+4.1: git://github.com/docker-library/wordpress@990b1b00b8ca4903e11e53e908b1996fbaab3c1a
+4: git://github.com/docker-library/wordpress@990b1b00b8ca4903e11e53e908b1996fbaab3c1a
+latest: git://github.com/docker-library/wordpress@990b1b00b8ca4903e11e53e908b1996fbaab3c1a


### PR DESCRIPTION
- `django`: correct exposed port
- `mongo`: numa enabled
- `rails`: generate script changes
- `wordpress`: use php-apache image's pid removal script