### PR TITLE
jruby secure download

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -1,9 +1,26 @@
 # maintainer: Brian Goff <cpuguy83@gmail.com> (@cpuguy83)
 
-1.7: git://github.com/cpuguy83/docker-jruby@e7af3d9a85d166f3dd4b600a629908bd05639fb5 1.7
-1.7.18: git://github.com/cpuguy83/docker-jruby@e7af3d9a85d166f3dd4b600a629908bd05639fb5 1.7
-latest: git://github.com/cpuguy83/docker-jruby@e7af3d9a85d166f3dd4b600a629908bd05639fb5 1.7
+1.7: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jre
+1.7.18: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jre
+latest: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jre
 
-1.7-onbuild: git://github.com/cpuguy83/docker-jruby@e7af3d9a85d166f3dd4b600a629908bd05639fb5 1.7/onbuild
-1.7.18-onbuild: git://github.com/cpuguy83/docker-jruby@e7af3d9a85d166f3dd4b600a629908bd05639fb5 1.7/onbuild
+1.7-jre: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jre
+1.7.18-jre: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jre
+
+1.7-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jdk
+1.7.18-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/jdk
+
+1.7-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/onbuild
+1.7.18-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 1.7/onbuild
+
+9.0.0.0: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
+9.0.0.0-jre: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
+9.0.0.0.pre1: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
+9.0.0.0.pre1-jre: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
+
+9.0.0.0-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jdk
+9.0.0.0.pre1-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jdk
+
+9.0.0.0-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/onbuild
+9.0.0.0.pre1-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/onbuild
 


### PR DESCRIPTION
JRuby download was recently updated with to use a proper https URL, updated here.
