### PR TITLE
Update docker-library images

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.29: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.2
-2.2: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.2
+2.2.29: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.2
+2.2: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.2
 
-2.4.10: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
-2.4: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
-2: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
-latest: git://github.com/docker-library/httpd@0eded82cb54587e19520566517311358c6124018 2.4
+2.4.10: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.4
+2.4: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.4
+2: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.4
+latest: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.4

--- a/library/mongo
+++ b/library/mongo
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.2
-2.2: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.2
+2.2.7: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
+2.2: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
 
-2.4.12: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.4
-2.4: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.4
+2.4.12: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.4
+2.4: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.4
 
-2.6.6: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
-2.6: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
-2: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
-latest: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.6
+2.6.6: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.6
+2.6: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.6
+2: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.6
+latest: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.6
 
-2.8.0-rc4: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8
-2.8.0: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8
-2.8: git://github.com/docker-library/mongo@75750813f758b32adbaba02fb391660d42cbcc1a 2.8
+2.8.0-rc4: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.8
+2.8.0: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.8
+2.8: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.8

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.3: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
-3.4: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
-3: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
-latest: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58
+3.4.3: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
+3.4: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
+3: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
+latest: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
 
-3.4.3-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
-3.4-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
-3-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
-management: git://github.com/docker-library/rabbitmq@9bc3dc75e36a35955b85de8c8b9bc825cfe57d58 management
+3.4.3-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
+3.4-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
+3-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
+management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management


### PR DESCRIPTION
- `httpd`: add PidFile-removing script (docker-library/httpd#3) and SSL support (docker-library/httpd#2)
- `mongo`: fix NUMA invocation to work on hosts that have NUMA disabled in the kernel (docker-library/mongo#15)
- `rabbitmq`: add empty "loopback_users" in base image so "guest" account works (docker-library/rabbitmq#4)