### PR TITLE
Switch Node image to use Joyent, Inc repo

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# maintainer: Joyent Image Team <soln@joyent.com> (@joyent)
 
-0.10.35: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
-0.10: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
-0: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
-latest: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10
+0.10.35: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
+0.10: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
+0: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
+latest: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
 
-0.10.35-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
-0.10-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
-0-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
-onbuild: git://github.com/docker-library/node@c91ccfb473556858d42a2ae32ebe24d8263690a4 0.10/onbuild
+0.10.35-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
+0.10-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
+0-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
+onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
 
-0.10.35-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
-0.10-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
-0-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.10/slim
+0.10.35-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
+0-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
+slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
 
-0.11.14: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11
-0.11: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11
+0.11.14: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11
+0.11: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11
 
-0.11.14-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
-0.11-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.11/onbuild
+0.11.14-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/onbuild
+0.11-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/onbuild
 
-0.11.14-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11/slim
-0.11-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.11/slim
+0.11.14-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/slim
+0.11-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/slim
 
-0.8.28: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8
-0.8: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8
+0.8.28: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8
+0.8: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8
 
-0.8.28-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
-0.8-onbuild: git://github.com/docker-library/node@ac05e7f96c477223f0d2da1817e84403363a65e8 0.8/onbuild
+0.8.28-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/onbuild
+0.8-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/onbuild
 
-0.8.28-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8/slim
-0.8-slim: git://github.com/docker-library/node@a672ac6b898963aae94f25c5fb5cb64efd6c1ba4 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/slim

--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# maintainer: Joyent Image Team <soln@joyent.com> (@joyent)
+# maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
 0.10.35: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
 0.10: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10


### PR DESCRIPTION
Our repo is here: https://github.com/joyent/docker-node

(It's pretty much a copy of https://github.com/docker-library/node, so no surprises :)