### PR TITLE
Odoo - Update wkhtmltopdf version to 0.12.2

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,5 +1,5 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@0c90527ef908add1f125406a81519f9626d982d3 8.0
-8: git://github.com/odoo/docker@0c90527ef908add1f125406a81519f9626d982d3 8.0
-latest: git://github.com/odoo/docker@0c90527ef908add1f125406a81519f9626d982d3 8.0
+8.0: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0
+8: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0
+latest: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0


### PR DESCRIPTION
Hello,

The wkhtmltopdf team released a new version and broke the link we were using in our Dockerfile, thus breaking the build. This commit uses the new version.

Regards