### PR TITLE
Add new "bashbrew list" subcommand

### DIFF
--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -33,5 +33,6 @@ fi
 # TODO that will change eventually!
 
 set -x
+./bashbrew.sh list --namespaces='_' "${repos[@]}"
 ./bashbrew.sh build --no-build "${repos[@]}"
 ./bashbrew.sh push --no-push "${repos[@]}"


### PR DESCRIPTION
This allows us to manipulate/use the repo lists from bashbrew directly in fun ways.

For example, `bashbrew list --namespaces='_' --all | xargs -n1 docker pull`.