### PR TITLE
Remove the explicit "latest-" from perl's "latest-threaded"

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -10,7 +10,7 @@ latest:          git://github.com/perl/docker-perl@r20141106.0 5.020.001-64bit
 5.18:            git://github.com/perl/docker-perl@r20141106.0 5.018.004-64bit
 5.18.4:          git://github.com/perl/docker-perl@r20141106.0 5.018.004-64bit
 
-latest-threaded: git://github.com/perl/docker-perl@r20141106.0 5.020.001-64bit,threaded
+threaded:        git://github.com/perl/docker-perl@r20141106.0 5.020.001-64bit,threaded
 
 5-threaded:      git://github.com/perl/docker-perl@r20141106.0 5.020.001-64bit,threaded
 


### PR DESCRIPTION
For all the images, "latest" is a convenience and even a misnomer.  It's really "default", and only exists such that users doing "just-the-image" get a useful tag, so users shouldn't be explicitly using "the-image:latest" and thus "the-image:latest-variant" doesn't make much sense, but "the-image:variant" does and can (and this matches the pattern of all the other official image tags too).

ping @PeterMartini