### PR TITLE
Add image for io.js

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,0 +1,16 @@
+# maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
+
+1.0.2: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
+1.0: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
+1: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
+latest: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
+
+1.0.2-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
+1.0-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
+1-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
+onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
+
+1.0.2-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
+1.0-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
+1-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
+slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim

--- a/library/iojs
+++ b/library/iojs
@@ -1,16 +1,16 @@
 # maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
 
-1.0.2: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
-1.0: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
-1: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
-latest: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
+1.0.2: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0
+1.0: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0
+1: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0
+latest: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0
 
 1.0.2-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
 1.0-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
 1-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
 onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
 
-1.0.2-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
-1.0-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
-1-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
+1.0.2-slim: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0/slim
+1.0-slim: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0/slim
+1-slim: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0/slim
+slim: git://github.com/iojs/docker-iojs@35f58a1d3be140a192b91c558a0d126d63dd0c48 1.0/slim

--- a/library/iojs
+++ b/library/iojs
@@ -1,14 +1,14 @@
 # maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
 
-1.0.2: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
-1.0: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
-1: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
-latest: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0
+1.0.2: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
+1.0: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
+1: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
+latest: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0
 
-1.0.2-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
-1.0-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
-1-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
-onbuild: git://github.com/iojs/docker-iojs@269b813b6843c20cd93cc901bfd7f59640078e12 1.0/onbuild
+1.0.2-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
+1.0-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
+1-onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
+onbuild: git://github.com/iojs/docker-iojs@ebe290918a3f5f8eb8e74bd4ea9fdf8fcabbb2d8 1.0/onbuild
 
 1.0.2-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim
 1.0-slim: git://github.com/iojs/docker-iojs@0dccce1ac9338bd36678d81d8a08a9b3ac381645 1.0/slim


### PR DESCRIPTION
Adds an [io.js](https://iojs.org/) official image.

I hope it's acceptable to have a http link instead of an email in the `maintainer` line.