### PR TITLE
Odoo - Fix wkhtmltopdf-0.12.2 broken url

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,5 +1,5 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0
-8: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0
-latest: git://github.com/odoo/docker@3a6e42c7a7698196dd42dc7c4b5782ab50885f89 8.0
+8.0: git://github.com/odoo/docker@a86b7e6dbc31d19b6180fdf00e56b4a0f5fe32ff 8.0
+8: git://github.com/odoo/docker@a86b7e6dbc31d19b6180fdf00e56b4a0f5fe32ff 8.0
+latest: git://github.com/odoo/docker@a86b7e6dbc31d19b6180fdf00e56b4a0f5fe32ff 8.0


### PR DESCRIPTION
Hello,

The image now uses a local copy on our server of the release 0.12.2.1 of wkhtmltopdf to prevent further problems of broken url due to updates. This is the second time they break the url within the past 2 weeks... (see previous PR https://github.com/docker-library/official-images/pull/394).

Regards