### PR TITLE
Update for node 0.11.15, npm 2.2.0 and new fingerprint

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.35: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
-0.10: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
-0: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
-latest: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10
+0.10.35: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10
+0.10: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10
+0: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10
+latest: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10
 
-0.10.35-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
-0.10-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
-0-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/onbuild
+0.10.35-onbuild: git://github.com/joyent/docker-node@4c84bad6279fe3f76cd0046f4d42eea90eb5818a 0.10/onbuild
+0.10-onbuild: git://github.com/joyent/docker-node@4c84bad6279fe3f76cd0046f4d42eea90eb5818a 0.10/onbuild
+0-onbuild: git://github.com/joyent/docker-node@4c84bad6279fe3f76cd0046f4d42eea90eb5818a 0.10/onbuild
+onbuild: git://github.com/joyent/docker-node@4c84bad6279fe3f76cd0046f4d42eea90eb5818a 0.10/onbuild
 
-0.10.35-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
-0-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.10/slim
+0.10.35-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10/slim
+0-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10/slim
+slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.10/slim
 
-0.11.14: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11
-0.11: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11
+0.11.15: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.11
+0.11: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.11
 
-0.11.14-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/onbuild
-0.11-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/onbuild
+0.11.15-onbuild: git://github.com/joyent/docker-node@70edbe38678c0eb88bcc14866ad1589053b21cc2 0.11/onbuild
+0.11-onbuild: git://github.com/joyent/docker-node@70edbe38678c0eb88bcc14866ad1589053b21cc2 0.11/onbuild
 
-0.11.14-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/slim
-0.11-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.11/slim
+0.11.15-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.11/slim
+0.11-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.11/slim
 
-0.8.28: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8
-0.8: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8
+0.8.28: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.8
+0.8: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.8
 
-0.8.28-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/onbuild
-0.8-onbuild: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/onbuild
+0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
+0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@21e69d768f26da8aade316a573673a2bf5bfeab7 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@ab7e765e3d0f8bb0fefa333faae90f8ea6b72677 0.8/slim


### PR DESCRIPTION
This bumps Node.js to 0.11.15, npm to 2.2.0, and includes an additional gpg fingerprint in the relevant dockerfiles for Julien Gilli.

This pull replaces #414 an #415 which can be closed/ignored. 

Sorry about that...we're still getting used to the workflow and the new fingerprint change for the 0.11.15 release caught us off guard :)