### PR TITLE
docker-library/php versions bumped

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.36-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4.36: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
+5.4.36-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4
+5.4-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4
+5.4.36: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4
+5.4: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4
 
-5.4.36-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
-5.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
+5.4.36-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4/apache
+5.4-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4/apache
 
-5.4.36-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
+5.4.36-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.4/fpm
 
-5.5.20-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5.20: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
+5.5.21-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5.21: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
 
-5.5.20-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
-5.5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
+5.5.21-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
+5.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
 
-5.5.20-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
+5.5.21-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
 
-5.6.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-latest: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5.6.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+latest: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
 
-5.6.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-5.6-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
+5.6.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+5.6-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
 
-5.6.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
+5.6.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm


### PR DESCRIPTION
https://github.com/docker-library/php/commit/c871678cc7c8dbc9277832e35f14f3534f2dd0fb and https://github.com/docker-library/php/issues/65