### PR TITLE
Add biicode image to dockerhub

### DIFF
--- a/library/biicode
+++ b/library/biicode
@@ -1,0 +1,4 @@
+# maintainer: David Sanchez <david.sanchez@biicode.com> (@davidsanfal)
+
+latest: git://github.com/biicode/docker-biicode@67dc087553e185f9834fbeb03fe82a753d77a2bb
+2.4.1: git://github.com/biicode/docker-biicode@67dc087553e185f9834fbeb03fe82a753d77a2bb


### PR DESCRIPTION
Hi Docker, I'm David and I write you from [biicode](https://www.biicode.com/) a small start-up that’s developing a C and C++ dependency manager.

We are interested in creating a official repository so we have done 2 MR, One to the docs repo with the biicode image info and another MR to the official-images repo with the image commit. Is this all we need to do?.

If anything is wrong or we skipped something in the way please let us know and we will fix it at soon as possible.

[Dockerfile Repo](https://github.com/biicode/docker-biicode)