### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.3.3: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
-1.3: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3
+1.3.3: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3
+1.3: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3
 
 1.3.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
 1.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
@@ -10,25 +10,25 @@
 1.3.3-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 1.3-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 
-1.3.3-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
-1.3-wheezy: git://github.com/docker-library/golang@b13bdad8632705cd56f887ffe7320076b1b56754 1.3/wheezy
+1.3.3-wheezy: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3/wheezy
+1.3-wheezy: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3/wheezy
 
-1.4.1: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4
-1.4: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4
-1: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4
-latest: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4
+1.4.1: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4
+1.4: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4
+1: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4
+latest: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4
 
 1.4.1-onbuild: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/onbuild
 1.4-onbuild: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/onbuild
 1-onbuild: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/onbuild
 onbuild: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/onbuild
 
-1.4.1-cross: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/cross
-1.4-cross: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/cross
-1-cross: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/cross
-cross: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/cross
+1.4.1-cross: git://github.com/docker-library/golang@90b57a935ad9275997fda8741a5a7864eb1d51b5 1.4/cross
+1.4-cross: git://github.com/docker-library/golang@90b57a935ad9275997fda8741a5a7864eb1d51b5 1.4/cross
+1-cross: git://github.com/docker-library/golang@90b57a935ad9275997fda8741a5a7864eb1d51b5 1.4/cross
+cross: git://github.com/docker-library/golang@90b57a935ad9275997fda8741a5a7864eb1d51b5 1.4/cross
 
-1.4.1-wheezy: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/wheezy
-1.4-wheezy: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/wheezy
-1-wheezy: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/wheezy
-wheezy: git://github.com/docker-library/golang@c1baf037d71331eb0b8d4c70cff4c29cf124c5e0 1.4/wheezy
+1.4.1-wheezy: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4/wheezy
+1.4-wheezy: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4/wheezy
+1-wheezy: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4/wheezy
+wheezy: git://github.com/docker-library/golang@304244cfe374d3477e746c057a5ec4dcf7a47657 1.4/wheezy

--- a/library/mongo
+++ b/library/mongo
@@ -11,6 +11,6 @@
 2: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 latest: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 
-2.8.0-rc5: git://github.com/docker-library/mongo@fc66d9cbedac47806c7ae05b1b291c4ee32f6e6a 2.8
-2.8.0: git://github.com/docker-library/mongo@fc66d9cbedac47806c7ae05b1b291c4ee32f6e6a 2.8
-2.8: git://github.com/docker-library/mongo@fc66d9cbedac47806c7ae05b1b291c4ee32f6e6a 2.8
+3.0.0-rc6: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0
+3.0.0: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0
+3.0: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.36-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4.36: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
-5.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4
+5.4.37-cli: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
+5.4-cli: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
+5.4.37: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
+5.4: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
 
-5.4.36-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
-5.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/apache
+5.4.37-apache: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/apache
+5.4-apache: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/apache
 
-5.4.36-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.4/fpm
+5.4.37-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
 
-5.5.20-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5.20: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
-5.5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5
+5.5.21-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5.21: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
 
-5.5.20-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
-5.5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/apache
+5.5.21-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
+5.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
 
-5.5.20-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.5/fpm
+5.5.21-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
 
-5.6.4-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-cli: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6.4: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5.6: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-5: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
-latest: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6
+5.6.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+latest: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
 
-5.6.4-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-5.6-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-5-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
-apache: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/apache
+5.6.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+5.6-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
 
-5.6.4-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-5-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
-fpm: git://github.com/docker-library/php@5d49ba5861c0245da96132b011c8dbdad8c28188 5.6/fpm
+5.6.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@42acf24d6056b82d396da6658943f5c26e7b5cc1 7-jre8
 
-8.0.17-jre7: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-jre7: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-8.0.17: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-8.0: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-8: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
-latest: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre7
+8.0.18-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8.0.18: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8.0: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+latest: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
 
-8.0.17-jre8: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre8
-jre8: git://github.com/docker-library/tomcat@7d5b334fc0770be842991ed9d8168c5b1ebb86f8 8-jre8
+8.0.18-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
+jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/wordpress@2e2036d3cf01811e9d58e2c4251efa813ad2000a
-4.1: git://github.com/docker-library/wordpress@2e2036d3cf01811e9d58e2c4251efa813ad2000a
-4: git://github.com/docker-library/wordpress@2e2036d3cf01811e9d58e2c4251efa813ad2000a
-latest: git://github.com/docker-library/wordpress@2e2036d3cf01811e9d58e2c4251efa813ad2000a
+4.1.0: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
+4.1: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
+4: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
+latest: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533


### PR DESCRIPTION
- `golang`: update to use `buildpack-deps:*-scm` (docker-library/golang#38)
- `mongo`: replace 2.8 with 3.0.0-rc6 (docker-library/mongo#19)
- `php`: 5.4.37, 5.5.21, 5.6.5
- `tomcat`: 8.0.18
- `wordpress`: use `/etc/hosts` instead of env (docker-library/wordpress#42) and add simple mysql-retry logic to entrypoint (docker-library/wordpress#48)