### PR TITLE
Update ubuntu-debootstrap for CVE-2015-0235

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,25 +1,28 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - 67a4f1c 2015-01-16 debootstraps
+#  - fbf8004 2015-01-16 debootstraps
+#  
+#  - 66a8e04 2015-01-27 debootstraps (CVE-2015-0235)
+#    Only 10.04 and 12.04 are vulnerable, so only they have been updated here.
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 10.04
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@66a8e048ccd22ac1ec226a3a547bbbbc9793c18b 12.04
 
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.04
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 14.10
 
-15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 15.04
-vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 15.04
+15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 15.04
+vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f 15.04
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@67a4f1c8a6be130c4badbcdf5bd327e7b93233a8 devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fbf8004623fb87b3e429655dddff7f0c1b48861f devel


### PR DESCRIPTION
Only 10.04 and 12.04 are vulnerable: http://www.ubuntu.com/usn/usn-2485-1/