### PR TITLE
Use "xargs -n1" on dirname since some versions don't support multiargs

### DIFF
--- a/bashbrew/git-set-mtimes
+++ b/bashbrew/git-set-mtimes
@@ -2,7 +2,7 @@
 set -e
 
 IFS=$'\n'
-files=( $({ git ls-files | xargs dirname | sort -u && git ls-files; } | sort -r) )
+files=( $({ git ls-files | xargs -n1 dirname | sort -u && git ls-files; } | sort -r) )
 unset IFS
 
 for f in "${files[@]}"; do


### PR DESCRIPTION
On my local box:
```console
$ dirname a/b c/d e/f
a
c
e
```

On the official build server:
```console
$ dirname a/b c/d e/f
dirname: extra operand `c/d'
Try `dirname --help' for more information.
```