### PR TITLE
Update buildpack-deps URL

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-jessie-curl: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
-curl: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
+jessie-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
+curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
 
-jessie-scm: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
-scm: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
+jessie-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
+scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 
-jessie: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
-latest: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
+jessie: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
+latest: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
 
-sid-curl: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
+sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
-sid-scm: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
+sid-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
 
-sid: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid
+sid: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid
 
-wheezy-curl: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
+wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
-wheezy-scm: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
+wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
 
-wheezy: git://github.com/docker-library/docker-buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.41: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
-5.5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
+5.5.41: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
+5.5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
 
-5.6.22: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-5.6: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-latest: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5.6.22: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5.6: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+latest: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
 
-5.7.5-m15: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
-5.7.5: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
-5.7: git://github.com/docker-library/docker-mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7.5-m15: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7.5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7


### PR DESCRIPTION
Was looking through Dockerfiles and realized we'd moved this repo quite some time ago.