### PR TITLE
Update ubuntu, especially for CVE-2015-0235

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -4,27 +4,27 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 5faea96 Update tarballs
-#    - `ubuntu:precise`: 20150115
-#    - `ubuntu:trusty`: 20150115
-#    - `ubuntu:utopic`: 20150115
-#    - `ubuntu:vivid`: 20150116
+#  - a9da4b3 Update tarballs
+#    - `ubuntu:precise`: 20150128
+#    - `ubuntu:trusty`: 20150128
+#    - `ubuntu:utopic`: 20150128
+#    - `ubuntu:vivid`: 20150127.1
 
-# 20150115
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 precise
+# 20150128
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c precise
 
-# 20150115
-14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 trusty
+# 20150128
+14.04.1: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c trusty
 
-# 20150115
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 utopic
+# 20150128
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c utopic
 
-# 20150116
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@5faea963599714ceb09e6f4f78155a3fc64389b7 vivid
+# 20150127.1
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@a9da4b3cd8977c2aacafe5d9d0056cbb360f2d1c vivid


### PR DESCRIPTION
- `ubuntu:precise`: 20150128
- `ubuntu:trusty`: 20150128
- `ubuntu:utopic`: 20150128
- `ubuntu:vivid`: 20150127.1