### PR TITLE
Add swarm to official images.

### DIFF
--- a/library/swarm
+++ b/library/swarm
@@ -1,0 +1,5 @@
+# maintainer: Andrea Luzzardi <al@docker.com> (@aluzzardi)
+# maintainer: Victor Vieux <vieux@docker.com> (@vieux)
+
+0.1.0-rc3: git://github.com/docker/swarm-library-image@c0f8204b2a1bb34233cd2144df51a4de9572440c
+latest: git://github.com/docker/swarm-library-image@c0f8204b2a1bb34233cd2144df51a4de9572440c


### PR DESCRIPTION
This is in order to distribute `swarm` as an official image so that it can be used as simply as:

`docker run swarm`