### PR TITLE
Use jdk for onbuild images

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -10,8 +10,8 @@ latest: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f6
 1.7-jdk: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f633493ae 1.7/jdk
 1.7.19-jdk: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f633493ae 1.7/jdk
 
-1.7-onbuild: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f633493ae 1.7/onbuild
-1.7.19-onbuild: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f633493ae 1.7/onbuild
+1.7-onbuild: git://github.com/cpuguy83/docker-jruby@627e1d1805efd8ff8b5f931f8d63a0de2c5b64e2 1.7/onbuild
+1.7.19-onbuild: git://github.com/cpuguy83/docker-jruby@627e1d1805efd8ff8b5f931f8d63a0de2c5b64e2 1.7/onbuild
 
 9.0.0.0: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
 9.0.0.0-jre: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jre
@@ -21,7 +21,7 @@ latest: git://github.com/cpuguy83/docker-jruby@68e55e5eaf8f8159ade4a305df0fd65f6
 9.0.0.0-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jdk
 9.0.0.0.pre1-jdk: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/jdk
 
-9.0.0.0-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/onbuild
-9.0.0.0.pre1-onbuild: git://github.com/cpuguy83/docker-jruby@7d3e3c8872c557c311cfbf85e54ebe4c82e8a725 9000/onbuild
+9.0.0.0-onbuild: git://github.com/cpuguy83/docker-jruby@627e1d1805efd8ff8b5f931f8d63a0de2c5b64e2 9000/onbuild
+9.0.0.0.pre1-onbuild: git://github.com/cpuguy83/docker-jruby@627e1d1805efd8ff8b5f931f8d63a0de2c5b64e2 9000/onbuild
 
 


### PR DESCRIPTION
Fixes cpuguy83/docker-jruby#2

Some people using the onbuild image use git as source URLs for gems in
their Gemfile.  Since they can't manually install git before `bundle
install` is run (because onbuild), they need git pre-installed.