### PR TITLE
CRUX: Removed crux:3.0 tag for glibc GHOST (CVE-2015-0235)

### DIFF
--- a/library/crux
+++ b/library/crux
@@ -2,4 +2,3 @@
 
 latest: git://github.com/therealprologic/docker-crux@46c53a82b42907e3954c792adb2f47e436b537ba
 3.1: git://github.com/therealprologic/docker-crux@46c53a82b42907e3954c792adb2f47e436b537ba
-3.0: git://github.com/therealprologic/docker-crux@7442b34f3c47665067abb0e8f724868f2899fc22


### PR DESCRIPTION
Fixes #449