### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.7.2-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
-1.7-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
-1-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
-python2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 2.7
+1.7.4-python2: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 2.7
+1.7-python2: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 2.7
+1-python2: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 2.7
+python2: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 2.7
 
 python2-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 2.7/onbuild
 
-1.7.2-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-1.7.2: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-1.7-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-1.7: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-1-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-1: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-python3: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
-latest: git://github.com/docker-library/django@b09fdb43e17d5ffd1e611dcbead7f5f88453fc02 3.4
+1.7.4-python3: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+1.7.4: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+1.7-python3: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+1.7: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+1-python3: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+1: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+python3: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
+latest: git://github.com/docker-library/django@982093f2ab178efc3a7ba9da051a8a7b6a142904 3.4
 
 python3-onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild
 onbuild: git://github.com/docker-library/django@e9721656ef7a246e6edb95b401d324dd2c6e310a 3.4/onbuild

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.25: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.4
-1.4: git://github.com/docker-library/haproxy@40cd6587e7da3d247ab2e9fede5021f30a1e773e 1.4
+1.4.26: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.4
+1.4: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.4
 
-1.5.10: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
-1.5: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
-1: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
-latest: git://github.com/docker-library/haproxy@424fd7e5b610dcea31ffb0f945c2a0da3b6740d3 1.5
+1.5.11: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
+1.5: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
+1: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
+latest: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5

--- a/library/java
+++ b/library/java
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-openjdk-6b33-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-openjdk-6b33: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-openjdk-6-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-openjdk-6: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-6b33-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-6b33: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-6-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
-6: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-6-jdk
+openjdk-6b34-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+openjdk-6b34: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+openjdk-6-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+openjdk-6: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+6b34-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+6b34: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+6-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+6: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
 
-openjdk-6b33-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-6-jre
-openjdk-6-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-6-jre
-6b33-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-6-jre
-6-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-6-jre
+openjdk-6b34-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
+openjdk-6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
+6b34-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
+6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
 
 openjdk-7u71-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
 openjdk-7u71: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.16: git://github.com/docker-library/mariadb@2e6a0de6022a63fb7d124488c492568f8150417b 10.0
-10.0: git://github.com/docker-library/mariadb@2e6a0de6022a63fb7d124488c492568f8150417b 10.0
-10: git://github.com/docker-library/mariadb@2e6a0de6022a63fb7d124488c492568f8150417b 10.0
-latest: git://github.com/docker-library/mariadb@2e6a0de6022a63fb7d124488c492568f8150417b 10.0
+10.0.16: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
+10.0: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
+10: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
+latest: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
 
-10.1.2: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.1
-10.1: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 10.1
+10.1.2: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
+10.1: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
 
-5.5.41: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5
-5.5: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5
-5: git://github.com/docker-library/mariadb@d06c367c4b199f91b36f5f6fabf8305282b8abac 5.5
+5.5.41: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5
+5.5: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5
+5: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -11,6 +11,6 @@
 2: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 latest: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 
-3.0.0-rc6: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0
-3.0.0: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0
-3.0: git://github.com/docker-library/mongo@58ff8729e6d3e0ede8d2b222124486915763d1b0 3.0
+3.0.0-rc7: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0
+3.0.0: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0
+3.0: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.41: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
-5.5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.5
+5.5.42: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.5
+5.5: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.5
 
-5.6.22: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-5.6: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
-latest: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.6
+5.6.23: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.6
+5.6: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.6
+5: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.6
+latest: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.6
 
-5.7.5-m15: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
-5.7.5: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
-5.7: git://github.com/docker-library/mysql@567028d4e177238c58760bcd69a8766a8f026e2a 5.7
+5.7.5-m15: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.7
+5.7.5: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.7
+5.7: git://github.com/docker-library/mysql@66f8feb4296894143ced202dd0042bc361096747 5.7

--- a/library/php
+++ b/library/php
@@ -1,40 +1,40 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.37-cli: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
-5.4-cli: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
-5.4.37: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
-5.4: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4
+5.4.37-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
+5.4-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
+5.4.37: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
+5.4: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
 
-5.4.37-apache: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/apache
-5.4-apache: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/apache
+5.4.37-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4/apache
+5.4-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4/apache
 
 5.4.37-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
 5.4-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
 
-5.5.21-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
-5.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
-5.5.21: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
-5.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5
+5.5.21-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
+5.5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
+5.5.21: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
+5.5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
 
-5.5.21-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
-5.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/apache
+5.5.21-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5/apache
+5.5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5/apache
 
 5.5.21-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
 5.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
 
-5.6.5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-5.6-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-5-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-cli: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-5.6.5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-5.6: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-5: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
-latest: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6
+5.6.5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5.6-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5.6.5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5.6: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+latest: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
 
-5.6.5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
-5.6-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
-5-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
-apache: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/apache
+5.6.5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
+5.6-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
+5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
+apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
 
 5.6.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
 5.6-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,17 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.4.0: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2
-2-2.4: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2
-2-2: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2
-2: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2
+2-2.5.0: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
+2-2.5: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
+2-2: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
+2: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
 
-2-2.4.0-onbuild: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2/onbuild
-2-2.4-onbuild: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2/onbuild
-2-2-onbuild: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2/onbuild
-2-onbuild: git://github.com/docker-library/pypy@0e9d197376519d7cc4cad52f378b7b289b524bad 2/onbuild
+2-2.5.0-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
+2-2.5-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
+2-2-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
+2-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
 
-2-2.4.0-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
-2-2.4-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
+2-2.5.0-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
+2-2.5-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 2-2-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 2-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.3: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
-3.4: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
-3: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
-latest: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752
+3.4.3: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
+3.4: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
+3: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
+latest: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
 
-3.4.3-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
-3.4-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
-3-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
-management: git://github.com/docker-library/rabbitmq@02d383bd9c9919b0c1401a6c9aa06ac790867752 management
+3.4.3-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
+3.4-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
+3-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
+management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management


### PR DESCRIPTION
- `django`: 1.7.4
- `haproxy`: 1.4.26 and 1.5.11
- `java`: 6b34
- `mariadb`: resync entrypoint with `mysql` (see `mysql` changes below; docker-library/mariadb#4)
- `mongo`: 3.0.0-rc7
- `mysql`: 5.5.42 and 5.6.23; read `DATADIR` from the MySQL configuration directly (docker-library/mysql#46)
- `php`: remove `Indexes` from Apache configuration (docker-library/php#66)
- `pypy`: 2-2.5.0
- `rabbitmq`: fix TTY logging enablement (docker-library/rabbitmq#7)