### PR TITLE
Removed unsupported iojs tags. Cleaned up main iojs Dockerfile.

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,18 +1,9 @@
 # maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
 
-1.0.4: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0
-1.0: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0
-
-1.0.4-onbuild: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0/onbuild
-1.0-onbuild: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0/onbuild
-
-1.0.4-slim: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0/slim
-1.0-slim: git://github.com/iojs/docker-iojs@39ab80a90ff9addd935d3acf1f5bc3eff49d6ffc 1.0/slim
-
-1.1.0: git://github.com/iojs/docker-iojs@e86ed9207ec0597a5da970445c15e7ea0df85360 1.1
-1.1: git://github.com/iojs/docker-iojs@e86ed9207ec0597a5da970445c15e7ea0df85360 1.1
-1: git://github.com/iojs/docker-iojs@e86ed9207ec0597a5da970445c15e7ea0df85360 1.1
-latest: git://github.com/iojs/docker-iojs@e86ed9207ec0597a5da970445c15e7ea0df85360 1.1
+1.1.0: git://github.com/iojs/docker-iojs@1d3030c80570f9fae6483dbba52e94841c7388a4 1.1
+1.1: git://github.com/iojs/docker-iojs@1d3030c80570f9fae6483dbba52e94841c7388a4 1.1
+1: git://github.com/iojs/docker-iojs@1d3030c80570f9fae6483dbba52e94841c7388a4 1.1
+latest: git://github.com/iojs/docker-iojs@1d3030c80570f9fae6483dbba52e94841c7388a4 1.1
 
 1.1.0-onbuild: git://github.com/iojs/docker-iojs@7242c2b1ef80356ee624979dddd63a4a0b67a214 1.1/onbuild
 1.1-onbuild: git://github.com/iojs/docker-iojs@7242c2b1ef80356ee624979dddd63a4a0b67a214 1.1/onbuild


### PR DESCRIPTION
As discussed in https://github.com/docker-library/official-images/pull/455