### PR TITLE
Updated Oracle Linux images that resolve CVE-2015-0235 (glibc update).

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,10 +1,10 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-7: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
-7.0: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
-latest: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/7.0
+7: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
+7.0: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
+latest: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/6.6
-6.6: git://github.com/oracle/docker-images.git@6657d15b4d2282674a2c8395f1e5c90364a3793b OracleLinux/6.6
+6: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/6.6
+6.6: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/6.6


### PR DESCRIPTION
Resolves issue #449 in the upstream repo.