### PR TITLE
Add ruby slim versions

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,50 +1,67 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.3-p551: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9
-1.9.3: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9
-1.9: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9
-1: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9
+1.9.3-p551: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
+1.9.3: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
+1.9: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
+1: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
 
 1.9.3-p551-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
 1.9.3-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
 1.9-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
 1-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
 
+1.9.3-p551-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
+1.9.3-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
+1.9-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
+1-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
+
 1.9.3-p551-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 1.9.3-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 1.9-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 
-2.0.0-p598: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0
-2.0.0: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0
-2.0: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0
+2.0.0-p598: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
+2.0.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
+2.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
 
 2.0.0-p598-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
 
+2.0.0-p598-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
+
 2.0.0-p598-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
 2.0.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
 2.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
 
-2.1.5: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1
-2.1: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1
+2.1.5: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
+2.1: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
 
 2.1.5-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 
+2.1.5-slim: git://github.com/docker-library/ruby@4a125ef1ad5c8d9d8a7560fcb86c9a7ed3c39dff 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@4a125ef1ad5c8d9d8a7560fcb86c9a7ed3c39dff 2.1/slim
+
 2.1.5-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 2.1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 
-2.2.0: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2
-2.2: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2
-2: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2
-latest: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2
+2.2.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
+2.2: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
+2: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
+latest: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
 
 2.2.0-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
+
+2.2.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
+2-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
+slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
 
 2.2.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy
 2.2-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy


### PR DESCRIPTION
Here are the sizes for the new slims:
```
REPOSITORY          TAG                  IMAGE ID            CREATED             VIRTUAL SIZE
ruby                2.2.0-slim           0df822a25dfb        2 days ago          294.7 MB
ruby                2.1.5-slim           a4913abd2ab4        2 days ago          296.8 MB
ruby                2.0.0-p598-slim      6ad4dd8f057c        2 days ago          285.3 MB
ruby                1.9.3-p551-slim      529525dbf1ef        2 days ago          254.3 MB
```