### PR TITLE
Update Wordpress image to support external db

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
-4.1: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
-4: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
-latest: git://github.com/docker-library/wordpress@58b35a6f212968a84cd260e96a43e6de6b607533
+4.1.0: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
+4.1: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
+4: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
+latest: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed


### PR DESCRIPTION
- `wordpress`: support external db with `WORDPRESS_DB_HOST` (docker-library/wordpress#55)