### PR TITLE
Node.js 0.12.0 and npm 2.5.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,43 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.36: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10
-0.10: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10
-0: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10
-latest: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10
+0.10.36: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10
+0.10: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10
 
 0.10.36-onbuild: git://github.com/joyent/docker-node@d23f190e500e91ecc636878a079ff971b29eab3e 0.10/onbuild
 0.10-onbuild: git://github.com/joyent/docker-node@d23f190e500e91ecc636878a079ff971b29eab3e 0.10/onbuild
-0-onbuild: git://github.com/joyent/docker-node@d23f190e500e91ecc636878a079ff971b29eab3e 0.10/onbuild
-onbuild: git://github.com/joyent/docker-node@d23f190e500e91ecc636878a079ff971b29eab3e 0.10/onbuild
 
-0.10.36-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10/slim
-0-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10/slim
-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.10/slim
+0.10.36-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10/slim
 
-0.11.16: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11
-0.11: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11
+0.11.16: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11
+0.11: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11
 
 0.11.16-onbuild: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/onbuild
 0.11-onbuild: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/onbuild
 
-0.11.16-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/slim
-0.11-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/slim
+0.11.16-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11/slim
+0.11-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11/slim
 
-0.8.28: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.8
-0.8: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.8
+0.12.0: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
+0.12: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
+0: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
+latest: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
+
+0.12.0-onbuild: git://github.com/joyent/docker-node@391620efd66f847d34054e495186a5af3234f044 0.12/onbuild
+0.12-onbuild: git://github.com/joyent/docker-node@391620efd66f847d34054e495186a5af3234f044 0.12/onbuild
+0-onbuild: git://github.com/joyent/docker-node@391620efd66f847d34054e495186a5af3234f044 0.12/onbuild
+onbuild: git://github.com/joyent/docker-node@391620efd66f847d34054e495186a5af3234f044 0.12/onbuild
+
+0.12.0-slim: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12/slim
+0-slim: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12/slim
+slim: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12/slim
+
+0.8.28: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.8
+0.8: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.8/slim


### PR DESCRIPTION
This adds Node.js 0.12.0, setting it to the "latest" and "0" tags and also includes npm 2.5.0