### PR TITLE
Remove the 0.11 tag now that 0.12 is available

### DIFF
--- a/library/node
+++ b/library/node
@@ -9,15 +9,6 @@
 0.10.36-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10/slim
 0.10-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.10/slim
 
-0.11.16: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11
-0.11: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11
-
-0.11.16-onbuild: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/onbuild
-0.11-onbuild: git://github.com/joyent/docker-node@ebfa426f39062608dbfacabc656095cd08716c9c 0.11/onbuild
-
-0.11.16-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11/slim
-0.11-slim: git://github.com/joyent/docker-node@a1aefc91ac380239998a9f8521bf233ee524d8d0 0.11/slim
-
 0.12.0: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
 0.12: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12
 0: git://github.com/joyent/docker-node@c04479fd0117c59d31e426a500ad4f5dd2399f19 0.12


### PR DESCRIPTION
This removes the 0.11 tag per our discussion in #468 . I also removed 0.11 from https://github.com/joyent/docker-node