### PR TITLE
Updated Oracle Linux images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,10 +1,14 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-7: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
-7.0: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
-latest: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/7.0
+7: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/7.0
+7.0: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/7.0
+latest: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/6.6
-6.6: git://github.com/oracle/docker.git@350a858aee60e763a69fd67c1eebeea434de2e2f OracleLinux/6.6
+6: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/6.6
+6.6: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/6.6
+
+# Oracle Linux 5
+5: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/5.11
+5.11: git://github.com/oracle/docker.git@3e2a0898efc8538bddb20c2e01f46a67a0262d54 OracleLinux/5.11


### PR DESCRIPTION
All three images are set to UTC and we have added Oracle Linux 5.11 (includes GHOST vulnerability fix).