### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-1.4.1: git://github.com/docker/docker@v1.4.1
-1.4: git://github.com/docker/docker@v1.4.1
-1: git://github.com/docker/docker@v1.4.1
-latest: git://github.com/docker/docker@v1.4.1
+1.5.0: git://github.com/docker/docker@v1.5.0
+1.5: git://github.com/docker/docker@v1.5.0
+1: git://github.com/docker/docker@v1.5.0
+latest: git://github.com/docker/docker@v1.5.0
 
 # "supported": one tag per major, only upstream-supported majors (which is currently only "latest")

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.7: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.3
-1.3: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.3
+1.3.8: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.3
+1.3: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.3
 
-1.4.2: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.4
-1.4: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.4
-1: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.4
-latest: git://github.com/docker-library/elasticsearch@2fe2cb3aa293a0e75ebc1f72d27cf1aad73d21cb 1.4
+1.4.3: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
+1.4: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
+1: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
+latest: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4

--- a/library/mongo
+++ b/library/mongo
@@ -11,6 +11,6 @@
 2: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 latest: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
 
-3.0.0-rc7: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0
-3.0.0: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0
-3.0: git://github.com/docker-library/mongo@4104fc20d89c91d248b12a3a38e99a1744dff5d2 3.0
+3.0.0-rc8: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0
+3.0.0: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0
+3.0: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.3: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
-3.4: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
-3: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
-latest: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901
+3.4.4: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
+3.4: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
+3: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
+latest: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
 
-3.4.3-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
-3.4-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
-3-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
-management: git://github.com/docker-library/rabbitmq@39d657a186b09097de9279f8a48d7c6f98cf6901 management
+3.4.4-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
+3.4-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
+3-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
+management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
-4.1: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
-4: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
-latest: git://github.com/docker-library/wordpress@dc184cf9712bd66c1836e8ecf94987a742c29eed
+4.1.0: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
+4.1: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
+4: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
+latest: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a


### PR DESCRIPTION
- `docker-dev`: 1.5.0
- `elasticsearch`: 1.3.8 and 1.4.3
- `mongo`: 3.0.0-rc8
- `rabbitmq`: 3.4.4; updated Erlang (docker-library/rabbitmq#9)
- `wordpress`: warn if both `WORDPRESS_DB_HOST` and linked MySQL are supplied (docker-library/wordpress#57)