### PR TITLE
Move MAINTAINERS to the top-level

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,2 @@
-Joffrey Fuhrer <joffrey@dotcloud.com> (@shin-)
 Tianon Gravi <admwiggin@gmail.com> (@tianon)
 Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -4,9 +4,6 @@ set -e
 # make sure we can GTFO
 trap 'echo >&2 Ctrl+C captured, exiting; exit 1' SIGINT
 
-# so we can have fancy stuff like !(pattern)
-shopt -s extglob
-
 dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 library="$dir/../library"
@@ -115,7 +112,7 @@ esac
 
 repos=()
 if [ "$buildAll" ]; then
-	repos=( "$library"/!(MAINTAINERS) )
+	repos=( "$library"/* )
 fi
 repos+=( "$@" )
 


### PR DESCRIPTION
This also removes the special-case inside bashbrew to ignore `library/MAINTAINERS`.