### PR TITLE
Update jetty:9-jre* images to Jetty 9.2.8

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,37 +1,37 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-7.6.16-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
-7.6-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
-7-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
-7.6.16: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
-7.6: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
-7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre7
+7.6.16-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
+7.6-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
+7-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
+7.6.16: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
+7.6: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
+7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
 
-7.6.16-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre8
-7.6-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre8
-7-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 7-jre8
+7.6.16-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
+7.6-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
+7-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
 
-8.1.16-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
-8.1-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
-8-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
-8.1.16: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
-8.1: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
-8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre7
+8.1.16-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
+8.1-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
+8-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
+8.1.16: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
+8.1: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
+8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
 
-8.1.16-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre8
-8.1-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre8
-8-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 8-jre8
+8.1.16-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
+8.1-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
+8-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
 
-9.2.7-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-9.2-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-9-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-jre7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-9.2.7: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-9.2: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-9: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
-latest: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre7
+9.2.8-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9.2-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9.2.8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9.2: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+latest: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
 
-9.2.7-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre8
-9.2-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre8
-9-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre8
-jre8: git://github.com/md5/docker-jetty@74bdfc42759346f2c43f0faf7e7521f227a5e219 9-jre8
+9.2.8-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
+9.2-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
+9-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
+jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8


### PR DESCRIPTION
From `jetty-announce`:

> The Highlights:
> 
>   + A new AsyncMiddleManServlet has been added to the jetty-proxy module
>     to allow organizations to implement content transforming (downstream
>     and upstream) services on a proxy setup.
>     (documentation is forthcoming)
>   + Updated protonego implementations for recently released Java JVMs
>   + General bug fixes
> 
> This release is considered a maintenance release of the Jetty 9.2 codebase,
> while we work on the upcoming Jetty 9.3.0 release with support for HTTP/2.

I'm not sure why the 7 and 8 images are showing up in this diff, but there's nothing wrong with the new shas either (cf. https://github.com/md5/docker-jetty/compare/74bdfc42759346f2c43f0faf7e7521f227a5e219...394a77a1d47d1777fefa67fb8699d0d8702e6724).

Also, may I get your opinion on whether I should include the changes needed to address md5/docker-jetty#2 and remove Jetty 7 and 8? They were apparently EOL'd at the end of 2014.
 