### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.8: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.3
-1.3: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.3
+1.3: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.3
 
-1.4.3: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
-1.4: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
-1: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
-latest: git://github.com/docker-library/elasticsearch@ed6fc6c6f26b38941199e135772c464f96dfd438 1.4
+1.4.4: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
+1.4: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
+1: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
+latest: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,6 +8,6 @@ latest: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bcc
 10.1.2: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
 10.1: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
 
-5.5.41: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5
-5.5: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5
-5: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 5.5
+5.5.42: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5
+5.5: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5
+5: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.37-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
-5.4-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
-5.4.37: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
-5.4: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4
+5.4.38-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
+5.4-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
+5.4.38: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
+5.4: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
 
-5.4.37-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4/apache
-5.4-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.4/apache
+5.4.38-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/apache
+5.4-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/apache
 
-5.4.37-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@d506059bc4361bfe9b0ce536c7d94f76a37d2c02 5.4/fpm
+5.4.38-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/fpm
 
-5.5.21-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
-5.5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
-5.5.21: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
-5.5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5
+5.5.22-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
+5.5-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
+5.5.22: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
+5.5: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
 
-5.5.21-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5/apache
-5.5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.5/apache
+5.5.22-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/apache
+5.5-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/apache
 
-5.5.21-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.5/fpm
+5.5.22-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/fpm
 
-5.6.5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-5.6-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-5-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-cli: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-5.6.5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-5.6: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-5: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
-latest: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6
+5.6.6-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5.6-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5.6.6: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5.6: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+latest: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
 
-5.6.5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
-5.6-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
-5-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
-apache: git://github.com/docker-library/php@63835823986369ab5982cc6ea1345a962fda5b4a 5.6/apache
+5.6.6-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
+5.6-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
+5-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
+apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
 
-5.6.5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
-5-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
-fpm: git://github.com/docker-library/php@c871678cc7c8dbc9277832e35f14f3534f2dd0fb 5.6/fpm
+5.6.6-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
+5-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
+fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
-4.1: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
-4: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
-latest: git://github.com/docker-library/wordpress@435677d101aa11c9b4e87ac5c90715d6562aeb2a
+4.1.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+4.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+4: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+latest: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01


### PR DESCRIPTION
- `elasticsearch`: 1.3.9, 1.4.4
- `mariadb`: 5.5.42
- `php`: 5.4.38, 5.5.22, 5.6.6
- `wordpress`: 4.1.1