### PR TITLE
Remove EOL'd Jetty versions 7 and 8

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,27 +1,5 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-7.6.16-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-7.6-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-7-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-7.6.16: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-7.6: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre7
-
-7.6.16-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
-7.6-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
-7-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 7-jre8
-
-8.1.16-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-8.1-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-8-jre7: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-8.1.16: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-8.1: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre7
-
-8.1.16-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
-8.1-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
-8-jre8: git://github.com/md5/docker-jetty@394a77a1d47d1777fefa67fb8699d0d8702e6724 8-jre8
-
 9.2.8-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
 9.2-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
 9-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7


### PR DESCRIPTION
The Jetty 7 and 8 tags will no longer be considered supported tags. They will not likely receive any future version updates from upstream, but I've created the [`eol/jetty-7`](https://github.com/md5/docker-jetty/tree/eol/jetty-7) and [`eol/jetty-8`](https://github.com/md5/docker-jetty/tree/eol/jetty-8) branches just in case I need to do any future updates. Those branches may also be useful to people who want to build the Jetty 7 and 8 images themselves.

See md5/docker-jetty#2 for background