### PR TITLE
Call out explicitly that Git tags are discouraged

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,41 @@ Also, the Hub descriptions for these images are currently stored separately in t
 
 ## Library definition files
 
-The library definition files are plain text files found in the `library/` subfolder of the official-images repository.
+The library definition files are plain text files found in the [`library/` directory of the `official-images` repository](https://github.com/docker-library/official-images/tree/master/library).
 
-### File names
+It is highly recommended that you browse some of the existing `library/` file contents (and history to get a feel for how they change over time) before creating a new one to become familiar with the prevailing conventions and further help streamline the review process (so that we can focus on content instead of esoteric formatting or tag usage/naming).
 
-The name of a definition file will determine the name of the image(s) it creates. For example, the `library/ubuntu` file will create images in the `<namespace>/ubuntu` repository. If multiple instructions are present in a single file, all images are expected to be created under a different tag.
+### Filenames
+
+The filename of a definition file will determine the name of the image repository it creates on the Docker Hub. For example, the `library/ubuntu` file will create tags in the `ubuntu` repository.
 
 ### Instruction format
 
 	<docker-tag>: <git-url>@<git-commit-id>
-	2.2.0: git://github.com/dotcloud/docker-redis@a4bf8923ee4ec566d3ddc212
 	
-	<docker-tag>: <git-url>@<git-tag>
-	2.4.0: git://github.com/dotcloud/docker-redis@2.4.0
+	4.1.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+	4.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+	4: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+	latest: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
 	
-	<docker-tag>: <git-url>@<git-tag-or-commit-id> <dockerfile-dir>
-	2.5.1: git://github.com/dotcloud/docker-redis@2.5.1 tools/dockerfiles/2.5.1
+	
+	<docker-tag>: <git-url>@<git-commit-id> <dockerfile-dir>
+	
+	2.6.17: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
+	2.6: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
+	
+	2.8.19: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+	2.8: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+	2: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+	latest: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+	
+	experimental: git://github.com/tianon/dockerfiles@90d86ad63c4a06b7d04d14ad830381b876183b3c debian/experimental
 
-Bashbrew will fetch data from the provided git repository from the provided reference. Generated image will be tagged as `<docker-tag>`. If a git tag is removed and added to another commit, **you should not expect the image to be rebuilt.** Create a new tag and submit a pull request instead.
+Bashbrew will fetch code out of the Git repository at the commit specified here. The generated image will be tagged as `<manifest-filename>:<docker-tag>`.
 
-Optionally, if `<dockerfile-dir>` is present, Bashbrew will look for the `Dockerfile` inside the specified subdirectory instead of at the root (and `<dockerfile-dir>` will be used as the "context" for the build).
+Using Git tags instead of explicit Git commit references is supported, but heavily discouraged. For example, if a Git tag is changed on the referenced repository to point to another commit, **the image will not be rebuilt**. Instead, either create a new tag (or reference an exact commit) and submit a pull request.
+
+Optionally, if `<dockerfile-dir>` is present, Bashbrew will look for the `Dockerfile` inside the specified subdirectory instead of at the root (and `<dockerfile-dir>` will be used as the ["context" for the build](https://docs.docker.com/reference/builder/)).
 
 ### Creating a new repository
 


### PR DESCRIPTION
Also, clarified some of the language around the file format itself, including concrete real-world examples of how it looks/works in practice, and the recommendation to go browse other existing files too.