### PR TITLE
New Alpine Linux base image

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,0 +1,10 @@
+# maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
+
+edge: git://github.com/gliderlabs/docker-alpine@09c2fde27b1aa585009a070dc9cc13a020a30cf9 versions/library-edge
+
+3.1: git://github.com/gliderlabs/docker-alpine@337bd45a6de1404ceb7c7a0a2fd01744b488eaef versions/library-3.1
+latest: git://github.com/gliderlabs/docker-alpine@337bd45a6de1404ceb7c7a0a2fd01744b488eaef versions/library-3.1
+
+2.7: git://github.com/gliderlabs/docker-alpine@2a7b889be5868aee4706fd8498e6b11630e8ace2 versions/library-2.7
+
+2.6: git://github.com/gliderlabs/docker-alpine@12cf56252dcb1535e0fbeb9c3e3586551af671ea versions/library-2.6


### PR DESCRIPTION
This is a new Alpine Base Linux image maintained by Glider Labs. Check our the extended build docs at http://gliderlabs.viewdocs.io/docker-alpine/build. Some notable differences between this and other Alpine Linux images out there:

* We (Glider Labs) are making an effort to maintain and support the image. We hang out in #docker-library and our own channel at #gliderlabs to answer questions.
* We build the images on CircleCI in transparent manner so everyone can see the build process.
* Every build has images as artifacts to make for easy testing from CI.
* Even though very basic, some tests (install a package).

To support Automated Builds on Docker Hub we also keep the `rootfs.tar.xz` around and force-push a commit to a branch for the version name (such as https://github.com/gliderlabs/docker-alpine/tree/rootfs-v3.1). We do a separate branch since builds are parallelized and force-pushes to a single branch would overwrite each other.