### PR TITLE
Update to Jetty 9.2.9

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,15 +1,15 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.8-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-9.2-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-9-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-jre7: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-9.2.8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-9.2: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-9: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
-latest: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre7
+9.2.9-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9.2-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9.2.9: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9.2: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+latest: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
 
-9.2.8-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
-9.2-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
-9-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
-jre8: git://github.com/md5/docker-jetty@5e8676bbd4dfec391b2555fd6481e5cfcb0eb90d 9-jre8
+9.2.9-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
+9.2-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
+9-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
+jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8


### PR DESCRIPTION
This is considered a critical security update to Jetty 9.2.3 through 9.2.8 by upstream (cf. https://bugs.eclipse.org/bugs/show_bug.cgi?id=460642)

This update also includes the addition of a `jetty` user, although the image doesn't use it yet.

cc/ @tianon @yosifkit 