### PR TITLE
Run generate-sb for ghost, mariadb, rabbitmq, rails, tomcat, and wordpress

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.5.8: git://github.com/docker-library/ghost@6c9ed9539b810926c46f91689e8f52f71bc6f623
-0.5: git://github.com/docker-library/ghost@6c9ed9539b810926c46f91689e8f52f71bc6f623
-0: git://github.com/docker-library/ghost@6c9ed9539b810926c46f91689e8f52f71bc6f623
-latest: git://github.com/docker-library/ghost@6c9ed9539b810926c46f91689e8f52f71bc6f623
+0.5.8: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
+0.5: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
+0: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
+latest: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.16: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
-10.0: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
-10: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
-latest: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.0
+10.0.16: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
+10.0: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
+10: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
+latest: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
 
-10.1.2: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
-10.1: git://github.com/docker-library/mariadb@307bb762ff7e529eab7551fc31b13bccb808c674 10.1
+10.1.2: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.1
+10.1: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.1
 
-5.5.42: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5
-5.5: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5
-5: git://github.com/docker-library/mariadb@04b34682d4826413f1f258cb0a5b82c3ea6480fa 5.5
+5.5.42: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
+5.5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
+5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.4: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
-3.4: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
-3: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
-latest: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0
+3.4.4: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
+3.4: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
+3: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
+latest: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
 
-3.4.4-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
-3.4-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
-3-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
-management: git://github.com/docker-library/rabbitmq@a8033b9187439fb065d198d0c67c40d78c169bc0 management
+3.4.4-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
+3.4-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
+3-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
+management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.0: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358
-4.2: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358
-4: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358
-latest: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358
+4.2.0: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
+4.2: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
+4: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
+latest: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
 
 onbuild: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358 onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@278a10ace50c5e7addd879fae5c5332e57b2fe37 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@278a10ace50c5e7addd879fae5c5332e57b2fe37 7-jre8
 
-8.0.18-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-jre7: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-8.0.18: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-8.0: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
-latest: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre7
+8.0.20-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8.0.20: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8.0: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+latest: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
 
-8.0.18-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
-jre8: git://github.com/docker-library/tomcat@5bc603137a5c85647c35d33170ff243dd6e78f39 8-jre8
+8.0.20-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
+jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,6 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
-4.1: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
-4: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
-latest: git://github.com/docker-library/wordpress@bbef6075afa043cbfe791b8de185105065c02c01
+4.1.1-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4.1.1: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4.1-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4.1: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+latest: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+
+4.1.1-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
+4.1-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
+4-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
+fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm


### PR DESCRIPTION
 - `ghost` license updated
 - `mariadb` remove unused `gosu`
 - `rabbitmq` license updated
 - `rails` license updated
 - `tomcat` update to 8.0.20
 - `wordpress` add fpm version, remove rsync