### PR TITLE
Jetty non-root default user

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,15 +1,15 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.9-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-9.2-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-9-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-jre7: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-9.2.9: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-9.2: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-9: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
-latest: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre7
+9.2.9-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9.2-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9.2.9: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9.2: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+latest: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
 
-9.2.9-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
-9.2-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
-9-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
-jre8: git://github.com/md5/docker-jetty@d36c03e677a70d00ea1be3965aafc09bb5cc6ceb 9-jre8
+9.2.9-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
+9.2-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
+9-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
+jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8


### PR DESCRIPTION
* Updates jetty image to use `setuid` module and user `jetty` by default
* Uses the `JETTY_BASE` feature to have use a separate base directory of `/var/lib/jetty`, owned by user `jetty`

No tags removed or added.

Refs: md5/docker-jetty#1, md5/docker-jetty#4

Diff: https://github.com/md5/docker-jetty/compare/d36c03e677a70d00ea1be3965aafc09bb5cc6ceb...4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05
