### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.7.4-python2: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7
-1.7-python2: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7
-1-python2: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7
-python2: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7
+1.7.5-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
+1.7-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
+1-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
+python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
 
 python2-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7/onbuild
 
-1.7.4-python3: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-1.7.4: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-1.7-python3: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-1.7: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-1-python3: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-1: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-python3: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
-latest: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4
+1.7.5-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1.7.5: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1.7-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1.7: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+latest: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
 
-python3-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4/onbuild
-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild
+onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.5.8: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
-0.5: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
-0: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
-latest: git://github.com/docker-library/ghost@33d2ce4d1fd4c99dcaa6fad56bbc2e7c6f37a512
+0.5.9: git://github.com/docker-library/ghost@4ee388e3ff8d7251cfe3f0ac062efb68a0cd2835
+0.5: git://github.com/docker-library/ghost@4ee388e3ff8d7251cfe3f0ac062efb68a0cd2835
+0: git://github.com/docker-library/ghost@4ee388e3ff8d7251cfe3f0ac062efb68a0cd2835
+latest: git://github.com/docker-library/ghost@4ee388e3ff8d7251cfe3f0ac062efb68a0cd2835

--- a/library/golang
+++ b/library/golang
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.3.3: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3
-1.3: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3
+1.3.3: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.3
+1.3: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.3
 
 1.3.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
 1.3-onbuild: git://github.com/docker-library/golang@4d4b14164e50c089a09b9364697749dc7f764824 1.3/onbuild
@@ -10,13 +10,13 @@
 1.3.3-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 1.3-cross: git://github.com/docker-library/golang@acc4ed5ba8dfad17bd484ac858950bc6a6f9acde 1.3/cross
 
-1.3.3-wheezy: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3/wheezy
-1.3-wheezy: git://github.com/docker-library/golang@2668a6b1db728588dec26cf74e7e7afa146fe5e6 1.3/wheezy
+1.3.3-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.3/wheezy
+1.3-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.3/wheezy
 
-1.4.2: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4
-1.4: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4
-1: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4
-latest: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4
+1.4.2: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4
+1.4: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4
+1: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4
+latest: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4
 
 1.4.2-onbuild: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/onbuild
 1.4-onbuild: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/onbuild
@@ -28,7 +28,7 @@ onbuild: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea710
 1-cross: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/cross
 cross: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/cross
 
-1.4.2-wheezy: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/wheezy
-1.4-wheezy: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/wheezy
-1-wheezy: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/wheezy
-wheezy: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030a056a6 1.4/wheezy
+1.4.2-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
+1.4-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
+1-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
+wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy

--- a/library/java
+++ b/library/java
@@ -14,22 +14,22 @@ openjdk-6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d
 6b34-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
 6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
 
-openjdk-7u71-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-openjdk-7u71: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-openjdk-7-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-openjdk-7: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-7u71-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-7u71: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-7-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-7: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-jdk: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
-latest: git://github.com/docker-library/java@8b20818d91705361ff42b597369620680d0af98c openjdk-7-jdk
+openjdk-7u75-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+openjdk-7u75: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+openjdk-7-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+openjdk-7: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+7u75-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+7u75: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+7-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+7: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+latest: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
 
-openjdk-7u71-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-7-jre
-openjdk-7-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-7-jre
-7u71-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-7-jre
-7-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-7-jre
-jre: git://github.com/docker-library/java@d63214d23aad827190c599e23351bd0bdd7dcadc openjdk-7-jre
+openjdk-7u75-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
+openjdk-7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
+7u75-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
+7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
+jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
 
 openjdk-8u40-b22-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
 openjdk-8u40-b22: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.16: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
-10.0: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
-10: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
-latest: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.0
+10.0.17: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
+10.0: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
+10: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
+latest: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
 
-10.1.2: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.1
-10.1: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 10.1
+10.1.3: git://github.com/docker-library/mariadb@23d4b39f4abee92e964dac62dc71ce0ce1910353 10.1
+10.1: git://github.com/docker-library/mariadb@23d4b39f4abee92e964dac62dc71ce0ce1910353 10.1
 
 5.5.42: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
 5.5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -3,14 +3,14 @@
 2.2.7: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
 2.2: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
 
-2.4.12: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.4
-2.4: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.4
+2.4.13: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
+2.4: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
 
-2.6.7: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
-2.6: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
-2: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
-latest: git://github.com/docker-library/mongo@1d641659a75cf2f8ce1b517c7fc2a0ebfd033eed 2.6
+2.6.8: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
+2.6: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
+2: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
 
-3.0.0-rc8: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0
-3.0.0: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0
-3.0: git://github.com/docker-library/mongo@f8371828ff30af2479b768bd39e0646ab13a1d40 3.0
+3.0.0: git://github.com/docker-library/mongo@a73d9fba3529a87564968be96798f95c2ddf0987 3.0
+3.0: git://github.com/docker-library/mongo@a73d9fba3529a87564968be96798f95c2ddf0987 3.0
+3: git://github.com/docker-library/mongo@a73d9fba3529a87564968be96798f95c2ddf0987 3.0
+latest: git://github.com/docker-library/mongo@a73d9fba3529a87564968be96798f95c2ddf0987 3.0

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.38-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
-5.4-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
-5.4.38: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
-5.4: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4
+5.4.38-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4
+5.4-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4
+5.4.38: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4
+5.4: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4
 
-5.4.38-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/apache
-5.4-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/apache
+5.4.38-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4/apache
+5.4-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4/apache
 
-5.4.38-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.4/fpm
+5.4.38-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.4/fpm
 
-5.5.22-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
-5.5-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
-5.5.22: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
-5.5: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5
+5.5.22-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5
+5.5-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5
+5.5.22: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5
+5.5: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5
 
-5.5.22-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/apache
-5.5-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/apache
+5.5.22-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5/apache
+5.5-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5/apache
 
-5.5.22-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.5/fpm
+5.5.22-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.5/fpm
 
-5.6.6-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-5.6-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-5-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-cli: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-5.6.6: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-5.6: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-5: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
-latest: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6
+5.6.6-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+5.6-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+5-cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+cli: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+5.6.6: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+5.6: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+5: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
+latest: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6
 
-5.6.6-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
-5.6-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
-5-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
-apache: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/apache
+5.6.6-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/apache
+5.6-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/apache
+5-apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/apache
+apache: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/apache
 
-5.6.6-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
-5-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
-fpm: git://github.com/docker-library/php@58775aa6924fcb854eb57315f019bbbf729c94d2 5.6/fpm
+5.6.6-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/fpm
+5-fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/fpm
+fpm: git://github.com/docker-library/php@93c2ef13265f9c3772a5bd5833bea0d2c1b86535 5.6/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 8.4
-8.4: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 8.4
-8: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 8.4
+8.4.22: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
+8.4: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
+8: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
 
-9.0.19: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.0
-9.0: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.0
+9.0.19: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.0
+9.0: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.0
 
-9.1.15: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.1
-9.1: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.1
+9.1.15: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.1
+9.1: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.1
 
-9.2.10: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.2
-9.2: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.2
+9.2.10: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.2
+9.2: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.2
 
-9.3.6: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.3
-9.3: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.3
+9.3.6: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.3
+9.3: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.3
 
-9.4.1: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.4
-9.4: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.4
-9: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.4
-latest: git://github.com/docker-library/postgres@8f80834e934b7deaccabb7bf81876190d72800f8 9.4
+9.4.1: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
+9.4: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
+9: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
+latest: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4

--- a/library/python
+++ b/library/python
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.9: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7
-2.7: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7
-2: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7
+2.7.9: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7
+2.7: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7
+2: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7
 
 2.7.9-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 
-2.7.9-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/slim
-2.7-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/slim
-2-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/slim
+2.7.9-slim: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/slim
+2.7-slim: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/slim
+2-slim: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/slim
 
-2.7.9-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 2.7/wheezy
+2.7.9-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3
-3.3: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3
+3.3.6: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3
+3.3: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3/slim
-3.3-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/slim
+3.3-slim: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/wheezy
 
-3.4.2: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4
-3.4: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4
-3: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4
-latest: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4
+3.4.3: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4
+3.4: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4
+3: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4
+latest: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4
 
-3.4.2-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
-3.4-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
-3-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
-onbuild: git://github.com/docker-library/python@e236058d5c3601af1d38ba27b4fe217c5d678c02 3.4/onbuild
+3.4.3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
+3.4-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
+3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
+onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 
-3.4.2-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/slim
-3.4-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/slim
-3-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/slim
-slim: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/slim
+3.4-slim: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/slim
+3-slim: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/slim
+slim: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/slim
 
-3.4.2-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/wheezy
-wheezy: git://github.com/docker-library/python@25134c1757699a357936b94924a97536f9526040 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
+wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.0: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
-4.2: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
-4: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
-latest: git://github.com/docker-library/rails@9de56127a19118f243b8a8f857cfa47e8fc9bdef
+4.2.0: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
+4.2: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
+4: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
+latest: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
 
-onbuild: git://github.com/docker-library/rails@3c87a6cf32d01204b95ba12a266d13c8c32e5358 onbuild
+onbuild: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -20,21 +20,21 @@
 1.9-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
 
-2.0.0-p598: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
-2.0.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
-2.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.0
+2.0.0-p643: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
+2.0.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
+2.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
 
-2.0.0-p598-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
-2.0.0-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
-2.0-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.0/onbuild
+2.0.0-p643-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
+2.0.0-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
+2.0-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
 
-2.0.0-p598-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.0/slim
+2.0.0-p643-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
 
-2.0.0-p598-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
-2.0.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
-2.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.0/wheezy
+2.0.0-p643-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
+2.0.0-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
+2.0-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
 
 2.1.5: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
 2.1: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
@@ -48,22 +48,22 @@
 2.1.5-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 2.1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 
-2.2.0: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
-2.2: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
-2: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
-latest: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.2
+2.2.1: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
+2.2: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
+2: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
+latest: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
 
-2.2.0-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
-2.2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
-2-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
-onbuild: git://github.com/docker-library/ruby@b7fefd2fa79882da90feb0718430680c77c5fa8b 2.2/onbuild
+2.2.1-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
+2.2-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
+2-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
+onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
 
-2.2.0-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
-2-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 2.2/slim
+2.2.1-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
+2-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
+slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
 
-2.2.0-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy
-2.2-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy
-2-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy
-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.2/wheezy
+2.2.1-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy
+2.2-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy
+2-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy
+wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy


### PR DESCRIPTION
- `django`: 1.7.5, Python 3.4.3
- `ghost`: 0.5.9
- `golang`: change `/go` to be `777` (docker-library/golang#44)
- `java`: 7u75-2.5.4-2
- `mariadb`: 10.1.3, 10.0.17
- `mongo`: 3.0.0
- `php`: more aggressive autoremove (docker-library/php#71)
- `postgres`: `POSTGRES_DB` (docker-library/postgres#49)
- `python`: 3.4.3, `--enable-unicode=ucs4` (docker-library/python#38)
- `rails`: Ruby 2.2.1
- `ruby`: 2.2.1, 2.0.0-p643