### PR TITLE
Start adding tests for docker-php-ext-*

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -34,6 +34,9 @@ declare -A imageTests=(
 	[mysql]='
 		mysql-basics
 	'
+	[php]='
+		php-ext-install
+	'
 # example onbuild
 #	[python:onbuild]='
 #		py-onbuild

--- a/test/tests/php-ext-install/container.sh
+++ b/test/tests/php-ext-install/container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+docker-php-ext-install pdo_mysql 2>&1

--- a/test/tests/php-ext-install/run.sh
+++ b/test/tests/php-ext-install/run.sh
@@ -1,0 +1,1 @@
+../run-bash-in-container.sh


### PR DESCRIPTION
This adds a single test for `docker-php-ext-install pdo_mysql`. More tests should be added for other common modules (e.g. `gd`, `intl`, `mbstring`, etc.).