### PR TITLE
Update jetty image

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,15 +1,15 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.9-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-9.2-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-9-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-jre7: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-9.2.9: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-9.2: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-9: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
-latest: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre7
+9.2.9-jre7: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+9.2-jre7: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+9-jre7: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+jre7: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+9.2.9: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+9.2: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+9: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
+latest: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre7
 
-9.2.9-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
-9.2-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
-9-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
-jre8: git://github.com/md5/docker-jetty@4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05 9-jre8
+9.2.9-jre8: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre8
+9.2-jre8: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre8
+9-jre8: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre8
+jre8: git://github.com/md5/docker-jetty@346cf67904dc0e0e0a47ea7796baa769ad76e4b1 9-jre8


### PR DESCRIPTION
* Support running Jetty in read-only containers (md5/docker-jetty#5)
  - Create `/tmp/jetty` and `/run/jetty` directories, owned by `jetty:jetty`
  - Set `JETTY_STATE=/run/jetty/jetty.state` and `TMPDIR=/tmp/jetty`

Diff: https://github.com/md5/docker-jetty/compare/4ad6b737e903f54b1ed529ab1c9afe9c6d8fde05...346cf67904dc0e0e0a47ea7796baa769ad76e4b1