### PR TITLE
Update jenkins

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -2,5 +2,5 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
 latest: git://github.com/cloudbees/jenkins-ci.org-docker@1bdf7cabcc49663dd174c470c2f2c08b4c3dcccb
-weekly: git://github.com/cloudbees/jenkins-ci.org-docker@46c675c450b7bdeffeb1c48b435a00c1966480f3
+1.596.1: git://github.com/cloudbees/jenkins-ci.org-docker@1bdf7cabcc49663dd174c470c2f2c08b4c3dcccb
 

--- a/library/jenkins
+++ b/library/jenkins
@@ -1,55 +1,6 @@
 # maintainer: Nicolas De Loof <nicolas.deloof@gmail.com> (@ndeloof)
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
-1.554.1: git://github.com/cloudbees/jenkins-ci.org-docker@f313389f8ab728d7b4207da36804ea54415c830b 1.554.1
-1.554.2: git://github.com/cloudbees/jenkins-ci.org-docker@f313389f8ab728d7b4207da36804ea54415c830b 1.554.2
-1.554.3: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.554.3
-1.555: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.555
-1.556: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.556
-1.557: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.557
-1.558: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.558
-1.559: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.559
-1.560: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.560
-1.561: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.561
-1.562: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.562
-1.563: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.563
-1.564: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.564
-1.565.1: git://github.com/cloudbees/jenkins-ci.org-docker@f313389f8ab728d7b4207da36804ea54415c830b 1.565.1
-1.565.2: git://github.com/cloudbees/jenkins-ci.org-docker@f313389f8ab728d7b4207da36804ea54415c830b 1.565.2
-1.565.3: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.565.3
-1.565: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.565
-1.566: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.566
-1.567: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.567
-1.568: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.568
-1.569: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.569
-1.570: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.570
-1.571: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.571
-1.572: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.572
-1.573: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.573
-1.574: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.574
-1.575: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.575
-1.576: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.576
-1.577: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.577
-1.578: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.578
-1.579: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.579
-1.580.1: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.580.1
-1.580.2: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.580.2
-latest: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.580.2
-1.580: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.580
-1.581: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.581
-1.582: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.582
-1.583: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.583
-1.584: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.584
-1.585: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.585
-1.586: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.586
-1.587: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.587
-1.588: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.588
-1.589: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.589
-1.590: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.590
-1.591: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.591
-1.592: git://github.com/cloudbees/jenkins-ci.org-docker@40c3e3f46939b9f9dcf8d46e62fa7daa80485588 1.592
-1.593: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.593
-1.594: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.594
-1.595: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.595
-1.596: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.596
-weekly: git://github.com/cloudbees/jenkins-ci.org-docker@c39540d22e2a9c20e691cbdc4c9c54aee77be357 1.596
+latest: git://github.com/cloudbees/jenkins-ci.org-docker@1bdf7cabcc49663dd174c470c2f2c08b4c3dcccb
+weekly: git://github.com/cloudbees/jenkins-ci.org-docker@46c675c450b7bdeffeb1c48b435a00c1966480f3
+


### PR DESCRIPTION
Following discussion on https://github.com/docker-library/official-images/pull/544
give up with tagged versions and only expose "latest" and "weekly"