### PR TITLE
Add Jetty 9.3.0.M2

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,15 +1,20 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.10-jre7: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-9.2-jre7: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-9-jre7: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-jre7: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-9.2.10: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-9.2: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-9: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
-latest: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre7
+9.2.10: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9.2: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9.2.10-jre7: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9.2-jre7: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9-jre7: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+latest: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+jre7: git://github.com/md5/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
 
-9.2.10-jre8: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre8
-9.2-jre8: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre8
-9-jre8: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre8
-jre8: git://github.com/md5/docker-jetty@9bd2e6ebab4df0dd78e462808aabfb85630e694a 9-jre8
+9.2.10-jre8: git://github.com/md5/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
+9.2-jre8: git://github.com/md5/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
+9-jre8: git://github.com/md5/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
+jre8: git://github.com/md5/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
+
+9.3.0.M2: git://github.com/md5/docker-jetty@9ba53126e90113aed256d7b5f095d1118b8e82e6 9.3-jre7
+9.3.0.M2-jre7: git://github.com/md5/docker-jetty@9ba53126e90113aed256d7b5f095d1118b8e82e6 9.3-jre7
+
+9.3.0.M2-jre8: git://github.com/md5/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.3-jre8


### PR DESCRIPTION
This adds `9.3.0.M2` builds of the `jetty` image for JRE 7 and 8. Until 9.3.0 is officially released, these images will only be tagged with the full `9.3.0.M#` version number, not `9.3`.