### PR TITLE
Updates to R version 3.1.3; also sets LANG

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,7 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-latest: git://github.com/rocker-org/rocker@fa244c6a6010d41fca568d2469be681959a1f3c4 r-base
+latest: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
+3.1.3: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
 3.1.2: git://github.com/rocker-org/rocker@fa244c6a6010d41fca568d2469be681959a1f3c4 r-base
 

--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,6 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-latest: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
-3.1.3: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
+latest: git://github.com/rocker-org/rocker@ee9569326e20d2e46f0f22bcc6a0396a545c37e2 r-base
+3.1.3: git://github.com/rocker-org/rocker@ee9569326e20d2e46f0f22bcc6a0396a545c37e2 r-base
 

--- a/library/r-base
+++ b/library/r-base
@@ -3,5 +3,4 @@
 
 latest: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
 3.1.3: git://github.com/rocker-org/rocker@90f657c14b1ce53a523343e7792d1801d536d320 r-base
-3.1.2: git://github.com/rocker-org/rocker@fa244c6a6010d41fca568d2469be681959a1f3c4 r-base
 


### PR DESCRIPTION
This updates the image to the latest version of R, 3.1.3, by setting the `R_BASE_VERSION` tag appropriately.  It also sets the `LANG = en_US.UTF-8` for more consistent behavior. 