### PR TITLE
Fixes for CVE-2015-2318, CVE-2015-2319, CVE-2015-2320 in Mono

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -1,23 +1,24 @@
 # maintainer: Jo Shields <jo.shields@xamarin.com> (@directhex)
 
-3.10.0: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.10.0
-3.10: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.10.0
+3.10.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
+3.10: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
 
-3.10.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
-3.10-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
+3.10.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0/onbuild
+3.10-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0/onbuild
 
-3.12.0: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.12.0
-3.12: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.12.0
-3: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.12.0
-latest: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.12.0
+3.12.1: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
+3.12.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
+3.12: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
+3: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
+latest: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
 
-3.12.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.12.0/onbuild
-3.12-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.12.0/onbuild
-3-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.12.0/onbuild
-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.12.0/onbuild
+3.12.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
+3.12-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
+3-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
+onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
 
-3.8.0: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.8.0
-3.8: git://github.com/mono/docker@2d7f8f39a10ab9fda43b33ba17f6985d1b2cd3d8 3.8.0
+3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
+3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 
-3.8.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
-3.8-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
+3.8.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild
+3.8-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild


### PR DESCRIPTION
As requested, I set up side repositories with security-fixed 3.8 and 3.10 versions, for Docker users.