### PR TITLE
Update debian wheezy/stable

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -2,6 +2,7 @@
 
 # commits: (master..dist)
 #  - d16e292 2015-03-07 debootstraps
+#  - 3c79fa1 2015-03-19 debootstraps
 
 8.0: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 jessie
 8: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 jessie
@@ -16,16 +17,16 @@ sid: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf72
 6: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 squeeze
 squeeze: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 stable
+stable: git://github.com/tianon/docker-brew-debian@3c79fa1610454b8971b2eeaa10bf84827133ad24 stable
 
 testing: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 testing
 
 unstable: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 unstable
 
-7.8: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 wheezy
-7: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 wheezy
-latest: git://github.com/tianon/docker-brew-debian@d16e29274c9c0465dc240a6717c7bf7271ba0070 wheezy
+7.8: git://github.com/tianon/docker-brew-debian@3c79fa1610454b8971b2eeaa10bf84827133ad24 wheezy
+7: git://github.com/tianon/docker-brew-debian@3c79fa1610454b8971b2eeaa10bf84827133ad24 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@3c79fa1610454b8971b2eeaa10bf84827133ad24 wheezy
+latest: git://github.com/tianon/docker-brew-debian@3c79fa1610454b8971b2eeaa10bf84827133ad24 wheezy
 
 rc-buggy: git://github.com/tianon/dockerfiles@696d1075a7cfb23b984c6dedf6817ce3483c1de9 debian/rc-buggy
 experimental: git://github.com/tianon/dockerfiles@696d1075a7cfb23b984c6dedf6817ce3483c1de9 debian/experimental


### PR DESCRIPTION
This includes some other updates, but will serve as a perfect kick-off for rebuilds of wheezy-based images for #569.