### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,17 +6,23 @@ curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db6936
 jessie-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 
-jessie: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
-latest: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie
+jessie: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 jessie
+latest: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 jessie
 
 sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
 sid-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
 
-sid: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid
+sid: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 sid
+
+squeeze-curl: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/curl
+
+squeeze-scm: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/scm
+
+squeeze: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze
 
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
 
-wheezy: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 wheezy

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.7.5-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
-1.7-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
-1-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
-python2: git://github.com/docker-library/django@c8c5306033e9141babdb49008be4529261245091 2.7
+1.7.7-python2: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 2.7
+1.7-python2: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 2.7
+1-python2: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 2.7
+python2: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 2.7
 
 python2-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7/onbuild
 
-1.7.5-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-1.7.5: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-1.7-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-1.7: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-1-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-1: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-python3: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
-latest: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4
+1.7.7-python3: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+1.7.7: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+1.7-python3: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+1.7: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+1-python3: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+1: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+python3: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
+latest: git://github.com/docker-library/django@3159ff10c57c54ff93b271c46b5f6a8737a7f0c7 3.4
 
 python3-onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild
 onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.3
-1.3: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.3
+1.3: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.3
 
-1.4.4: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
-1.4: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
-1: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
-latest: git://github.com/docker-library/elasticsearch@03a5bda1ff2d27b000e5236082b26975a6a44c2e 1.4
+1.4.4: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
+1.4: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
+1: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
+latest: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4

--- a/library/java
+++ b/library/java
@@ -31,22 +31,16 @@ openjdk-7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bde
 7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
 jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
 
-openjdk-8u40-b22-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-openjdk-8u40-b22: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-openjdk-8u40-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-openjdk-8u40: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8u40-b22-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8u40-b22: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8u40-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8u40: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
-8: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jdk
+openjdk-8u40-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+openjdk-8u40: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+8u40-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+8u40: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+8: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
 
-openjdk-8u40-b22-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
-openjdk-8u40-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
-8u40-b22-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
-8u40-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@4735dcec5fec2833635b8f6634d24d7e22c617b2 openjdk-8-jre
+openjdk-8u40-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
+8u40-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre

--- a/library/logstash
+++ b/library/logstash
@@ -1,5 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.2: git://github.com/docker-library/logstash@d87d3511533cdf9074a3fddeb81b770cbb6bf05c
-1.4: git://github.com/docker-library/logstash@d87d3511533cdf9074a3fddeb81b770cbb6bf05c
-latest: git://github.com/docker-library/logstash@d87d3511533cdf9074a3fddeb81b770cbb6bf05c
+1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
+1.4.2: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
+1.4: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
+latest: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,9 +5,6 @@
 10: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
 latest: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
 
-10.1.3: git://github.com/docker-library/mariadb@23d4b39f4abee92e964dac62dc71ce0ce1910353 10.1
-10.1: git://github.com/docker-library/mariadb@23d4b39f4abee92e964dac62dc71ce0ce1910353 10.1
-
 5.5.42: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
 5.5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
 5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.22: git://github.com/docker-library/memcached@5fb6459a1eb138dcd9cfcd5fa1aef62ee511d335
-1.4: git://github.com/docker-library/memcached@5fb6459a1eb138dcd9cfcd5fa1aef62ee511d335
-1: git://github.com/docker-library/memcached@5fb6459a1eb138dcd9cfcd5fa1aef62ee511d335
-latest: git://github.com/docker-library/memcached@5fb6459a1eb138dcd9cfcd5fa1aef62ee511d335
+1.4.22: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
+1.4: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
+1: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
+latest: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c

--- a/library/mongo
+++ b/library/mongo
@@ -10,7 +10,7 @@
 2.6: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
 2: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
 
-3.0.0: git://github.com/docker-library/mongo@102976234a6bd5d73bc568c7feb56f6338ebe2db 3.0
-3.0: git://github.com/docker-library/mongo@102976234a6bd5d73bc568c7feb56f6338ebe2db 3.0
-3: git://github.com/docker-library/mongo@102976234a6bd5d73bc568c7feb56f6338ebe2db 3.0
-latest: git://github.com/docker-library/mongo@102976234a6bd5d73bc568c7feb56f6338ebe2db 3.0
+3.0.1: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
+3.0: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
+3: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
+latest: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.41: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.5
-5.5: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.5
+5.5.42: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.5
+5.5: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.5
 
-5.6.22: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.6
-5.6: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.6
-5: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.6
-latest: git://github.com/docker-library/percona@d82f9f4ad99fd325dc7a51cb9d9198f965f4b9bb 5.6
+5.6.23: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
+5.6: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
+5: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
+latest: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
-8.4: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
-8: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 8.4
+8.4.22: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
+8.4: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
+8: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
 
-9.0.19: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.0
-9.0: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.0
+9.0.19: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.0
+9.0: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.0
 
-9.1.15: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.1
-9.1: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.1
+9.1.15: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.1
+9.1: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.1
 
-9.2.10: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.2
-9.2: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.2
+9.2.10: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.2
+9.2: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.2
 
-9.3.6: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.3
-9.3: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.3
+9.3.6: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.3
+9.3: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.3
 
-9.4.1: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
-9.4: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
-9: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
-latest: git://github.com/docker-library/postgres@ebecea2954a6b1aea2c6cdf591df5d37ca779bdb 9.4
+9.4.1: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
+9.4: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
+9: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
+latest: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.4.4: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
-3.4: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
-3: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
-latest: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd
+3.5.0: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
+3.5: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
+3: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
+latest: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
 
-3.4.4-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
-3.4-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
-3-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
-management: git://github.com/docker-library/rabbitmq@2a908fca05c991099dd01f9f0fee3ee3d7bf2cdd management
+3.5.0-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
+3.5-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
+3-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
+management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.0: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
-4.2: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
-4: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
-latest: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd
+4.2.1: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
+4.2: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
+4: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
+latest: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
 
 onbuild: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd onbuild

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.3.2: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
-7.3: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
-7: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
-latest: git://github.com/docker-library/sentry@08e7bf99eee1e7a879422fc474b73a6fafecbc31
+7.4.1: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
+7.4: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
+7: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
+latest: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.1-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-4.1.1: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-4.1-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-4.1: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-4-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-apache: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-4: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
-latest: git://github.com/docker-library/wordpress@5062fe6e01e576cda9bb79045b9347e4fe0b2f5f apache
+4.1.1-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4.1.1: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4.1-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4.1: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+latest: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
 
-4.1.1-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
-4.1-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
-4-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
-fpm: git://github.com/docker-library/wordpress@54e2ef6cceedffd0ef808c00bfffd038d67404da fpm
+4.1.1-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
+4.1-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
+4-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
+fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm


### PR DESCRIPTION
- `buildpack-deps`: `squeeze` (docker-library/buildpack-deps#21), `liblzma-dev` (docker-library/buildpack-deps#19)
- `django`: 1.7.7
- `elasticsearch`: `java:7-jre` (docker-library/elasticsearch#4)
- `java`: 8u40 (GA of OpenJDK 8!)
- `logstash`: `logstash` user (docker-library/logstash#7)
- `mariadb`: remove 10.1 (docker-library/mariadb#7)
- `memcached`: LICENSE
- `mongo`: 3.0.1
- `percona`: 5.5.42, 5.6.23
- `postgres`: correct perms on `/run/postgresql` (docker-library/postgres#52)
- `rabbitmq`: 3.5.0
- `rails`: 4.2.1
- `sentry`: 7.4.1
- `wordpress`: add comments in `.htaccess` (docker-library/wordpress#65)