### PR TITLE
Update haproxy, mongodb, ruby

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.26: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.4
-1.4: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.4
+1.4.26: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
+1.4: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
 
-1.5.11: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
-1.5: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
-1: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
-latest: git://github.com/docker-library/haproxy@0cd4f607087468b5b321acbbe27c69465b202ada 1.5
+1.5.11: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
+1.5: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
+1: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
+latest: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5

--- a/library/mongo
+++ b/library/mongo
@@ -6,9 +6,9 @@
 2.4.13: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
 2.4: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
 
-2.6.8: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
-2.6: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
-2: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.6
+2.6.9: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
+2.6: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
+2: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
 
 3.0.1: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
 3.0: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0

--- a/library/ruby
+++ b/library/ruby
@@ -1,25 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.3-p551: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
-1.9.3: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
-1.9: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
-1: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 1.9
-
-1.9.3-p551-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
-1.9.3-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
-1.9-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
-1-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 1.9/onbuild
-
-1.9.3-p551-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
-1.9.3-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
-1.9-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
-1-slim: git://github.com/docker-library/ruby@8164fe030868a3fc680dc53277b9572feedf112a 1.9/slim
-
-1.9.3-p551-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
-1.9.3-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
-1.9-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
-1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 1.9/wheezy
-
 2.0.0-p643: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
 2.0.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
 2.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0


### PR DESCRIPTION
- `haproxy` fix libpcre
- `mongo` bump `2.6` series
- `ruby` drop unsupported `1.9`