### PR TITLE
Update rabbitmq and elasticsearch

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,9 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.3
-1.3: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.3
+1.3: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.3
 
-1.4.4: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
-1.4: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
-1: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
-latest: git://github.com/docker-library/elasticsearch@3d4e29cbbad1867796c13956686352042c4f17c3 1.4
+1.4.4: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
+1.4: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
+1: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
+latest: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
+
+1.5.0: git://github.com/docker-library/elasticsearch@caa1d539d66bbc6b9aec0c821460ae924197198c 1.5
+1.5: git://github.com/docker-library/elasticsearch@caa1d539d66bbc6b9aec0c821460ae924197198c 1.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.0: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
-3.5: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
-3: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
-latest: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7
+3.5.0: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
+3.5: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
+3: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
+latest: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
 
-3.5.0-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
-3.5-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
-3-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
-management: git://github.com/docker-library/rabbitmq@46b8c75905e6666eb737c17a5d813cf41efbe4f7 management
+3.5.0-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
+3.5-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
+3-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
+management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management


### PR DESCRIPTION
- `elasticsearch` add 1.5, entrypoint to step down from root
- `rabbitmq` entrypoint to step down from root to fix 3.5