### PR TITLE
Add library file for Rakudo Star

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,0 +1,5 @@
+# maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
+
+2015.03:  git://github.com/perl6/docker@4256f33719f7669abfc951e9b224026ee659cac9
+
+latest:  git://github.com/perl6/docker@4256f33719f7669abfc951e9b224026ee659cac9

--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,5 +1,5 @@
 # maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
 
-2015.03:  git://github.com/perl6/docker@4256f33719f7669abfc951e9b224026ee659cac9
+2015.03:  git://github.com/perl6/docker@4250489944483969ff68d94476bfd81e0a2170ce
 
-latest:  git://github.com/perl6/docker@4256f33719f7669abfc951e9b224026ee659cac9
+latest:  git://github.com/perl6/docker@4250489944483969ff68d94476bfd81e0a2170ce


### PR DESCRIPTION
Rakudo is a compiler for the Perl 6 programming language.  Rakudo Star
is an early adopter distribution for Perl 6, including a virtual machine
(MoarVM or JVM), the Rakudo compiler, and a series of useful modules.

The Dockerfile in `perl6/docker` builds an image containing Rakudo running on top of MoarVM; support for the JVM will be added if there is interest.