### PR TITLE
Update images for consistency

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,14 +1,14 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.6.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.6
-4.6: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.6
+4.6.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.6
+4.6: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.6
 
-4.7.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.7
-4.7: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.7
+4.7.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.7
+4.7: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.7
 
-4.8.4: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.8
-4.8: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.8
+4.8.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.8
+4.8: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.8
 
-4.9.2: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9
-4.9: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9
-latest: git://github.com/docker-library/gcc@0d76d76561f3e8581576f9ccc71079e3455a0bea 4.9
+4.9.2: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9
+4.9: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9
+latest: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.5.10: git://github.com/docker-library/ghost@a908596689f8244d312b6ad5975e04c9eede5ce9
-0.5: git://github.com/docker-library/ghost@a908596689f8244d312b6ad5975e04c9eede5ce9
-0: git://github.com/docker-library/ghost@a908596689f8244d312b6ad5975e04c9eede5ce9
-latest: git://github.com/docker-library/ghost@a908596689f8244d312b6ad5975e04c9eede5ce9
+0.5.10: git://github.com/docker-library/ghost@d07b3e679d043aa359037c133053858800e6d2c8
+0.5: git://github.com/docker-library/ghost@d07b3e679d043aa359037c133053858800e6d2c8
+0: git://github.com/docker-library/ghost@d07b3e679d043aa359037c133053858800e6d2c8
+latest: git://github.com/docker-library/ghost@d07b3e679d043aa359037c133053858800e6d2c8

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.3.6: git://github.com/docker-library/julia@3ebca9477c82374d1123574261b369387772de1b
-0.3: git://github.com/docker-library/julia@3ebca9477c82374d1123574261b369387772de1b
-latest: git://github.com/docker-library/julia@3ebca9477c82374d1123574261b369387772de1b
+0.3.7: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676
+0.3: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676
+latest: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676

--- a/library/logstash
+++ b/library/logstash
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
-1.4.2: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
-1.4: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
-latest: git://github.com/docker-library/logstash@23051d204fd091d3adc780cb35e260d6660b621f
+1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
+1.4.2: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
+1.4: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
+latest: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.22: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
-1.4: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
-1: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
-latest: git://github.com/docker-library/memcached@02d67343c042b0bcf3479f64594b0e14d796434c
+1.4.22: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
+1.4: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
+1: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
+latest: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.39-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4
-5.4-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4
-5.4.39: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4
-5.4: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4
+5.4.39-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4
+5.4-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4
+5.4.39: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4
+5.4: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4
 
-5.4.39-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4/apache
-5.4-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4/apache
+5.4.39-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4/apache
+5.4-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.4/apache
 
-5.4.39-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.4/fpm
+5.4.39-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.4/fpm
 
-5.5.23-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5
-5.5-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5
-5.5.23: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5
-5.5: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5
+5.5.23-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5
+5.5-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5
+5.5.23: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5
+5.5: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5
 
-5.5.23-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5/apache
-5.5-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5/apache
+5.5.23-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5/apache
+5.5-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.5/apache
 
-5.5.23-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.5/fpm
+5.5.23-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.5/fpm
 
-5.6.7-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-5.6-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-5-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-cli: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-5.6.7: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-5.6: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-5: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
-latest: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6
+5.6.7-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+5.6-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+5-cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+cli: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+5.6.7: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+5.6: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+5: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
+latest: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6
 
-5.6.7-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/apache
-5.6-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/apache
-5-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/apache
-apache: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/apache
+5.6.7-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6/apache
+5.6-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6/apache
+5-apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6/apache
+apache: git://github.com/docker-library/php@2c6f50838565b103cc0b1c71aa11b6354a2707db 5.6/apache
 
-5.6.7-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/fpm
-5-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/fpm
-fpm: git://github.com/docker-library/php@dd4503a7f06edf792d045e1dc60cef8828965265 5.6/fpm
+5.6.7-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.6/fpm
+5-fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.6/fpm
+fpm: git://github.com/docker-library/php@0d49708c9983607adc23ed09f778caa54b7312f8 5.6/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.5.0: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
-2-2.5: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
-2-2: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
-2: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2
+2-2.5.1: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2
+2-2.5: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2
+2-2: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2
+2: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2
 
-2-2.5.0-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
-2-2.5-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
-2-2-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
-2-onbuild: git://github.com/docker-library/pypy@2525314e292c8e5e9b0059decd97753c4a4b6b85 2/onbuild
+2-2.5.1-onbuild: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2/onbuild
+2-2.5-onbuild: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2/onbuild
+2-2-onbuild: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2/onbuild
+2-onbuild: git://github.com/docker-library/pypy@6d72f0d0dfb0848f87a7f89e8401129dc3edd982 2/onbuild
 
-2-2.5.0-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
+2-2.5.1-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 2-2.5-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 2-2-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim
 2-slim: git://github.com/docker-library/pypy@b205b0255a3816166e4a91fc28521e25e9875485 2/slim

--- a/library/redis
+++ b/library/redis
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
-2.6: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.6
+2.6.17: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
+2.6: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
 
-2.8.19: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
-2.8: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
-2: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
-latest: git://github.com/docker-library/redis@062335e0a8d20cab2041f25dfff2fbaf58544471 2.8
+2.8.19: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
+2.8: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
+2: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
+latest: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8

--- a/library/ruby
+++ b/library/ruby
@@ -1,47 +1,47 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p643: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
-2.0.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
-2.0: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0
+2.0.0-p643: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0
+2.0.0: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0
+2.0: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0
 
 2.0.0-p643-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/onbuild
 
-2.0.0-p643-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/slim
+2.0.0-p643-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.0/slim
 
 2.0.0-p643-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
 2.0.0-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
 2.0-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.0/wheezy
 
-2.1.5: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
-2.1: git://github.com/docker-library/ruby@1f5d7ef4e2659596e007871db90b80b2f235b845 2.1
+2.1.5: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.1
+2.1: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.1
 
 2.1.5-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@069e9f5f9aa4903f4a3cb4baf6325d08d9d366e6 2.1/onbuild
 
-2.1.5-slim: git://github.com/docker-library/ruby@4a125ef1ad5c8d9d8a7560fcb86c9a7ed3c39dff 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@4a125ef1ad5c8d9d8a7560fcb86c9a7ed3c39dff 2.1/slim
+2.1.5-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.1/slim
 
 2.1.5-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 2.1-wheezy: git://github.com/docker-library/ruby@8c8394eebfff558f3aa00780e09f73f04e8eca56 2.1/wheezy
 
-2.2.1: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
-2.2: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
-2: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
-latest: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2
+2.2.1: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2
+2.2: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2
+2: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2
+latest: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2
 
 2.2.1-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/onbuild
 
-2.2.1-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
-2-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
-slim: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/slim
+2.2.1-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2/slim
+2-slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2/slim
+slim: git://github.com/docker-library/ruby@69582bf7de57fe358d4c3c7c23400aebaf626b92 2.2/slim
 
 2.2.1-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy
 2.2-wheezy: git://github.com/docker-library/ruby@90c4e3be58d565007c518d311d4bd05086a1638c 2.2/wheezy

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.4.1: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
-7.4: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
-7: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
-latest: git://github.com/docker-library/sentry@3ed50226bd7e1aeb8cfcfd542ee452e84f97a4e2
+7.4.3: git://github.com/docker-library/sentry@fa2944e107453d781d5fa41fd61fb5fbf216b993
+7.4: git://github.com/docker-library/sentry@fa2944e107453d781d5fa41fd61fb5fbf216b993
+7: git://github.com/docker-library/sentry@fa2944e107453d781d5fa41fd61fb5fbf216b993
+latest: git://github.com/docker-library/sentry@fa2944e107453d781d5fa41fd61fb5fbf216b993

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@278a10ace50c5e7addd879fae5c5332e57b2fe37 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@278a10ace50c5e7addd879fae5c5332e57b2fe37 7-jre8
 
-8.0.20-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-jre7: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-8.0.20: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-8.0: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
-latest: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre7
+8.0.21-jre7: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+jre7: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+8.0.21: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+8.0: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+8: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
+latest: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre7
 
-8.0.20-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
-jre8: git://github.com/docker-library/tomcat@af71a3020ae05a63741db44c69d722f00e1d382a 8-jre8
+8.0.21-jre8: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre8
+jre8: git://github.com/docker-library/tomcat@41b2a08dbf016a551c859559a4e27c4f4fce2964 8-jre8


### PR DESCRIPTION
- `gcc` Fix removal of needed libraries, ensure cc/c89/c99 exist
- `ghost` Use && instead of ; for consistency
- `julia` Bump to `0.3.7`
- `logstash` Use && instead of ; for consistency
- `memcached` Use && instead of ; for consistency
- `php` Use && instead of ; for consistency, clean out {conf,sites}-enabled
- `pypy` Bump to `2-2.5.1`
- `redis` Use && instead of ; for consistency
- `ruby` Use && instead of ; for consistency
- `sentry` Bump to `7.4.3`
- `tomcat` Bump to `8.0.21`