### PR TITLE
Let bashbrew tolerate EOL diversity

### DIFF
--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -195,7 +195,7 @@ for repoTag in "${repos[@]}"; do
 	fi
 	
 	# parse the repo library file
-	IFS=$'\n'
+	IFS=$'\r\n'
 	repoTagLines=( $("${cmd[@]}" | grep -vE '^#|^\s*$') )
 	unset IFS
 	


### PR DESCRIPTION
This fixes issues where the library file has line endings besides `LF`.