### PR TITLE
update centos image with systemd-container

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -2,9 +2,9 @@
 # Build date 20150102_1408
 
 # CentOS 7 rolling builds
-latest: git://github.com/CentOS/sig-cloud-instance-images@bfa76ddefb6cd4f4e743e0c03ee69d78b56ee406 docker
-centos7: git://github.com/CentOS/sig-cloud-instance-images@bfa76ddefb6cd4f4e743e0c03ee69d78b56ee406 docker
-7: git://github.com/CentOS/sig-cloud-instance-images@bfa76ddefb6cd4f4e743e0c03ee69d78b56ee406 docker
+latest: git://github.com/CentOS/sig-cloud-instance-images@64153cd9035aef40824d0df8c9eeb6b79845cf28 docker
+centos7: git://github.com/CentOS/sig-cloud-instance-images@64153cd9035aef40824d0df8c9eeb6b79845cf28 docker
+7: git://github.com/CentOS/sig-cloud-instance-images@64153cd9035aef40824d0df8c9eeb6b79845cf28 docker
 
 # CentOS 6 rolling builds
 centos6: git://github.com/CentOS/sig-cloud-instance-images@e83bb5bf3b38bda254b46908234999355265cd96 docker


### PR DESCRIPTION
No env values are set, and the default command is still /bin/bash. 
This update just makes it easier to use systemd. 