### PR TITLE
update swarm to 0.2.0

### DIFF
--- a/library/swarm
+++ b/library/swarm
@@ -2,6 +2,5 @@
 # maintainer: Victor Vieux <vieux@docker.com> (@vieux)
 # maintainer: Alexandre Beslic <abronan@docker.com> (@abronan)
 
-0.2.0-rc2: git://github.com/docker/swarm-library-image@c0914e905ed2923be60b27aec29395384b65c4c4
-0.1.0: git://github.com/docker/swarm-library-image@d9999a8a797d8e9744f1bfc0e7211d016478b2fc
-latest: git://github.com/docker/swarm-library-image@d9999a8a797d8e9744f1bfc0e7211d016478b2fc
+0.2.0: git://github.com/docker/swarm-library-image@3c2dd0f73b7351744af64efb38e4fa5a015cc114
+latest: git://github.com/docker/swarm-library-image@3c2dd0f73b7351744af64efb38e4fa5a015cc114


### PR DESCRIPTION
I removed `0.1.0` are we aren't maintaining it anymore, correct @tianon ?