### PR TITLE
7.10.1, belated 7.8.4, move to new upstream PPA

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,5 +2,10 @@
 # maintainer: Peter Salvatore <peter@psftw.com> (@psftw)
 # maintainer: Christopher Biscardi <biscarch@sketcht.com> (@chrisbiscardi)
 
-latest: git://github.com/darinmorrison/docker-haskell@399ec9abffb3c86d6747d7ab5dc40556d6de9e4b 7.8
-7.8: git://github.com/darinmorrison/docker-haskell@399ec9abffb3c86d6747d7ab5dc40556d6de9e4b 7.8
+7.10.1: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.10
+7.10: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.10
+7: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.10
+latest: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.10
+
+7.8.4: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.8
+7.8: git://github.com/freebroccolo/docker-haskell@8ebd12bf273855afabc2d270b8c0a7aa233b0ea4 7.8


### PR DESCRIPTION
The deb.haskell.org repository has been abandoned in this version update
since it was not up to date and has been taken offline after a recent
compromise.  We have settled on sticking with a Debian base and
utilizing a PPA maintained by an active GHC committer.  The new PPA
packages are based on the original source, but have been actively
maintained.  The 7.8.4 release, which is the last in the 7.8 series is
being included even though it should have gone out months ago when it
was initially released and is now basically dead-end.  There are still a
number of libraries that fail on 7.10 at this point.  With the next
version bump we plan to properly drop the 7.8 tag.