### PR TITLE
Updates for elasticsearch, mongo, mysql

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,5 +8,5 @@
 1: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
 latest: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
 
-1.5.0: git://github.com/docker-library/elasticsearch@caa1d539d66bbc6b9aec0c821460ae924197198c 1.5
-1.5: git://github.com/docker-library/elasticsearch@caa1d539d66bbc6b9aec0c821460ae924197198c 1.5
+1.5.1: git://github.com/docker-library/elasticsearch@cec506d931f75619876292a47b9f9e8edd4ddc47 1.5
+1.5: git://github.com/docker-library/elasticsearch@cec506d931f75619876292a47b9f9e8edd4ddc47 1.5

--- a/library/mongo
+++ b/library/mongo
@@ -10,7 +10,7 @@
 2.6: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
 2: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
 
-3.0.1: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
-3.0: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
-3: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
-latest: git://github.com/docker-library/mongo@b1c4c5028bd10fe01ddd3fbcdb4b0828580c14e0 3.0
+3.0.2: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
+3.0: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
+3: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
+latest: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0

--- a/library/mysql
+++ b/library/mysql
@@ -8,6 +8,6 @@
 5: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
 latest: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
 
-5.7.6-m16: git://github.com/docker-library/mysql@95a8d25a230dda44709b8942c46c63595b93b73a 5.7
-5.7.6: git://github.com/docker-library/mysql@95a8d25a230dda44709b8942c46c63595b93b73a 5.7
-5.7: git://github.com/docker-library/mysql@95a8d25a230dda44709b8942c46c63595b93b73a 5.7
+5.7.7-rc: git://github.com/docker-library/mysql@837e11e42695aa5e9927b2418edaf7a666057c50 5.7
+5.7.7: git://github.com/docker-library/mysql@837e11e42695aa5e9927b2418edaf7a666057c50 5.7
+5.7: git://github.com/docker-library/mysql@837e11e42695aa5e9927b2418edaf7a666057c50 5.7


### PR DESCRIPTION
- `elasticsearch` bump to `1.5.1`
- `mongo` bump to `3.0.2`
- `mysql` bump to `5.7.7-rc`