### PR TITLE
Add official roma image to dockerhub

### DIFF
--- a/library/roma
+++ b/library/roma
@@ -1,0 +1,4 @@
+# maintainer: Rui Bando <bando.rui@gmail.com> (@banrui)
+
+latest: git://github.com/roma/docker@95233a26fe743dea843a68f4f8120079915c8f7a
+1.1.0: git://github.com/roma/docker@95233a26fe743dea843a68f4f8120079915c8f7a


### PR DESCRIPTION
Hi Docker team, I'm Rui Bando from ROMA team. 
ROMA is one of the data storing systems for distributed key-value stores. 
Refere to [website](http://roma-kvs.org).

We would like to create a official repository. So I sent 2 pull requests.
- docs repo with ROMA image info.
- oficial-images repo with the image commit.