### PR TITLE
Update Jenkins to 1.605 weekly, add weekly tag

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -1,6 +1,7 @@
 # maintainer: Nicolas De Loof <nicolas.deloof@gmail.com> (@ndeloof)
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 
-latest: git://github.com/cloudbees/jenkins-ci.org-docker@66dc63923438e70eaebd68da41bc7b9ea35ce2aa
+latest: git://github.com/cloudbees/jenkins-ci.org-docker@46c675c450b7bdeffeb1c48b435a00c1966480f3
+weekly: git://github.com/cloudbees/jenkins-ci.org-docker@46c675c450b7bdeffeb1c48b435a00c1966480f3
 1.596.2: git://github.com/cloudbees/jenkins-ci.org-docker@66dc63923438e70eaebd68da41bc7b9ea35ce2aa
 


### PR DESCRIPTION
Update the 'latest' tag to 1.605 and add the weekly tag which also
points at this same hash.