### PR TITLE
update r-base to R 3.2.0 released on April 16

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,6 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-latest: git://github.com/rocker-org/rocker@ee9569326e20d2e46f0f22bcc6a0396a545c37e2 r-base
-3.1.3: git://github.com/rocker-org/rocker@ee9569326e20d2e46f0f22bcc6a0396a545c37e2 r-base
+latest: git://github.com/rocker-org/rocker@849e42992a3ce5bf6f004bcbfc76605aff3f3c08 r-base
+3.2.0: git://github.com/rocker-org/rocker@849e42992a3ce5bf6f004bcbfc76605aff3f3c08 r-base
 


### PR DESCRIPTION
Here is a PR for the newest R version released two days ago.  I updated the Debian package, and per a kind reminder of @cboettig just updated out rocker/r-base image which built fine.

Let is know if you have any questions.  Following standard practice by the R Core team, this image should remain current for about two months before a first revisoin R 3.2.1 may appear.