### PR TITLE
Update iojs to v1.8.1

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,16 +1,16 @@
 # maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
 
-1.7.1: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7
-1.7: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7
-1: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7
-latest: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7
+1.8.1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
+1.8: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
+1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
+latest: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
 
-1.7.1-onbuild: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/onbuild
-1.7-onbuild: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/onbuild
-1-onbuild: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/onbuild
-onbuild: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/onbuild
+1.8.1-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
+1.8-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
+1-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
+onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
 
-1.7.1-slim: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/slim
-1.7-slim: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/slim
-1-slim: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/slim
-slim: git://github.com/iojs/docker-iojs@dc31c0b95945ca981495a2aa9def8c2db8864087 1.7/slim
+1.8.1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
+1.8-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
+1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
+slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim


### PR DESCRIPTION
This PR updated io.js to v1.8.1

Changeset: https://github.com/iojs/docker-iojs/compare/dc31c...4cf03
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>