### PR TITLE
Update debian (2015-04-21 debootstraps)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -1,31 +1,31 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - 8105df0 2015-03-30 debootstraps
+#  - 188b272 2015-04-21 debootstraps
 
-8.0: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 jessie
-8: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 jessie
-jessie: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 jessie
+8.0: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 jessie
+8: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 jessie
+jessie: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 sid
+sid: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 squeeze
-6: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 squeeze
+6: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 stable
+stable: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 stable
 
-testing: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 testing
+testing: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 unstable
+unstable: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 unstable
 
-7.8: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 wheezy
-7: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 wheezy
-latest: git://github.com/tianon/docker-brew-debian@8105df0412f86c08d11e86f7f6bab6160ff1e837 wheezy
+7.8: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
+7: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
+latest: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@98df9cbde165576bf6bee980487d9fc1fd51e320 debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@98df9cbde165576bf6bee980487d9fc1fd51e320 debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@cbaa8629f8619689ff4caae5b209d2928bcae8be debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@cbaa8629f8619689ff4caae5b209d2928bcae8be debian/experimental


### PR DESCRIPTION
This might be the final update of this image before `jessie` officially becomes `stable` (which is scheduled to happen next Monday)!

An important bit to note with this update is the switch from the unofficial http://http.debian.net over to the newly-legitimized http://httpredir.debian.org :metal:.