### PR TITLE
Update ubuntu (utopic and vivid)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -4,31 +4,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 662c631 Update tarballs
+#  - 7fef77c Update tarballs
 #    - `ubuntu:precise`: 20150320
 #    - `ubuntu:trusty`: 20150320
-#    - `ubuntu:utopic`: 20150319
-#    - `ubuntu:vivid`: 20150319.1
+#    - `ubuntu:utopic`: 20150418
+#    - `ubuntu:vivid`: 20150421
 
 # 20150320
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 precise
-precise-20150320: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 precise
+precise-20150320: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 precise
 
 # 20150320
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 trusty
-trusty-20150320: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 trusty
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 trusty
+trusty-20150320: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 trusty
 
-# 20150319
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 utopic
-utopic-20150319: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 utopic
+# 20150418
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 utopic
+utopic-20150418: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 utopic
 
-# 20150319.1
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 vivid
-vivid-20150319.1: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@662c6317181e3a0f53abdee253d68307a62f3fd3 vivid
+# 20150421
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 vivid
+vivid-20150421: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@7fef77c821d7f806373c04675358ac6179eaeaf3 vivid


### PR DESCRIPTION
This is probably the last update before the `vivid` release, which is scheduled for Thursday!

- `ubuntu:utopic`: 20150418
- `ubuntu:vivid`: 20150421