### PR TITLE
Updates to ghost, java, logstash, memcached, php, rabbitmq, rails, wordpress

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.5.10: git://github.com/docker-library/ghost@2fb73b3ab955365b2f7b5267536aad87f1cd65df
-0.5: git://github.com/docker-library/ghost@2fb73b3ab955365b2f7b5267536aad87f1cd65df
-0: git://github.com/docker-library/ghost@2fb73b3ab955365b2f7b5267536aad87f1cd65df
-latest: git://github.com/docker-library/ghost@2fb73b3ab955365b2f7b5267536aad87f1cd65df
+0.6.0: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
+0.6: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
+0: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
+latest: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12

--- a/library/java
+++ b/library/java
@@ -1,46 +1,46 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-openjdk-6b34-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-openjdk-6b34: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-openjdk-6-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-openjdk-6: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-6b34-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-6b34: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-6-jdk: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
-6: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jdk
+openjdk-6b34-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+openjdk-6b34: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+openjdk-6-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+openjdk-6: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+6b34-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+6b34: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+6-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
+6: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jdk
 
-openjdk-6b34-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
-openjdk-6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
-6b34-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
-6-jre: git://github.com/docker-library/java@3faf377815bd5409f91a007b092d38a36134baf5 openjdk-6-jre
+openjdk-6b34-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jre
+openjdk-6-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jre
+6b34-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jre
+6-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-6-jre
 
-openjdk-7u75-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-openjdk-7u75: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-openjdk-7-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-openjdk-7: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-7u75-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-7u75: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-7-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-7: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-jdk: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
-latest: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jdk
+openjdk-7u75-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+openjdk-7u75: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+openjdk-7-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+openjdk-7: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+7u75-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+7u75: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+7-jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+7: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+jdk: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
+latest: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jdk
 
-openjdk-7u75-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
-openjdk-7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
-7u75-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
-7-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
-jre: git://github.com/docker-library/java@4c5beb8bdb21c746bef683f18bdeddee157f61fd openjdk-7-jre
+openjdk-7u75-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jre
+openjdk-7-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jre
+7u75-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jre
+7-jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jre
+jre: git://github.com/docker-library/java@aac815a21ffd5690192e06202d6c065a49ed655f openjdk-7-jre
 
-openjdk-8u40-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-openjdk-8u40: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-8u40-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-8u40: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
-8: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jdk
+openjdk-8u45-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+openjdk-8u45: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+8u45-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+8u45: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+8: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
 
-openjdk-8u40-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
-8u40-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@1992f5ab6b5b6b4748c9628125dbea37df405d99 openjdk-8-jre
+openjdk-8u45-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
+8u45-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre

--- a/library/logstash
+++ b/library/logstash
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
-1.4.2: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
-1.4: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
-latest: git://github.com/docker-library/logstash@df0f0a1099b27a715963fe252329dc649eac9616
+1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
+1.4.2: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
+1.4: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
+latest: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.22: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
-1.4: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
-1: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
-latest: git://github.com/docker-library/memcached@db06f15a297319ae2f91573206a0f49228ef07a2
+1.4.23: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
+1.4: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
+1: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
+latest: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.39-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4
-5.4-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4
-5.4.39: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4
-5.4: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4
+5.4.40-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
+5.4-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
+5.4.40: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
+5.4: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
 
-5.4.39-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4/apache
-5.4-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4/apache
+5.4.40-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/apache
+5.4-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/apache
 
-5.4.39-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.4/fpm
+5.4.40-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/fpm
 
-5.5.23-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5
-5.5-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5
-5.5.23: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5
-5.5: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5
+5.5.24-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
+5.5-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
+5.5.24: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
+5.5: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
 
-5.5.23-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5/apache
-5.5-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5/apache
+5.5.24-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/apache
+5.5-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/apache
 
-5.5.23-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.5/fpm
+5.5.24-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/fpm
 
-5.6.7-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-5.6-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-5-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-cli: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-5.6.7: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-5.6: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-5: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
-latest: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6
+5.6.8-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5.6-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5.6.8: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5.6: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+latest: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
 
-5.6.7-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/apache
-5.6-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/apache
-5-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/apache
-apache: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/apache
+5.6.8-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
+5.6-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
+5-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
+apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
 
-5.6.7-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/fpm
-5-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/fpm
-fpm: git://github.com/docker-library/php@13112ed409335f211edbaf9b74db1c87b329b6d8 5.6/fpm
+5.6.8-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
+5-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
+fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.0: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
-3.5: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
-3: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
-latest: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab
+3.5.1: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
+3.5: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
+3: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
+latest: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
 
-3.5.0-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
-3.5-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
-3-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
-management: git://github.com/docker-library/rabbitmq@7eeb4899848388f196182b1853464d9bde9e33ab management
+3.5.1-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
+3.5-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
+3-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
+management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.1: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
-4.2: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
-4: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
-latest: git://github.com/docker-library/rails@ff5df251379dd7f95c005e95d1586d6d338285e4
+4.2.1: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
+4.2: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
+4: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
+latest: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
 
-onbuild: git://github.com/docker-library/rails@2c0ee48228c1286e53001f0b95fa28e7524b57cd onbuild
+onbuild: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9 onbuild

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.1-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-4.1.1: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-4.1-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-4.1: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-4-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-apache: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-4: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
-latest: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef apache
+4.1.2-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4.1.2: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4.1-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4.1: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+latest: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
 
-4.1.1-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
-4.1-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
-4-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
-fpm: git://github.com/docker-library/wordpress@862d97aa4c6c7e879b366f53dd853212adccedef fpm
+4.1.2-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
+4.1-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
+4-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
+fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.2-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-4.1.2: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-4.1-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-4.1: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-4-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-apache: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-4: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
-latest: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 apache
+4.1.2-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4.1.2: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4.1-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4.1: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+latest: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
 
-4.1.2-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
-4.1-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
-4-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
-fpm: git://github.com/docker-library/wordpress@08575ffd71dc9f13fdff14f44f8a7da0dd58bb34 fpm
+4.1.2-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
+4.1-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
+4-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
+fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm


### PR DESCRIPTION
- `ghost` bump `0.6.0`
- `java` bump `8u45`, `LANG C.UTF-8`
- `logstash` gosu bump to fix `$HOME`
- `memcached` bump `1.4.23`
- `php` bump `5.6.8`, `5.5.24`, `5.4.40`, enable more extensions that fail `phpize`
- `rabbitmq` bump `3.5.1`
- `rails` ruby bump `2.2.2`
- `wordpress` bump `4.1.2`