### PR TITLE
Update ubuntu-debootstrap (2015-04-21 debootstraps)

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,25 +1,25 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - 665236a 2015-03-19 debootstraps
+#  - de46e6f 2015-04-21 debootstraps
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
 
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.04
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.10
 
-15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 15.04
-vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce 15.04
+15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 15.04
+vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 15.04
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@665236ab3a0502f974c9c41d8b36475a06d7e2ce devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb devel


### PR DESCRIPTION
This is probably the last update before the `vivid` release, which is scheduled for Thursday!

Additionally (and perhaps even more noteworthy), this is likely the last update of `lucid`/`10.04` at all, since it's scheduled for EOL on next Thursday (April 30).