### PR TITLE
Add debian-apt-get test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -11,6 +11,9 @@ declare -A testAlias=(
 	[jruby]='ruby'
 	[pypy]='python'
 
+	[ubuntu]='debian'
+	[ubuntu-debootstrap]='debian'
+
 	[mariadb]='mysql'
 	[percona]='mysql'
 )
@@ -25,6 +28,9 @@ declare -A imageTests=(
 	[clojure]='
 	'
 	[crate]='
+	'
+	[debian]='
+		debian-apt-get
 	'
 	[django]='
 	'

--- a/test/tests/debian-apt-get/container.sh
+++ b/test/tests/debian-apt-get/container.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# We have to eat stderr here because of:
+# W: Conflicting distribution: http://http.debian.net rc-buggy InRelease (expected rc-buggy but got experimental)
+# W: Conflicting distribution: http://archive.ubuntu.com devel Release (expected devel but got vivid)
+# W: Conflicting distribution: http://archive.ubuntu.com devel-updates Release (expected devel-updates but got vivid)
+# W: Conflicting distribution: http://archive.ubuntu.com devel-security Release (expected devel-security but got vivid)
+apt-get update &> /dev/null
+
+# We have to eat stderr here because of:
+# debconf: delaying package configuration, since apt-utils is not installed
+apt-get install -y hello &> /dev/null
+
+exec hello

--- a/test/tests/debian-apt-get/expected-std-out.txt
+++ b/test/tests/debian-apt-get/expected-std-out.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/tests/debian-apt-get/run.sh
+++ b/test/tests/debian-apt-get/run.sh
@@ -1,0 +1,1 @@
+../run-bash-in-container.sh


### PR DESCRIPTION
Kind of basic, but it gets the point across. :+1:

```console
$ bashbrew list --uniq debian ubuntu ubuntu-debootstrap | xargs ./test/run.sh -t debian-apt-get
testing debian:8.0
	'debian-apt-get' [1/1]...passed
testing debian:oldstable
	'debian-apt-get' [1/1]...passed
testing debian:sid
	'debian-apt-get' [1/1]...passed
testing debian:6.0.10
	'debian-apt-get' [1/1]...passed
testing debian:stable
	'debian-apt-get' [1/1]...passed
testing debian:testing
	'debian-apt-get' [1/1]...passed
testing debian:unstable
	'debian-apt-get' [1/1]...passed
testing debian:7.8
	'debian-apt-get' [1/1]...passed
testing debian:rc-buggy
	'debian-apt-get' [1/1]...passed
testing debian:experimental
	'debian-apt-get' [1/1]...passed
testing ubuntu:12.04.5
	'debian-apt-get' [1/1]...passed
testing ubuntu:14.04.2
	'debian-apt-get' [1/1]...passed
testing ubuntu:14.10
	'debian-apt-get' [1/1]...passed
testing ubuntu:15.04
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:10.04.4
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:12.04.5
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:14.04.2
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:14.10
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:15.04
	'debian-apt-get' [1/1]...passed
testing ubuntu-debootstrap:devel
	'debian-apt-get' [1/1]...passed
```