### PR TITLE
Add pinning to mariadb to fix failing 5.5 build

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.17: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
-10.0: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
-10: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
-latest: git://github.com/docker-library/mariadb@b8b0d3551e7d878f4ff58ed73bc0203926db3b85 10.0
+10.0.17: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
+10.0: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
+10: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
+latest: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
 
-5.5.42: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
-5.5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
-5: git://github.com/docker-library/mariadb@88f83ef75823271f600ffef4ccfcd9ab253ca497 5.5
+5.5.42: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5
+5.5: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5
+5: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5


### PR DESCRIPTION
See docker-library/mariadb#12