### PR TITLE
Switch to HA keyserver for GPG keys

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,20 +1,20 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.10: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-9.2: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-9: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-9.2.10-jre7: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-9.2-jre7: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-9-jre7: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-latest: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
-jre7: git://github.com/appropriate/docker-jetty@185c044adf7a3a4c56db3cf354e44d678343d0cd 9.2-jre7
+9.2.10: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9.2: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9.2.10-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9.2-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+latest: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
 
-9.2.10-jre8: git://github.com/appropriate/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
-jre8: git://github.com/appropriate/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.2-jre8
+9.2.10-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
+jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
 
-9.3.0.M2: git://github.com/appropriate/docker-jetty@9ba53126e90113aed256d7b5f095d1118b8e82e6 9.3-jre7
-9.3.0.M2-jre7: git://github.com/appropriate/docker-jetty@9ba53126e90113aed256d7b5f095d1118b8e82e6 9.3-jre7
+9.3.0.M2: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre7
+9.3.0.M2-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre7
 
-9.3.0.M2-jre8: git://github.com/appropriate/docker-jetty@0098b2821ec823bdb7ab04e55f9259ea47a9a4e0 9.3-jre8
+9.3.0.M2-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre8


### PR DESCRIPTION
Diff for 9.2 images: https://github.com/appropriate/docker-jetty/compare/185c044adf7a3a4c56db3cf354e44d678343d0cd...6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92

Diff for 9.3 images: https://github.com/appropriate/docker-jetty/compare/0098b2821ec823bdb7ab04e55f9259ea47a9a4e0...6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92

cf. docker-library/php#92