### PR TITLE
Debian: current latest is jessie

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -25,7 +25,7 @@ unstable: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8
 7.8: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
 7: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
 wheezy: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
-latest: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 wheezy
+latest: git://github.com/tianon/docker-brew-debian@188b27233cedf32048ee12378e8f8c6fc0fc0cb4 jessie
 
 rc-buggy: git://github.com/tianon/dockerfiles@cbaa8629f8619689ff4caae5b209d2928bcae8be debian/rc-buggy
 experimental: git://github.com/tianon/dockerfiles@cbaa8629f8619689ff4caae5b209d2928bcae8be debian/experimental


### PR DESCRIPTION
Update docker-library/debian to jessie as latest