### PR TITLE
Mono 4.0.1 (and no more alpha)

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -10,12 +10,10 @@
 3.12.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
 3.12: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
 3: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
-latest: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
 
 3.12.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
 3.12-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
 3-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
 
 3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
@@ -23,4 +21,13 @@ onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3
 3.8.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild
 3.8-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild
 
-alpha: git://github.com/mono/docker@f639c9ba71c3e3601c079b353e12351bd008b11e alpha
+4.0.1: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
+4.0.0: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
+4.0: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
+4: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
+4.0.0-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
+4.0-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
+4-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
+
+latest: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
+onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild


### PR DESCRIPTION
The build failure problem from the previous alpha has been fixed - and that fix is in the new stable 4.0.1 release packages that this PR points to. It ought to work fine now. YMMV IANAL IDDQD