### PR TITLE
Update Busybox to 1.23.1

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -2,7 +2,9 @@
 
 buildroot-2013.08.1: git://github.com/jpetazzo/docker-busybox@220a689ce359914af3e08a698d1d74ec7aa0a444
 buildroot-2014.02: git://github.com/jpetazzo/docker-busybox@91641afe424df5e838bac254d43e09f051ab8c3e
-latest: git://github.com/jpetazzo/docker-busybox@91641afe424df5e838bac254d43e09f051ab8c3e
+buildroot-2014.11: git://github.com/jpetazzo/docker-busybox@ecf371ebf22db67a3396c78bc48929f630617074
+buildroot-2015.02: git://github.com/jpetazzo/docker-busybox@83cfcdf9f35c0e9140c77f769cbecb7b87509b68
+latest: git://github.com/jpetazzo/docker-busybox@83cfcdf9f35c0e9140c77f769cbecb7b87509b68
 ubuntu-12.04: git://github.com/jpetazzo/docker-busybox@4f6cb64c3b3255c58021dc75100da0088796a108
 ubuntu-14.04: git://github.com/jpetazzo/docker-busybox@ca435164f45c40d761fad9ef9b5a76a6ba0d5f1a
 


### PR DESCRIPTION
- Add buildroot-2014.11 tag
- Add buildroot-2015.02 tag (Busybox 1.23.1)
- Update latest to be buildroot-2015.02

Signed-off-by: Dave Tucker <dt@docker.com>