### PR TITLE
Update elasticsearch, gcc, ghost, httpd, logstash, mariadb, mongo, percona, php, postgres, python, rabbitmq, wordpress

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.3
-1.3: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@eb0f9ee6627079d45ca9a64cc30cff0f6dfe07a1 1.3
+1.3: git://github.com/docker-library/elasticsearch@eb0f9ee6627079d45ca9a64cc30cff0f6dfe07a1 1.3
 
-1.4.4: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
-1.4: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
-1: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
-latest: git://github.com/docker-library/elasticsearch@48be16b576157d74b38202f40ffbab04f02d668f 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
+1.4: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
+1: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
+latest: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
 
-1.5.1: git://github.com/docker-library/elasticsearch@cec506d931f75619876292a47b9f9e8edd4ddc47 1.5
-1.5: git://github.com/docker-library/elasticsearch@cec506d931f75619876292a47b9f9e8edd4ddc47 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.5
+1.5: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.5

--- a/library/gcc
+++ b/library/gcc
@@ -1,14 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.6.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.6
-4.6: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.6
+4.6.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.6
+4.6: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.6
 
-4.7.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.7
-4.7: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.7
+4.7.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.7
+4.7: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.7
 
-4.8.4: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.8
-4.8: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.8
+4.8.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.8
+4.8: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.8
 
-4.9.2: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9
-4.9: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9
-latest: git://github.com/docker-library/gcc@0a661380d1c6ec9c030bff10fbf70ce48ec1411e 4.9
+4.9.2: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.9
+4.9: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.9
+
+5.1.0: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1
+5.1: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1
+latest: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.6.0: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
-0.6: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
-0: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
-latest: git://github.com/docker-library/ghost@7afddd95e2826213657961ba91208efcd0cb5c12
+0.6.2: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
+0.6: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
+0: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
+latest: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.29: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.2
-2.2: git://github.com/docker-library/httpd@047048112cb4f8997b1a51f4295f44584b436a83 2.2
+2.2.29: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.2
+2.2: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.2
 
-2.4.12: git://github.com/docker-library/httpd@9c77579dcf981f060732bf41845edea8e39a130b 2.4
-2.4: git://github.com/docker-library/httpd@9c77579dcf981f060732bf41845edea8e39a130b 2.4
-2: git://github.com/docker-library/httpd@9c77579dcf981f060732bf41845edea8e39a130b 2.4
-latest: git://github.com/docker-library/httpd@9c77579dcf981f060732bf41845edea8e39a130b 2.4
+2.4.12: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.4
+2.4: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.4
+2: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.4
+latest: git://github.com/docker-library/httpd@63cd0ad57a12c76ff70d0f501f6c2f1580fa40f5 2.4

--- a/library/logstash
+++ b/library/logstash
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
-1.4.2: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
-1.4: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
-latest: git://github.com/docker-library/logstash@a1e1ec3a0ab114e935181ae5b9adf5f0b9371ca4
+1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
+1.4.2: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
+1.4: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
+latest: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.17: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
-10.0: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
-10: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
-latest: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 10.0
+10.0.17: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
+10.0: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
+10: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
+latest: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
 
-5.5.42: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5
-5.5: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5
-5: git://github.com/docker-library/mariadb@43191705a6ed906f5a4f3cd0e11dd79f207a7265 5.5
+5.5.42: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5
+5.5: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5
+5: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
-2.2: git://github.com/docker-library/mongo@d9fb48dbdb0b9c35d35902429fe1a28527959f25 2.2
+2.2.7: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.2
+2.2: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.2
 
-2.4.13: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
-2.4: git://github.com/docker-library/mongo@ea56087e928b5d734bf7661384ebf3c432d70f28 2.4
+2.4.13: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.4
+2.4: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.4
 
-2.6.9: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
-2.6: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
-2: git://github.com/docker-library/mongo@faab1fed954b4267168fd22b4bc534a62365e7a2 2.6
+2.6.9: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
+2.6: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
+2: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
 
-3.0.2: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
-3.0: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
-3: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
-latest: git://github.com/docker-library/mongo@39b64d5bffdb00d9b0b4a3d177ec66dcda12a6d6 3.0
+3.0.2: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 3.0
+3.0: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 3.0
+3: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 3.0
+latest: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 3.0

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.42: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.5
-5.5: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.5
+5.5.42: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.5
+5.5: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.5
 
-5.6.23: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
-5.6: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
-5: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
-latest: git://github.com/docker-library/percona@93aba2b5d3c9f6e4ede1a9560de9ab12df7bb401 5.6
+5.6.23: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
+5.6: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
+5: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
+latest: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.40-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
-5.4-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
-5.4.40: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
-5.4: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4
+5.4.40-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
+5.4-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
+5.4.40: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
+5.4: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
 
-5.4.40-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/apache
-5.4-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/apache
+5.4.40-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.4/apache
+5.4-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.4/apache
 
-5.4.40-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.4/fpm
+5.4.40-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4/fpm
 
-5.5.24-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
-5.5-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
-5.5.24: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
-5.5: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5
+5.5.24-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
+5.5-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
+5.5.24: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
+5.5: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
 
-5.5.24-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/apache
-5.5-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/apache
+5.5.24-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.5/apache
+5.5-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.5/apache
 
-5.5.24-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.5/fpm
+5.5.24-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5/fpm
 
-5.6.8-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-5.6-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-5-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-cli: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-5.6.8: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-5.6: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-5: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
-latest: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6
+5.6.8-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5.6-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5.6.8: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5.6: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+latest: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
 
-5.6.8-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
-5.6-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
-5-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
-apache: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/apache
+5.6.8-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
+5.6-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
+5-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
+apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
 
-5.6.8-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
-5-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
-fpm: git://github.com/docker-library/php@f6aa601699145091daaa32cc7728fc28fc842c69 5.6/fpm
+5.6.8-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
+5-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
+fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-8.4.22: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
-8.4: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
-8: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 8.4
+8.4.22: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 8.4
+8.4: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 8.4
+8: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 8.4
 
-9.0.19: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.0
-9.0: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.0
+9.0.19: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.0
+9.0: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.0
 
-9.1.15: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.1
-9.1: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.1
+9.1.15: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.1
+9.1: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.1
 
-9.2.10: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.2
-9.2: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.2
+9.2.10: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.2
+9.2: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.2
 
-9.3.6: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.3
-9.3: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.3
+9.3.6: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.3
+9.3: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.3
 
-9.4.1: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
-9.4: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
-9: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
-latest: git://github.com/docker-library/postgres@e616341507a7beec3a161b0a366ba0d3400328fd 9.4
+9.4.1: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.4
+9.4: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.4
+9: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.4
+latest: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 9.4

--- a/library/python
+++ b/library/python
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.9: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7
-2.7: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7
-2: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7
+2.7.9: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
+2.7: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
+2: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
 
 2.7.9-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 
-2.7.9-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7/slim
-2.7-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7/slim
-2-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 2.7/slim
+2.7.9-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
+2.7-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
+2-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
 
-2.7.9-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 2.7/wheezy
+2.7.9-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.3
-3.3: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.3
+3.3.6: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3
+3.3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.3/slim
-3.3-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/slim
+3.3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@542719bf6a9b47066626296222a3189c23e80213 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4
-3.4: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4
-3: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4
-latest: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4
+3.4.3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
+3.4: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
+3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
+latest: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4/slim
-3.4-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4/slim
-3-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4/slim
-slim: git://github.com/docker-library/python@a736fc19a99afe3d77ba108263aad53bd1b9ab65 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
+3.4-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
+3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
+slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
-wheezy: git://github.com/docker-library/python@c6e8f0d345bd475a80d3c85c13861bb9dc2ea116 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
+wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.1: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
-3.5: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
-3: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
-latest: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab
+3.5.1: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea
+3.5: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea
+3: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea
+latest: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea
 
-3.5.1-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
-3.5-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
-3-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
-management: git://github.com/docker-library/rabbitmq@3acb380f45d6ff62dbf8396c35fe1907931941ab management
+3.5.1-management: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea management
+3.5-management: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea management
+3-management: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea management
+management: git://github.com/docker-library/rabbitmq@6b4b5eb5a0d806409ec8660d05816cc2288c96ea management

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.2-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-4.1.2: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-4.1-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-4.1: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-4-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-apache: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-4: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
-latest: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef apache
+4.2.1-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4.2.1: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4.2-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4.2: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+latest: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
 
-4.1.2-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
-4.1-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
-4-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
-fpm: git://github.com/docker-library/wordpress@d7be0b140da5e9ccddd0eab818e89e088ab1d5ef fpm
+4.2.1-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
+4.2-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
+4-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
+fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm


### PR DESCRIPTION
- `elasticsearch` use high-avail keyserver, bump 1.4.5 & 1.5.2
- `gcc` use high-avail keyserver, add 5.1
- `ghost` bump 0.6.2
- `httpd` use high-avail keyserver
- `logstash` use high-avail keyserver
- `mariadb` use high-avail keyserver
- `mongo` use high-avail keyserver
- `percona` use high-avail keyserver
- `php` use high-avail keyserver, `clear_env = no`
- `postgres` use high-avail keyserver
- `python` use high-avail keyserver
- `rabbitmq` use high-avail keyserver
- `wordpress` bump 4.2.1