### PR TITLE
Update test/tests/ruby-bundler/Gemfile.lock for jruby support

### DIFF
--- a/test/tests/ruby-bundler/Gemfile.lock
+++ b/test/tests/ruby-bundler/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     mini_portile (0.6.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    nokogiri (1.6.5-java)
     rack (1.6.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -20,6 +21,7 @@ GEM
     rspec-support (3.1.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
```console
$ bashbrew list --uniq ruby jruby | xargs ./test/run.sh -t ruby-bundler
testing ruby:2.0.0-p645
	'ruby-bundler' [1/1]...passed
testing ruby:2.0.0-p645-onbuild
	'ruby-bundler' [1/1]...passed
testing ruby:2.0.0-p645-slim
testing ruby:2.0.0-p645-wheezy
	'ruby-bundler' [1/1]...passed
testing ruby:2.1.6
	'ruby-bundler' [1/1]...passed
testing ruby:2.1.6-onbuild
	'ruby-bundler' [1/1]...passed
testing ruby:2.1.6-slim
testing ruby:2.1.6-wheezy
	'ruby-bundler' [1/1]...passed
testing ruby:2.2.2
	'ruby-bundler' [1/1]...passed
testing ruby:2.2.2-onbuild
	'ruby-bundler' [1/1]...passed
testing ruby:2.2.2-slim
testing ruby:2.2.2-wheezy
	'ruby-bundler' [1/1]...passed
testing jruby:1.7
	'ruby-bundler' [1/1]...passed
testing jruby:1.7-jdk
	'ruby-bundler' [1/1]...passed
testing jruby:1.7-onbuild
	'ruby-bundler' [1/1]...passed
testing jruby:9.0.0.0
	'ruby-bundler' [1/1]...passed
testing jruby:9.0.0.0-jdk
	'ruby-bundler' [1/1]...passed
testing jruby:9.0.0.0-onbuild
	'ruby-bundler' [1/1]...passed
```