### PR TITLE
Update open suse images

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,8 +1,8 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.1
-13.1: git://github.com/openSUSE/docker-containers-build@7e7f861b9af9aae20a84467172cc64f84e4e594a docker
-bottle: git://github.com/openSUSE/docker-containers-build@7e7f861b9af9aae20a84467172cc64f84e4e594a docker
+13.1: git://github.com/openSUSE/docker-containers-build@03088d2bb7e900824c88c22f934a41c108c789f8 docker
+bottle: git://github.com/openSUSE/docker-containers-build@03088d2bb7e900824c88c22f934a41c108c789f8 docker
 
 # openSUSE 13.2
 13.2: git://github.com/openSUSE/docker-containers-build@5acd0a9ff955ed6f6aabc0be8903af9f42c540f8 docker

--- a/library/opensuse
+++ b/library/opensuse
@@ -1,13 +1,13 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.1
-13.1: git://github.com/openSUSE/docker-containers-build@03088d2bb7e900824c88c22f934a41c108c789f8 docker
-bottle: git://github.com/openSUSE/docker-containers-build@03088d2bb7e900824c88c22f934a41c108c789f8 docker
+13.1: git://github.com/openSUSE/docker-containers-build@0d21bc58cd26da2a0a59588affc506b977d6a846 docker
+bottle: git://github.com/openSUSE/docker-containers-build@0d21bc58cd26da2a0a59588affc506b977d6a846 docker
 
 # openSUSE 13.2
-13.2: git://github.com/openSUSE/docker-containers-build@5acd0a9ff955ed6f6aabc0be8903af9f42c540f8 docker
-harlequin: git://github.com/openSUSE/docker-containers-build@5acd0a9ff955ed6f6aabc0be8903af9f42c540f8 docker
-latest: git://github.com/openSUSE/docker-containers-build@5acd0a9ff955ed6f6aabc0be8903af9f42c540f8 docker
+13.2: git://github.com/openSUSE/docker-containers-build@cae38d2559dfb9698464bee2e9f4fa97ea017055 docker
+harlequin: git://github.com/openSUSE/docker-containers-build@cae38d2559dfb9698464bee2e9f4fa97ea017055 docker
+latest: git://github.com/openSUSE/docker-containers-build@cae38d2559dfb9698464bee2e9f4fa97ea017055 docker
 
 # openSUSE Tumbleweed
 tumbleweed: git://github.com/openSUSE/docker-containers-build@4a40cb4fab2652a7fd8cda3fc33ce3298b728a5e docker


### PR DESCRIPTION
Required to fix an issue with 13.1.
Also these images include the official repositories' keys.

Unfortunately building tumbleweed doesn't work right now. I'll submit a separated pull request later.
