### PR TITLE
Upgrade Alpine images for OpenSSL and musl security fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,10 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-edge: git://github.com/gliderlabs/docker-alpine@09c2fde27b1aa585009a070dc9cc13a020a30cf9 versions/library-edge
+edge: git://github.com/gliderlabs/docker-alpine@74b34e1cf0e0560647bd3ec50eea0d40d31d9ca2 versions/library-edge
 
-3.1: git://github.com/gliderlabs/docker-alpine@337bd45a6de1404ceb7c7a0a2fd01744b488eaef versions/library-3.1
-latest: git://github.com/gliderlabs/docker-alpine@337bd45a6de1404ceb7c7a0a2fd01744b488eaef versions/library-3.1
+3.1: git://github.com/gliderlabs/docker-alpine@c25821dfa89db456533303a5c3efdf07960a7dea versions/library-3.1
+latest: git://github.com/gliderlabs/docker-alpine@c25821dfa89db456533303a5c3efdf07960a7dea versions/library-3.1
 
-2.7: git://github.com/gliderlabs/docker-alpine@2a7b889be5868aee4706fd8498e6b11630e8ace2 versions/library-2.7
+2.7: git://github.com/gliderlabs/docker-alpine@8c64ff86ea6db6130df31f619abf63cb03894040 versions/library-2.7
 
-2.6: git://github.com/gliderlabs/docker-alpine@12cf56252dcb1535e0fbeb9c3e3586551af671ea versions/library-2.6
+2.6: git://github.com/gliderlabs/docker-alpine@40cb90c769ea7b52f124fff3d692ca61431bafdb versions/library-2.6


### PR DESCRIPTION
These are mostly security fixes for #569. But includes some musl libc security backports as well. 