### PR TITLE
Improve the "ruby-standard-libs" test, especially with regards to jruby-specific exclusion and failure output

### DIFF
--- a/test/tests/ruby-standard-libs/container.rb
+++ b/test/tests/ruby-standard-libs/container.rb
@@ -8,7 +8,7 @@ stdlib = [
 	'coverage',
 	'csv',
 	'date',
-#	'dbm', 'gdbm', # TODO figure out a way to make this one load conditionally based on whether we're _not_ on jruby (since jruby doesn't have dbm)
+	'dbm',
 	'delegate',
 	'digest',
 	'drb',
@@ -21,6 +21,7 @@ stdlib = [
 	'fileutils',
 	'find',
 	'forwardable',
+	'gdbm',
 	'getoptlong',
 	'io/console',
 	'io/nonblock',
@@ -52,8 +53,7 @@ stdlib = [
 	'pp',
 	'prettyprint',
 	'prime',
-# prints all sorts of info to stderr, not easy to test right now
-#	'profile',
+	#'profile', # prints all sorts of info to stderr, not easy to test right now
 	'profiler',
 	'pstore',
 	'psych',
@@ -93,12 +93,31 @@ stdlib = [
 	'xmlrpc/client',
 	'xmlrpc/server',
 	'yaml',
-	'zlib'
+	'zlib',
 ]
 
-stdlib.each do |lib|
-	#puts "Testing #{lib}"
-	require lib
+if defined? RUBY_ENGINE && RUBY_ENGINE == 'jruby'
+	# these libraries don't work or don't exist on JRuby ATM
+	stdlib.delete('dbm')
+	stdlib.delete('gdbm')
+	stdlib.delete('mkmf')
+	stdlib.delete('objspace')
+	stdlib.delete('sdbm')
 end
 
-puts 'ok'
+result = 'ok'
+stdlib.each do |lib|
+	#puts "Testing #{lib}"
+	begin
+		require lib
+	rescue Exception => e
+		result = 'failure'
+		STDERR.puts "\n\nrequire '#{lib}' failed: #{e.message}\n"
+		STDERR.puts e.backtrace.join("\n")
+		STDERR.puts "\n"
+	end
+end
+
+exit(1) unless result == 'ok'
+
+puts result


### PR DESCRIPTION
Example output:
```console
$ ./test/run.sh -t ruby-standard-libs jruby
testing jruby
	'ruby-standard-libs' [1/1]...

require 'pty' failed: Could not open library 'libutil' : libutil: cannot open shared object file: No such file or directory. Could not open library 'libutil.so' : libutil.so: cannot open shared object file: No such file or directory
/opt/jruby/lib/ruby/shared/ffi/library.rb:114:in `ffi_lib'
org/jruby/RubyArray.java:2412:in `map'
/opt/jruby/lib/ruby/shared/ffi/library.rb:84:in `ffi_lib'
/opt/jruby/lib/ruby/shared/pty.rb:10:in `LibUtil'
/opt/jruby/lib/ruby/shared/pty.rb:5:in `PTY'
/opt/jruby/lib/ruby/shared/pty.rb:3:in `(root)'
org/jruby/RubyKernel.java:1071:in `require'
/opt/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:54:in `require'
./container.rb:112:in `(root)'
org/jruby/RubyArray.java:1613:in `each'
./container.rb:109:in `(root)'

failed; unexpected output:
--- /home/tianon/docker/stackbrew/test/tests/ruby-standard-libs/expected-std-out.txt	2015-02-05 16:52:04.000000000 -0700
+++ -	2015-04-30 14:08:32.098253037 -0600
@@ -1 +1 @@
-ok
+failure
```