### PR TITLE
Update ubuntu-debootstrap (2015-04-30 debootstraps)

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,25 +1,25 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - de46e6f 2015-04-21 debootstraps
+#  - d73a8b7 2015-04-30 debootstraps
 
-10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
-10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
-lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 10.04
+10.04.4: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 10.04
+10.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 10.04
+lucid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 10.04
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 12.04
 
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.04
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 14.10
 
-15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 15.04
-vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb 15.04
+15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 15.04
+vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 15.04
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@de46e6f570e25740246c8eee66ab0ad19866cffb devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@d73a8b79dc510277b98265ab30adbd1514b88593 devel


### PR DESCRIPTION
This is `lucid`'s final update. :+1: