### PR TITLE
Update docker-library

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -21,6 +21,12 @@ squeeze-scm: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd
 
 squeeze: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze
 
+stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
+
+stretch-scm: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/scm
+
+stretch: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch
+
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm

--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.17: git://github.com/docker-library/celery@92bcbab09f2c2e342a57d3a1b643e7646908c76f
-3.1: git://github.com/docker-library/celery@92bcbab09f2c2e342a57d3a1b643e7646908c76f
-3: git://github.com/docker-library/celery@92bcbab09f2c2e342a57d3a1b643e7646908c76f
-latest: git://github.com/docker-library/celery@92bcbab09f2c2e342a57d3a1b643e7646908c76f
+3.1.18: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
+3.1: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
+3: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
+latest: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f

--- a/library/gcc
+++ b/library/gcc
@@ -1,17 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.6.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.6
-4.6: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.6
+# Last Modified: 2014-06-12
+4.7.4: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.7
+4.7: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.7
+# Docker EOL: 2016-06-12
 
-4.7.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.7
-4.7: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.7
+# Last Modified: 2014-12-19
+4.8.4: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.8
+4.8: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.8
+# Docker EOL: 2016-12-19
 
-4.8.4: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.8
-4.8: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.8
+# Last Modified: 2014-10-30
+4.9.2: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.9
+4.9: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.9
+# Docker EOL: 2016-10-30
 
-4.9.2: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.9
-4.9: git://github.com/docker-library/gcc@db7f7a49616ea18f46a0187572df9336cf893f95 4.9
-
-5.1.0: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1
-5.1: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1
-latest: git://github.com/docker-library/gcc@89bf864ba7332ec37c07209d435908d7af853630 5.1
+# Last Modified: 2015-04-22
+5.1.0: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
+5.1: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
+latest: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
+# Docker EOL: 2017-04-22

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,6 +5,6 @@
 10: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
 latest: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
 
-5.5.42: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5
-5.5: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5
-5: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 5.5
+5.5.43: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
+5.5: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
+5: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.23: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
-1.4: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
-1: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
-latest: git://github.com/docker-library/memcached@b5e2aa3874dcd9259a7d45ff35953e975d2adab7
+1.4.24: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
+1.4: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
+1: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
+latest: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7

--- a/library/mongo
+++ b/library/mongo
@@ -3,8 +3,8 @@
 2.2.7: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.2
 2.2: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.2
 
-2.4.13: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.4
-2.4: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.4
+2.4.14: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
+2.4: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
 
 2.6.9: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
 2.6: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.1: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
-4.2: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
-4: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
-latest: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9
+4.2.1: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa
+4.2: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa
+4: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa
+latest: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa
 
-onbuild: git://github.com/docker-library/rails@c5ae701892b5588c782c772d3edd35909acf99b9 onbuild
+onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild


### PR DESCRIPTION
- `buildpack-deps`: add `stretch` (docker-library/buildpack-deps#25)
- `celery`: 3.1.18
- `gcc`: remove 4.6 (docker-library/gcc#15, docker-library/gcc#16, docker-library/gcc#17)
- `mariadb`: 5.5.43+maria-1~wheezy
- `memcached`: 1.4.24
- `mongo`: 2.4.14
- `rails`: relax `FROM` for less meaningless `Dockerfile` churn (docker-library/rails#29)