### PR TITLE
Remove "latest" tag from "docker-dev"

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -3,6 +3,8 @@
 1.6.0: git://github.com/docker/docker@v1.6.0
 1.6: git://github.com/docker/docker@v1.6.0
 1: git://github.com/docker/docker@v1.6.0
-latest: git://github.com/docker/docker@v1.6.0
+
+# "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
+# if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)
 
 # "supported": one tag per major, only upstream-supported majors (which is currently only "latest")


### PR DESCRIPTION
	# "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
	# if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)

This is just to further solidify the idea that "docker-dev" is _not_ for the latest and greatest builds of `github.com/docker/docker`.