### PR TITLE
Add io.js v2.0.0-rc-3

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,5 +1,19 @@
 # maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
 
+2.0.0-rc: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0
+2.0.0: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0
+2.0: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0
+2: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0
+
+2.0.0-onbuild: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/onbuild
+2.0-onbuild: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/onbuild
+2-onbuild: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/onbuild
+
+2.0.0-rc-slim: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/slim
+2.0.0-slim: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/slim
+2.0-slim: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/slim
+2-slim: git://github.com/iojs/docker-iojs@8bd7f519f023e8a39dd0caf64db0f65f6f77fbbc 2.0/slim
+
 1.8.1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
 1.8: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
 1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8


### PR DESCRIPTION
This PR adds io.js v2.0.0-rc-3 related tags. The `:latest`, `:slim`, and `:onbuild` tags are kept at their current positions until io.js v2 is released and considered stable.

Changeset: https://github.com/iojs/docker-iojs/compare/4cf03...8bd7f

Related: iojs/docker-iojs#55 iojs/docker-iojs#51
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>