### PR TITLE
Adding more versions of Perl

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,21 +1,51 @@
 # maintainer: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
 
-latest:          git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit
+latest:          git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit
 
-5:               git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit
+5:               git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit
 
-5.20:            git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit
-5.20.2:          git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit
+5.20:            git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit
+5.20.2:          git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit
 
-5.18:            git://github.com/perl/docker-perl@r20150215.0 5.018.004-64bit
-5.18.4:          git://github.com/perl/docker-perl@r20150215.0 5.018.004-64bit
+5.18:            git://github.com/perl/docker-perl@r20150503.0 5.018.004-64bit
+5.18.4:          git://github.com/perl/docker-perl@r20150503.0 5.018.004-64bit
 
-threaded:        git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit,threaded
+5.16:            git://github.com/perl/docker-perl@r20150503.0 5.016.003-64bit
+5.16.3:          git://github.com/perl/docker-perl@r20150503.0 5.016.003-64bit
 
-5-threaded:      git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit,threaded
+5.14:            git://github.com/perl/docker-perl@r20150503.0 5.014.004-64bit
+5.14.4:          git://github.com/perl/docker-perl@r20150503.0 5.014.004-64bit
 
-5.20-threaded:   git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit,threaded
-5.20.2-threaded: git://github.com/perl/docker-perl@r20150215.0 5.020.002-64bit,threaded
+5.12:            git://github.com/perl/docker-perl@r20150503.0 5.012.005-64bit
+5.12.5:          git://github.com/perl/docker-perl@r20150503.0 5.012.005-64bit
 
-5.18-threaded:   git://github.com/perl/docker-perl@r20150215.0 5.018.004-64bit,threaded
-5.18.4-threaded: git://github.com/perl/docker-perl@r20150215.0 5.018.004-64bit,threaded
+5.10:            git://github.com/perl/docker-perl@r20150503.0 5.010.001-64bit
+5.10.1:          git://github.com/perl/docker-perl@r20150503.0 5.010.001-64bit
+
+5.8:            git://github.com/perl/docker-perl@r20150503.0 5.008.009-64bit
+5.8.9:          git://github.com/perl/docker-perl@r20150503.0 5.008.009-64bit
+
+threaded:        git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit,threaded
+
+5-threaded:      git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit,threaded
+
+5.20-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit,threaded
+5.20.2-threaded: git://github.com/perl/docker-perl@r20150503.0 5.020.002-64bit,threaded
+
+5.18-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.018.004-64bit,threaded
+5.18.4-threaded: git://github.com/perl/docker-perl@r20150503.0 5.018.004-64bit,threaded
+
+5.16-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.016.003-64bit,threaded
+5.16.3-threaded: git://github.com/perl/docker-perl@r20150503.0 5.016.003-64bit,threaded
+
+5.14-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.014.004-64bit,threaded
+5.14.4-threaded: git://github.com/perl/docker-perl@r20150503.0 5.014.004-64bit,threaded
+
+5.12-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.012.005-64bit,threaded
+5.12.5-threaded: git://github.com/perl/docker-perl@r20150503.0 5.012.005-64bit,threaded
+
+5.10-threaded:   git://github.com/perl/docker-perl@r20150503.0 5.010.001-64bit,threaded
+5.10.1-threaded: git://github.com/perl/docker-perl@r20150503.0 5.010.001-64bit,threaded
+
+5.8-threaded:    git://github.com/perl/docker-perl@r20150503.0 5.008.009-64bit,threaded
+5.8.9-threaded:  git://github.com/perl/docker-perl@r20150503.0 5.008.009-64bit,threaded


### PR DESCRIPTION
Requested in https://github.com/Perl/docker-perl/issues/11

The versions prior to 5.18 are not maintained by perl5-porters
any longer, but for those developing modules on top of Perl
its often useful to have quick reference images for backwards
compatibility testing.