### PR TITLE
Update debian experimental and rc-buggy to use httpredir.debian.org as well

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -29,5 +29,5 @@ unstable: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0
 7: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 wheezy
 wheezy: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@0b288b65558ebc0fb0d7b457294a8ae52d9b0609 debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@0b288b65558ebc0fb0d7b457294a8ae52d9b0609 debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@b957ce88af19e9b78f51750cfe54546e361fb9cc debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@b957ce88af19e9b78f51750cfe54546e361fb9cc debian/experimental


### PR DESCRIPTION
From https://github.com/tianon/dockerfiles/commit/9e2782cb470c0dcc04ff6a6f73379996c4ac9df9 and https://github.com/tianon/dockerfiles/commit/b957ce88af19e9b78f51750cfe54546e361fb9cc