### PR TITLE
Updated npm to 2.9.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,45 +1,45 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.38: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10
-0.10: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10
+0.10.38: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10
+0.10: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10
 
 0.10.38-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
 0.10-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
 
-0.10.38-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10/slim
+0.10.38-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10/slim
 
-0.10.38-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.10/wheezy
+0.10.38-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.10/wheezy
 
-0.12.2: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12
-0.12: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12
-0: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12
-latest: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12
+0.12.2: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12
+0.12: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12
+0: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12
+latest: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12
 
 0.12.2-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
 0.12-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
 0-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
 onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
 
-0.12.2-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/slim
-0-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/slim
-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/slim
+0.12.2-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/slim
+0-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/slim
+slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/slim
 
-0.12.2-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.12/wheezy
+0.12.2-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.12/wheezy
 
-0.8.28: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8
-0.8: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8
+0.8.28: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8
+0.8: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8/slim
 
-0.8.28-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8/wheezy
-0.8-wheezy: git://github.com/joyent/docker-node@762a8f163f02b6de8e4022d1f8ff3a38f4c8340f 0.8/wheezy
+0.8.28-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8/wheezy
+0.8-wheezy: git://github.com/joyent/docker-node@3c692e61970814671339c1ff3f5ffb4dd8b600e1 0.8/wheezy


### PR DESCRIPTION
This bumps npm to 2.9.0.

We also added a new script to run test builds of all the images. All images build successfully with npm 2.9.0.