### PR TITLE
point to updated clojure with increased security

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,6 +1,6 @@
 # maintainer: Paul Lam <paul@quantisan.com> (@Quantisan)
 
-latest: git://github.com/Quantisan/docker-clojure@5c988033c6510c7d91a5f6c7a91b4f63f8f90768
+latest: git://github.com/Quantisan/docker-clojure@5d7cbbaa5702774fd8b84935d84ebaea851f9049
 
-lein-2.5.1: git://github.com/Quantisan/docker-clojure@5c988033c6510c7d91a5f6c7a91b4f63f8f90768
+lein-2.5.1: git://github.com/Quantisan/docker-clojure@5d7cbbaa5702774fd8b84935d84ebaea851f9049
 lein-2.4.3: git://github.com/Quantisan/docker-clojure@30ed1b891ea059a33ca56f04ecf6f467bbbd2362

--- a/library/clojure
+++ b/library/clojure
@@ -1,6 +1,6 @@
 # maintainer: Paul Lam <paul@quantisan.com> (@Quantisan)
 
-latest: git://github.com/Quantisan/docker-clojure@5d7cbbaa5702774fd8b84935d84ebaea851f9049
+latest: git://github.com/Quantisan/docker-clojure@1d04a60b0cccecbc3208dffa5fcf087ce8e6e65b
 
-lein-2.5.1: git://github.com/Quantisan/docker-clojure@5d7cbbaa5702774fd8b84935d84ebaea851f9049
+lein-2.5.1: git://github.com/Quantisan/docker-clojure@1d04a60b0cccecbc3208dffa5fcf087ce8e6e65b
 lein-2.4.3: git://github.com/Quantisan/docker-clojure@30ed1b891ea059a33ca56f04ecf6f467bbbd2362


### PR DESCRIPTION
Made some security enhancements on the Clojure image for v2.5.1:

- use non-root user to run
- check SHA of downloaded `lein` package to reduce man-in-the-middle attack
- use the `lein-pkg` script to install as recommended by Leiningen team for downstream packagers
