### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.14: git://github.com/docker-library/cassandra@7651f5e4e134d802e57a07846842c11ddc929b88 2.0
-2.0: git://github.com/docker-library/cassandra@7651f5e4e134d802e57a07846842c11ddc929b88 2.0
+2.0.14: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.0
+2.0: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.0
 
-2.1.5: git://github.com/docker-library/cassandra@7651f5e4e134d802e57a07846842c11ddc929b88 2.1
-2.1: git://github.com/docker-library/cassandra@7651f5e4e134d802e57a07846842c11ddc929b88 2.1
-latest: git://github.com/docker-library/cassandra@7651f5e4e134d802e57a07846842c11ddc929b88 2.1
+2.1.5: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1
+2.1: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1
+latest: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1

--- a/library/django
+++ b/library/django
@@ -1,17 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8-python2: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 2.7
-1-python2: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 2.7
-python2: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 2.7
+1.8.1-python2: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 2.7
+1.8-python2: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 2.7
+1-python2: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 2.7
+python2: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 2.7
 
 python2-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7/onbuild
 
-1.8-python3: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
-1.8: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
-1-python3: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
-1: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
-python3: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
-latest: git://github.com/docker-library/django@d9d98f91189e5ec41df2ebfaedbbed3fa99448cd 3.4
+1.8.1-python3: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+1.8.1: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+1.8-python3: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+1.8: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+1-python3: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+1: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+python3: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
+latest: git://github.com/docker-library/django@949f40a74d6d46d93a745b0080df10c9e7ad1240 3.4
 
 python3-onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild
 onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild

--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-1.6.0: git://github.com/docker/docker@v1.6.0
-1.6: git://github.com/docker/docker@v1.6.0
-1: git://github.com/docker/docker@v1.6.0
+1.6.1: git://github.com/docker/docker@v1.6.1
+1.6: git://github.com/docker/docker@v1.6.1
+1: git://github.com/docker/docker@v1.6.1
 
 # "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
 # if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)

--- a/library/drupal
+++ b/library/drupal
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.36: git://github.com/docker-library/drupal@7e4e3c38aadbfaf5e6662d2f0ddf2070f1e0e357 7
-7: git://github.com/docker-library/drupal@7e4e3c38aadbfaf5e6662d2f0ddf2070f1e0e357 7
-latest: git://github.com/docker-library/drupal@7e4e3c38aadbfaf5e6662d2f0ddf2070f1e0e357 7
+7.37: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 7
+7: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 7
+latest: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 7
 
-8.0.0-beta9: git://github.com/docker-library/drupal@55d3e328aee754e41f7b702a00a882d64e195e88 8
-8.0.0: git://github.com/docker-library/drupal@55d3e328aee754e41f7b702a00a882d64e195e88 8
-8.0: git://github.com/docker-library/drupal@55d3e328aee754e41f7b702a00a882d64e195e88 8
-8: git://github.com/docker-library/drupal@55d3e328aee754e41f7b702a00a882d64e195e88 8
+8.0.0-beta10: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
+8.0.0: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
+8.0: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
+8: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8

--- a/library/gcc
+++ b/library/gcc
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
 # Last Modified: 2014-06-12
-4.7.4: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.7
-4.7: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.7
+4.7.4: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.7
+4.7: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.7
 # Docker EOL: 2016-06-12
 
 # Last Modified: 2014-12-19
-4.8.4: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.8
-4.8: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.8
+4.8.4: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.8
+4.8: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.8
 # Docker EOL: 2016-12-19
 
 # Last Modified: 2014-10-30
-4.9.2: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.9
-4.9: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 4.9
+4.9.2: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.9
+4.9: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.9
 # Docker EOL: 2016-10-30
 
 # Last Modified: 2015-04-22
-5.1.0: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
-5.1: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
-latest: git://github.com/docker-library/gcc@7ff08a9976fff760739628f7f0198e1593a4e930 5.1
+5.1.0: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
+5.1: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
+latest: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
 # Docker EOL: 2017-04-22

--- a/library/haproxy
+++ b/library/haproxy
@@ -3,7 +3,7 @@
 1.4.26: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
 1.4: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
 
-1.5.11: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
-1.5: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
-1: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
-latest: git://github.com/docker-library/haproxy@942dc7ef85fe823b72d5592a745519dac0138039 1.5
+1.5.12: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
+1.5: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
+1: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
+latest: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.3.7: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676
-0.3: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676
-latest: git://github.com/docker-library/julia@a85d92cbc1396ed7ba6007108412bea518271676
+0.3.8: git://github.com/docker-library/julia@cfeffd777768134ae9671fd02807e1a48f268037
+0.3: git://github.com/docker-library/julia@cfeffd777768134ae9671fd02807e1a48f268037
+latest: git://github.com/docker-library/julia@cfeffd777768134ae9671fd02807e1a48f268037

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.42: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.5
-5.5: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.5
+5.5.43: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.5
+5.5: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.5
 
-5.6.23: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
-5.6: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
-5: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
-latest: git://github.com/docker-library/percona@dc21e836f1e0ee8ca3edd8e8944c7ea6956e8465 5.6
+5.6.24: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
+5.6: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
+5: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
+latest: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6

--- a/library/redis
+++ b/library/redis
@@ -3,11 +3,11 @@
 2.6.17: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
 2.6: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
 
-2.8.19: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
-2.8: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
-2: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.8
+2.8.20: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
+2.8: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
+2: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
 
-3.0.0: git://github.com/docker-library/redis@5a2cfe30d3ddb6c1786d603b746fe7e7aa8823ae 3.0
-3.0: git://github.com/docker-library/redis@5a2cfe30d3ddb6c1786d603b746fe7e7aa8823ae 3.0
-3: git://github.com/docker-library/redis@5a2cfe30d3ddb6c1786d603b746fe7e7aa8823ae 3.0
-latest: git://github.com/docker-library/redis@5a2cfe30d3ddb6c1786d603b746fe7e7aa8823ae 3.0
+3.0.1: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
+3.0: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
+3: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
+latest: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre8
 
-8.0.21-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-8.0.21: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-8.0: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
-latest: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre7
+8.0.22-jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+8.0.22: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+8.0: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+8: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
+latest: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
 
-8.0.21-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre8
-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 8-jre8
+8.0.22-jre8: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre8
+jre8: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.1-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-4.2.1: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-4.2-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-4.2: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-4-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-apache: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-4: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
-latest: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 apache
+4.2.2-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4.2.2: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4.2-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4.2: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+latest: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
 
-4.2.1-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
-4.2-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
-4-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
-fpm: git://github.com/docker-library/wordpress@f72c6758fd75fc9c4a4ca2c0baabcd92b90381b9 fpm
+4.2.2-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
+4.2-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
+4-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
+fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm


### PR DESCRIPTION
- `cassandra`: removed some comments (docker-library/cassandra#1)
- `django`: 1.8.1 (docker-library/django#6)
- `docker-dev`: 1.6.1
- `drupal`: 7.37 and 8.0.0-beta10
- `gcc`: `/usr/local/lib64` fix (docker-library/gcc#19)
- `haproxy`: 1.5.12
- `julia`: 0.3.8
- `percona`: 5.5.43-rel37.2-1.wheezy and 5.6.24-72.2-1.wheezy
- `redis`: 2.8.20 and 3.0.1
- `tomcat`: 8.0.22
- `wordpress`: 4.2.2 (docker-library/wordpress#79)