### PR TITLE
Update io.js to v2.0.1

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -12,17 +12,17 @@
 1.8-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
 1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
 
-2.0.0: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0
-2.0: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0
-2: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0
-latest: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0
+2.0.1: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
+2.0: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
+2: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
+latest: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
 
-2.0.0-onbuild: git://github.com/iojs/docker-iojs@18d119c1876b4d7981b0009653ea40e85e46d8a1 2.0/onbuild
-2.0-onbuild: git://github.com/iojs/docker-iojs@18d119c1876b4d7981b0009653ea40e85e46d8a1 2.0/onbuild
-2-onbuild: git://github.com/iojs/docker-iojs@18d119c1876b4d7981b0009653ea40e85e46d8a1 2.0/onbuild
-onbuild: git://github.com/iojs/docker-iojs@18d119c1876b4d7981b0009653ea40e85e46d8a1 2.0/onbuild
+2.0.1-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
+2.0-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
+2-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
+onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
 
-2.0.0-slim: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0/slim
-2.0-slim: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0/slim
-2-slim: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0/slim
-slim: git://github.com/iojs/docker-iojs@a40aaf633751594a26ccdaa65b35a115d73f69a7 2.0/slim
+2.0.1-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
+2.0-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
+2-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
+slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim


### PR DESCRIPTION
This PR updates v2 images of io.js to v2.0.1.

Changeset: https://github.com/iojs/docker-iojs/compare/a40aaf...8caf041

Related: iojs/docker-iojs#57
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>