### PR TITLE
Add ArangoDB Official images

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,4 +4,7 @@
 2.5.3: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.3
 2.5.4: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.4
 2.5.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
-2.6.0: git://github.com/arangodb/arangodb-docker@97dc897532f2c5eb26fd2a8853f0afc35bbe26a4 jessie/2.6.0
+2.6.0: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.0
+2.6.1: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.1
+2.6.2: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.2
+

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,5 +1,5 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.5.3: git://github.com/arangodb/arangodb-docker@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3
-latest: git://github.com/arangodb/arangodb-docker@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3
+2.5.3: git://github.com/arangodb/arangodb-docker@bb50713d9f6986f113f02ecdfa8c84134c2d88ec jessie/2.5.3
+latest: git://github.com/arangodb/arangodb-docker@bb50713d9f6986f113f02ecdfa8c84134c2d88ec jessie/2.5.3

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,7 +1,7 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.5.3: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.3
-2.5.4: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.4
-2.5.5: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.5
-latest: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/latest
+2.5.3: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.3
+2.5.4: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.4
+2.5.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
+2.6.0: git://github.com/arangodb/arangodb-docker@97dc897532f2c5eb26fd2a8853f0afc35bbe26a4 jessie/2.6.0

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,0 +1,5 @@
+# maintainer: Frank Celler <info@arangodb.com> (@fceller)
+# maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
+
+2.5.3: git://github.com/arangodb/arangodb-docker@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3
+latest: git://github.com/stuartpb/rethinkdb-dockerfiles@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,5 +1,7 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.5.3: git://github.com/arangodb/arangodb-docker@bb50713d9f6986f113f02ecdfa8c84134c2d88ec jessie/2.5.3
-latest: git://github.com/arangodb/arangodb-docker@bb50713d9f6986f113f02ecdfa8c84134c2d88ec jessie/2.5.3
+2.5.3: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/2.5.3
+2.5.4: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/2.5.4
+2.5.5: git://github.com/arangodb/arangodb-docker@023bc25eb5cc0db82725d43034dd7608ad06b9dc jessie/2.5.5
+latest: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/latest

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,7 +1,7 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.5.3: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/2.5.3
-2.5.4: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/2.5.4
-2.5.5: git://github.com/arangodb/arangodb-docker@023bc25eb5cc0db82725d43034dd7608ad06b9dc jessie/2.5.5
-latest: git://github.com/arangodb/arangodb-docker@1a13c1dfa561b3c8ccf9d9b3bef46ed95b3ed740 jessie/latest
+2.5.3: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.3
+2.5.4: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.4
+2.5.5: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/2.5.5
+latest: git://github.com/arangodb/arangodb-docker@0df28959b87df57f53782523a8c7bb51a1f78cd8 jessie/latest

--- a/library/arangodb
+++ b/library/arangodb
@@ -2,4 +2,4 @@
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
 2.5.3: git://github.com/arangodb/arangodb-docker@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3
-latest: git://github.com/stuartpb/rethinkdb-dockerfiles@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3
+latest: git://github.com/arangodb/arangodb-docker@a3e07b15d585b464257449e4a5d9c8f4dc33ab6e jessie/2.5.3

--- a/library/arangodb
+++ b/library/arangodb
@@ -4,7 +4,7 @@
 2.5.3: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.3
 2.5.4: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.4
 2.5.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
-2.6.0: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.0
-2.6.1: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.1
-2.6.2: git://github.com/arangodb/arangodb-docker@9880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.2
+2.6.0: git://github.com/arangodb/arangodb-docker@880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.0
+2.6.1: git://github.com/arangodb/arangodb-docker@880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.1
+2.6.2: git://github.com/arangodb/arangodb-docker@880ef700389025c8ed9220a3f6211365b774ed0a jessie/2.6.2
 


### PR DESCRIPTION
ArangoDB is a the multi-model NoSQL database - http://arangodb.org
