### PR TITLE
Update several images

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
-# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+# maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 
-1.6.1: git://github.com/docker/docker@v1.6.1
-1.6: git://github.com/docker/docker@v1.6.1
-1: git://github.com/docker/docker@v1.6.1
+1.6.2: git://github.com/docker/docker@v1.6.2
+1.6: git://github.com/docker/docker@v1.6.2
+1: git://github.com/docker/docker@v1.6.2
 
 # "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
 # if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.6.2: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
-0.6: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
-0: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
-latest: git://github.com/docker-library/ghost@79fd9cb79dd767aa7414aa6ef65af967c929dfab
+0.6.3: git://github.com/docker-library/ghost@a68d52ed1d59702d150c3c64c91b41d86ccb6605
+0.6: git://github.com/docker-library/ghost@a68d52ed1d59702d150c3c64c91b41d86ccb6605
+0: git://github.com/docker-library/ghost@a68d52ed1d59702d150c3c64c91b41d86ccb6605
+latest: git://github.com/docker-library/ghost@a68d52ed1d59702d150c3c64c91b41d86ccb6605

--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 # maintainer: Paul Tagliamonte <paultag@hylang.org> (@paultag)
 
-latest: git://github.com/hylang/hy@0.10.1
-0: git://github.com/hylang/hy@0.10.1
-0.10: git://github.com/hylang/hy@0.10.1
-0.10.1: git://github.com/hylang/hy@0.10.1
+latest: git://github.com/hylang/hy@0.11.0
+0: git://github.com/hylang/hy@0.11.0
+0.11: git://github.com/hylang/hy@0.11.0
+0.11.0: git://github.com/hylang/hy@0.11.0

--- a/library/java
+++ b/library/java
@@ -31,16 +31,16 @@ openjdk-7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31
 7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 
-openjdk-8u45-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-openjdk-8u45: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-8u45-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-8u45: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
-8: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jdk
+openjdk-8u45-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+openjdk-8u45: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+8u45-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+8u45: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+8: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
 
-openjdk-8u45-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
-8u45-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@d912163e5aa10f916be7ac40ac0de7e8a82c4547 openjdk-8-jre
+openjdk-8u45-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
+8u45-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre

--- a/library/logstash
+++ b/library/logstash
@@ -1,6 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.2-1-2c0f5a1: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
-1.4.2: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
-1.4: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
-latest: git://github.com/docker-library/logstash@739e777543451352f3500d9a0d8f97412d6fdad8
+1.5.0: git://github.com/docker-library/logstash@74708b040ec13a17b49d93a5db0ae11e70e0c1cb
+1.5: git://github.com/docker-library/logstash@74708b040ec13a17b49d93a5db0ae11e70e0c1cb
+latest: git://github.com/docker-library/logstash@74708b040ec13a17b49d93a5db0ae11e70e0c1cb

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.17: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
-10.0: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
-10: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
-latest: git://github.com/docker-library/mariadb@69caa8fb5920391ddf045e226ef7af6215d392d0 10.0
+10.0.19: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
+10.0: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
+10: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
+latest: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
 
 5.5.43: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
 5.5: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.40-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
-5.4-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
-5.4.40: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
-5.4: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4
+5.4.41-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4
+5.4-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4
+5.4.41: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4
+5.4: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4
 
-5.4.40-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.4/apache
-5.4-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.4/apache
+5.4.41-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4/apache
+5.4-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4/apache
 
-5.4.40-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.4/fpm
+5.4.41-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.4/fpm
 
-5.5.24-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
-5.5-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
-5.5.24: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
-5.5: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5
+5.5.25-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5
+5.5-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5
+5.5.25: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5
+5.5: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5
 
-5.5.24-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.5/apache
-5.5-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.5/apache
+5.5.25-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5/apache
+5.5-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5/apache
 
-5.5.24-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.5/fpm
+5.5.25-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.5/fpm
 
-5.6.8-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-5.6-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-5-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-cli: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-5.6.8: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-5.6: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-5: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
-latest: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6
+5.6.9-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+5.6-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+5-cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+cli: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+5.6.9: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+5.6: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+5: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
+latest: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6
 
-5.6.8-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
-5.6-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
-5-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
-apache: git://github.com/docker-library/php@1dcb6d17643e48ea1329ede9cf9a08b2f697b2fd 5.6/apache
+5.6.9-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/apache
+5.6-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/apache
+5-apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/apache
+apache: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/apache
 
-5.6.8-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
-5-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
-fpm: git://github.com/docker-library/php@6c517d12b4e52fb39dc8a132201b808ce4fc68d5 5.6/fpm
+5.6.9-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/fpm
+5-fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/fpm
+fpm: git://github.com/docker-library/php@2fbee27c9466852e92459433a97cc0912bb64571 5.6/fpm

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,26 +1,26 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.43-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
-6.0.43: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
-6.0: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
-6: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre7
+6.0.44-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6.0-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6.0.44: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6.0: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
 
-6.0.43-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre8
-6.0-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre8
-6-jre8: git://github.com/docker-library/tomcat@1ac581da0dbef3f191cbb2d5fbfc4292e32bb0dd 6-jre8
+6.0.44-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
+6.0-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
+6-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
 
-7.0.61-jre7: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
-7.0.61: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
-7.0: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
-7: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre7
+7.0.62-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
+7.0.62: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
+7.0: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
+7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre7
 
-7.0.61-jre8: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@fa5fe9c4327c92a99fa2ae63ff876acc8e5389e5 7-jre8
+7.0.62-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 7-jre8
 
 8.0.22-jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7
 8.0-jre7: git://github.com/docker-library/tomcat@ef856d48e431a9b83730b5c14c0d9a84d70156a5 8-jre7


### PR DESCRIPTION
- `docker-dev`: update to 1.6.2 and update email to make it more clear it's upstream
- `ghost`: 0.6.3
- `hylang`: 0.11.0 (bump on behalf of @paultag, because :heart:; `Dockerfile` is unchanged from previous versions)
- `java`: 8u45-b14-2
- `logstash`: 1.5.0
- `mariadb`: 10.0.19+maria-1~wheezy
- `php`: 5.4.41, 5.5.25, and 5.6.9
- `tomcat`: 6.0.44 and 7.0.62