### PR TITLE
Update to May beta and Java 7.1 SR2 FP10

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,5 +1,5 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@dcurrie)
 
-8.5.5: git://github.com/WASdev/ci.docker@dab136acfd77b33ec3b4238b41583b868ec3381f websphere-liberty/8.5.5/developer
-latest: git://github.com/WASdev/ci.docker@dab136acfd77b33ec3b4238b41583b868ec3381f websphere-liberty/8.5.5/developer
-beta: git://github.com/WASdev/ci.docker@29986d2f2e06c73bb5679f3fbb059976c534774e websphere-liberty/beta
+8.5.5: git://github.com/WASdev/ci.docker@94085e885f7bf6025b68ae57de6b9aa9988fa9d8 websphere-liberty/8.5.5/developer
+latest: git://github.com/WASdev/ci.docker@94085e885f7bf6025b68ae57de6b9aa9988fa9d8 websphere-liberty/8.5.5/developer
+beta: git://github.com/WASdev/ci.docker@94085e885f7bf6025b68ae57de6b9aa9988fa9d8 websphere-liberty/beta


### PR DESCRIPTION
Move websphere-liberty:beta to May beta and move all images up to Java 7.1 SR2 FP10. The latter contains a fix to the installer which means it now honors the install directory in the response file and the extra mv is no longer needed. Someone (with Windows) has managed to slip some carriage returns in to the index.yml when the May beta was added so there's a commit to handle those.