### PR TITLE
Update io.js to v2.0.2

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -12,17 +12,17 @@
 1.8-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
 1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
 
-2.0.1: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
-2.0: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
-2: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
-latest: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0
+2.0.2: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
+2.0: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
+2: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
+latest: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
 
-2.0.1-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
-2.0-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
-2-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
-onbuild: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/onbuild
+2.0.2-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
+2.0-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
+2-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
+onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
 
-2.0.1-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
-2.0-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
-2-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
-slim: git://github.com/iojs/docker-iojs@8caf041be35322d93ca81d214b5fc1160b348e67 2.0/slim
+2.0.2-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
+2.0-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
+2-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
+slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim


### PR DESCRIPTION
This PR updates v2 images of io.js to v2.0.2.

Changeset: https://github.com/nodejs/docker-iojs/compare/8caf041...8bddc38

Related: nodejs/docker-iojs#59
Signed-off-by: Hans Kristian Flaatten hans.kristian.flaatten@turistforeningen.no

