### PR TITLE
Update npm to 2.10.0 and node to 0.12.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,45 +1,45 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.38: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10
-0.10: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10
+0.10.38: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10
+0.10: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10
 
 0.10.38-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
 0.10-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
 
-0.10.38-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10/slim
+0.10.38-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10/slim
 
-0.10.38-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.10/wheezy
+0.10.38-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.10/wheezy
 
-0.12.2: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12
-0.12: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12
-0: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12
-latest: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12
+0.12.3: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12
+0.12: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12
+0: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12
+latest: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12
 
-0.12.2-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
-0.12-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
-0-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
-onbuild: git://github.com/joyent/docker-node@b76b7095bc741fda7f509e629706e5a0b9eab1fb 0.12/onbuild
+0.12.3-onbuild: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/onbuild
+0.12-onbuild: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/onbuild
+0-onbuild: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/onbuild
+onbuild: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/onbuild
 
-0.12.2-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/slim
-0-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/slim
-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/slim
+0.12.3-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/slim
+0-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/slim
+slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/slim
 
-0.12.2-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.12/wheezy
+0.12.3-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.12/wheezy
 
-0.8.28: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8
-0.8: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8
+0.8.28: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8
+0.8: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8/slim
 
-0.8.28-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8/wheezy
-0.8-wheezy: git://github.com/joyent/docker-node@413687b73f1f3d43286bfda1ea8008509538d8bd 0.8/wheezy
+0.8.28-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8/wheezy
+0.8-wheezy: git://github.com/joyent/docker-node@530696ff3003a169521a61a0e04bbf980b7228d5 0.8/wheezy


### PR DESCRIPTION
This updates npm to 2.10.0 and node to 0.12.3.

Test builds look good!