### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.14: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.0
-2.0: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.0
+2.0.15: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.0
+2.0: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.0
 
-2.1.5: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1
-2.1: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1
-latest: git://github.com/docker-library/cassandra@86059b706a4147b529774d2a954aec618407357c 2.1
+2.1.5: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1
+2.1: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1
+latest: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1

--- a/library/java
+++ b/library/java
@@ -31,16 +31,16 @@ openjdk-7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31
 7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 
-openjdk-8u45-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-openjdk-8u45: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-8u45-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-8u45: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
-8: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jdk
+openjdk-8u45-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+openjdk-8u45: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+8u45-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+8u45: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+8: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
 
-openjdk-8u45-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
-8u45-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@b4a3c296023e590e410f645ab83d3c11a30cf535 openjdk-8-jre
+openjdk-8u45-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
+8u45-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre

--- a/library/mongo
+++ b/library/mongo
@@ -6,9 +6,9 @@
 2.4.14: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
 2.4: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
 
-2.6.9: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
-2.6: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
-2: git://github.com/docker-library/mongo@c9a1b066a0f35f679c2f8e1854a21e025867d938 2.6
+2.6.10: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
+2.6: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
+2: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
 
 3.0.3: git://github.com/docker-library/mongo@65491bce9f2b6941dbde4ddaf16171dad5fe50d1 3.0
 3.0: git://github.com/docker-library/mongo@65491bce9f2b6941dbde4ddaf16171dad5fe50d1 3.0

--- a/library/python
+++ b/library/python
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.9: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
-2.7: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
-2: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7
+2.7.9: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7
+2.7: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7
+2: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7
 
 2.7.9-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@d550e292eec57e83af58e05410243d387d6483a8 2.7/onbuild
 
-2.7.9-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
-2.7-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
-2-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/slim
+2.7.9-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/slim
+2.7-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/slim
+2-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/slim
 
-2.7.9-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 2.7/wheezy
+2.7.9-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3
-3.3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3
+3.3.6: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3
+3.3: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@8dfe392dff2ffdda90672857e027ff3ee142f9ff 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/slim
-3.3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3/slim
+3.3-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
-3.4: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
-3: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
-latest: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4
+3.4.3: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4
+3.4: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4
+3: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4
+latest: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 onbuild: git://github.com/docker-library/python@db31004d42a1aabbb9109177b2794f088f245b33 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
-3.4-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
-3-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
-slim: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/slim
+3.4-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/slim
+3-slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/slim
+slim: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
-wheezy: git://github.com/docker-library/python@a467ae88510bf64dd4f35253d9a41af3b3cef7b6 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/wheezy
+wheezy: git://github.com/docker-library/python@12105a2a8c01fad6059a5248cea4e1f30d991cb7 3.4/wheezy


### PR DESCRIPTION
- `cassandra`: 2.0.15
- `java`: 8u45-b14-3
- `mongo`: 2.6.10
- `python`: explicit version of `pip` (docker-library/python#46)