### PR TITLE
Update debian (2015-05-19 debootstraps)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -2,33 +2,33 @@
 # maintainer: Paul Tagliamonte <paultag@debian.org> (@paultag)
 
 # commits: (master..dist)
-#  - b637abe 2015-04-28 debootstraps
+#  - f86bb68 2015-05-19 debootstraps
 
-8.0: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 jessie
-8: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 jessie
-jessie: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 jessie
-latest: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 jessie
+8.0: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c jessie
+8: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c jessie
+jessie: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c jessie
+latest: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c jessie
 
-oldstable: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c oldstable
 
-sid: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 sid
+sid: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 squeeze
-6: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c squeeze
+6.0: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c squeeze
+6: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 stable
+stable: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c stable
 
-stretch: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 stretch
+stretch: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c stretch
 
-testing: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 testing
+testing: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c testing
 
-unstable: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 unstable
+unstable: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c unstable
 
-7.8: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 wheezy
-7: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@b637abe5e26f8b283a28d63cdc0413926ed54596 wheezy
+7.8: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c wheezy
+7: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@f86bb68c8e84829c7babb0db18bef1327103676c wheezy
 
-rc-buggy: git://github.com/tianon/dockerfiles@b957ce88af19e9b78f51750cfe54546e361fb9cc debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@b957ce88af19e9b78f51750cfe54546e361fb9cc debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@1a24085d66f91cd9842101fea0e2fabc52535eb0 debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@1a24085d66f91cd9842101fea0e2fabc52535eb0 debian/experimental


### PR DESCRIPTION
Built from/including https://github.com/docker/docker/pull/13326.