### PR TITLE
Update iojs to v2.1.0 and v1.8.2

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,28 +1,22 @@
-# maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)
+# maintainer: io.js Docker team <https://github.com/nodejs/docker-iojs> (@iojs)
 
-1.8.1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
-1.8: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
-1: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8
+1.8.2: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8
+1.8: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8
+1: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8
 
-1.8.1-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
-1.8-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
-1-onbuild: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/onbuild
+1.8.2-onbuild: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/onbuild
+1.8-onbuild: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/onbuild
+1-onbuild: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/onbuild
 
-1.8.1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
-1.8-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
-1-slim: git://github.com/iojs/docker-iojs@4cf03be7e0b4abcd60a3a93947d9351c3b8b4be7 1.8/slim
+1.8.2-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
+1.8-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
+1-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
 
-2.0.2: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
-2.0: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
-2: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
-latest: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0
+2.1.0: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
+2.1: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
 
-2.0.2-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
-2.0-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
-2-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
-onbuild: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/onbuild
+2.1.0-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
+2.1-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
 
-2.0.2-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
-2.0-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
-2-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
-slim: git://github.com/iojs/docker-iojs@8bddc385cbf2e499d52dc18fbb4227781c5f68e8 2.0/slim
+2.1.0-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim
+2.1-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim


### PR DESCRIPTION
Related: nodejs/docker-iojs#63
Related: nodejs/docker-iojs#62
Related: nodejs/docker-iojs#61