### PR TITLE
removing lein 2.4 as it's been deprecated by 2.5

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,4 +3,4 @@
 latest: git://github.com/Quantisan/docker-clojure@1d04a60b0cccecbc3208dffa5fcf087ce8e6e65b
 
 lein-2.5.1: git://github.com/Quantisan/docker-clojure@1d04a60b0cccecbc3208dffa5fcf087ce8e6e65b
-lein-2.4.3: git://github.com/Quantisan/docker-clojure@30ed1b891ea059a33ca56f04ecf6f467bbbd2362
+


### PR DESCRIPTION
you're right there https://github.com/docker-library/official-images/pull/724#issuecomment-101058913 that 2.4 isn't needed anymore