### PR TITLE
Add Alpine 3.2 and bump others for package backports

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,12 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-edge: git://github.com/gliderlabs/docker-alpine@74b34e1cf0e0560647bd3ec50eea0d40d31d9ca2 versions/library-edge
+edge: git://github.com/gliderlabs/docker-alpine@e3d7f98026c2920a097dc69967261a92d738bc78 versions/library-edge
 
-3.1: git://github.com/gliderlabs/docker-alpine@c25821dfa89db456533303a5c3efdf07960a7dea versions/library-3.1
-latest: git://github.com/gliderlabs/docker-alpine@c25821dfa89db456533303a5c3efdf07960a7dea versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@083646733405f45e47a31359bf641b2605baad58 versions/library-3.2
+latest: git://github.com/gliderlabs/docker-alpine@083646733405f45e47a31359bf641b2605baad58 versions/library-3.2
 
-2.7: git://github.com/gliderlabs/docker-alpine@8c64ff86ea6db6130df31f619abf63cb03894040 versions/library-2.7
+3.1: git://github.com/gliderlabs/docker-alpine@27f41fc0c001a4f85b67e6788c43ff718e1019c2 versions/library-3.1
 
-2.6: git://github.com/gliderlabs/docker-alpine@40cb90c769ea7b52f124fff3d692ca61431bafdb versions/library-2.6
+2.7: git://github.com/gliderlabs/docker-alpine@a5207230a06d1d11ebbdf8ade37693841eca7e0e versions/library-2.7
+
+2.6: git://github.com/gliderlabs/docker-alpine@17b3e0697ea26e79388ffc6b61a14da4d6e64c33 versions/library-2.6


### PR DESCRIPTION
Added Alpine version 3.2 and bumped other versions for various security backports. Closes #761.