### PR TITLE
Updates for cassandra, elasticsearch, java, php

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.15: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.0
-2.0: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.0
+2.0.15: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.0
+2.0: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.0
 
-2.1.5: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1
-2.1: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1
-latest: git://github.com/docker-library/cassandra@34ec1cba1b6364d4701a4878b795d0a75b7c8afc 2.1
+2.1.5: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1
+2.1: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1
+latest: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@eb0f9ee6627079d45ca9a64cc30cff0f6dfe07a1 1.3
-1.3: git://github.com/docker-library/elasticsearch@eb0f9ee6627079d45ca9a64cc30cff0f6dfe07a1 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.3
+1.3: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
-1.4: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
-1: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
-latest: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
+1.4: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
+1: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
+latest: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.5
-1.5: git://github.com/docker-library/elasticsearch@83fdaa617fc15a6363f08935190a7edd55ab35c0 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
+1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5

--- a/library/java
+++ b/library/java
@@ -31,16 +31,16 @@ openjdk-7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31
 7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 
-openjdk-8u45-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-openjdk-8u45: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-8u45-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-8u45: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
-8: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jdk
+openjdk-8u45-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+openjdk-8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+8u45-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
 
-openjdk-8u45-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
-8u45-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@e740b6fad61854adfbdf553638d33f1c80176d79 openjdk-8-jre
+openjdk-8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
+8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.41-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4
-5.4-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4
-5.4.41: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4
-5.4: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4
+5.4.41-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
+5.4-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
+5.4.41: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
+5.4: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
 
-5.4.41-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4/apache
-5.4-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4/apache
+5.4.41-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/apache
+5.4-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/apache
 
-5.4.41-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.4/fpm
+5.4.41-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/fpm
 
-5.5.25-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5
-5.5-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5
-5.5.25: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5
-5.5: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5
+5.5.25-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
+5.5-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
+5.5.25: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
+5.5: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
 
-5.5.25-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5/apache
-5.5-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5/apache
+5.5.25-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/apache
+5.5-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/apache
 
-5.5.25-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.5/fpm
+5.5.25-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/fpm
 
-5.6.9-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-5.6-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-5-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-cli: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-5.6.9: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-5.6: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-5: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
-latest: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6
+5.6.9-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5.6-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5.6.9: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5.6: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+latest: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
 
-5.6.9-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/apache
-5.6-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/apache
-5-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/apache
-apache: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/apache
+5.6.9-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
+5.6-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
+5-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
+apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
 
-5.6.9-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/fpm
-5-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/fpm
-fpm: git://github.com/docker-library/php@ec8e44b3b8d5a18d414a9f9205c40e71e829f858 5.6/fpm
+5.6.9-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
+5-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
+fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm


### PR DESCRIPTION
- `cassandra` three new env variables for cross datacenter
- `elasticsearch` FROM java:8
- `java` java:8 -> FROM debian:jessie!
- `php` use $ini consistently in docker-php-ext-install