### PR TITLE
Update to Jetty 9.2.11 and 9.3.0.RC1; drop 9.3-jre7 image

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,20 +1,17 @@
 # maintainer: Mike Dillon <mike@embody.org> (@md5)
 
-9.2.10: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-9.2: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-9: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-9.2.10-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-9.2-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-9-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-latest: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre7
+9.2.11: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9.2: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9.2.11-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9.2-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+latest: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
 
-9.2.10-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.2-jre8
+9.2.11-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
 
-9.3.0.M2: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre7
-9.3.0.M2-jre7: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre7
-
-9.3.0.M2-jre8: git://github.com/appropriate/docker-jetty@6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92 9.3-jre8
+9.3.0.RC1-jre8: git://github.com/appropriate/docker-jetty@422c0de08ad2388b26a5e8d6ba9af85753db9a07 9.3-jre8


### PR DESCRIPTION
9.2 diff: https://github.com/appropriate/docker-jetty/compare/6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92...7946910db1db4f4a206379f023ad82f2c9b107e9 ([whitespace friendly](https://github.com/appropriate/docker-jetty/compare/6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92...7946910db1db4f4a206379f023ad82f2c9b107e9?w=1))
9.3 diff: https://github.com/appropriate/docker-jetty/compare/6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92...422c0de08ad2388b26a5e8d6ba9af85753db9a07 ([whitespace friendly](https://github.com/appropriate/docker-jetty/compare/6a38e700ebcff515bc94d2fbe8c1b3fa991f5a92...422c0de08ad2388b26a5e8d6ba9af85753db9a07))