### PR TITLE
Update iojs to v2.2.1

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -12,17 +12,17 @@
 1.8-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
 1-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
 
-2.1.0: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
-2.1: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
-2: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
-latest: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1
+2.2.1: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
+2.2: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
+2: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
+latest: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
 
-2.1.0-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
-2.1-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
-2-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/onbuild
+2.2.1-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
+2.2-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
+2-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
 
-2.1.0-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim
-2.1-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim
-2-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim
-slim: git://github.com/nodejs/docker-iojs@42ff29ba4bbdd9077f887f4861c772d2fff87055 2.1/slim
+2.2.1-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
+2.2-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
+2-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
+slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim


### PR DESCRIPTION
Related: nodejs/docker-iojs#66
Related: nodejs/docker-iojs#67