### PR TITLE
Adding whalesay image

### DIFF
--- a/library/whalesay
+++ b/library/whalesay
@@ -1,0 +1,3 @@
+# maintainer: Mary Anthony <mary@docker.com> (@moxiegirl)
+
+latest: git://github.com/git@github.com:moxiegirl/whalesay@a2e4beab921d577835e1ead253002275a84afc93


### PR DESCRIPTION
For Dockercon, the WWW team is creating a tutorial that walks users through a demo of the product.   For the demo, users run and later build their own demo from whalesay.  So, it would be better if the image were an "official image" because we want users to search for official images as part of the demo.

Actually, I'm not sure if this is entirely the correct format.  I tried to follow the doc but it was a bit too general for me.  Um, I'm adding fixing that to my todo list.

Signed-off-by: Mary Anthony <mary@docker.com>