### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.15: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.0
-2.0: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.0
+2.0.15: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
+2.0: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
 
-2.1.5: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1
-2.1: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1
-latest: git://github.com/docker-library/cassandra@44b6b4016498a95d90f571f89e04be2139141b71 2.1
+2.1.5: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1
+2.1: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1
+latest: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.2-python2: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 2.7
-1.8-python2: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 2.7
-1-python2: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 2.7
-python2: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 2.7
+1.8.2-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
+1.8-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
+1-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
+python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
 
-python2-onbuild: git://github.com/docker-library/django@a3ae98081865ff8aab7524c98318568c32828ed1 2.7/onbuild
+python2-onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7/onbuild
 
-1.8.2-python3: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-1.8.2: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-1.8-python3: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-1.8: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-1-python3: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-1: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-python3: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
-latest: git://github.com/docker-library/django@73c0ea2e1fbe9a34efe74128f997b3c55bf835f7 3.4
+1.8.2-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1.8.2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1.8-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1.8: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+latest: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
 
-python3-onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild
-onbuild: git://github.com/docker-library/django@bbafaaab189c626ae85dc7fae60b7c589e8783e6 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4/onbuild
+onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 7
 latest: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 7
 
-8.0.0-beta10: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
-8.0.0: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
-8.0: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
-8: git://github.com/docker-library/drupal@48f3bfc8895d89c01babb0358ff1925d318c4279 8
+8.0.0-beta11: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
+8.0.0: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
+8.0: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
+8: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.3.8: git://github.com/docker-library/julia@22d68e94ea5e4febf3fc6b2167e9a538e3cad4c1
-0.3: git://github.com/docker-library/julia@22d68e94ea5e4febf3fc6b2167e9a538e3cad4c1
-latest: git://github.com/docker-library/julia@22d68e94ea5e4febf3fc6b2167e9a538e3cad4c1
+0.3.9: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120
+0.3: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120
+latest: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.43: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.5
-5.5: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.5
+5.5.44: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.5
+5.5: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.5
 
-5.6.24: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
-5.6: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
-5: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
-latest: git://github.com/docker-library/mysql@1f430aeee538aec3b51554ca9fc66955231b3563 5.6
+5.6.25: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.6
+5.6: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.6
+5: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.6
+latest: git://github.com/docker-library/mysql@fd23594c7faa59294a87aebb5bb441359c375eb9 5.6
 
 5.7.7-rc: git://github.com/docker-library/mysql@837e11e42695aa5e9927b2418edaf7a666057c50 5.7
 5.7.7: git://github.com/docker-library/mysql@837e11e42695aa5e9927b2418edaf7a666057c50 5.7

--- a/library/postgres
+++ b/library/postgres
@@ -4,11 +4,11 @@
 8.4: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 8.4
 8: git://github.com/docker-library/postgres@77438cd8e1c2b780b4f859c5efd904ae3c6c508a 8.4
 
-9.0.20: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.0
-9.0: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.0
+9.0.20: git://github.com/docker-library/postgres@904b4637237bf17657674bafe3ca42d241e3e745 9.0
+9.0: git://github.com/docker-library/postgres@904b4637237bf17657674bafe3ca42d241e3e745 9.0
 
-9.1.16: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.1
-9.1: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.1
+9.1.16: git://github.com/docker-library/postgres@904b4637237bf17657674bafe3ca42d241e3e745 9.1
+9.1: git://github.com/docker-library/postgres@904b4637237bf17657674bafe3ca42d241e3e745 9.1
 
 9.2.11: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.2
 9.2: git://github.com/docker-library/postgres@4b132fa76a50598aa422f9cf5b5b52d9d4fc5802 9.2

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.5.1: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2
-2-2.5: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2
-2-2: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2
-2: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2
+2-2.6.0: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
+2-2.6: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
+2-2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
+2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
 
-2-2.5.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-2.5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-2.6.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-2.6-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-2.5.1-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2/slim
-2-2.5-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2/slim
-2-2-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2/slim
-2-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 2/slim
+2-2.6.0-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
+2-2.6-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
+2-2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
+2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3
-3-2.4: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3
-3-2: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3
-3: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3
-latest: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3
+3-2.4.0: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
+3-2.4: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
+3-2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
+3: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
+latest: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f0
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3/slim
-3-2-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3/slim
-3-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3/slim
-slim: git://github.com/docker-library/pypy@22b56eb4d32732147f6ce39745febd074f072ecf 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
+3-2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
+3-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
+slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim

--- a/library/python
+++ b/library/python
@@ -1,61 +1,61 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7
-2.7: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7
-2: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7
+2.7.10: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
+2.7: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
+2: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
 
 2.7.10-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/slim
-2.7-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/slim
-2-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/slim
+2.7.10-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
+2.7-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
+2-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
 
-2.7.10-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/wheezy
+2.7.10-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2
-3.2: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2
+3.2.6: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2
+3.2: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2/slim
-3.2-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/slim
+3.2-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3
-3.3: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3
+3.3.6: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3
+3.3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/slim
-3.3-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/slim
+3.3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4
-3.4: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4
-3: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4
-latest: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4
+3.4.3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
+3.4: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
+3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
+latest: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/slim
-3.4-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/slim
-3-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/slim
-slim: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
+3.4-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
+3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
+slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/wheezy
-wheezy: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
+wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.5.0: git://github.com/docker-library/sentry@69b3007ea0b3b54c173342d6a0d91bdd7ed5f3e1
-7.5: git://github.com/docker-library/sentry@69b3007ea0b3b54c173342d6a0d91bdd7ed5f3e1
-7: git://github.com/docker-library/sentry@69b3007ea0b3b54c173342d6a0d91bdd7ed5f3e1
-latest: git://github.com/docker-library/sentry@69b3007ea0b3b54c173342d6a0d91bdd7ed5f3e1
+7.5.3: git://github.com/docker-library/sentry@64fdd27c9aaf27da23cd89a2bca73b523594f1f8
+7.5: git://github.com/docker-library/sentry@64fdd27c9aaf27da23cd89a2bca73b523594f1f8
+7: git://github.com/docker-library/sentry@64fdd27c9aaf27da23cd89a2bca73b523594f1f8
+latest: git://github.com/docker-library/sentry@64fdd27c9aaf27da23cd89a2bca73b523594f1f8


### PR DESCRIPTION
- `cassandra`: multiple datacenter support (docker-library/cassandra#6)
- `django`: relax `FROM` so rebuilds happen more naturally with base image changes
- `drupal`: 8.0.0-beta11
- `julia`: 0.3.9
- `mysql`: 5.5.44 and 5.6.25
- `postgres`: 9.0.20-2.pgdg70+1 and 9.1.16-2.pgdg70+1
- `pypy`: 2.6.0 and pip 7.0.3
- `python`: pip 7.0.3
- `sentry`: 7.5.3