### PR TITLE
Add initial mongo-basics test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -56,6 +56,7 @@ declare -A imageTests=(
 	[memcached]='
 	'
 	[mongo]='
+		mongo-basics
 	'
 	[mono]='
 	'

--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+image="$1"
+
+cname="mongo-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" "$image")"
+trap "docker rm -f $cid > /dev/null" EXIT
+
+mongo() {
+	docker run --rm -i --link "$cname":mongo --entrypoint mongo "$image" --host mongo "$@"
+}
+
+mongo_eval() {
+	mongo --quiet --eval "$@"
+}
+
+tries=10
+while ! mongo_eval 'quit(db.stats().ok ? 0 : 1);' &> /dev/null; do
+	(( tries-- ))
+	if [ $tries -le 0 ]; then
+		echo >&2 'mongod failed to accept connetions in a reasonable amount of time!'
+		mongo --eval 'db.stats();' # to hopefully get a useful error message
+		false
+	fi
+	sleep 2
+done
+
+[ "$(mongo_eval 'db.test.count();')" = 0 ]
+mongo_eval 'db.test.save({ _id: 1, a: 2, b: 3, c: "hello" });' > /dev/null
+[ "$(mongo_eval 'db.test.count();')" = 1 ]
+mongo_eval 'db.test.save({ _id: 1, a: 3, b: 4, c: "hello" });' > /dev/null
+[ "$(mongo_eval 'db.test.count();')" = 1 ]
+[ "$(mongo_eval 'db.test.findOne().a;')" = 3 ]
+
+[ "$(mongo_eval 'db.test2.count();')" = 0 ]
+mongo_eval 'db.test2.save({ _id: "abc" });' > /dev/null
+[ "$(mongo_eval 'db.test2.count();')" = 1 ]
+[ "$(mongo_eval 'db.test.count();')" = 1 ]
+mongo_eval 'db.test2.drop();' > /dev/null
+[ "$(mongo_eval 'db.test2.count();')" = 0 ]
+[ "$(mongo_eval 'db.test.count();')" = 1 ]
+[ "$(mongo_eval 'db.test.count();' database-that-does-not-exist)" = 0 ]
+
+mongo_eval 'db.dropDatabase();' > /dev/null
+[ "$(mongo_eval 'db.test.count();')" = 0 ]


### PR DESCRIPTION
Fixes #600

```console
$ bashbrew list --uniq mongo | xargs ./test/run.sh -t mongo-basics
testing mongo:2.2.7
	'mongo-basics' [1/1]...passed
testing mongo:2.4.14
	'mongo-basics' [1/1]...passed
testing mongo:2.6.10
	'mongo-basics' [1/1]...passed
testing mongo:3.0.3
	'mongo-basics' [1/1]...passed
```