### PR TITLE
Update redis to 2.8.21 and 3.0.2

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -3,11 +3,11 @@
 2.6.17: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
 2.6: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
 
-2.8.20: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
-2.8: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
-2: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 2.8
+2.8.21: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
+2.8: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
+2: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
 
-3.0.1: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
-3.0: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
-3: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
-latest: git://github.com/docker-library/redis@3b5b408972da5d788a483dfcd0e49b99937e5fc2 3.0
+3.0.2: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
+3.0: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
+3: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
+latest: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0


### PR DESCRIPTION
https://github.com/docker-library/redis/pull/25