### PR TITLE
Reorganize python-imports to include "curses"

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -1,6 +1,7 @@
+import curses
+
 import zlib
-import bz2
-
 assert(zlib.decompress(zlib.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
-assert(bz2.decompress(bz2.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
 
+import bz2
+assert(bz2.decompress(bz2.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')


### PR DESCRIPTION
```console
$ ./test/run.sh -t python-imports python:3 python:3-slim python:2 python:2-slim
testing python:3
	'python-imports' [1/1]...passed
testing python:3-slim
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 1, in <module>
    import curses
  File "/usr/local/lib/python3.4/curses/__init__.py", line 13, in <module>
    from _curses import *
ImportError: No module named '_curses'
failed
testing python:2
	'python-imports' [1/1]...passed
testing python:2-slim
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 1, in <module>
    import curses
  File "/usr/local/lib/python2.7/curses/__init__.py", line 15, in <module>
    from _curses import *
ImportError: No module named _curses
failed
```