### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -3,6 +3,6 @@
 2.0.15: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
 2.0: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
 
-2.1.5: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1
-2.1: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1
-latest: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.1
+2.1.6: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1
+2.1: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1
+latest: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,8 +5,11 @@
 
 1.4.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
 1.4: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
-1: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
-latest: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
 
 1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
+
+1.6.0: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
+1.6: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
+1: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
+latest: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6

--- a/library/python
+++ b/library/python
@@ -1,59 +1,59 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
-2.7: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
-2: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7
+2.7.10: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
+2.7: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
+2: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
 
 2.7.10-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
-2.7-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
-2-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/slim
+2.7.10-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
+2.7-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
+2-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
 
 2.7.10-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
 2.7-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
 2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2
-3.2: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2
+3.2.6: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2
+3.2: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/slim
-3.2-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2/slim
+3.2-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2/slim
 
 3.2.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
 3.2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3
-3.3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3
+3.3.6: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3
+3.3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/slim
-3.3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3/slim
+3.3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3/slim
 
 3.3.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
 3.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
-3.4: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
-3: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
-latest: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4
+3.4.3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
+3.4: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
+3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
+latest: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
-3.4-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
-3-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
-slim: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
+3.4-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
+3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
+slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
 
 3.4.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
 3.4-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy


### PR DESCRIPTION
- `cassandra`: 2.1.6
- `elasticsearch`: 1.6.0 (docker-library/elasticsearch#33)
- `python`: fix curses in slim variants (docker-library/python#52)