### PR TITLE
Updating ROS to include Jade

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -4,5 +4,14 @@ indigo-ros-core:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf3419
 indigo-ros-base:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
 indigo-robot:       git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-robot
 indigo-perception:  git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-perception
-
+indigo:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
 latest:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
+# Docker EOL: 2019-04
+# LTS
+
+jade-ros-core:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
+# Docker EOL: 2017-04


### PR DESCRIPTION
Keeping `latest` tag at latest LTS release, Indigo,
same behavior as ubuntu.

Adding distro tags pointing to distro-`ros-base`

Adding notes on expected EOL