### PR TITLE
Update ubuntu-debootstrap (2015-06-11 debootstraps), especially for CVE-2015-4000

### DIFF
--- a/library/ubuntu-debootstrap
+++ b/library/ubuntu-debootstrap
@@ -1,24 +1,24 @@
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # commits: (master..dist)
-#  - 5979d06 2015-05-20 debootstraps
+#  - fa74aca 2015-06-11 debootstraps
 
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 12.04
-12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 12.04
-precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 12.04
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 12.04
+12.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 12.04
+precise: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 12.04
 
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.04
-14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.04
-trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.04
-latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.04
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.04
+14.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.04
+trusty: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.04
+latest: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.04
 
-14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.10
-utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 14.10
+14.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.10
+utopic: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 14.10
 
-15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 15.04
-vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 15.04
+15.04: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 15.04
+vivid: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 15.04
 
-15.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 15.10
-wily: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 15.10
+15.10: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 15.10
+wily: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a 15.10
 
-devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@5979d06b34b01f0eff76ab7b0219645297f0b360 devel
+devel: git://github.com/tianon/docker-brew-ubuntu-debootstrap@fa74aca5f4e00f326492f5840eb001948a4d405a devel


### PR DESCRIPTION
https://github.com/docker-library/official-images/issues/807