### PR TITLE
Update ubuntu, especially for CVE-2015-4000

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,37 +5,37 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 65db460 Update tarballs
-#    - `ubuntu:precise`: 20150528
-#    - `ubuntu:trusty`: 20150528
-#    - `ubuntu:utopic`: 20150528
-#    - `ubuntu:vivid`: 20150528
-#    - `ubuntu:wily`: 20150528.1
+#  - 67accc0 Update tarballs
+#    - `ubuntu:precise`: 20150612
+#    - `ubuntu:trusty`: 20150612
+#    - `ubuntu:utopic`: 20150612
+#    - `ubuntu:vivid`: 20150611
+#    - `ubuntu:wily`: 20150611
 
-# 20150528
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 precise
-precise-20150528: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 precise
+# 20150612
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
+precise-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
 
-# 20150528
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 trusty
-trusty-20150528: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 trusty
+# 20150612
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
+trusty-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
 
-# 20150528
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 utopic
-utopic-20150528: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 utopic
+# 20150612
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
+utopic-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
 
-# 20150528
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 vivid
-vivid-20150528: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 vivid
+# 20150611
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
+vivid-20150611: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
 
-# 20150528.1
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 wily
-wily-20150528.1: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@65db460809b22fe8976c05d0364fa40dd6ae7314 wily
+# 20150611
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily
+wily-20150611: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily


### PR DESCRIPTION
https://github.com/docker-library/official-images/issues/807

- `ubuntu:precise`: 20150612
- `ubuntu:trusty`: 20150612
- `ubuntu:utopic`: 20150612
- `ubuntu:vivid`: 20150611
- `ubuntu:wily`: 20150611