### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.2-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
-1.8-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
-1-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
-python2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7
+1.8.2-python2: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7
+1.8-python2: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7
+1-python2: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7
+python2: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7
 
-python2-onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 2.7/onbuild
+python2-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7/onbuild
 
-1.8.2-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-1.8.2: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-1.8-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-1.8: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-1-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-1: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-python3: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
-latest: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4
+1.8.2-python3: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+1.8.2: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+1.8-python3: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+1.8: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+1-python3: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+1: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+python3: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
+latest: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4
 
-python3-onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4/onbuild
-onbuild: git://github.com/docker-library/django@3525bc25b5878858ef3a9f2ee5d2aeddbc1b68b2 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild
+onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild

--- a/library/irssi
+++ b/library/irssi
@@ -1,7 +1,7 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.17: git://github.com/jfrazelle/irssi@dfefff246e4a04dee588feafc1d720b5247a112e
-0.8: git://github.com/jfrazelle/irssi@dfefff246e4a04dee588feafc1d720b5247a112e
-0: git://github.com/jfrazelle/irssi@dfefff246e4a04dee588feafc1d720b5247a112e
-latest: git://github.com/jfrazelle/irssi@dfefff246e4a04dee588feafc1d720b5247a112e
+0.8.17: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
+0.8: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
+0: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
+latest: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08

--- a/library/kibana
+++ b/library/kibana
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/kibana@eef820b7b3f13fe82dadd0381ed1ca880cb6c90c
-4.1: git://github.com/docker-library/kibana@eef820b7b3f13fe82dadd0381ed1ca880cb6c90c
-4: git://github.com/docker-library/kibana@eef820b7b3f13fe82dadd0381ed1ca880cb6c90c
-latest: git://github.com/docker-library/kibana@eef820b7b3f13fe82dadd0381ed1ca880cb6c90c
+4.1.0: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
+4.1: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
+4: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
+latest: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,6 +5,6 @@
 10: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
 latest: git://github.com/docker-library/mariadb@b26758f0cde0b55ec4087074c1279db215a18d69 10.0
 
-5.5.43: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
-5.5: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
-5: git://github.com/docker-library/mariadb@471e5cbdea21c3b080809ba3376990b12cf4da05 5.5
+5.5.44: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5
+5.5: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5
+5: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5

--- a/library/php
+++ b/library/php
@@ -1,42 +1,42 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.41-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
-5.4-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
-5.4.41: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
-5.4: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4
+5.4.42-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4
+5.4-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4
+5.4.42: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4
+5.4: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4
 
-5.4.41-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/apache
-5.4-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/apache
+5.4.42-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/apache
+5.4-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/apache
 
-5.4.41-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.4/fpm
+5.4.42-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/fpm
 
-5.5.25-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
-5.5-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
-5.5.25: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
-5.5: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5
+5.5.26-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
+5.5-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
+5.5.26: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
+5.5: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
 
-5.5.25-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/apache
-5.5-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/apache
+5.5.26-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/apache
+5.5-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/apache
 
-5.5.25-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.5/fpm
+5.5.26-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/fpm
 
-5.6.9-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-5.6-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-5-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-cli: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-5.6.9: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-5.6: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-5: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
-latest: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6
+5.6.10-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5.6-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5.6.10: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5.6: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+latest: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
 
-5.6.9-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
-5.6-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
-5-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
-apache: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/apache
+5.6.10-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
+5.6-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
+5-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
+apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
 
-5.6.9-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
-5-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
-fpm: git://github.com/docker-library/php@58559e7dec9df4af7475dd3ab62864700cf9feae 5.6/fpm
+5.6.10-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
+5-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
+fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.21: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.0
-9.0: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.0
+9.0.22: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.0
+9.0: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.0
 
-9.1.17: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.1
-9.1: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.1
+9.1.18: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.1
+9.1: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.1
 
-9.2.12: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.2
-9.2: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.2
+9.2.13: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.2
+9.2: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.2
 
-9.3.8: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.3
-9.3: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.3
+9.3.9: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.3
+9.3: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.3
 
-9.4.3: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.4
-9.4: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.4
-9: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.4
-latest: git://github.com/docker-library/postgres@a6d4922823aa8011513bb9c160c26c689301823a 9.4
+9.4.4: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.4
+9.4: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.4
+9: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.4
+latest: git://github.com/docker-library/postgres@bfca9b8a92a99ccfc8f04933b7ecc29a108c7f49 9.4

--- a/library/python
+++ b/library/python
@@ -1,61 +1,61 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
-2.7: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
-2: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7
+2.7.10: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7
+2.7: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7
+2: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7
 
-2.7.10-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
-2.7-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
-2-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 2.7/onbuild
+2.7.10-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
+2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
+2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
-2.7-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
-2-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 2.7/slim
+2.7.10-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7/slim
+2.7-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7/slim
+2-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 2.7/slim
 
-2.7.10-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 2.7/wheezy
+2.7.10-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2
-3.2: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2
+3.2.6: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.2
+3.2: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.2
 
-3.2.6-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
-3.2-onbuild: git://github.com/docker-library/python@8ac0675e338b0f0429154a088a6b11811e21e948 3.2/onbuild
+3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
+3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2/slim
-3.2-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.2/slim
+3.2-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3
-3.3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3
+3.3.6: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.3
+3.3: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.3
 
-3.3.6-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
-3.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.3/onbuild
+3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
+3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3/slim
-3.3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.3/slim
+3.3-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
-3.4: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
-3: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
-latest: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4
+3.4.3: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4
+3.4: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4
+3: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4
+latest: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4
 
-3.4.3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
-3.4-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
-3-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
-onbuild: git://github.com/docker-library/python@526ee08b34a8cd403ff47cc03001f8025738e70e 3.4/onbuild
+3.4.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
+3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
+3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
+onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
-3.4-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
-3-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
-slim: git://github.com/docker-library/python@82380dd56cd24089456ee6a9a5a69953a16124aa 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4/slim
+3.4-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4/slim
+3-slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4/slim
+slim: git://github.com/docker-library/python@6d962f44cb44c9e8272345aad396f705e723c27b 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
-wheezy: git://github.com/docker-library/python@38e00bb6badca06d9def72d53c0d14d8b53e2933 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
+wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy


### PR DESCRIPTION
- `django`: avoid pip's cache (docker-library/python#50)
- `irssi`: license and minor `update.sh` fix (just sick of seeing this update being pending -- no actual `Dockerfile` changes here)
- `kibana`: support `ELASTICSEARCH_URL` variable (docker-library/kibana#3)
- `mariadb`: 5.5.44+maria-1~wheezy
- `php`: 5.4.42, 5.5.26, and 5.6.10
- `postgres`: 9.0.22-1.pgdg70+1, 9.1.18-1.pgdg70+1, 9.2.13-1.pgdg70+1, 9.3.9-1.pgdg70+1, and 9.4.4-1.pgdg70+1
- `python`: avoid pip's cache (docker-library/python#50)