### PR TITLE
Update docker-library images

### DIFF
--- a/library/kibana
+++ b/library/kibana
@@ -1,6 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.1.0: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
-4.1: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
-4: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
-latest: git://github.com/docker-library/kibana@3d09dab632ca2919f554b7a40058e8806e58248f
+4.0.3: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
+4.0: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
+
+4.1.0: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
+4.1: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
+4: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
+latest: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.44: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.5
-5.5: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.5
+5.5.44: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.5
+5.5: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.5
 
-5.6.25: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.6
-5.6: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.6
-5: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.6
-latest: git://github.com/docker-library/mysql@ae647b4e7b39ed49c453a31de63e3578a992fbf4 5.6
+5.6.25: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
+5.6: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
+5: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
+latest: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
 
-5.7.7-rc: git://github.com/docker-library/mysql@0fd8c6845ed83239f36daa48a66c8e42eac3dc46 5.7
-5.7.7: git://github.com/docker-library/mysql@0fd8c6845ed83239f36daa48a66c8e42eac3dc46 5.7
-5.7: git://github.com/docker-library/mysql@0fd8c6845ed83239f36daa48a66c8e42eac3dc46 5.7
+5.7.7-rc: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7
+5.7.7: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7
+5.7: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7


### PR DESCRIPTION
- `kibana`: add 4.0 back (docker-library/kibana#5)
- `mysql`: use `ha` keyserver pool and add `--innodb-read-only` to prevent bugs around `--verbose --help` configuration fetching (docker-library/mysql#78)