### PR TITLE
Update to Jetty 9.3.0.v20150612; 9.3 is latest

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,17 +1,20 @@
-# maintainer: Mike Dillon <mike@embody.org> (@md5)
+# maintainer: Mike Dillon <mike@appropriate.io> (@md5)
 
-9.2.11: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-9.2: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-9: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9.3.0: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9.3.0-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+
+9.2.11: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9.2: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9.2.11-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+
 9.2.11-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
 9.2-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
 9-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-latest: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
 jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-
-9.2.11-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-
-9.3.0.RC1-jre8: git://github.com/appropriate/docker-jetty@422c0de08ad2388b26a5e8d6ba9af85753db9a07 9.3-jre8


### PR DESCRIPTION
* Updated my email address as maintainer
* 9.2 tags are the same
* Changed `latest`, `9`, and `jre8` to point at 9.3
* 9.3 diff: https://github.com/appropriate/docker-jetty/compare/422c0de08ad2388b26a5e8d6ba9af85753db9a07...833fb99b9e49140dec67d2af3c6b51901c83bbce