### PR TITLE
Update io.js to v2.3.0

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -12,17 +12,17 @@
 1.8-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
 1-slim: git://github.com/nodejs/docker-iojs@97280882b765c720fa88b88bccbc57e3b3266e43 1.8/slim
 
-2.2.1: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
-2.2: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
-2: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
-latest: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2
+2.3.0: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3
+2.3: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3
+2: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3
+latest: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3
 
-2.2.1-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
-2.2-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
-2-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/onbuild
+2.3.0-onbuild: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/onbuild
+2.3-onbuild: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/onbuild
+2-onbuild: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/onbuild
 
-2.2.1-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
-2.2-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
-2-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
-slim: git://github.com/nodejs/docker-iojs@76a4255dd8985607301f003220c80f43b72c55e1 2.2/slim
+2.3.0-slim: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/slim
+2.3-slim: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/slim
+2-slim: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/slim
+slim: git://github.com/nodejs/docker-iojs@fc1c0fa8a7e78d4811852bd7d7518975ba93bf61 2.3/slim


### PR DESCRIPTION
This PR updates iojs `:2` Docker images to v2.3.0.

Changeset: https://github.com/nodejs/docker-iojs/compare/76a4255...fc1c0fa

Related: nodejs/docker-iojs#69
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>