### PR TITLE
Update swarm to 0.3.0

### DIFF
--- a/library/swarm
+++ b/library/swarm
@@ -2,6 +2,5 @@
 # maintainer: Victor Vieux <vieux@docker.com> (@vieux)
 # maintainer: Alexandre Beslic <abronan@docker.com> (@abronan)
 
-0.3.0-rc3: git://github.com/docker/swarm-library-image@206d90c3d59ccc2e1b232d37edf3b492ca81693b
-0.2.0: git://github.com/docker/swarm-library-image@3c2dd0f73b7351744af64efb38e4fa5a015cc114
-latest: git://github.com/docker/swarm-library-image@3c2dd0f73b7351744af64efb38e4fa5a015cc114
+0.3.0: git://github.com/docker/swarm-library-image@206d90c3d59ccc2e1b232d37edf3b492ca81693b
+latest: git://github.com/docker/swarm-library-image@206d90c3d59ccc2e1b232d37edf3b492ca81693b


### PR DESCRIPTION
This PR promotes `0.3.0-rc3` to final.

Please do not merge until Engine is out.

/cc @tianon 

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>