### PR TITLE
update Node.js to 0.10.39 and npm to 2.11.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,45 +1,45 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.38: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10
-0.10: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10
+0.10.39: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10
+0.10: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10
 
-0.10.38-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
-0.10-onbuild: git://github.com/joyent/docker-node@1a414011089f16390800995f469f5f08446baf7f 0.10/onbuild
+0.10.39-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
+0.10-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
 
-0.10.38-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10/slim
+0.10.39-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/slim
 
-0.10.38-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.10/wheezy
+0.10.39-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
 
-0.12.4: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12
-0.12: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12
-0: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12
-latest: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12
+0.12.4: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
+0.12: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
+0: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
+latest: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
 
 0.12.4-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
 0.12-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
 0-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
 onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
 
-0.12.4-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/slim
-0-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/slim
-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/slim
+0.12.4-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
+0-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
+slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
 
-0.12.4-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.12/wheezy
+0.12.4-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
 
-0.8.28: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8
-0.8: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8
+0.8.28: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8
+0.8: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/slim
 
-0.8.28-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8/wheezy
-0.8-wheezy: git://github.com/joyent/docker-node@cb1434d434ca52b31e81452d887e76fc7b24cbef 0.8/wheezy
+0.8.28-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/wheezy
+0.8-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/wheezy

--- a/library/node
+++ b/library/node
@@ -12,25 +12,25 @@
 0.10.39-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
 0.10-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
 
-0.12.4: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
-0.12: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
-0: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
-latest: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12
+0.12.5: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
+0.12: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
+0: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
+latest: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
 
-0.12.4-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
-0.12-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
-0-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
-onbuild: git://github.com/joyent/docker-node@428d5e69763aad1f2d8f17c883112850535e8290 0.12/onbuild
+0.12.5-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
+0.12-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
+0-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
+onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
 
-0.12.4-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
-0-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/slim
+0.12.5-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
+0-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
+slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
 
-0.12.4-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.12/wheezy
+0.12.5-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
 
 0.8.28: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8
 0.8: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8


### PR DESCRIPTION
This updates the 0.10.* release of Node.js to 0.10.39  and npm to 2.11.3. Node.js 0.10.39 includes upgrade OpenSSL  (1.0.1o) which fixes several security vulnerabilities:

http://blog.nodejs.org/2015/06/22/node-v0-10-39-maintenance/