### PR TITLE
Fedora 20 is EOL, remove fedora:{20,heisenbug}

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -4,5 +4,3 @@ latest: git://github.com/fedora-cloud/docker-brew-fedora@e5a0a567230ca8350d2be9b
 22: git://github.com/fedora-cloud/docker-brew-fedora@e5a0a567230ca8350d2be9b100604858fc898c0b
 21: git://github.com/fedora-cloud/docker-brew-fedora@e32493b9601c3535cd6e0d0a8ff61d8fa95afb83
 rawhide: git://github.com/fedora-cloud/docker-brew-fedora@3e0c45e6baeec263e42d062b1ab21fd9a3e4f6d9
-20: git://github.com/fedora-cloud/docker-brew-fedora@58a9aeac899b94e6ea1b1cbe6853b9b134c7ebc5
-heisenbug: git://github.com/fedora-cloud/docker-brew-fedora@58a9aeac899b94e6ea1b1cbe6853b9b134c7ebc5


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>