### PR TITLE
Download node binary and SHASUMs via HTTPS

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,45 +1,45 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.39: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10
-0.10: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10
+0.10.39: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10
+0.10: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10
 
 0.10.39-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
 0.10-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
 
-0.10.39-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/slim
+0.10.39-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/slim
 
-0.10.39-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/wheezy
+0.10.39-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
 
-0.12.5: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
-0.12: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
-0: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
-latest: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12
+0.12.5: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
+0.12: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
+0: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
+latest: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
 
 0.12.5-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
 0.12-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
 0-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
 onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
 
-0.12.5-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
-0-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
-slim: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/slim
+0.12.5-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
+0-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
+slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
 
-0.12.5-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/wheezy
+0.12.5-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
 
-0.8.28: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8
-0.8: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8
+0.8.28: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
+0.8: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/slim
 
-0.8.28-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/wheezy
-0.8-wheezy: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.8/wheezy
+0.8.28-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/wheezy
+0.8-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/wheezy


### PR DESCRIPTION
This updates the Dockerfiles so that the Node.js binaries and SHASUM files are downloaded via https rather than http. For the slim variant, this also meant having to install (then uninstall) the ca-certificates package.

All the test builds look good!