### PR TITLE
Move the "latest" tag to point to "java:8"

### DIFF
--- a/library/java
+++ b/library/java
@@ -22,14 +22,11 @@ openjdk-7: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409e
 7u79: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jdk
 7-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jdk
 7: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jdk
-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jdk
-latest: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jdk
 
 openjdk-7u79-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 openjdk-7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 7u79-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 7-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-7-jre
 
 openjdk-8u45-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
 openjdk-8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
@@ -39,8 +36,11 @@ openjdk-8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda
 8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
 8-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
 8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+latest: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
 
 openjdk-8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
 openjdk-8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
 8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
 8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
+jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre


### PR DESCRIPTION
Also updates "jdk" and "jre" to point to their respective Java 8 version.