### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,29 +6,59 @@ curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db6936
 jessie-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 
-jessie: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 jessie
-latest: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 jessie
+jessie: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da jessie
+latest: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da jessie
+
+precise-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/curl
+
+precise-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/scm
+
+precise: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da precise
 
 sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
 sid-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
 
-sid: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 sid
+sid: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da sid
 
 squeeze-curl: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/curl
 
 squeeze-scm: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/scm
 
-squeeze: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze
+squeeze: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da squeeze
 
 stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
 
 stretch-scm: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/scm
 
-stretch: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch
+stretch: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da stretch
+
+trusty-curl: git://github.com/docker-library/buildpack-deps@21f2d32bcf321ff095a23c0edc1d8be2b7989962 trusty/curl
+
+trusty-scm: git://github.com/docker-library/buildpack-deps@bb6691a2782687748549baac903340fc21a5533c trusty/scm
+
+trusty: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da trusty
+
+utopic-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/curl
+
+utopic-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/scm
+
+utopic: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da utopic
+
+vivid-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/curl
+
+vivid-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/scm
+
+vivid: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da vivid
 
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
 
-wheezy: git://github.com/docker-library/buildpack-deps@44070019e0c6c4f83461f2058d110cc418da09c4 wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da wheezy
+
+wily-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/curl
+
+wily-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/scm
+
+wily: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da wily

--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.15: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
-2.0: git://github.com/docker-library/cassandra@a918a72ca6bfc1becaa0ba25e9720b83071d0f4c 2.0
+2.0.16: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.0
+2.0: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.0
 
-2.1.6: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1
-2.1: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1
-latest: git://github.com/docker-library/cassandra@5280fcc3d55d651a037991d0a1982b95b8d02bcc 2.1
+2.1.7: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.1
+2.1: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.1
+latest: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.1

--- a/library/gcc
+++ b/library/gcc
@@ -5,15 +5,15 @@
 4.7: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.7
 # Docker EOL: 2016-06-12
 
-# Last Modified: 2014-12-19
-4.8.4: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.8
-4.8: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.8
-# Docker EOL: 2016-12-19
+# Last Modified: 2015-06-23
+4.8.5: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.8
+4.8: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.8
+# Docker EOL: 2017-06-23
 
-# Last Modified: 2014-10-30
-4.9.2: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.9
-4.9: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.9
-# Docker EOL: 2016-10-30
+# Last Modified: 2015-06-26
+4.9.3: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.9
+4.9: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.9
+# Docker EOL: 2017-06-26
 
 # Last Modified: 2015-04-22
 5.1.0: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1

--- a/library/haproxy
+++ b/library/haproxy
@@ -3,7 +3,7 @@
 1.4.26: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
 1.4: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
 
-1.5.12: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
-1.5: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
-1: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
-latest: git://github.com/docker-library/haproxy@5d81ba89af4cb970a3288f463c60bf9bcc8b9682 1.5
+1.5.13: git://github.com/docker-library/haproxy@527329104e0e7a01d9742c46dfd24b4f6cdddf98 1.5
+1.5: git://github.com/docker-library/haproxy@527329104e0e7a01d9742c46dfd24b4f6cdddf98 1.5
+1: git://github.com/docker-library/haproxy@527329104e0e7a01d9742c46dfd24b4f6cdddf98 1.5
+latest: git://github.com/docker-library/haproxy@527329104e0e7a01d9742c46dfd24b4f6cdddf98 1.5

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.3.9: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120
-0.3: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120
-latest: git://github.com/docker-library/julia@d7222c1c8af09b75565ea89fd00658d712823120
+0.3.10: git://github.com/docker-library/julia@46509c3b9178016189872738ef7fb38946df970c
+0.3: git://github.com/docker-library/julia@46509c3b9178016189872738ef7fb38946df970c
+latest: git://github.com/docker-library/julia@46509c3b9178016189872738ef7fb38946df970c

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.2: git://github.com/docker-library/rails@ae30cd01e0f5bb0229907445fd5b7f0f518d84cd
-4.2: git://github.com/docker-library/rails@ae30cd01e0f5bb0229907445fd5b7f0f518d84cd
-4: git://github.com/docker-library/rails@ae30cd01e0f5bb0229907445fd5b7f0f518d84cd
-latest: git://github.com/docker-library/rails@ae30cd01e0f5bb0229907445fd5b7f0f518d84cd
+4.2.3: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
+4.2: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
+4: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
+latest: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
 
 onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p645: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0
-2.0.0: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0
-2.0: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0
+2.0.0-p645: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
+2.0.0: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
+2.0: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
 
 2.0.0-p645-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 
-2.0.0-p645-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/slim
+2.0.0-p645-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
 
-2.0.0-p645-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/wheezy
-2.0.0-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/wheezy
-2.0-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.0/wheezy
+2.0.0-p645-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
+2.0.0-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
+2.0-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
 
-2.1.6: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1
-2.1: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1
+2.1.6: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1
+2.1: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1
 
 2.1.6-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 
-2.1.6-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1/slim
+2.1.6-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/slim
 
-2.1.6-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1/wheezy
-2.1-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.1/wheezy
+2.1.6-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/wheezy
+2.1-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/wheezy
 
-2.2.2: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2
-2.2: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2
-2: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2
-latest: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2
+2.2.2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
+2.2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
+2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
+latest: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
 
 2.2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 
-2.2.2-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/slim
-2-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/slim
-slim: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/slim
+2.2.2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
+2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
+slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
 
-2.2.2-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/wheezy
-2.2-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/wheezy
-2-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/wheezy
-wheezy: git://github.com/docker-library/ruby@cc89354ca37fc7372c93cbc358cc3f59186506b4 2.2/wheezy
+2.2.2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
+2.2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
+2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
+wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.5.4: git://github.com/docker-library/sentry@db33d550ffe0a50f33cd0085653d971f77456b95
-7.5: git://github.com/docker-library/sentry@db33d550ffe0a50f33cd0085653d971f77456b95
-7: git://github.com/docker-library/sentry@db33d550ffe0a50f33cd0085653d971f77456b95
-latest: git://github.com/docker-library/sentry@db33d550ffe0a50f33cd0085653d971f77456b95
+7.6.0: git://github.com/docker-library/sentry@6fce092844de38bcd3b546ba654429604adc3718
+7.6: git://github.com/docker-library/sentry@6fce092844de38bcd3b546ba654429604adc3718
+7: git://github.com/docker-library/sentry@6fce092844de38bcd3b546ba654429604adc3718
+latest: git://github.com/docker-library/sentry@6fce092844de38bcd3b546ba654429604adc3718


### PR DESCRIPTION
- `buildpack-deps`: add ubuntu variants (docker-library/buildpack-deps#27, docker-library/buildpack-deps#28), replace `build-essential` with more specific packages (docker-library/buildpack-deps#29)
- `cassandra`: 2.0.16 and 2.1.7
- `gcc`: 4.8.5 and 4.9.3
- `haproxy`: 1.5.13
- `julia`: 0.3.10
- `rails`: 4.2.3
- `ruby`: bundler 1.10.5
- `sentry`: 7.6.0