### PR TITLE
Fix bad rakudo star tag

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,5 +1,5 @@
 # maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
 
-2015.05:  git://github.com/perl6/docker@1590c9763cfeff123e6ab7991a49d4f3ba06661a
+2015.06:  git://github.com/perl6/docker@1590c9763cfeff123e6ab7991a49d4f3ba06661a
 
 latest:  git://github.com/perl6/docker@1590c9763cfeff123e6ab7991a49d4f3ba06661a


### PR DESCRIPTION
Should be 2015.06, not 2015.05