### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
 latest: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
 
-8.0.0-beta11: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
-8.0.0: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
-8.0: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
-8: git://github.com/docker-library/drupal@625b0ae065656c3c71cb9d511b8df6a04986f6ae 8
+8.0.0-beta12: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
+8.0.0: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
+8.0: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
+8: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8

--- a/library/kibana
+++ b/library/kibana
@@ -3,7 +3,7 @@
 4.0.3: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
 4.0: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
 
-4.1.0: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
-4.1: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
-4: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
-latest: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.1
+4.1.1: git://github.com/docker-library/kibana@9c61015ec5a8f9a7da32a9a3e28f9a0caf29fc8b 4.1
+4.1: git://github.com/docker-library/kibana@9c61015ec5a8f9a7da32a9a3e28f9a0caf29fc8b 4.1
+4: git://github.com/docker-library/kibana@9c61015ec5a8f9a7da32a9a3e28f9a0caf29fc8b 4.1
+latest: git://github.com/docker-library/kibana@9c61015ec5a8f9a7da32a9a3e28f9a0caf29fc8b 4.1

--- a/library/logstash
+++ b/library/logstash
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.5.1: git://github.com/docker-library/logstash@0e8b123ab8a392d4f6aac8cbb02d2071af8f4271
-1.5: git://github.com/docker-library/logstash@0e8b123ab8a392d4f6aac8cbb02d2071af8f4271
-latest: git://github.com/docker-library/logstash@0e8b123ab8a392d4f6aac8cbb02d2071af8f4271
+1.5.2: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6
+1.5: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6
+latest: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6

--- a/library/mongo
+++ b/library/mongo
@@ -15,5 +15,5 @@
 3: git://github.com/docker-library/mongo@ab203d1904c8621d64e20683610cc238fa0a628b 3.0
 latest: git://github.com/docker-library/mongo@ab203d1904c8621d64e20683610cc238fa0a628b 3.0
 
-3.1.4: git://github.com/docker-library/mongo@986013684d49e905152f5aa9ab5966fb13bf4211 3.1
-3.1: git://github.com/docker-library/mongo@986013684d49e905152f5aa9ab5966fb13bf4211 3.1
+3.1.5: git://github.com/docker-library/mongo@407c99a1e783451c4964d8565507fd494f869895 3.1
+3.1: git://github.com/docker-library/mongo@407c99a1e783451c4964d8565507fd494f869895 3.1

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.44: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.5
-5.5: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.5
+5.5.44: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.5
+5.5: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.5
 
-5.6.25: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
-5.6: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
-5: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
-latest: git://github.com/docker-library/mysql@9041eeb49d92368fcbad87dc45957afea0c5662b 5.6
+5.6.25: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.6
+5.6: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.6
+5: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.6
+latest: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.6
 
-5.7.7-rc: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7
-5.7.7: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7
-5.7: git://github.com/docker-library/mysql@18ec1909b895f981f1a9b539b602b38872bc5289 5.7
+5.7.7-rc: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.7
+5.7.7: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.7
+5.7: git://github.com/docker-library/mysql@c361883449d1db5a2291c3f8eb54fba60be4d5b5 5.7

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.43: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.5
-5.5: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.5
+5.5.44: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.5
+5.5: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.5
 
-5.6.24: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
-5.6: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
-5: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
-latest: git://github.com/docker-library/percona@cbac3e22c3a2f73548a2203070d755efd33581ba 5.6
+5.6.25: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.6
+5.6: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.6
+5: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.6
+latest: git://github.com/docker-library/percona@29e213ac15e014366eb339572811fa1b445d8b81 5.6

--- a/library/php
+++ b/library/php
@@ -11,32 +11,32 @@
 5.4.42-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/fpm
 5.4-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.4/fpm
 
-5.5.26-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
-5.5-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
-5.5.26: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
-5.5: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5
+5.5.26-cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5
+5.5-cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5
+5.5.26: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5
+5.5: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5
 
-5.5.26-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/apache
-5.5-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/apache
+5.5.26-apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5/apache
+5.5-apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5/apache
 
-5.5.26-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.5/fpm
+5.5.26-fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.5/fpm
 
-5.6.10-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-5.6-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-5-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-cli: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-5.6.10: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-5.6: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-5: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
-latest: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6
+5.6.10-cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+5.6-cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+5-cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+cli: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+5.6.10: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+5.6: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+5: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
+latest: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6
 
-5.6.10-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
-5.6-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
-5-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
-apache: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/apache
+5.6.10-apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/apache
+5.6-apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/apache
+5-apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/apache
+apache: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/apache
 
-5.6.10-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
-5-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
-fpm: git://github.com/docker-library/php@ae130b2f845162fbf84da0ffad07d7a64eff57cd 5.6/fpm
+5.6.10-fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/fpm
+5-fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/fpm
+fpm: git://github.com/docker-library/php@a413eb0123d10321928696ffea7442bed7dc0dc7 5.6/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.6.0: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
-2-2.6: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
-2-2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
-2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2
+2-2.6.0: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2
+2-2.6: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2
+2-2: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2
+2: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2
 
 2-2.6.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-2.6-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-2.6.0-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
-2-2.6-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
-2-2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
-2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 2/slim
+2-2.6.0-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2/slim
+2-2.6-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2/slim
+2-2-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2/slim
+2-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
-3-2.4: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
-3-2: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
-3: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
-latest: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3
+3-2.4.0: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3
+3-2.4: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3
+3-2: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3
+3: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3
+latest: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca751
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
-3-2-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
-3-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
-slim: git://github.com/docker-library/pypy@0f672a6bbfcce5c20b3cea8bbbfbeeca7512c80f 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3/slim
+3-2-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3/slim
+3-slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3/slim
+slim: git://github.com/docker-library/pypy@118eb35d46e15b7fcdbf86f753cd5f62cd2d045c 3/slim

--- a/library/python
+++ b/library/python
@@ -1,61 +1,61 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7
-2.7: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7
-2: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7
+2.7.10: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7
+2.7: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7
+2: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7
 
 2.7.10-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7/slim
-2.7-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7/slim
-2-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 2.7/slim
+2.7.10-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/slim
+2.7-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/slim
+2-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/slim
 
-2.7.10-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/wheezy
+2.7.10-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.2
-3.2: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.2
+3.2.6: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2
+3.2: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.2/slim
-3.2-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2/slim
+3.2-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.3
-3.3: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.3
+3.3.6: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3
+3.3: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.3/slim
-3.3-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3/slim
+3.3-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4
-3.4: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4
-3: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4
-latest: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4
+3.4.3: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4
+3.4: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4
+3: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4
+latest: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4/slim
-3.4-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4/slim
-3-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4/slim
-slim: git://github.com/docker-library/python@89890623a062f79d5dd6d8f5e1ecc6d823bff588 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/slim
+3.4-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/slim
+3-slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/slim
+slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
-wheezy: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
+wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.3: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744
-3.5: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744
-3: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744
-latest: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744
+3.5.3: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
+3.5: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
+3: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
+latest: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
 
-3.5.3-management: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744 management
-3.5-management: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744 management
-3-management: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744 management
-management: git://github.com/docker-library/rabbitmq@5bdfc8547e813bbe2e0ef725738252792780d744 management
+3.5.3-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
+3.5-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
+3-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
+management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management


### PR DESCRIPTION
- `drupal`: 8.0.0-beta12
- `kibana`: 4.1.1
- `logstash`: 1.5.2
- `mongo`: 3.1.5
- `mysql`: fix `my_print_defaults` duplication (docker-library/mysql#75)
- `percona`: 5.5.44-rel37.3-1.wheezy and 5.6.25-73.0-1.wheezy
- `php`: switch from bz2 to xz (docker-library/php#110)
- `pypy`: pip 7.1.0
- `python`: pip 7.1.0
- `rabbitmq`: simple support for alternate `default_vhost`, `default_user`, `default_pass` (docker-library/rabbitmq#28)