### PR TITLE
Update Node.js to 0.12.6

### DIFF
--- a/library/node
+++ b/library/node
@@ -12,25 +12,25 @@
 0.10.39-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
 0.10-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
 
-0.12.5: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
-0.12: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
-0: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
-latest: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12
+0.12.6: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
+0.12: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
+0: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
+latest: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
 
-0.12.5-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
-0.12-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
-0-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
-onbuild: git://github.com/joyent/docker-node@975349606a637b266d7ecf7eae3b009f59716e74 0.12/onbuild
+0.12.6-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
+0.12-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
+0-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
+onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
 
-0.12.5-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
-0-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/slim
+0.12.6-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
+0-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
+slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
 
-0.12.5-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.12/wheezy
+0.12.6-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
 
 0.8.28: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
 0.8: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8


### PR DESCRIPTION
This updates Node.js to 0.12.6 per http://blog.nodejs.org/2015/07/03/node-v0-12-6-stable/