### PR TITLE
Update rabbitmq with much simpler "Erlang Cookie" specification

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.3: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
-3.5: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
-3: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
-latest: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35
+3.5.3: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
+3.5: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
+3: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
+latest: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
 
-3.5.3-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
-3.5-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
-3-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
-management: git://github.com/docker-library/rabbitmq@97e1f49042fd2cf6153ddf7c17112f391558fd35 management
+3.5.3-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
+3.5-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
+3-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
+management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management


### PR DESCRIPTION
See https://github.com/docker-library/rabbitmq/pull/30.