### PR TITLE
Update ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,37 +5,37 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 67accc0 Update tarballs
-#    - `ubuntu:precise`: 20150612
-#    - `ubuntu:trusty`: 20150612
-#    - `ubuntu:utopic`: 20150612
+#  - 4f7764b Update tarballs
+#    - `ubuntu:precise`: 20150626
+#    - `ubuntu:trusty`: 20150630
+#    - `ubuntu:utopic`: 20150625
 #    - `ubuntu:vivid`: 20150611
-#    - `ubuntu:wily`: 20150611
+#    - `ubuntu:wily`: 20150708
 
-# 20150612
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
-precise-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 precise
+# 20150626
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 precise
+precise-20150626: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 precise
 
-# 20150612
-14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
-trusty-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 trusty
+# 20150630
+14.04.2: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 trusty
+trusty-20150630: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 trusty
 
-# 20150612
-14.10: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
-utopic-20150612: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
-utopic: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 utopic
-
-# 20150611
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
-vivid-20150611: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 vivid
+# 20150625
+14.10: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 utopic
+utopic-20150625: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 utopic
+utopic: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 utopic
 
 # 20150611
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily
-wily-20150611: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@67accc07b2f77dbf00dc4e2d5b90c00abc225ec6 wily
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 vivid
+vivid-20150611: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 vivid
+
+# 20150708
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 wily
+wily-20150708: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@4f7764b8eb70271b6a736341e090699fe058a198 wily


### PR DESCRIPTION
- `ubuntu:precise`: 20150626
- `ubuntu:trusty`: 20150630
- `ubuntu:utopic`: 20150625
- `ubuntu:vivid`: 20150611
- `ubuntu:wily`: 20150708

This bump will also trigger rebuilds for #878 on affected images.