### PR TITLE
Update Node.js to 0.10.40 and 0.12.7

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,36 +1,36 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.39: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10
-0.10: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10
+0.10.40: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10
+0.10: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10
 
-0.10.39-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
-0.10-onbuild: git://github.com/joyent/docker-node@95a86848466834d2170740c12c337f1145bb6d39 0.10/onbuild
+0.10.40-onbuild: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
+0.10-onbuild: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
 
-0.10.39-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/slim
+0.10.40-slim: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/slim
 
-0.10.39-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.10/wheezy
+0.10.40-wheezy: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/wheezy
 
-0.12.6: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
-0.12: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
-0: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
-latest: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12
+0.12.7: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
+0.12: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
+0: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
+latest: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
 
-0.12.6-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
-0.12-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
-0-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
-onbuild: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/onbuild
+0.12.7-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
+0.12-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
+0-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
+onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 
-0.12.6-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
-0-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
-slim: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/slim
+0.12.7-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
+0-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
+slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
 
-0.12.6-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@4654fb4bd58a36ae016a907c10b75daf9251a15d 0.12/wheezy
+0.12.7-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
 
 0.8.28: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
 0.8: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8


### PR DESCRIPTION
Test build looks good. 

This is per:

http://blog.nodejs.org/2015/07/09/node-v0-10-40-maintenance/
http://blog.nodejs.org/2015/07/09/node-v0-12-7-stable/

OpenSSL! Yay!