### PR TITLE
Upgrade iojs to 2.3.4 to fix CVE-2015-1793

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,28 +1,28 @@
 # maintainer: io.js Docker team <https://github.com/nodejs/docker-iojs> (@iojs)
 
-1.8.3: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8
-1.8: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8
-1: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8
+1.8.4: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
+1.8: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
+1: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
 
-1.8.3-onbuild: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/onbuild
-1.8-onbuild: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/onbuild
-1-onbuild: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/onbuild
+1.8.4-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
+1.8-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
+1-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
 
-1.8.3-slim: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/slim
-1.8-slim: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/slim
-1-slim: git://github.com/nodejs/docker-iojs@652460262ec379dc264ed3ceee572cfce8ef8f85 1.8/slim
+1.8.4-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
+1.8-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
+1-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
 
-2.3.3: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3
-2.3: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3
-2: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3
-latest: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3
+2.3.4: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3
+2.3: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3
+2: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3
+latest: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3
 
-2.3.3-onbuild: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/onbuild
-2.3-onbuild: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/onbuild
-2-onbuild: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/onbuild
+2.3.4-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/onbuild
+2.3-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/onbuild
+2-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/onbuild
 
-2.3.3-slim: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/slim
-2.3-slim: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/slim
-2-slim: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/slim
-slim: git://github.com/nodejs/docker-iojs@e471c5ca70d3ebeeb6e2854257d78f5299a8aab7 2.3/slim
+2.3.4-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/slim
+2.3-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/slim
+2-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/slim
+slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 2.3/slim


### PR DESCRIPTION
Follow-up on https://github.com/nodejs/docker-iojs/pull/78
@wblankenship let me know if this helps.