### PR TITLE
Updated Oracle Linux images.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,15 +1,15 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/7.1
-7: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/7.1
-7.1: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/7.1
-7.0: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/7.0
+latest: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/7.1
+7: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/7.1
+7.1: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/7.1
+7.0: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/6.6
-6.6: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/6.6
+6: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/6.6
+6.6: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/5.11
-5.11: git://github.com/oracle/docker.git@6c9db7af34475aba8f37a8caadc503e5fabf3e5e OracleLinux/5.11
+5: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/5.11
+5.11: git://github.com/oracle/docker.git@647ce02cb30c7236a725d10bf45ae9c3ec121d73 OracleLinux/5.11


### PR DESCRIPTION
Updated images to support upstream Docker Engine RPM builds on Oracle Linux 6.

Signed-off-by: Avi Miller <avi.miller@gmail.com>