### PR TITLE
update r-base to 3.2.1

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,6 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-latest: git://github.com/rocker-org/rocker@849e42992a3ce5bf6f004bcbfc76605aff3f3c08 r-base
-3.2.0: git://github.com/rocker-org/rocker@849e42992a3ce5bf6f004bcbfc76605aff3f3c08 r-base
+3.2.1: git://github.com/rocker-org/rocker@9f26417d0987d0b8517491270da0541aa9b754cc r-base
+latest: git://github.com/rocker-org/rocker@9f26417d0987d0b8517491270da0541aa9b754cc r-base
 


### PR DESCRIPTION
This PR updates the r-base container to the current version R 3.2.1 released in June