### PR TITLE
Update jetty:9.2 image to 9.2.12.v20150709

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -9,12 +9,12 @@
 latest: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
 jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
 
-9.2.11: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-9.2: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-9.2.11-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre8
+9.2.12: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8
+9.2: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8
+9.2.12-jre8: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8
 
-9.2.11-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-9.2-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-9-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
-jre7: git://github.com/appropriate/docker-jetty@7946910db1db4f4a206379f023ad82f2c9b107e9 9.2-jre7
+9.2.12-jre7: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre7
+9.2-jre7: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre7
+9-jre7: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre7
+jre7: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre7


### PR DESCRIPTION
Diff: https://github.com/appropriate/docker-jetty/compare/7946910db1db4f4a206379f023ad82f2c9b107e9...5a279411ea214c702a23cfa67085284ba5b1c90a