### PR TITLE
Update openSUSE 13.2 images

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,9 +1,9 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.2
-13.2: git://github.com/openSUSE/docker-containers-build@f3ec3b0d747c125729ab239d2c561f270adede06 docker
-harlequin: git://github.com/openSUSE/docker-containers-build@f3ec3b0d747c125729ab239d2c561f270adede06 docker
-latest: git://github.com/openSUSE/docker-containers-build@f3ec3b0d747c125729ab239d2c561f270adede06 docker
+13.2: git://github.com/openSUSE/docker-containers-build@f0d013a574959008b872ac3f4dd0b04584fa650f docker
+harlequin: git://github.com/openSUSE/docker-containers-build@f0d013a574959008b872ac3f4dd0b04584fa650f docker
+latest: git://github.com/openSUSE/docker-containers-build@f0d013a574959008b872ac3f4dd0b04584fa650f docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@04f0622f4ab30f81e4bee907302b023031aeab9f docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@fde689a584cb1373f5c205f5985f4a0c431653e7 docker


### PR DESCRIPTION
Reduce the image size of openSUSE 13.2 and the Tumbleweed one.