### PR TITLE
Add redis 32bit variant

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,13 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
-2.6: git://github.com/docker-library/redis@5a480f7c9f05822c31204a7197d209ef9db1a32c 2.6
+2.6.17: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6
+2.6: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6
 
-2.8.21: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
-2.8: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
-2: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 2.8
+2.6.17-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
+2.6-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
 
-3.0.2: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
-3.0: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
-3: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
-latest: git://github.com/docker-library/redis@171071dacb7961cac8254627806f6c6faeeea278 3.0
+2.8.21: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
+2.8: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
+2: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
+
+2.8.21-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
+
+3.0.2: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+3.0: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+3: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+latest: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+
+3.0.2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
+32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit


### PR DESCRIPTION
See https://github.com/docker-library/redis/pull/28 (http://redis.io/topics/memory-optimization#using-32-bit-instances)