### PR TITLE
Update jetty:9.3 image to 9.3.1.v2015071

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,13 +1,13 @@
 # maintainer: Mike Dillon <mike@appropriate.io> (@md5)
 
-9.3.0: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-9.3: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-9: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-9.3.0-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-9.3-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-latest: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
-jre8: git://github.com/appropriate/docker-jetty@833fb99b9e49140dec67d2af3c6b51901c83bbce 9.3-jre8
+9.3.1: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+9.3.1-jre8: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@c8cf3d52378ca0f3af76eb2219dece8eb7592724 9.3-jre8
 
 9.2.12: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8
 9.2: git://github.com/appropriate/docker-jetty@5a279411ea214c702a23cfa67085284ba5b1c90a 9.2-jre8


### PR DESCRIPTION
Diff: https://github.com/appropriate/docker-jetty/compare/833fb99b9e49140dec67d2af3c6b51901c83bbce...c8cf3d52378ca0f3af76eb2219dece8eb7592724#diff-c54295bae78627199e88a262caa351d3