### PR TITLE
Update elasticsearch 1.7 & 1.6.1

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -9,7 +9,10 @@
 1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 
-1.6.0: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
-1.6: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
-1: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
-latest: git://github.com/docker-library/elasticsearch@f37f98c251bd4bc92573df82c3af70d819f052bb 1.6
+1.6.1: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f: 1.6
+1.6: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.6
+
+1.7: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7
+
+1: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7
+latest: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -9,10 +9,10 @@
 1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 
-1.6.1: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f: 1.6
-1.6: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.6
+1.6.1: git://github.com/docker-library/elasticsearch@262c357e3fe763c945c85feeec241a5b407de93c 1.6
+1.6: git://github.com/docker-library/elasticsearch@262c357e3fe763c945c85feeec241a5b407de93c 1.6
 
-1.7: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7
-
-1: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7
-latest: git://github.com/docker-library/elasticsearch@a0153cd49d67ec0caa644c89df36ac94ff4a3f8f 1.7
+1.7.0: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
+1.7: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
+1: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
+latest: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7


### PR DESCRIPTION
- `elasticsearch`: 1.6.1 & 1.7.0 (docker-library/elasticsearch#42)