### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,59 +6,53 @@ curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db6936
 jessie-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 
-jessie: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da jessie
-latest: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da jessie
+jessie: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea jessie
+latest: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea jessie
 
 precise-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/curl
 
 precise-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/scm
 
-precise: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da precise
+precise: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea precise
 
 sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
 sid-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
 
-sid: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da sid
-
-squeeze-curl: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/curl
-
-squeeze-scm: git://github.com/docker-library/buildpack-deps@f086230fb870874c39bd85f3ee65f86fd4ca8c97 squeeze/scm
-
-squeeze: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da squeeze
+sid: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea sid
 
 stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
 
 stretch-scm: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/scm
 
-stretch: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da stretch
+stretch: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea stretch
 
 trusty-curl: git://github.com/docker-library/buildpack-deps@21f2d32bcf321ff095a23c0edc1d8be2b7989962 trusty/curl
 
 trusty-scm: git://github.com/docker-library/buildpack-deps@bb6691a2782687748549baac903340fc21a5533c trusty/scm
 
-trusty: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da trusty
+trusty: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea trusty
 
 utopic-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/curl
 
 utopic-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/scm
 
-utopic: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da utopic
+utopic: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea utopic
 
 vivid-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/curl
 
 vivid-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/scm
 
-vivid: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da vivid
+vivid: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea vivid
 
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
 
-wheezy: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea wheezy
 
 wily-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/curl
 
 wily-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/scm
 
-wily: git://github.com/docker-library/buildpack-deps@6da64bd1dca4bae0a817b3e1886300c526fe67da wily
+wily: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea wily

--- a/library/golang
+++ b/library/golang
@@ -33,8 +33,8 @@ cross: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030
 1-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 
-1.5beta1: git://github.com/docker-library/golang@6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654 1.5
-1.5: git://github.com/docker-library/golang@6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654 1.5
+1.5beta2: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5
+1.5: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5
 
-1.5beta1-onbuild: git://github.com/docker-library/golang@6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654 1.5/onbuild
-1.5-onbuild: git://github.com/docker-library/golang@6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654 1.5/onbuild
+1.5beta2-onbuild: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5/onbuild
+1.5-onbuild: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5/onbuild

--- a/library/python
+++ b/library/python
@@ -59,3 +59,15 @@ slim: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5
 3.4-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
 3-wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
 wheezy: git://github.com/docker-library/python@5fc2d82f706e338286f31908ef416afe7b5fba7b 3.4/wheezy
+
+3.5.0b3: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5
+3.5.0: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5
+3.5: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5
+
+3.5.0b3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+3.5.0-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+
+3.5.0b3-slim: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/slim
+3.5.0-slim: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/slim
+3.5-slim: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/slim

--- a/library/redis
+++ b/library/redis
@@ -14,12 +14,12 @@
 2.8-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
 2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
 
-3.0.2: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-3.0: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-3: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-latest: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+3.0.3: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+3.0: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+3: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+latest: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
 
-3.0.2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
+3.0.3-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit


### PR DESCRIPTION
- `buildpack-deps`: libwebp-dev (docker-library/buildpack-deps#32), remove squeeze (docker-library/buildpack-deps#33)
- `golang`: 1.5beta2
- `python`: 3.5.0b3 (docker-library/python#57)
- `redis`: 3.0.3 (docker-library/redis#29)