### PR TITLE
Update Redis 3.0.3

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -14,12 +14,12 @@
 2.8-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
 2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
 
-3.0.2: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-3.0: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-3: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
-latest: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0
+3.0.3: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+3.0: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+3: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
+latest: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0
 
-3.0.2-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 3.0/32bit
+3.0.3-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit
+32bit: git://github.com/docker-library/redis@37efc31242c8415d4f2e6d84255af0c7b97567c5 3.0/32bit


### PR DESCRIPTION
- `redis`: 3.0.3 (docker-library/redis#29)