### PR TITLE
Add "redis" to "celery" so it can support using Redis as a broker

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.18: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
-3.1: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
-3: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
-latest: git://github.com/docker-library/celery@f218be880b85241399b63b6f25e22208cfe3e07f
+3.1.18: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3.1: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+latest: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278


### PR DESCRIPTION
Accompanying docs are "coming soon" (have to get the feature working first). :+1: