### PR TITLE
Update docker-library images

### DIFF
--- a/library/logstash
+++ b/library/logstash
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.5.2: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6
-1.5: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6
-latest: git://github.com/docker-library/logstash@717e7ebdcd04755ecd710ff91ec88fc5217db6d6
+1.5.3: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84
+1.5: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84
+latest: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.20: git://github.com/docker-library/mariadb@617aef0f7ec7d5dc2fd352378b5cd8a515078c93 10.0
-10.0: git://github.com/docker-library/mariadb@617aef0f7ec7d5dc2fd352378b5cd8a515078c93 10.0
-10: git://github.com/docker-library/mariadb@617aef0f7ec7d5dc2fd352378b5cd8a515078c93 10.0
-latest: git://github.com/docker-library/mariadb@617aef0f7ec7d5dc2fd352378b5cd8a515078c93 10.0
+10.0.20: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
+10.0: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
+10: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
+latest: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
 
-5.5.44: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5
-5.5: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5
-5: git://github.com/docker-library/mariadb@2a2cbaceb669988d161f6766147ff56e641be68e 5.5
+5.5.44: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5
+5.5: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5
+5: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -15,5 +15,5 @@
 3: git://github.com/docker-library/mongo@36a085b1233d2492ce3970571522e17ac163aa94 3.0
 latest: git://github.com/docker-library/mongo@36a085b1233d2492ce3970571522e17ac163aa94 3.0
 
-3.1.5: git://github.com/docker-library/mongo@36a085b1233d2492ce3970571522e17ac163aa94 3.1
-3.1: git://github.com/docker-library/mongo@36a085b1233d2492ce3970571522e17ac163aa94 3.1
+3.1.6: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1
+3.1: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.0
-9.0: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.0
+9.0.22: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.0
+9.0: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.0
 
-9.1.18: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.1
-9.1: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.1
+9.1.18: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.1
+9.1: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.1
 
-9.2.13: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.2
-9.2: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.2
+9.2.13: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.2
+9.2: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.2
 
-9.3.9: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.3
-9.3: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.3
+9.3.9: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.3
+9.3: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.3
 
-9.4.4: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.4
-9.4: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.4
-9: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.4
-latest: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.4
+9.4.4: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.4
+9.4: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.4
+9: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.4
+latest: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.4
 
-9.5-alpha1: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.5
-9.5: git://github.com/docker-library/postgres@cb70a79c1a8248d7e0db89d79dfbd08dd481be7f 9.5
+9.5-alpha1: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.5
+9.5: git://github.com/docker-library/postgres@9c7bb73021815a17fae056508f54b764d7aefc5b 9.5


### PR DESCRIPTION
- `logstash`: 1.5.3
- `mariadb`: switch 10.0 to jessie (docker-library/mariadb#17)
- `mongo`: 3.1.6
- `postgres`: use `PG_VERSION` instead of just empty directory for "database detection" (docker-library/postgres#72)