### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,8 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.16: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.0
-2.0: git://github.com/docker-library/cassandra@711f62f57e181eb373910246e27036aaa14eb54f 2.0
+2.0.16: git://github.com/docker-library/cassandra@b9b173c523af2da70fdd898565a556af12d6b23a 2.0
+2.0: git://github.com/docker-library/cassandra@b9b173c523af2da70fdd898565a556af12d6b23a 2.0
 
-2.1.8: git://github.com/docker-library/cassandra@3a63378f4be40687816258e1cb9f96e2dd76104f 2.1
-2.1: git://github.com/docker-library/cassandra@3a63378f4be40687816258e1cb9f96e2dd76104f 2.1
-latest: git://github.com/docker-library/cassandra@3a63378f4be40687816258e1cb9f96e2dd76104f 2.1
+2.1.8: git://github.com/docker-library/cassandra@1a2fa7d60b9fca1135df05e3b0f7795d3485e2d6 2.1
+2.1: git://github.com/docker-library/cassandra@1a2fa7d60b9fca1135df05e3b0f7795d3485e2d6 2.1
+
+2.2.0: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
+2.2: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
+2: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
+latest: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2

--- a/library/php
+++ b/library/php
@@ -41,17 +41,17 @@ apache: git://github.com/docker-library/php@32887c1de338d0ad582393b5f1dafd292334
 5-fpm: git://github.com/docker-library/php@32887c1de338d0ad582393b5f1dafd292334423f 5.6/fpm
 fpm: git://github.com/docker-library/php@32887c1de338d0ad582393b5f1dafd292334423f 5.6/fpm
 
-7.0.0beta1-cli: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
-7.0-cli: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
-7-cli: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
-7.0.0beta1: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
-7.0: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
-7: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0
+7.0.0beta2-cli: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
+7.0-cli: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
+7-cli: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
+7.0.0beta2: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
+7.0: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
+7: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0
 
-7.0.0beta1-apache: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/apache
-7.0-apache: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/apache
-7-apache: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/apache
+7.0.0beta2-apache: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/apache
+7.0-apache: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/apache
+7-apache: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/apache
 
-7.0.0beta1-fpm: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/fpm
-7-fpm: git://github.com/docker-library/php@0e983d18f2f306d48ac973f0d144c2a969b1f536 7.0/fpm
+7.0.0beta2-fpm: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/fpm
+7-fpm: git://github.com/docker-library/php@7e116d79061e57bed779e1f2512fbc80b43bf43d 7.0/fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.3: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
-3.5: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
-3: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
-latest: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a
+3.5.4: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac
+3.5: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac
+3: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac
+latest: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac
 
-3.5.3-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
-3.5-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
-3-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
-management: git://github.com/docker-library/rabbitmq@aae4d2b9773419a7421e413337068b32feb4995a management
+3.5.4-management: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac management
+3.5-management: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac management
+3-management: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac management
+management: git://github.com/docker-library/rabbitmq@9374efb2bf4c75ce3011517cf6c292e85b0949ac management

--- a/library/ruby
+++ b/library/ruby
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p645: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
-2.0.0: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
-2.0: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0
+2.0.0-p645: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0
+2.0.0: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0
+2.0: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0
 
 2.0.0-p645-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 
-2.0.0-p645-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/slim
+2.0.0-p645-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
 
-2.0.0-p645-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
-2.0.0-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
-2.0-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.0/wheezy
+2.0.0-p645-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/wheezy
+2.0.0-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/wheezy
+2.0-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/wheezy
 
-2.1.6: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1
-2.1: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1
+2.1.6: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1
+2.1: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1
 
 2.1.6-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 
-2.1.6-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/slim
+2.1.6-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/slim
 
-2.1.6-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/wheezy
-2.1-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.1/wheezy
+2.1.6-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/wheezy
+2.1-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/wheezy
 
-2.2.2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
-2.2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
-2: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
-latest: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2
+2.2.2: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2
+2.2: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2
+2: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2
+latest: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2
 
 2.2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 
-2.2.2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
-2-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
-slim: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/slim
+2.2.2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
+2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
+slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
 
-2.2.2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
-2.2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
-2-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
-wheezy: git://github.com/docker-library/ruby@5b80d07084f0fb590126cdea49e6b0036f44cd9a 2.2/wheezy
+2.2.2-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/wheezy
+2.2-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/wheezy
+2-wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/wheezy
+wheezy: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/wheezy

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.6.2: git://github.com/docker-library/sentry@f91422340daafd427feacf91994520ade4e10127
-7.6: git://github.com/docker-library/sentry@f91422340daafd427feacf91994520ade4e10127
-7: git://github.com/docker-library/sentry@f91422340daafd427feacf91994520ade4e10127
-latest: git://github.com/docker-library/sentry@f91422340daafd427feacf91994520ade4e10127
+7.6.2: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
+7.6: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
+7: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
+latest: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.2-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-4.2.2: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-4.2-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-4.2: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-4-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-apache: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-4: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
-latest: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f apache
+4.2.3-apache: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+4.2.3: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+4.2-apache: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+4.2: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+4-apache: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+apache: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+4: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
+latest: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 apache
 
-4.2.2-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
-4.2-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
-4-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
-fpm: git://github.com/docker-library/wordpress@1420b4c44ba0cf13d2d1d1e41bbc3bc74e83ce9f fpm
+4.2.3-fpm: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 fpm
+4.2-fpm: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 fpm
+4-fpm: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 fpm
+fpm: git://github.com/docker-library/wordpress@62313377280ec6a44525910dcb8ed78bf6313092 fpm


### PR DESCRIPTION
- `cassandra`: 2.2.0 (docker-library/cassandra#18)
- `php`: 7.0.0beta2 (docker-library/php#119)
- `rabbitmq`: 3.5.4
- `ruby`: bundler 1.10.6
- `sentry`: default `sentry.conf.py` for easy linking again (docker-library/sentry#15)
- `wordpress`: 4.2.3