### PR TITLE
Add image for Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -1,15 +1,15 @@
 # maintainer: Michael Babker <michael.babker@joomla.org> (@mbabker)
 
-3.4.3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-3.4.3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-3.4-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-3.4: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
-latest: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4.3-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3.4.3: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3.4-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3.4: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+latest: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
 
-3.4.3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
-3.4-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
-3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+3.4.3-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
+3.4-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
+3-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
+fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm

--- a/library/joomla
+++ b/library/joomla
@@ -1,15 +1,15 @@
 # maintainer: Michael Babker <michael.babker@joomla.org> (@mbabker)
 
-3.4.3-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-3.4.3: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-3.4-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-3.4: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-3-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-3: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
-latest: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3.4.3-apache: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+3.4.3: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+3.4-apache: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+3.4: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+3-apache: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+apache: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+3: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
+latest: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 apache
 
-3.4.3-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
-3.4-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
-3-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
+3.4.3-fpm: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 fpm
+3.4-fpm: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 fpm
+3-fpm: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 fpm
+fpm: git://github.com/joomla/docker-joomla@40426bb7634578f171c8cdef72bca6a11d26e571 fpm

--- a/library/joomla
+++ b/library/joomla
@@ -1,15 +1,15 @@
 # maintainer: Michael Babker <michael.babker@joomla.org> (@mbabker)
 
-3.4.3-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-3.4.3: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-3.4-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-3.4: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-3-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-apache: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-3: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
-latest: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe apache
+3.4.3-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3.4.3: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3.4-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3.4: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3-apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+apache: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+3: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
+latest: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 apache
 
-3.4.3-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
-3.4-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
-3-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
-fpm: git://github.com/joomla/docker-joomla@ba5df1da80e0df1ec30ba93c6a369b9cacdc57fe fpm
+3.4.3-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
+3.4-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
+3-fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm
+fpm: git://github.com/joomla/docker-joomla@4c50e3a8e1af930d9be8317e3bf68cd9b76ef036 fpm

--- a/library/joomla
+++ b/library/joomla
@@ -1,0 +1,15 @@
+# maintainer: Michael Babker <michael.babker@joomla.org> (@mbabker)
+
+3.4.3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4.3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+latest: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+
+3.4.3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+3.4-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm


### PR DESCRIPTION
This PR adds a Docker image for the Joomla! CMS

Docs PR: https://github.com/docker-library/docs/pull/293