### PR TITLE
Elasticsearch Update 1.7.1 and 1.6.2

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -9,10 +9,10 @@
 1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
 
-1.6.1: git://github.com/docker-library/elasticsearch@262c357e3fe763c945c85feeec241a5b407de93c 1.6
-1.6: git://github.com/docker-library/elasticsearch@262c357e3fe763c945c85feeec241a5b407de93c 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@a96386022c9f76299e592e32965d167a2480c866 1.6
+1.6: git://github.com/docker-library/elasticsearch@a96386022c9f76299e592e32965d167a2480c866 1.6
 
-1.7.0: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
-1.7: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
-1: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
-latest: git://github.com/docker-library/elasticsearch@b44f120df3ddaaa1c238774b695c752a521f0aed 1.7
+1.7.1: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
+1.7: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
+1: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
+latest: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7


### PR DESCRIPTION
docker-library/elasticsearch/pull/43