### PR TITLE
Upgrade to iojs-2.5.0

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -1,28 +1,28 @@
 # maintainer: io.js Docker team <https://github.com/nodejs/docker-iojs> (@iojs)
 
-1.8.4: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
-1.8: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
-1: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8
+1.8.4: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8
+1.8: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8
+1: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8
 
-1.8.4-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
-1.8-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
-1-onbuild: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/onbuild
+1.8.4-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/onbuild
+1.8-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/onbuild
+1-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/onbuild
 
-1.8.4-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
-1.8-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
-1-slim: git://github.com/nodejs/docker-iojs@6aebfae094f8ecc0de141d0109c744e4956f3e75 1.8/slim
+1.8.4-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/slim
+1.8-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/slim
+1-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 1.8/slim
 
-2.4.0: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4
-2.4: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4
-2: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4
-latest: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4
+2.5.0: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
+2.5: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
+2: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
+latest: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
 
-2.4.0-onbuild: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/onbuild
-2.4-onbuild: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/onbuild
-2-onbuild: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/onbuild
+2.5.0-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
+2.5-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
+2-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
 
-2.4.0-slim: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/slim
-2.4-slim: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/slim
-2-slim: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/slim
-slim: git://github.com/nodejs/docker-iojs@17c560895ea29460c8ac59ba0605878cb7679dd1 2.4/slim
+2.5.0-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
+2.5-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
+2-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
+slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim


### PR DESCRIPTION
As described here:
https://github.com/nodejs/docker-iojs/pull/82

Also added the GPG key of our new iojs releaser @cjihrig for 1.8.x and 2.5.x images.
related: https://github.com/nodejs/io.js/commit/a3c1b9720e517038ea7bf08fd658c07f0de74c33
and https://github.com/nodejs/io.js/pull/2239#issuecomment-124719132