### PR TITLE
Update npm to 2.13.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,45 +1,45 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 
-0.10.40: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10
-0.10: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10
+0.10.40: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10
+0.10: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10
 
 0.10.40-onbuild: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
 0.10-onbuild: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
 
-0.10.40-slim: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/slim
-0.10-slim: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/slim
+0.10.40-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10/slim
+0.10-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10/slim
 
-0.10.40-wheezy: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/wheezy
-0.10-wheezy: git://github.com/joyent/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/wheezy
+0.10.40-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10/wheezy
+0.10-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.10/wheezy
 
-0.12.7: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
-0.12: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
-0: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
-latest: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12
+0.12.7: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12
+0.12: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12
+0: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12
+latest: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12
 
 0.12.7-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 0.12-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 0-onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 onbuild: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 
-0.12.7-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
-0.12-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
-0-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
-slim: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/slim
+0.12.7-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/slim
+0.12-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/slim
+0-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/slim
+slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/slim
 
-0.12.7-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
-0.12-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
-0-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
-wheezy: git://github.com/joyent/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/wheezy
+0.12.7-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/wheezy
+0.12-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/wheezy
+0-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/wheezy
+wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.12/wheezy
 
-0.8.28: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
-0.8: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8
+0.8.28: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8
+0.8: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8
 
 0.8.28-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 0.8-onbuild: git://github.com/joyent/docker-node@0c2ff5172aabc30ce38303d9bb340ae3e94f3a91 0.8/onbuild
 
-0.8.28-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/slim
-0.8-slim: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/slim
+0.8.28-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8/slim
+0.8-slim: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8/slim
 
-0.8.28-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/wheezy
-0.8-wheezy: git://github.com/joyent/docker-node@3e0d2b62fa8524e05ef512564613863ee7f13255 0.8/wheezy
+0.8.28-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8/wheezy
+0.8-wheezy: git://github.com/joyent/docker-node@840ec06882964c85ee8f41ab2d3e87c0a7adf2eb 0.8/wheezy


### PR DESCRIPTION
This updates the npm to 2.13.2 for 0.8, 0.10, and 0.12.