### PR TITLE
Move websphere-liberty images to base on OpenJRE java:jre

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,5 +1,5 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@dcurrie)
 
-8.5.5: git://github.com/WASdev/ci.docker@89f96d3fced697cd7dc74e29f04114a3a5d8a550 websphere-liberty/8.5.5/developer
-latest: git://github.com/WASdev/ci.docker@89f96d3fced697cd7dc74e29f04114a3a5d8a550 websphere-liberty/8.5.5/developer
-beta: git://github.com/WASdev/ci.docker@0706850c20822ca4452c890b0592918a2afe3a29 websphere-liberty/beta
+8.5.5: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/8.5.5/developer/webProfile6
+latest: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/8.5.5/developer/webProfile6
+beta: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/beta


### PR DESCRIPTION
Due to the current lack of geographic export controls on Docker Hub we have had to the remove the IBM JRE from this image and we are instead rebasing on top of the java:jre official repository (with the most immediately apparent side effects being a 130MB increase in the image size and a switch from Ubuntu to Debian as the base OS).