### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
 latest: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
 
-8.0.0-beta12: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
-8.0.0: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
-8.0: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
-8: git://github.com/docker-library/drupal@7554aab85d66d4c28b158212fcc457f902cdd3a2 8
+8.0.0-beta13: git://github.com/docker-library/drupal@6d662e039b3a3bfbb042f3e541b427495bac62c4 8
+8.0.0: git://github.com/docker-library/drupal@6d662e039b3a3bfbb042f3e541b427495bac62c4 8
+8.0: git://github.com/docker-library/drupal@6d662e039b3a3bfbb042f3e541b427495bac62c4 8
+8: git://github.com/docker-library/drupal@6d662e039b3a3bfbb042f3e541b427495bac62c4 8

--- a/library/golang
+++ b/library/golang
@@ -33,8 +33,8 @@ cross: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030
 1-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 
-1.5beta2: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5
-1.5: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5
+1.5beta3: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5
+1.5: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5
 
-1.5beta2-onbuild: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5/onbuild
-1.5-onbuild: git://github.com/docker-library/golang@9a3a1ca455a97585ff74267835bea05006833866 1.5/onbuild
+1.5beta3-onbuild: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5/onbuild
+1.5-onbuild: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5/onbuild

--- a/library/logstash
+++ b/library/logstash
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.5.3: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84
-1.5: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84
-latest: git://github.com/docker-library/logstash@d6d0039fe82bf964d3a90822bb9ce12f72924e84
+1.5.3: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965
+1.5: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965
+latest: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.6: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 6.0
-6.0: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 6.0
-6: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 6.0
+6.0.9: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 6.0
+6.0: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 6.0
+6: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 6.0
 
-7.0.4: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 7.0
-7.0: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 7.0
-7: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 7.0
+7.0.7: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 7.0
+7.0: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 7.0
+7: git://github.com/docker-library/owncloud@0d3751af4e930cf323c82cf884d9409ef6d40e9d 7.0
 
 8.0.5: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 8.0
 8.0: git://github.com/docker-library/owncloud@f89dd58b776970f9b3ed22ab8672e757813f0979 8.0

--- a/library/sentry
+++ b/library/sentry
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.6.2: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
-7.6: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
-7: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
-latest: git://github.com/docker-library/sentry@60493984a039cdde4e55e85fc7aa8003b2a574f9
+7.7.0: git://github.com/docker-library/sentry@3115587c614e64c66419a26b4f7be6ac067e3a79
+7.7: git://github.com/docker-library/sentry@3115587c614e64c66419a26b4f7be6ac067e3a79
+7: git://github.com/docker-library/sentry@3115587c614e64c66419a26b4f7be6ac067e3a79
+latest: git://github.com/docker-library/sentry@3115587c614e64c66419a26b4f7be6ac067e3a79


### PR DESCRIPTION
- `drupal`: 8.0.0-beta13
- `golang`: 1.5beta3 (docker-library/golang#55)
- `logstash`: switch to Java 8 (docker-library/logstash#20)
- `owncloud`: proper latest versions (6.0.9, 7.0.7; docker-library/owncloud#6)
- `sentry`: allow database host/port to come from environment instead of links (docker-library/sentry#16, docker-library/sentry#17)