### PR TITLE
Add new "mysql-initdb" test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -62,6 +62,7 @@ declare -A imageTests=(
 	'
 	[mysql]='
 		mysql-basics
+		mysql-initdb
 	'
 	[node]='
 	'

--- a/test/tests/mysql-initdb/initdb.sql
+++ b/test/tests/mysql-initdb/initdb.sql
@@ -1,0 +1,4 @@
+CREATE TABLE test (a INT, b INT, c VARCHAR(255));
+INSERT INTO test VALUES (1, 2, 'hello');
+INSERT INTO test VALUES (2, 3, 'goodbye!');
+DELETE FROM test WHERE a = 1;


### PR DESCRIPTION
Also, some minor reformatting to "mysql-basics" for consistency and readability.

This is for the new functionality in https://github.com/docker-library/mysql/pull/90.