### PR TITLE
Upgrade iojs to 3.0.0

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -15,14 +15,26 @@
 2.5.0: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
 2.5: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
 2: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
-latest: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5
 
 2.5.0-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
 2.5-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
 2-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/onbuild
 
 2.5.0-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 2.5-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 2-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
+
+3.0.0: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
+3.0: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
+3: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
+latest: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
+
+3.0.0-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
+3.0-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
+3-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
+
+3.0.0-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
+3.0-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
+3-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
+slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim


### PR DESCRIPTION
Add the 3.0 build of iojs
Related: https://github.com/nodejs/docker-iojs/pull/83