### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -33,12 +33,6 @@ trusty-scm: git://github.com/docker-library/buildpack-deps@bb6691a2782687748549b
 
 trusty: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea trusty
 
-utopic-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/curl
-
-utopic-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d utopic/scm
-
-utopic: git://github.com/docker-library/buildpack-deps@1f3d93c27c45732774639eff8ade2b75cf13bbea utopic
-
 vivid-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/curl
 
 vivid-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/scm

--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.18: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-3.1: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-3: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-latest: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3.1.18: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
+3.1: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
+3: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
+latest: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8

--- a/library/golang
+++ b/library/golang
@@ -33,8 +33,8 @@ cross: git://github.com/docker-library/golang@396f40c6188614c7acd6d8299a0ea71030
 1-wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 wheezy: git://github.com/docker-library/golang@1a422afd7db928a821e97906ed27ed606e2f072a 1.4/wheezy
 
-1.5beta3: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5
-1.5: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5
+1.5rc1: git://github.com/docker-library/golang@128a04e883b619d006ba07ea2ccae964b2efcf92 1.5
+1.5: git://github.com/docker-library/golang@128a04e883b619d006ba07ea2ccae964b2efcf92 1.5
 
-1.5beta3-onbuild: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5/onbuild
-1.5-onbuild: git://github.com/docker-library/golang@6a6c0b41d2dcf4697ef19bc4082092c3905fe436 1.5/onbuild
+1.5rc1-onbuild: git://github.com/docker-library/golang@128a04e883b619d006ba07ea2ccae964b2efcf92 1.5/onbuild
+1.5-onbuild: git://github.com/docker-library/golang@128a04e883b619d006ba07ea2ccae964b2efcf92 1.5/onbuild

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,3 +1,3 @@
-# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/hello-world@b7a78b7ccca62cc478919b101f3ab1334899df2b
+latest: git://github.com/docker-library/hello-world@897aa7529c3c3d9e9374fd16847dee50d720a7fd

--- a/library/java
+++ b/library/java
@@ -28,19 +28,19 @@ openjdk-7-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806
 7u79-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
 7-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
 
-openjdk-8u45-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-openjdk-8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-8u45-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-8u45: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-8-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-8: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-jdk: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
-latest: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jdk
+openjdk-8u66-jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+openjdk-8u66: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+openjdk-8-jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+openjdk-8: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+8u66-jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+8u66: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+8-jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+8: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
+latest: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
 
-openjdk-8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
-8u45-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
-jre: git://github.com/docker-library/java@fe489e584bd248f6ed6b379beed27eda755c5ba9 openjdk-8-jre
+openjdk-8u66-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
+8u66-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
+jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.20: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
-10.0: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
-10: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
-latest: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 10.0
+10.0.21: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
+10.0: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
+10: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
+latest: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
 
-5.5.44: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5
-5.5: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5
-5: git://github.com/docker-library/mariadb@4fb7e0e3a475acbb8e01ceefb67764bb185d4520 5.5
+5.5.45: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5
+5.5: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5
+5: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5


### PR DESCRIPTION
- `buildpack-deps`: remove utopic (EOL)
- `celery`: no functional change (`.travis.yml` added)
- `golang`: 1.5rc1 (docker-library/golang#56)
- `hello-world`: https (docker-library/hello-world#5), build-in-container (docker-library/hello-world#6)
- `java`: 8u66
- `mariadb`: 10.0.21+maria-1~jessie and 5.5.45+maria-1~wheezy