### PR TITLE
New kernel and EE7 images.

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -11,5 +11,6 @@ webProfile7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d
 javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
 8.5.5.6-javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
 8.5.5.6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
 latest: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
 beta: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/beta

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,5 +1,15 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@dcurrie)
 
-8.5.5: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/8.5.5/developer/webProfile6
-latest: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/8.5.5/developer/webProfile6
-beta: git://github.com/WASdev/ci.docker@11097607e19b923fb1c1a59802a42afe18afc5cd websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/kernel
+8.5.5.6-kernel: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/common
+8.5.5.6-common: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.6-webProfile6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.6-webProfile7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+8.5.5.6-javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+8.5.5.6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/beta


### PR DESCRIPTION
Previous latest image now tagged webProfile6. New webProfile7 image added that contains Java EE7 Web Profile features. The webProfile6 and webProfile7 images build on a common image which provides a base set of features. This in turn builds on a kernel image that contains no runtime features that can be used as the basis for custom images. Also added is a javaee7 image which builds on webProfile7 and adds all of the remaining features for Java EE7 Full Platform.

The image tags with version numbers only exist to signpost the current version being used. Liberty has a 'zero migration' policy which means a given feature set should continue to work regardless of the version number.