### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.18: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
-3.1: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
-3: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
-latest: git://github.com/docker-library/celery@64fa64bff9c31f5caef8b38064deb4f5a43203a8
+3.1.18: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3.1: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+latest: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.3
-1.3: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.3
+1.3: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
-1.4: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.4
+1.4: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
-1.5: git://github.com/docker-library/elasticsearch@0d458a654cf9f7b7199f4faf4a838e6928ee954e 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.5
+1.5: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@a96386022c9f76299e592e32965d167a2480c866 1.6
-1.6: git://github.com/docker-library/elasticsearch@a96386022c9f76299e592e32965d167a2480c866 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.6
+1.6: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.6
 
-1.7.1: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
-1.7: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
-1: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
-latest: git://github.com/docker-library/elasticsearch@98f29d4ab35e95bfd3fcc1997cc739a1e4301ccc 1.7
+1.7.1: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
+1.7: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
+1: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
+latest: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.6.4: git://github.com/docker-library/ghost@acecb713094c19f216e84d3cef9d2fceb64550a9
-0.6: git://github.com/docker-library/ghost@acecb713094c19f216e84d3cef9d2fceb64550a9
-0: git://github.com/docker-library/ghost@acecb713094c19f216e84d3cef9d2fceb64550a9
-latest: git://github.com/docker-library/ghost@acecb713094c19f216e84d3cef9d2fceb64550a9
+0.6.4: git://github.com/docker-library/ghost@853fca5101d1698b97e95aae4fbc7d99b902bea9
+0.6: git://github.com/docker-library/ghost@853fca5101d1698b97e95aae4fbc7d99b902bea9
+0: git://github.com/docker-library/ghost@853fca5101d1698b97e95aae4fbc7d99b902bea9
+latest: git://github.com/docker-library/ghost@853fca5101d1698b97e95aae4fbc7d99b902bea9

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,3 +1,3 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/hello-world@897aa7529c3c3d9e9374fd16847dee50d720a7fd
+latest: git://github.com/docker-library/hello-world@22ecfe456f254d5babe6e413bed2de77cfaba047

--- a/library/irssi
+++ b/library/irssi
@@ -1,7 +1,7 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.17: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
-0.8: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
-0: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
-latest: git://github.com/jfrazelle/irssi@a6f457f7ed2a0fb5f32f7f0ee6794ac78a573d08
+0.8.17: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
+0.8: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
+0: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
+latest: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6

--- a/library/mongo
+++ b/library/mongo
@@ -6,9 +6,9 @@
 2.4.14: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
 2.4: git://github.com/docker-library/mongo@b7630a1644d934c4c4d57a121e2ca42a50e99c44 2.4
 
-2.6.10: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
-2.6: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
-2: git://github.com/docker-library/mongo@b7d2dead92baec7c7f391966659815038d74aa61 2.6
+2.6.11: git://github.com/docker-library/mongo@2fb5754a5ac0e4a65ff735433379d60f0b564312 2.6
+2.6: git://github.com/docker-library/mongo@2fb5754a5ac0e4a65ff735433379d60f0b564312 2.6
+2: git://github.com/docker-library/mongo@2fb5754a5ac0e4a65ff735433379d60f0b564312 2.6
 
 3.0.5: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0
 3.0: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.45: git://github.com/docker-library/mysql@2d67d42872d2c2c0e93ed557eaa70b0943248b4d 5.5
-5.5: git://github.com/docker-library/mysql@2d67d42872d2c2c0e93ed557eaa70b0943248b4d 5.5
+5.5.45: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.5
+5.5: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.5
 
-5.6.26: git://github.com/docker-library/mysql@14fb0f936d027acbd2abd8e6b8704388a22877a8 5.6
-5.6: git://github.com/docker-library/mysql@14fb0f936d027acbd2abd8e6b8704388a22877a8 5.6
-5: git://github.com/docker-library/mysql@14fb0f936d027acbd2abd8e6b8704388a22877a8 5.6
-latest: git://github.com/docker-library/mysql@14fb0f936d027acbd2abd8e6b8704388a22877a8 5.6
+5.6.26: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
+5.6: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
+5: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
+latest: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
 
-5.7.8-rc: git://github.com/docker-library/mysql@4df6cba7a1f3e7d586db0b66864c9d3b1a866a4e 5.7
-5.7.8: git://github.com/docker-library/mysql@4df6cba7a1f3e7d586db0b66864c9d3b1a866a4e 5.7
-5.7: git://github.com/docker-library/mysql@4df6cba7a1f3e7d586db0b66864c9d3b1a866a4e 5.7
+5.7.8-rc: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7
+5.7.8: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7
+5.7: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,17 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.9: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 6.0
-6.0: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 6.0
-6: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 6.0
+6.0.9: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
+6.0: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
+6: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
 
-7.0.7: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 7.0
-7.0: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 7.0
-7: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 7.0
+7.0.8: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 7.0
+7.0: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 7.0
+7: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 7.0
 
-8.0.5: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.0
-8.0: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.0
+8.0.5: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 8.0
+8.0: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 8.0
 
-8.1.0: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.1
-8.1: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.1
-8: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.1
-latest: git://github.com/docker-library/owncloud@1ba39a1b6afe7fc0622f7668dafd87e51097c022 8.1
+8.1.1: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
+8.1: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
+8: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
+latest: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1

--- a/library/php
+++ b/library/php
@@ -1,57 +1,57 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.43-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4
-5.4-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4
-5.4.43: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4
-5.4: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4
+5.4.44-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4
+5.4-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4
+5.4.44: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4
+5.4: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4
 
-5.4.43-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4/apache
-5.4-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4/apache
+5.4.44-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4/apache
+5.4-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4/apache
 
-5.4.43-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.4/fpm
+5.4.44-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.4/fpm
 
-5.5.27-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5
-5.5-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5
-5.5.27: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5
-5.5: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5
+5.5.28-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5
+5.5-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5
+5.5.28: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5
+5.5: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5
 
-5.5.27-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5/apache
-5.5-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5/apache
+5.5.28-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5/apache
+5.5-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5/apache
 
-5.5.27-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.5/fpm
+5.5.28-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.5/fpm
 
-5.6.11-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-5.6-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-5-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-5.6.11: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-5.6: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-5: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
-latest: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6
+5.6.12-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+5.6-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+5-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+5.6.12: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+5.6: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+5: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
+latest: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6
 
-5.6.11-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/apache
-5.6-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/apache
-5-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/apache
-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/apache
+5.6.12-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/apache
+5.6-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/apache
+5-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/apache
+apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/apache
 
-5.6.11-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/fpm
-5-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/fpm
-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 5.6/fpm
+5.6.12-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
+5-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
+fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
 
-7.0.0beta2-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
-7.0-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
-7-cli: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
-7.0.0beta2: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
-7.0: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
-7: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0
+7.0.0beta3-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7.0-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7.0.0beta3: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7.0: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
 
-7.0.0beta2-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/apache
-7.0-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/apache
-7-apache: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/apache
+7.0.0beta3-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
+7.0-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
+7-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
 
-7.0.0beta2-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/fpm
-7-fpm: git://github.com/docker-library/php@8dc762e7181fdc56148e13fbbdeef16271a14ea0 7.0/fpm
+7.0.0beta3-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm
+7-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -17,5 +17,5 @@
 9: git://github.com/docker-library/postgres@a82c28e1c407ef5ddfc2a6014dac87bcc4955a26 9.4
 latest: git://github.com/docker-library/postgres@a82c28e1c407ef5ddfc2a6014dac87bcc4955a26 9.4
 
-9.5-alpha1: git://github.com/docker-library/postgres@a82c28e1c407ef5ddfc2a6014dac87bcc4955a26 9.5
-9.5: git://github.com/docker-library/postgres@a82c28e1c407ef5ddfc2a6014dac87bcc4955a26 9.5
+9.5-alpha2: git://github.com/docker-library/postgres@7fed4298db2dc8fb86844a1a41c86f4356f5f45b 9.5
+9.5: git://github.com/docker-library/postgres@7fed4298db2dc8fb86844a1a41c86f4356f5f45b 9.5

--- a/library/redis
+++ b/library/redis
@@ -1,14 +1,14 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6
-2.6: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6
+2.6.17: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.6
+2.6: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.6
 
 2.6.17-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
 2.6-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
 
-2.8.21: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
-2.8: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
-2: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8
+2.8.21: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.8
+2.8: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.8
+2: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.8
 
 2.8.21-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit
 2.8-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.8/32bit

--- a/library/redmine
+++ b/library/redmine
@@ -4,16 +4,16 @@
 2.6: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
 2: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
 
-2.6.6-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 2.6/passenger
+2.6.6-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
 
 3.0.4: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 3.0: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 3: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 latest: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 
-3.0.4-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 3.0/passenger
-passenger: git://github.com/docker-library/redmine@6fa3c5e195b9f75705d7cded4e5385de5a94c37d 3.0/passenger
+3.0.4-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
+passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p645: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.0
-2.0.0: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.0
-2.0: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.0
+2.0.0-p645: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0
+2.0.0: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0
+2.0: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0
 
 2.0.0-p645-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.0/onbuild
 
-2.0.0-p645-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.0/slim
+2.0.0-p645-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.0/slim
 
-2.1.6: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.1
-2.1: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.1
+2.1.6: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.1
+2.1: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.1
 
 2.1.6-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.1/onbuild
 
-2.1.6-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.1/slim
+2.1.6-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.1/slim
 
-2.2.2: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.2
-2.2: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.2
-2: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.2
-latest: git://github.com/docker-library/ruby@d67b6c0361aa2aceb4f9bc3fd155000584490a10 2.2
+2.2.2: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2
+2.2: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2
+2: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2
+latest: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2
 
 2.2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@4ccabb5557ce2001aa1ae2a5f719340eb33c0383 2.2/onbuild
 
-2.2.2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
-2-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
-slim: git://github.com/docker-library/ruby@3c8701dbc263001651f8a0ac44bfb1c6113b69fa 2.2/slim
+2.2.2-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2/slim
+2-slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2/slim
+slim: git://github.com/docker-library/ruby@d88c77ea84b114fdfcdaa022a4e43bb067d5ac81 2.2/slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.4-apache: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-4.2.4: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-4.2-apache: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-4.2: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-4-apache: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-apache: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-4: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
-latest: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 apache
+4.2.4-apache: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+4.2.4: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+4.2-apache: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+4.2: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+4-apache: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+apache: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+4: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
+latest: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 apache
 
-4.2.4-fpm: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 fpm
-4.2-fpm: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 fpm
-4-fpm: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 fpm
-fpm: git://github.com/docker-library/wordpress@ba89e6a1834c7142b9d8ac7a0353dcd0205a4312 fpm
+4.2.4-fpm: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 fpm
+4.2-fpm: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 fpm
+4-fpm: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 fpm
+fpm: git://github.com/docker-library/wordpress@695385bc1bb1b3c930b114193786e5ae9a0b05a7 fpm


### PR DESCRIPTION
- `celery`: https://github.com/docker-library/celery/commit/033c91ff69ea30b49ddfa321dd8c5493f90e1764
- `elasticsearch`: https://github.com/docker-library/elasticsearch/commit/4e491a77c3f54d1d05e862f4d948a416214d1fc5
- `ghost`: https://github.com/docker-library/ghost/commit/7200faa197049ae01f10d9cc44dbe7e4361b15f0
- `hello-world`: https://github.com/docker-library/hello-world/commit/2224815f1ccd0b5b86f84c7de42296c7901749a6
- `irssi`: https://github.com/jfrazelle/irssi/commit/46f8d10e03934bf9bd698999205013675e9c049d
- `mongo`: 2.6.11
- `mysql`: `skip-name-resolve` (docker-library/mysql#89)
- `owncloud`: 7.0.8 and 8.1.1
- `php`: https://github.com/docker-library/php/commit/757528222b84cd8204d5fe54dba31cb804b26b70
- `postgres`: 9.5~alpha2-1.pgdg80+1
- `redis`: https://github.com/docker-library/redis/commit/d2877d50bb73f272ac8b0ed0044f7faf61a54770
- `redmine`: https://github.com/infosiftr/redmine/commit/dbd8af6479e68f08610e8e9bf9c43f6718f88d22
- `ruby`: `--no-document` (docker-library/ruby#49)
- `wordpress`: fix FPM support (docker-library/wordpress#92)