### PR TITLE
Update library/registry image to v2.1.0

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -1,11 +1,11 @@
 # maintainer: Stephen Day <stephen.day@docker.com> (@stevvooe)
 # maintainer: Olivier Gambier <olivier.gambier@docker.com> (@dmp42)
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
+# maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
 latest: git://github.com/docker/docker-registry@0.9.1
 0.8.1: git://github.com/docker/docker-registry@0.8.1
 0.9.1: git://github.com/docker/docker-registry@0.9.1
 
-2: git://github.com/docker/distribution@1341222284b3a6b4e77fb64571ad423ed58b0d34
-2.0: git://github.com/docker/distribution@1341222284b3a6b4e77fb64571ad423ed58b0d34
-2.0.1: git://github.com/docker/distribution@1341222284b3a6b4e77fb64571ad423ed58b0d34
+2: git://github.com/docker/distribution-library-image@d5ee820f89fc8ca7b66bd88f70554e89319808e0
+2.1: git://github.com/docker/distribution-library-image@d5ee820f89fc8ca7b66bd88f70554e89319808e0


### PR DESCRIPTION
Add new tag "2.1", and update tag "2" to point at this new release.

These tags now point to distribution-library-image, which is a slimmed
down image, rather than the golang-derived image used to build registry
from source.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>