### PR TITLE
Add Couchbase Server 3.1.0

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,21 +1,21 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
-enterprise: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
+latest: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
+enterprise: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
 
-3.1.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
-enterprise-3.1.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
+3.1.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
+enterprise-3.1.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
 
-3.0.3: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.3
-enterprise-3.0.3: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.3
+3.0.3: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.3
+enterprise-3.0.3: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.3
 
-3.0.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.2
-enterprise-3.0.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.2
+3.0.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.2
+enterprise-3.0.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.2
 
-community: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/3.0.1
-community-3.0.1: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/3.0.1
+community: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/3.0.1
+community-3.0.1: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/3.0.1
 
-2.5.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/2.5.2
-enterprise-2.5.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/2.5.2
+2.5.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/2.5.2
+enterprise-2.5.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/2.5.2
 
-community-2.2.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/2.2.0
+community-2.2.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/2.2.0

--- a/library/couchbase
+++ b/library/couchbase
@@ -1,17 +1,21 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.3
-enterprise: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.3
-3.0.3: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.3
-enterprise-3.0.3: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.3
+latest: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
+enterprise: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
 
-3.0.2: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.2
-enterprise-3.0.2: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/3.0.2
+3.1.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
+enterprise-3.1.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.1.0
 
-community: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e community/couchbase-server/3.0.1
-community-3.0.1: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e community/couchbase-server/3.0.1
+3.0.3: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.3
+enterprise-3.0.3: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.3
 
-2.5.2: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/2.5.2
-enterprise-2.5.2: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e enterprise/couchbase-server/2.5.2
+3.0.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.2
+enterprise-3.0.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/3.0.2
 
-community-2.2.0: git://github.com/couchbase/docker@695e9dbe4f8928ec4b66a83568d3d583c8215b1e community/couchbase-server/2.2.0
+community: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/3.0.1
+community-3.0.1: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/3.0.1
+
+2.5.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/2.5.2
+enterprise-2.5.2: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa enterprise/couchbase-server/2.5.2
+
+community-2.2.0: git://github.com/couchbase/docker@906b651a6f374c70832dd440375a821b1ec890fa community/couchbase-server/2.2.0


### PR DESCRIPTION
Adds Couchbase Server 3.1.0. Also incorporates some Dockerfile cleanups from myself and some more significant changes from @hookenz (switching to runit to launch PID 1, basing off Ubuntu official image rather than Centos).