### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.16: git://github.com/docker-library/cassandra@b9b173c523af2da70fdd898565a556af12d6b23a 2.0
-2.0: git://github.com/docker-library/cassandra@b9b173c523af2da70fdd898565a556af12d6b23a 2.0
+2.0.16: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
+2.0: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
 
-2.1.8: git://github.com/docker-library/cassandra@1a2fa7d60b9fca1135df05e3b0f7795d3485e2d6 2.1
-2.1: git://github.com/docker-library/cassandra@1a2fa7d60b9fca1135df05e3b0f7795d3485e2d6 2.1
+2.1.8: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.1
+2.1: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.1
 
-2.2.0: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
-2.2: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
-2: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
-latest: git://github.com/docker-library/cassandra@081e3c47f144279ac5fe16a024581f3fd9b62521 2.2
+2.2.0: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2
+2.2: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2
+2: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2
+latest: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2

--- a/library/drupal
+++ b/library/drupal
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.38: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
-7: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
-latest: git://github.com/docker-library/drupal@fc7b306913e96ced8e28d23fa47bb9ee19e8f427 7
+7.38: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 7
+7: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 7
+latest: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 7
 
-8.0.0-beta14: git://github.com/docker-library/drupal@4fb3024cae477daa93b0e169b1c909cc8bfda869 8
-8.0.0: git://github.com/docker-library/drupal@4fb3024cae477daa93b0e169b1c909cc8bfda869 8
-8.0: git://github.com/docker-library/drupal@4fb3024cae477daa93b0e169b1c909cc8bfda869 8
-8: git://github.com/docker-library/drupal@4fb3024cae477daa93b0e169b1c909cc8bfda869 8
+8.0.0-beta14: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 8
+8.0.0: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 8
+8.0: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 8
+8: git://github.com/docker-library/drupal@dbf78461358a217af8118453abb5e06a554763bd 8

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.3
-1.3: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.3
+1.3: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.4
-1.4: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.4
+1.4: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.5
-1.5: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.5
+1.5: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.6
-1.6: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.6
+1.6: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.6
 
-1.7.1: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
-1.7: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
-1: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
-latest: git://github.com/docker-library/elasticsearch@258e9b89c3fe675b966a49deb0c26727c7d20551 1.7
+1.7.1: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
+1.7: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
+1: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
+latest: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7

--- a/library/logstash
+++ b/library/logstash
@@ -1,5 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.5.3: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965
-1.5: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965
-latest: git://github.com/docker-library/logstash@f30253f69235d1c9faf87b192a6a726b65bf8965
+1.4.4-1-5608c19: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
+1.4.4-1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
+1.4.4: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
+1.4: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
+
+1.5.3-1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
+1.5.3: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
+1.5: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
+1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
+latest: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.21: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
-10.0: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
-10: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
-latest: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 10.0
+10.0.21: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
+10.0: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
+10: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
+latest: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
 
-5.5.45: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5
-5.5: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5
-5: git://github.com/docker-library/mariadb@7da96103bcb14bff77c6e15b415aa0d5582cb922 5.5
+5.5.45: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5
+5.5: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5
+5: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5

--- a/library/owncloud
+++ b/library/owncloud
@@ -8,10 +8,10 @@
 7.0: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 7.0
 7: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 7.0
 
-8.0.5: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 8.0
-8.0: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 8.0
+8.0.6: git://github.com/docker-library/owncloud@9407be83adf4886035585f99ecab12661fd05cf5 8.0
+8.0: git://github.com/docker-library/owncloud@9407be83adf4886035585f99ecab12661fd05cf5 8.0
 
-8.1.1: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
-8.1: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
-8: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
-latest: git://github.com/docker-library/owncloud@4c6abd947ad841b215745ff98adece6a4e6617e2 8.1
+8.1.1: git://github.com/docker-library/owncloud@64c05c881fa66e9649ca8dca322c8ac01849294d 8.1
+8.1: git://github.com/docker-library/owncloud@64c05c881fa66e9649ca8dca322c8ac01849294d 8.1
+8: git://github.com/docker-library/owncloud@64c05c881fa66e9649ca8dca322c8ac01849294d 8.1
+latest: git://github.com/docker-library/owncloud@64c05c881fa66e9649ca8dca322c8ac01849294d 8.1

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.44: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.5
-5.5: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.5
+5.5.44: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.5
+5.5: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.5
 
-5.6.25: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.6
-5.6: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.6
-5: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.6
-latest: git://github.com/docker-library/percona@e32f419e1c59931c8b0c2e392e09d8f102f798a0 5.6
+5.6.25: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
+5.6: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
+5: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
+latest: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6


### PR DESCRIPTION
- `cassandra`: `--link` for seeding (docker-library/cassandra#21)
- `drupal`: update Drupal 7 to use PHP 5.6 (docker-library/drupal#9)
- `elasticsearch`: minor template updates (docker-library/elasticsearch#45)
- `logstash`: add 1.4 as a supported version (docker-library/logstash#21)
- `mariadb`: add `initdb` directory support (docker-library/mariadb#18)
- `owncloud`: 8.0.6, caching modules (docker-library/owncloud#16)
- `percona`: add `initdb` directory support (docker-library/percona#6)