### PR TITLE
Upgrade to iojs-3.1.0

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -24,17 +24,17 @@
 2.5-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 2-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 
-3.0.0: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
-3.0: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
-3: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
-latest: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0
+3.1.0: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
+3.1: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
+3: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
+latest: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
 
-3.0.0-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
-3.0-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
-3-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/onbuild
+3.1.0-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
+3.1-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
+3-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
 
-3.0.0-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
-3.0-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
-3-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
-slim: git://github.com/nodejs/docker-iojs@50f9f41551ce6a2e7d26a0b7ff5f58931cfcc8cd 3.0/slim
+3.1.0-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
+3.1-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
+3-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
+slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim


### PR DESCRIPTION
Reference: https://github.com/nodejs/docker-iojs/pull/84

3.0.0 had some memory leaks that are fixed in 3.1.0 as described in the iojs release proposal: https://github.com/nodejs/node/pull/2347