### PR TITLE
Update java

### DIFF
--- a/library/java
+++ b/library/java
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-openjdk-6b35-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-openjdk-6b35: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-openjdk-6-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-openjdk-6: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-6b35-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-6b35: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-6-jdk: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
-6: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jdk
+openjdk-6b36-jdk: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+openjdk-6b36: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+openjdk-6-jdk: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+openjdk-6: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+6b36-jdk: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+6b36: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+6-jdk: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
+6: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jdk
 
-openjdk-6b35-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jre
-openjdk-6-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jre
-6b35-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jre
-6-jre: git://github.com/docker-library/java@318ba809c9f0e3c7095b363c5a31409ee6880208 openjdk-6-jre
+openjdk-6b36-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
+openjdk-6-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
+6b36-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
+6-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
 
 openjdk-7u79-jdk: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
 openjdk-7u79: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
@@ -39,8 +39,8 @@ openjdk-8: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe1
 jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
 latest: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
 
-openjdk-8u66-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
-8u66-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
-8-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
-jre: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jre
+openjdk-8u66-jre: git://github.com/docker-library/java@0f82de10e4aaa8b78d7f79cf725fd1fad1dc85e0 openjdk-8-jre
+openjdk-8-jre: git://github.com/docker-library/java@0f82de10e4aaa8b78d7f79cf725fd1fad1dc85e0 openjdk-8-jre
+8u66-jre: git://github.com/docker-library/java@0f82de10e4aaa8b78d7f79cf725fd1fad1dc85e0 openjdk-8-jre
+8-jre: git://github.com/docker-library/java@0f82de10e4aaa8b78d7f79cf725fd1fad1dc85e0 openjdk-8-jre
+jre: git://github.com/docker-library/java@0f82de10e4aaa8b78d7f79cf725fd1fad1dc85e0 openjdk-8-jre


### PR DESCRIPTION
Bump to 6b36-1.13.8-1~deb7u1

Fix `libfontconfig1` related NPE with a temporary fix until upstream fixes the `.deb` (docker-library/java#48)