### PR TITLE
Logstash upgrade 1.4.5 and 1.5.4

### DIFF
--- a/library/logstash
+++ b/library/logstash
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.4-1-5608c19: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
-1.4.4-1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
-1.4.4: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
-1.4: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.4
+1.4.5-1-a2bacae: git://github.com/docker-library/logstash@29f240de10ac358dba1bed7e777ab35742029858 1.4
+1.4.5-1: git://github.com/docker-library/logstash@29f240de10ac358dba1bed7e777ab35742029858 1.4
+1.4.5: git://github.com/docker-library/logstash@29f240de10ac358dba1bed7e777ab35742029858 1.4
+1.4: git://github.com/docker-library/logstash@29f240de10ac358dba1bed7e777ab35742029858 1.4
 
-1.5.3-1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
-1.5.3: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
-1.5: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
-1: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
-latest: git://github.com/docker-library/logstash@0b3880a5ace17d08bee8734d43b211d5d67c94d1 1.5
+1.5.4-1: git://github.com/docker-library/logstash@722165120c05043a69c0482d7fecaff404428e51 1.5
+1.5.4: git://github.com/docker-library/logstash@722165120c05043a69c0482d7fecaff404428e51 1.5
+1.5: git://github.com/docker-library/logstash@722165120c05043a69c0482d7fecaff404428e51 1.5
+1: git://github.com/docker-library/logstash@722165120c05043a69c0482d7fecaff404428e51 1.5
+latest: git://github.com/docker-library/logstash@722165120c05043a69c0482d7fecaff404428e51 1.5


### PR DESCRIPTION
Pull request:
docker-library/logstash/pull/24