### PR TITLE
updates r-base to R 3.2.2 released a few days ago

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,6 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.2.1: git://github.com/rocker-org/rocker@9f26417d0987d0b8517491270da0541aa9b754cc r-base
-latest: git://github.com/rocker-org/rocker@9f26417d0987d0b8517491270da0541aa9b754cc r-base
+3.2.2: git://github.com/rocker-org/rocker@ee6e1da2e7020978a6aaf3916f8aba9edd16e72d r-base
+latest: git://github.com/rocker-org/rocker@ee6e1da2e7020978a6aaf3916f8aba9edd16e72d r-base
 


### PR DESCRIPTION
This PR updates the r-base container to the current version R 3.2.2 released on August 14.  

This R version has built without issue outside of Docker; the rocker/r-base container built fine as well.