### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,10 +6,10 @@
 1: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8
 latest: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8
 
-1.8.1-dind: git://github.com/docker-library/docker@0437f58a50d2558d61751461c8d47aeef318f0bd 1.8/dind
-1.8-dind: git://github.com/docker-library/docker@0437f58a50d2558d61751461c8d47aeef318f0bd 1.8/dind
-1-dind: git://github.com/docker-library/docker@0437f58a50d2558d61751461c8d47aeef318f0bd 1.8/dind
-dind: git://github.com/docker-library/docker@0437f58a50d2558d61751461c8d47aeef318f0bd 1.8/dind
+1.8.1-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
+1.8-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
+1-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
+dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
 
 1.8.1-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
 1.8-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
@@ -19,71 +19,8 @@ git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f633
 1.7.1: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7
 1.7: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7
 
-1.7.1-dind: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/dind
-1.7-dind: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/dind
+1.7.1-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.7/dind
+1.7-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.7/dind
 
 1.7.1-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/git
 1.7-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/git
-
-1.6.2: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6
-1.6: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6
-
-1.6.2-dind: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6/dind
-1.6-dind: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6/dind
-
-1.6.2-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6/git
-1.6-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.6/git
-
-1.5.0: git://github.com/docker-library/docker@a6881f8ea008fa99afc5189e2258cc81a90243c5 1.5
-1.5: git://github.com/docker-library/docker@a6881f8ea008fa99afc5189e2258cc81a90243c5 1.5
-
-1.5.0-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.5/dind
-1.5-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.5/dind
-
-1.5.0-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.5/git
-1.5-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.5/git
-
-1.4.1: git://github.com/docker-library/docker@f1341e1e9a099073463b1e8192c45435ce3e6760 1.4
-1.4: git://github.com/docker-library/docker@f1341e1e9a099073463b1e8192c45435ce3e6760 1.4
-
-1.4.1-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.4/dind
-1.4-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.4/dind
-
-1.4.1-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.4/git
-1.4-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.4/git
-
-1.3.3: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.3
-1.3: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.3
-
-1.3.3-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.3/dind
-1.3-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.3/dind
-
-1.3.3-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.3/git
-1.3-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.3/git
-
-1.2.0: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.2
-1.2: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.2
-
-1.2.0-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.2/dind
-1.2-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.2/dind
-
-1.2.0-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.2/git
-1.2-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.2/git
-
-1.1.2: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.1
-1.1: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.1
-
-1.1.2-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.1/dind
-1.1-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.1/dind
-
-1.1.2-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.1/git
-1.1-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.1/git
-
-1.0.1: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.0
-1.0: git://github.com/docker-library/docker@e68ca233d592bf527ad7c163cc2f3fe5936bba90 1.0
-
-1.0.1-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.0/dind
-1.0-dind: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.0/dind
-
-1.0.1-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.0/git
-1.0-git: git://github.com/docker-library/docker@299e01eaf7185fd94f1c6b59c365867695caa828 1.0/git

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.45: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.5
-5.5: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.5
+5.5.45: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.5
+5.5: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.5
 
-5.6.26: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
-5.6: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
-5: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
-latest: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.6
+5.6.26: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.6
+5.6: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.6
+5: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.6
+latest: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.6
 
-5.7.8-rc: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7
-5.7.8: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7
-5.7: git://github.com/docker-library/mysql@c402b76d72d0089d6e84a2e24c143e99c3cb2919 5.7
+5.7.8-rc: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.7
+5.7.8: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.7
+5.7: git://github.com/docker-library/mysql@b3b265602da7c733c66582ac016a491d28b9b1f9 5.7

--- a/library/php
+++ b/library/php
@@ -41,17 +41,17 @@ apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b1
 5-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
 fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
 
-7.0.0beta3-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
-7.0-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
-7-cli: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
-7.0.0beta3: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
-7.0: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
-7: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0
+7.0.0RC1-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7.0-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7.0.0RC1: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7.0: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
 
-7.0.0beta3-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
-7.0-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
-7-apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/apache
+7.0.0RC1-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
+7.0-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
+7-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
 
-7.0.0beta3-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm
-7-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 7.0/fpm
+7.0.0RC1-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm
+7-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.6.0: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2
-2-2.6: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2
-2-2: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2
-2: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2
+2-2.6.0: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2
+2-2.6: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2
+2-2: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2
+2: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2
 
 2-2.6.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-2.6-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-2.6.0-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2/slim
-2-2.6-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2/slim
-2-2-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2/slim
-2-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 2/slim
+2-2.6.0-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2/slim
+2-2.6-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2/slim
+2-2-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2/slim
+2-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3
-3-2.4: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3
-3-2: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3
-3: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3
-latest: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3
+3-2.4.0: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
+3-2.4: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
+3-2: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
+3: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
+latest: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3/slim
-3-2-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3/slim
-3-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3/slim
-slim: git://github.com/docker-library/pypy@e91faa125363042d9b385876182e70e28d5d460b 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
+3-2-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
+3-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
+slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim

--- a/library/python
+++ b/library/python
@@ -1,64 +1,64 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7
-2.7: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7
-2: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7
+2.7.10: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
+2.7: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
+2: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
 
 2.7.10-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/slim
-2.7-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/slim
-2-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/slim
+2.7.10-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
+2.7-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
+2-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
 
-2.7.10-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 2.7/wheezy
+2.7.10-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2
-3.2: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2
+3.2.6: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
+3.2: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2/slim
-3.2-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/slim
+3.2-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3
-3.3: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3
+3.3.6: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3
+3.3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3/slim
-3.3-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/slim
+3.3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4
-3.4: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4
-3: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4
-latest: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4
+3.4.3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
+3.4: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
+3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
+latest: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/slim
-3.4-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/slim
-3-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/slim
-slim: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/slim
+3.4.3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
+3.4-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
+3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
+slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/wheezy
-wheezy: git://github.com/docker-library/python@46db56362d8f00a6e498fe4802d036588c8c4c7f 3.4/wheezy
+3.4.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
+3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
+wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
 
 3.5.0b3: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5
 3.5.0: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5

--- a/library/redmine
+++ b/library/redmine
@@ -4,16 +4,16 @@
 2.6: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
 2: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
 
-2.6.6-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 2.6/passenger
+2.6.6-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 2.6/passenger
 
 3.0.4: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 3.0: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 3: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 latest: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
 
-3.0.4-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
-passenger: git://github.com/docker-library/redmine@2dfa232c7f591e9d458d10eb4a485f84cf33cf4d 3.0/passenger
+3.0.4-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 3.0/passenger
+passenger: git://github.com/docker-library/redmine@39d56044137528a841b176e9e5152f22df18f6e4 3.0/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@24e869945b9d9d3f02f979524b8caf989d08ed6c 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@24e869945b9d9d3f02f979524b8caf989d08ed6c 7-jre8
 
-8.0.24-jre7: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-jre7: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-8.0.24: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-8.0: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-8: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
-latest: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre7
+8.0.26-jre7: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+jre7: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+8.0.26: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+8.0: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+8: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
+latest: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre7
 
-8.0.24-jre8: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre8
-jre8: git://github.com/docker-library/tomcat@2f17559d7a1c62dbc17b63750b31a0beea205120 8-jre8
+8.0.26-jre8: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre8
+jre8: git://github.com/docker-library/tomcat@9afdd27634a5b847a3b7aa2d611ad5828659d228 8-jre8


### PR DESCRIPTION
- `docker`: remove older releases and update `DIND_COMMIT`
- `mysql`: fix `MYSQL_ALLOW_EMPTY_PASSWORD` feature (docker-library/mysql#93)
- `php`: 7.0.0RC1 (docker-library/php#127)
- `pypy`: pip 7.1.2
- `python`: pip 7.1.2
- `redmine`: passenger 5.0.16
- `tomcat`: 8.0.26