### PR TITLE
Update docker-library images

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.24: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
-1.4: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
-1: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
-latest: git://github.com/docker-library/memcached@d6775e2c9c9b6b6ad719b942f4d56d63a29718f7
+1.4.24: git://github.com/docker-library/memcached@5c034b3b8ab7216181f3c25f080b4d1dbb8bf888
+1.4: git://github.com/docker-library/memcached@5c034b3b8ab7216181f3c25f080b4d1dbb8bf888
+1: git://github.com/docker-library/memcached@5c034b3b8ab7216181f3c25f080b4d1dbb8bf888
+latest: git://github.com/docker-library/memcached@5c034b3b8ab7216181f3c25f080b4d1dbb8bf888

--- a/library/mongo
+++ b/library/mongo
@@ -10,10 +10,10 @@
 2.6: git://github.com/docker-library/mongo@2fb5754a5ac0e4a65ff735433379d60f0b564312 2.6
 2: git://github.com/docker-library/mongo@2fb5754a5ac0e4a65ff735433379d60f0b564312 2.6
 
-3.0.5: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0
-3.0: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0
-3: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0
-latest: git://github.com/docker-library/mongo@9d8b9c61e8e3ccc8d256aa49905f4755cd6c236e 3.0
+3.0.6: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
+3.0: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
+3: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
+latest: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
 
 3.1.6: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1
 3.1: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.3: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
-4.2: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
-4: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
-latest: git://github.com/docker-library/rails@e3a9c6f610e9d1e428cecfae02feddcd1e22b36c
+4.2.4: git://github.com/docker-library/rails@7926577517fb974f9de9ca1511162d6d5e000435
+4.2: git://github.com/docker-library/rails@7926577517fb974f9de9ca1511162d6d5e000435
+4: git://github.com/docker-library/rails@7926577517fb974f9de9ca1511162d6d5e000435
+latest: git://github.com/docker-library/rails@7926577517fb974f9de9ca1511162d6d5e000435
 
 onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild


### PR DESCRIPTION
- `memcached`: allow direct flags passing (docker-library/memcached#3)
- `mongo`: 3.0.6
- `rails`: 4.2.4