### PR TITLE
Update docker-dev to 1.8.1

### DIFF
--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 
-1.7.1: git://github.com/docker/docker@786b29d4db80a6175e72b47a794ee044918ba734
-1.7: git://github.com/docker/docker@786b29d4db80a6175e72b47a794ee044918ba734
-1: git://github.com/docker/docker@786b29d4db80a6175e72b47a794ee044918ba734
+1.8.1: git://github.com/docker/docker@d12ea79c9de6d144ce6bc7ccfe41c507cca6fd35
+1.8: git://github.com/docker/docker@d12ea79c9de6d144ce6bc7ccfe41c507cca6fd35
+1: git://github.com/docker/docker@d12ea79c9de6d144ce6bc7ccfe41c507cca6fd35
 
 # "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
 # if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)


### PR DESCRIPTION
I wish we had an easy way to see what people actually use this image for, because I'm seriously considering deprecating it (especially now that we've got the `docker` image instead, which is way more useful than this one ever was).