### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.21: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
-10.0: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
-10: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
-latest: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 10.0
+10.0.21: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
+10.0: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
+10: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
+latest: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
 
-5.5.45: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5
-5.5: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5
-5: git://github.com/docker-library/mariadb@0196e310a3bd7511ee6090150925a3301c4daaad 5.5
+5.5.45: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5
+5.5: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5
+5: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -15,5 +15,5 @@
 3: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
 latest: git://github.com/docker-library/mongo@d5aca073ca71a7023e0d4193bd14642c6950d454 3.0
 
-3.1.6: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1
-3.1: git://github.com/docker-library/mongo@a1da445a507ca1acde631af6750e5b28c98bbc20 3.1
+3.1.7: git://github.com/docker-library/mongo@3e6585721fc78b156a5ce832cf9bb282bbf833ab 3.1
+3.1: git://github.com/docker-library/mongo@3e6585721fc78b156a5ce832cf9bb282bbf833ab 3.1

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.44: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.5
-5.5: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.5
+5.5.44: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.5
+5.5: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.5
 
-5.6.25: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
-5.6: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
-5: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
-latest: git://github.com/docker-library/percona@5a2fb69779d2a30130b024f2cf3eef6e320043bc 5.6
+5.6.25: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
+5.6: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
+5: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
+latest: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.0
-9.0: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.0
+9.0.22: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
+9.0: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
 
-9.1.18: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.1
-9.1: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.1
+9.1.18: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.1
+9.1: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.1
 
-9.2.13: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.2
-9.2: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.2
+9.2.13: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.2
+9.2: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.2
 
-9.3.9: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.3
-9.3: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.3
+9.3.9: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.3
+9.3: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.3
 
-9.4.4: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.4
-9.4: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.4
-9: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.4
-latest: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.4
+9.4.4: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
+9.4: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
+9: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
+latest: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
 
-9.5-alpha2: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.5
-9.5: git://github.com/docker-library/postgres@c444bceb4ffbeda91f8e406a8dc38891188ff6b6 9.5
+9.5-alpha2: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.5
+9.5: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.5


### PR DESCRIPTION
- `mariadb`: fix `MYSQL_ALLOW_EMPTY_PASSWORD` feature (docker-library/mariadb#19)
- `mongo`: 3.1.7
- `percona`: fix `MYSQL_ALLOW_EMPTY_PASSWORD` feature (docker-library/percona#8)
- `postgres`: export `POSTGRES_USER` and `POSTGRES_DB` for initdb scripts (docker-library/postgres#84)