### PR TITLE
Upgrade to iojs-3.2.0

### DIFF
--- a/library/iojs
+++ b/library/iojs
@@ -24,17 +24,17 @@
 2.5-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 2-slim: git://github.com/nodejs/docker-iojs@0a5fc1175cdb1704b172c72f3d34d53f8310da31 2.5/slim
 
-3.1.0: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
-3.1: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
-3: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
-latest: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1
+3.2.0: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2
+3.2: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2
+3: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2
+latest: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2
 
-3.1.0-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
-3.1-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
-3-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
-onbuild: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/onbuild
+3.2.0-onbuild: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/onbuild
+3.2-onbuild: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/onbuild
+3-onbuild: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/onbuild
+onbuild: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/onbuild
 
-3.1.0-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
-3.1-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
-3-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
-slim: git://github.com/nodejs/docker-iojs@662d803695a66cc3f01687bdca93ef23f416d030 3.1/slim
+3.2.0-slim: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/slim
+3.2-slim: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/slim
+3-slim: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/slim
+slim: git://github.com/nodejs/docker-iojs@68a13ab0f190d079b484c67b9eb266ce999420b0 3.2/slim


### PR DESCRIPTION
Upgrade: https://github.com/nodejs/docker-iojs/pull/86

GPG keys of 2 new releasers @jasnell and @sam-github added to the Dockerfiles:
https://github.com/nodejs/docker-iojs/pull/85