### PR TITLE
Specify "curl" command explicitly in jetty-hello-web

### DIFF
--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -22,8 +22,8 @@ _request() {
 
 	local url="${2#/}"
 
-	docker run --rm -i --link "$cid":jetty \
-		"$clientImage" -fsSL -X"$method" "http://jetty:8080/$url"
+	docker run --rm -i --link "$cid":jetty "$clientImage" \
+		curl -fsSL -X"$method" "http://jetty:8080/$url"
 }
 
 # Check that we can request /index.jsp with no params


### PR DESCRIPTION
I realized after #1002 was merged that using `jetty` as the client test image will only work if I specify `curl` as the `CMD` :confounded: 