### PR TITLE
Update jetty CMD; add @gregw as co-maintainer

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,20 +1,21 @@
 # maintainer: Mike Dillon <mike@appropriate.io> (@md5)
+# maintainer: Greg Wilkins <gregw@webtide.com> (@gregw)
 
-9.3.2: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-9.3: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-9: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-9.3.2-jre8: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-9.3-jre8: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-latest: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
-jre8: git://github.com/appropriate/docker-jetty@23013842cc95e6bc8b9ae1562a8712b6ecd57d10 9.3-jre8
+9.3.2: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+9.3.2-jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.3-jre8
 
-9.2.13: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre8
-9.2: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre8
-9.2.13-jre8: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre8
+9.2.13: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8
+9.2: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8
+9.2.13-jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8
 
-9.2.13-jre7: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre7
-9.2-jre7: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre7
-9-jre7: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre7
-jre7: git://github.com/appropriate/docker-jetty@2e132c7023d13c14190ff71196a81d62008518b5 9.2-jre7
+9.2.13-jre7: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre7
+9.2-jre7: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre7
+9-jre7: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre7
+jre7: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre7


### PR DESCRIPTION
This PR updates the default `CMD` to use `start.jar` directly instead of `jetty.sh`. It is still possible to use `jetty.sh`, but it was intended for init scripts and does too much stuff that we don't need or want in a Docker image. Changing to use `start.jar` means that users can now pass additional command line arguments as well.

We also updated to `Dockerfile` to properly `chown` the whole `$JETTY_BASE` directory

I've also added @gregw from the Jetty Project to the library file as a co-maintainer! :tada: :dancers: 

Diff: https://github.com/appropriate/docker-jetty/compare/2e132c7023d13c14190ff71196a81d62008518b5...8166bf5a7ac46194530d81e0281d0d729fb4b7a8