### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,47 +6,47 @@ curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db6936
 jessie-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/scm
 
-jessie: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 jessie
-latest: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 jessie
+jessie: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 jessie
+latest: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 jessie
 
 precise-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/curl
 
 precise-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d precise/scm
 
-precise: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 precise
+precise: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 precise
 
 sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
 sid-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/scm
 
-sid: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 sid
+sid: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 sid
 
 stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
 
 stretch-scm: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/scm
 
-stretch: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 stretch
+stretch: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 stretch
 
 trusty-curl: git://github.com/docker-library/buildpack-deps@21f2d32bcf321ff095a23c0edc1d8be2b7989962 trusty/curl
 
 trusty-scm: git://github.com/docker-library/buildpack-deps@bb6691a2782687748549baac903340fc21a5533c trusty/scm
 
-trusty: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 trusty
+trusty: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 trusty
 
 vivid-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/curl
 
 vivid-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d vivid/scm
 
-vivid: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 vivid
+vivid: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 vivid
 
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/scm
 
-wheezy: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 wheezy
 
 wily-curl: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/curl
 
 wily-scm: git://github.com/docker-library/buildpack-deps@4cd7279c3bbe2359e5e3798a267760a886422d6d wily/scm
 
-wily: git://github.com/docker-library/buildpack-deps@0607cef1785743cfa675cd3f3072c25674edc001 wily
+wily: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 wily

--- a/library/cassandra
+++ b/library/cassandra
@@ -3,8 +3,8 @@
 2.0.16: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
 2.0: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
 
-2.1.8: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.1
-2.1: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.1
+2.1.9: git://github.com/docker-library/cassandra@c7d43443c2e80ee9edd0814c8e8332781f7d93ae 2.1
+2.1: git://github.com/docker-library/cassandra@c7d43443c2e80ee9edd0814c8e8332781f7d93ae 2.1
 
 2.2.0: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2
 2.2: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.2

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,18 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.3
-1.3: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.3
+1.3: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.4
-1.4: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.4
+1.4: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.5
-1.5: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.5
+1.5: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.6
-1.6: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.6
+1.6: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.6
 
-1.7.1: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
-1.7: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
-1: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
-latest: git://github.com/docker-library/elasticsearch@58ca884e21e67128c046ec9293d45c32b46a4d27 1.7
+1.7.1: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.7
+1.7: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.7
+1: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.7
+latest: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.7
+
+2.0.0-beta1: git://github.com/docker-library/elasticsearch@e9d0fcae535ef0f0c1b3612e805d326f464f32b2 2.0
+2.0.0: git://github.com/docker-library/elasticsearch@e9d0fcae535ef0f0c1b3612e805d326f464f32b2 2.0
+2.0: git://github.com/docker-library/elasticsearch@e9d0fcae535ef0f0c1b3612e805d326f464f32b2 2.0
+2: git://github.com/docker-library/elasticsearch@e9d0fcae535ef0f0c1b3612e805d326f464f32b2 2.0

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.3.0-apache: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-4.3.0: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-4.3-apache: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-4.3: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-4-apache: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-apache: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-4: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
-latest: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 apache
+4.3.0-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4.3.0: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4.3-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4.3: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+latest: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
 
-4.3.0-fpm: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 fpm
-4.3-fpm: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 fpm
-4-fpm: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 fpm
-fpm: git://github.com/docker-library/wordpress@4f8894bb38d628e8105711d89363156e5706f2c3 fpm
+4.3.0-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
+4.3-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
+4-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
+fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm


### PR DESCRIPTION
- `buildpack-deps`: `libgeoip-dev` (docker-library/buildpack-deps#34)
- `cassandra`: 2.1.9
- `elasticsearch`: 2.0.0~beta1
- `wordpress`: `WORDPRESS_TABLE_PREFIX` (docker-library/wordpress#98)