### PR TITLE
Add gcc 5.2, remove 4.7, fix minor style issues

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,22 +1,24 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-# Last Modified: 2014-06-12
-4.7.4: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.7
-4.7: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 4.7
-# Docker EOL: 2016-06-12
-
 # Last Modified: 2015-06-23
-4.8.5: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.8
-4.8: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.8
-# Docker EOL: 2017-06-23
+4.8.5: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.8
+4.8: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.8
+# Docker EOL: 2016-06-23
 
 # Last Modified: 2015-06-26
-4.9.3: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.9
-4.9: git://github.com/docker-library/gcc@555b0facd42d0b7742494edf3b8d230e4a6e1b0b 4.9
-# Docker EOL: 2017-06-26
+4.9.3: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
+4.9: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
+4: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
+# Docker EOL: 2016-06-26
 
 # Last Modified: 2015-04-22
-5.1.0: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
-5.1: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
-latest: git://github.com/docker-library/gcc@4b70286ab13a6c4c08efb62983f907d3fa9b1462 5.1
-# Docker EOL: 2017-04-22
+5.1.0: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 5.1
+5.1: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 5.1
+# Docker EOL: 2016-04-22
+
+# Last Modified: 2015-07-16
+5.2.0: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
+5.2: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
+5: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
+latest: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
+# Docker EOL: 2016-07-16


### PR DESCRIPTION
See docker-library/gcc#21 and docker-library/gcc#22 for details.