### PR TITLE
Postgres test enhancements

### DIFF
--- a/test/tests/postgres-basics/run.sh
+++ b/test/tests/postgres-basics/run.sh
@@ -24,7 +24,10 @@ psql() {
 		"$@"
 }
 
-tries=10
+: ${POSTGRES_TEST_TRIES:=10}
+: ${POSTGRES_TEST_SLEEP:=2}
+
+tries="$POSTGRES_TEST_TRIES"
 while ! echo 'SELECT 1' | psql &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
@@ -32,7 +35,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi
-	sleep 2
+	sleep "$POSTGRES_TEST_SLEEP"
 done
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | psql

--- a/test/tests/postgres-basics/run.sh
+++ b/test/tests/postgres-basics/run.sh
@@ -35,6 +35,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep "$POSTGRES_TEST_SLEEP"
 done
 

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -44,6 +44,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep "${POSTGRES_TEST_SLEEP}"
 done
 

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -33,7 +33,10 @@ psql() {
 		"$@"
 }
 
-tries=10
+: ${POSTGRES_TEST_TRIES:=10}
+: ${POSTGRES_TEST_SLEEP:=2}
+
+tries="$POSTGRES_TEST_TRIES"
 while ! echo 'SELECT 1' | psql &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
@@ -41,7 +44,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi
-	sleep 2
+	sleep "${POSTGRES_TEST_SLEEP}"
 done
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | psql)" = 1 ]


### PR DESCRIPTION
This PR updates the `postgres-*` tests to allow the number of connection attempts and sleep duration to be configured. This is helpful when using the tests against derived images that take longer to initialize due to long-running `docker-entrypoint-initdb.d` scripts.

I also made the tests output a "." for each connection attempt to show that the test is still doing something. I think this would be a nice addition to the other tests that have a connection loop. Let me know if you want me to split that changes from this PR and include it in a separate PR that adds that functionality to all such tests.