### PR TITLE
Update ubuntu:wily to 20150829

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - cb63850 Update tarballs
+#  - 6dba3ee Update tarballs
 #    - `ubuntu:precise`: 20150813
 #    - `ubuntu:trusty`: 20150814
 #    - `ubuntu:vivid`: 20150813
-#    - `ubuntu:wily`: 20150818
+#    - `ubuntu:wily`: 20150829
 
 # 20150813
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 precise
-precise-20150813: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 precise
+precise-20150813: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 precise
 
 # 20150814
-14.04.3: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 trusty
-trusty-20150814: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 trusty
+14.04.3: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 trusty
+trusty-20150814: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 trusty
 
 # 20150813
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 vivid
-vivid-20150813: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 vivid
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 vivid
+vivid-20150813: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 vivid
 
-# 20150818
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 wily
-wily-20150818: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@cb63850552bfbdc7faa5f8b7c3b73b14d4e79e40 wily
+# 20150829
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 wily
+wily-20150829: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@6dba3ee12ff996640d1043139d5abf8c744862e2 wily


### PR DESCRIPTION
See also https://github.com/docker/docker/pull/15989.

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 udev : Breaks: systemd (< 224-2) but 224-1ubuntu3 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
The command '/bin/sh -c apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```