### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -17,8 +17,8 @@
 # Docker EOL: 2016-04-22
 
 # Last Modified: 2015-07-16
-5.2.0: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
-5.2: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
-5: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
-latest: git://github.com/docker-library/gcc@8a59b9222b78e6089c59b9b551f5610178e24696 5.2
+5.2.0: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
+5.2: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
+5: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
+latest: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
 # Docker EOL: 2016-07-16

--- a/library/golang
+++ b/library/golang
@@ -22,3 +22,8 @@ latest: git://github.com/docker-library/golang@bcc3800fbed7f5116ff27ae82e0d881ef
 1.5-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 1-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
+
+1.5.0-wheezy: git://github.com/docker-library/golang@58111b7243e7fb03e20c93ec8f0946cbbf5e2fec 1.5/wheezy
+1.5-wheezy: git://github.com/docker-library/golang@58111b7243e7fb03e20c93ec8f0946cbbf5e2fec 1.5/wheezy
+1-wheezy: git://github.com/docker-library/golang@58111b7243e7fb03e20c93ec8f0946cbbf5e2fec 1.5/wheezy
+wheezy: git://github.com/docker-library/golang@58111b7243e7fb03e20c93ec8f0946cbbf5e2fec 1.5/wheezy

--- a/library/percona
+++ b/library/percona
@@ -1,7 +1,7 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.44: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.5
-5.5: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.5
+5.5.45: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
+5.5: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
 
 5.6.25: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
 5.6: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6


### PR DESCRIPTION
- `gcc`: switch 5.2 to jessie (docker-library/gcc#23)
- `golang`: add 1.5-wheezy (docker-library/golang#61)
- `percona`: 5.5.45-rel37.4-1.jessie