### PR TITLE
Improve test retry output

### DIFF
--- a/test/tests/docker-dind/run.sh
+++ b/test/tests/docker-dind/run.sh
@@ -29,6 +29,7 @@ while ! docker_ version &> /dev/null; do
 		docker_ version # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep 2
 done
 

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -36,6 +36,8 @@ while [ "$tried" -ge 0 -a "$(_request GET / --output /dev/null || echo $?)" = 7 
 		exit 1
 	fi
 
+	echo >&2 -n .
+
 	sleep "$duration"
 done
 

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -33,7 +33,8 @@ while [ "$tried" -ge 0 -a "$(_request GET / --output /dev/null || echo $?)" = 7 
 
 	if [ "$tried" -le 0 ]; then
 		echo >&2 "Unable to connect to Jetty. Aborting."
-		exit 1
+		( set -x && docker logs "$cid" ) >&2 || true
+		false
 	fi
 
 	echo >&2 -n .

--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -20,6 +20,7 @@ while ! mongo_eval 'quit(db.stats().ok ? 0 : 1);' &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
 		echo >&2 'mongod failed to accept connections in a reasonable amount of time!'
+		( set -x && docker logs "$cid" ) >&2 || true
 		mongo --eval 'db.stats();' # to hopefully get a useful error message
 		false
 	fi

--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -23,6 +23,7 @@ while ! mongo_eval 'quit(db.stats().ok ? 0 : 1);' &> /dev/null; do
 		mongo --eval 'db.stats();' # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep 2
 done
 

--- a/test/tests/mysql-basics/run.sh
+++ b/test/tests/mysql-basics/run.sh
@@ -42,6 +42,7 @@ while ! echo 'SELECT 1' | mysql &> /dev/null; do
 		echo 'SELECT 1' | mysql # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep 2
 done
 

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -44,6 +44,7 @@ while ! echo 'SELECT 1' | mysql &> /dev/null; do
 		echo 'SELECT 1' | mysql # to hopefully get a useful error message
 		false
 	fi
+	echo >&2 -n .
 	sleep 2
 done
 

--- a/test/tests/postgres-basics/run.sh
+++ b/test/tests/postgres-basics/run.sh
@@ -32,6 +32,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
 		echo >&2 'postgres failed to accept connections in a reasonable amount of time!'
+		( set -x && docker logs "$cid" ) >&2 || true
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -41,6 +41,7 @@ while ! echo 'SELECT 1' | psql &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
 		echo >&2 'postgres failed to accept connections in a reasonable amount of time!'
+		( set -x && docker logs "$cid" ) >&2 || true
 		echo 'SELECT 1' | psql # to hopefully get a useful error message
 		false
 	fi


### PR DESCRIPTION
This PR updates all the tests that have a retry connection loop to output a period for each connection attempt. It also has them dump the output of `docker logs` to aid in debugging.

It's probably worth pulling this code into a function that can be reused across tests instead of copying and pasting the boilerplate.