### PR TITLE
Update PHP 7.0 to RC2

### DIFF
--- a/library/php
+++ b/library/php
@@ -41,17 +41,17 @@ apache: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b1
 5-fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
 fpm: git://github.com/docker-library/php@789a45b03fe31ca1ac7f490bafe300e728b18bb9 5.6/fpm
 
-7.0.0RC1-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
-7.0-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
-7-cli: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
-7.0.0RC1: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
-7.0: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
-7: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0
+7.0.0RC2-cli: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
+7.0-cli: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
+7-cli: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
+7.0.0RC2: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
+7.0: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
+7: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0
 
-7.0.0RC1-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
-7.0-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
-7-apache: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/apache
+7.0.0RC2-apache: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/apache
+7.0-apache: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/apache
+7-apache: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/apache
 
-7.0.0RC1-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm
-7-fpm: git://github.com/docker-library/php@f5e091ac3815dce80ca496298e0cb94638844b10 7.0/fpm
+7.0.0RC2-fpm: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/fpm
+7-fpm: git://github.com/docker-library/php@8c25cfb2c5773a02e98ad7488a65db5123d4f2f7 7.0/fpm


### PR DESCRIPTION
Followup to PR on php repo which has been merged: https://github.com/docker-library/php/commit/8c25cfb2c5773a02e98ad7488a65db5123d4f2f7#diff-01deebfa87b938c89ecb3dcb4effcbe2