### PR TITLE
Update debian with 2015-09-07 debootstraps, especially for 7.9 and 8.2

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -2,41 +2,41 @@
 # maintainer: Paul Tagliamonte <paultag@debian.org> (@paultag)
 
 # commits: (master..dist)
-#  - b962c5c 2015-08-20 debootstraps
+#  - 89e5cad 2015-09-07 debootstraps
 
-8.1: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c jessie
-8: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c jessie
-jessie: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c jessie
-latest: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c jessie
+8.2: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 jessie
+8: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 jessie
+jessie: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 jessie
+latest: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 jessie
 
-jessie-backports: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c jessie/backports
+jessie-backports: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 jessie/backports
 
-oldstable: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 oldstable
 
-oldstable-backports: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c oldstable/backports
+oldstable-backports: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 oldstable/backports
 
-sid: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c sid
+sid: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c squeeze
-6.0: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c squeeze
-6: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 squeeze
+6: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c stable
+stable: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 stable
 
-stable-backports: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c stable/backports
+stable-backports: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 stable/backports
 
-stretch: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c stretch
+stretch: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 stretch
 
-testing: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c testing
+testing: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c unstable
+unstable: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 unstable
 
-7.8: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c wheezy
-7: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c wheezy
+7.9: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 wheezy
+7: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 wheezy
 
-wheezy-backports: git://github.com/tianon/docker-brew-debian@b962c5cf4cc855bd0ad2dae2dd21dc7a691f368c wheezy/backports
+wheezy-backports: git://github.com/tianon/docker-brew-debian@89e5cad1df49d5d6778a9d7cb23d4de2639e1542 wheezy/backports
 
-rc-buggy: git://github.com/tianon/dockerfiles@bd2201002c61d439005bb7e7f9fa42593a561651 debian/rc-buggy
-experimental: git://github.com/tianon/dockerfiles@bd2201002c61d439005bb7e7f9fa42593a561651 debian/experimental
+rc-buggy: git://github.com/tianon/dockerfiles@698f86772367cf08c80396a1624b4d8fb59f94aa debian/rc-buggy
+experimental: git://github.com/tianon/dockerfiles@698f86772367cf08c80396a1624b4d8fb59f94aa debian/experimental


### PR DESCRIPTION
Also, a large amount of the GCC-5 transition made it into testing! (https://lists.debian.org/debian-devel-announce/2015/09/msg00001.html)