### PR TITLE
Retry script for tests

### DIFF
--- a/test/retry.sh
+++ b/test/retry.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+opts="$(getopt -o 'i:c:t:s:' --long 'image:,cid:,tries:,sleep:' -- "$@")"
+eval set -- "$opts"
+while true; do
+	flag=$1
+	shift
+	case "$flag" in
+		--image|-i) image="$1" && shift ;;
+		--cid|-c) cid="$1" && shift ;;
+		--tries|-t) tries="$1" && shift ;;
+		--sleep|-s) sleep="$1" && shift ;;
+		--) break;;
+	esac
+done
+
+if [ $# -eq 0 ]; then
+	echo >&2 'retry.sh requires a command to run'
+	false
+fi
+
+: ${tries:=10}
+: ${sleep:=2}
+
+while ! eval "$@" &> /dev/null; do
+	(( tries-- ))
+	if [ $tries -le 0 ]; then
+		echo >&2 "${image:-the container} failed to accept connections in a reasonable amount of time!"
+		[ "$cid" ] && ( set -x && docker logs "$cid" ) >&2 || true
+		eval "$@" # to hopefully get a useful error message
+		false
+	fi
+	echo >&2 -n .
+	sleep "$sleep"
+done

--- a/test/run.sh
+++ b/test/run.sh
@@ -18,43 +18,6 @@ environments.
 EOUSAGE
 }
 
-retry() {
-	[ -z "$image" -o -z "$cid" ] && { echo >&2 'The retry function requires $image and $cid to be set'; false; }
-
-	opts="$(getopt -o 't:s:' --long 'tries:,sleep:' -- "$@")"
-	eval set -- "$opts"
-	while true; do
-		flag=$1
-		shift
-		case "$flag" in
-			--tries|-t) tries="$1" && shift ;;
-			--sleep|-s) sleep="$1" && shift ;;
-			--) break;;
-		esac
-	done
-
-	if [ $# -eq 0 ]; then
-		echo >&2 'The retry function requires a command to run'
-		false
-	fi
-
-	: ${tries:=10}
-	: ${sleep:=2}
-
-	while ! eval "$@" &> /dev/null; do
-		(( tries-- ))
-		if [ $tries -le 0 ]; then
-			echo >&2 "$image failed to accept connections in a reasonable amount of time!"
-			( set -x && docker logs "$cid" ) >&2 || true
-			eval "$@" # to hopefully get a useful error message
-			false
-		fi
-		echo >&2 -n .
-		sleep "$sleep"
-	done
-}
-export -f retry
-
 # arg handling
 opts="$(getopt -o 'ht:?' --long 'dry-run,help,test:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"

--- a/test/tests/docker-dind/run.sh
+++ b/test/tests/docker-dind/run.sh
@@ -20,18 +20,7 @@ docker_() {
 		"$@"
 }
 
-tries=10
-while ! docker_ version &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		echo >&2 'docker daemon failed to accept connections in a reasonable amount of time!'
-		( set -x && docker logs "$cid" ) >&2 || true
-		docker_ version # to hopefully get a useful error message
-		false
-	fi
-	echo >&2 -n .
-	sleep 2
-done
+retry 'docker_ version'
 
 docker_ pull busybox
 

--- a/test/tests/docker-dind/run.sh
+++ b/test/tests/docker-dind/run.sh
@@ -20,7 +20,7 @@ docker_() {
 		"$@"
 }
 
-retry 'docker_ version'
+. "$dir/../../retry.sh" 'docker_ version'
 
 docker_ pull busybox
 

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ "$DEBUG" ] && set -x
+
 set -eo pipefail
 
 dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
@@ -25,7 +27,7 @@ _request() {
 }
 
 # Make sure that Jetty is listening on port 8080
-retry --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" = 7 ]'
+. "$dir/../../retry.sh" --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" = 7 ]'
 
 # Check that we can request /index.jsp with no params
 [ "$(_request GET "/" | tail -1)" = "null" ]

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -25,22 +25,7 @@ _request() {
 }
 
 # Make sure that Jetty is listening on port 8080
-attempts=40
-tried="$attempts"
-duration=0.25
-while [ "$tried" -ge 0 -a "$(_request GET / --output /dev/null || echo $?)" = 7 ]; do
-	(( tried-- ))
-
-	if [ "$tried" -le 0 ]; then
-		echo >&2 "Unable to connect to Jetty. Aborting."
-		( set -x && docker logs "$cid" ) >&2 || true
-		false
-	fi
-
-	echo >&2 -n .
-
-	sleep "$duration"
-done
+retry --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" = 7 ]'
 
 # Check that we can request /index.jsp with no params
 [ "$(_request GET "/" | tail -1)" = "null" ]

--- a/test/tests/mysql-basics/run.sh
+++ b/test/tests/mysql-basics/run.sh
@@ -33,7 +33,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-retry "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" "echo 'SELECT 1' | mysql"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | mysql
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 0 ]

--- a/test/tests/mysql-basics/run.sh
+++ b/test/tests/mysql-basics/run.sh
@@ -33,18 +33,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-tries=20
-while ! echo 'SELECT 1' | mysql &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		echo >&2 'mysqld failed to accept connections in a reasonable amount of time!'
-		( set -x && docker logs "$cid" ) >&2 || true
-		echo 'SELECT 1' | mysql # to hopefully get a useful error message
-		false
-	fi
-	echo >&2 -n .
-	sleep 2
-done
+retry "echo 'SELECT 1' | mysql"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | mysql
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 0 ]

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -35,18 +35,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-tries=20
-while ! echo 'SELECT 1' | mysql &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		echo >&2 'mysqld failed to accept connections in a reasonable amount of time!'
-		( set -x && docker logs "$cid" ) >&2 || true
-		echo 'SELECT 1' | mysql # to hopefully get a useful error message
-		false
-	fi
-	echo >&2 -n .
-	sleep 2
-done
+retry --tries 20 "echo 'SELECT 1' | mysql"
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 1 ]
 [ "$(echo 'SELECT c FROM test' | mysql)" = 'goodbye!' ]

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -35,7 +35,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-retry --tries 20 "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" --tries 20 "echo 'SELECT 1' | mysql"
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 1 ]
 [ "$(echo 'SELECT c FROM test' | mysql)" = 'goodbye!' ]

--- a/test/tests/postgres-basics/run.sh
+++ b/test/tests/postgres-basics/run.sh
@@ -24,21 +24,7 @@ psql() {
 		"$@"
 }
 
-: ${POSTGRES_TEST_TRIES:=10}
-: ${POSTGRES_TEST_SLEEP:=2}
-
-tries="$POSTGRES_TEST_TRIES"
-while ! echo 'SELECT 1' | psql &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		echo >&2 'postgres failed to accept connections in a reasonable amount of time!'
-		( set -x && docker logs "$cid" ) >&2 || true
-		echo 'SELECT 1' | psql # to hopefully get a useful error message
-		false
-	fi
-	echo >&2 -n .
-	sleep "$POSTGRES_TEST_SLEEP"
-done
+retry --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | psql
 [ "$(echo 'SELECT COUNT(*) FROM test' | psql)" = 0 ]

--- a/test/tests/postgres-basics/run.sh
+++ b/test/tests/postgres-basics/run.sh
@@ -24,7 +24,7 @@ psql() {
 		"$@"
 }
 
-retry --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
+. "$dir/../../retry.sh" --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | psql
 [ "$(echo 'SELECT COUNT(*) FROM test' | psql)" = 0 ]

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -33,7 +33,7 @@ psql() {
 		"$@"
 }
 
-retry --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
+. "$dir/../../retry.sh" --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | psql)" = 1 ]
 [ "$(echo 'SELECT c FROM test' | psql)" = 'goodbye!' ]

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -33,21 +33,7 @@ psql() {
 		"$@"
 }
 
-: ${POSTGRES_TEST_TRIES:=10}
-: ${POSTGRES_TEST_SLEEP:=2}
-
-tries="$POSTGRES_TEST_TRIES"
-while ! echo 'SELECT 1' | psql &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		echo >&2 'postgres failed to accept connections in a reasonable amount of time!'
-		( set -x && docker logs "$cid" ) >&2 || true
-		echo 'SELECT 1' | psql # to hopefully get a useful error message
-		false
-	fi
-	echo >&2 -n .
-	sleep "${POSTGRES_TEST_SLEEP}"
-done
+retry --tries "$POSTGRES_TEST_TRIES" --sleep "$POSTGRES_TEST_SLEEP" "echo 'SELECT 1' | psql"
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | psql)" = 1 ]
 [ "$(echo 'SELECT c FROM test' | psql)" = 'goodbye!' ]


### PR DESCRIPTION
As discussed in #1025, I've refactored the retry functionality into a helper script.

I've converted all of the tests with retry loops to use this function, except for `mongo-basics`. The reason I didn't convert that one yet is that it uses a different command for the retry loop and for the final attempt to get error output.

I also don't much like the use of `. "$dir/../../retry.sh"`, but I couldn't figure out a better way to do it. Besides the hokey relative path thing, the reason I source `retry.sh` instead of just executing it is to ensure that functions declared in the test are still in scope without having to use `export -f` to make them visible.