### PR TITLE
bump for Alpine 3.2.3 and musl security fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,12 +1,12 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-edge: git://github.com/gliderlabs/docker-alpine@30dffbd27c88623a061804f8d36f46991edf354f versions/library-edge
+2.6: git://github.com/gliderlabs/docker-alpine@c369eb24b9cd81149b355fc785173e3dde098001 versions/library-2.6
 
-3.2: git://github.com/gliderlabs/docker-alpine@f2e97b32d9d5a3378ceddf33d30623106517a3a8 versions/library-3.2
-latest: git://github.com/gliderlabs/docker-alpine@f2e97b32d9d5a3378ceddf33d30623106517a3a8 versions/library-3.2
+2.7: git://github.com/gliderlabs/docker-alpine@19859598cbba40c4b8851339164c3998694dee65 versions/library-2.7
 
-3.1: git://github.com/gliderlabs/docker-alpine@c843254fc27384286fe6218815919a61cff74e83 versions/library-3.1
+3.1: git://github.com/gliderlabs/docker-alpine@1a65d4ea2ceb1db6d1579c99226a0858c45563ce versions/library-3.1
 
-2.7: git://github.com/gliderlabs/docker-alpine@b05051f894698f86133174ef1967ba9e4057ddf5 versions/library-2.7
+3.2: git://github.com/gliderlabs/docker-alpine@7621dffecfb794a7639dabb468732102e6f265bb versions/library-3.2
+latest: git://github.com/gliderlabs/docker-alpine@7621dffecfb794a7639dabb468732102e6f265bb versions/library-3.2
 
-2.6: git://github.com/gliderlabs/docker-alpine@a4928ccda5c1c3e4555c361d938cf0d393d4da06 versions/library-2.6
+edge: git://github.com/gliderlabs/docker-alpine@16384184f6870fa786e7dc590bf9fdbddee77bd7 versions/library-edge


### PR DESCRIPTION
Related to #878. Bumping Alpine for 3.2.3 which contains some security fixes.