### PR TITLE
Update websphere-liberty images to 8.5.5.7

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,16 +1,16 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@dcurrie)
 
-kernel: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/kernel
-8.5.5.6-kernel: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/common
-8.5.5.6-common: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.6-webProfile6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.6-webProfile7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
-8.5.5.6-javaee7: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
-8.5.5.6: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@c424138b69111e82fbacb08fb4f18913d2e977fd websphere-liberty/8.5.5/developer/javaee7
+kernel: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/kernel
+8.5.5.6-kernel: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/common
+8.5.5.6-common: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.6-webProfile6: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.6-webProfile7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.6-javaee7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.6: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
 beta: git://github.com/WASdev/ci.docker@65818b1c55cce5c9eac55c8ece2c2bc97f789d9d websphere-liberty/beta


### PR DESCRIPTION
NB: override-cmd tests will still fail - looking to discuss the license acceptance issue at a face-to-face meeting next week