### PR TITLE
Added spagobi official library definition file

### DIFF
--- a/library/spagobi
+++ b/library/spagobi
@@ -1,0 +1,6 @@
+# maintainer: Fabrizio Lovato <fabrizio.lovato@eng.it> (@fabrizyo)
+
+5.1-all-in-one: git://github.com/EngineeringSPA/SpagoBI-Docker@5336ddd1a400b42d86cc42427736d022ce66ae08 5.1-all-in-one
+all-in-one: git://github.com/EngineeringSPA/SpagoBI-Docker@5336ddd1a400b42d86cc42427736d022ce66ae08 5.1-all-in-one
+5.1: git://github.com/EngineeringSPA/SpagoBI-Docker@5336ddd1a400b42d86cc42427736d022ce66ae08 5.1-all-in-one
+5: git://github.com/EngineeringSPA/SpagoBI-Docker@5336ddd1a400b42d86cc42427736d022ce66ae08 5.1-all-in-one


### PR DESCRIPTION
Hi,
  I'm in charge to dockerize SpagoBI: it's a opensource suite for Business Intelligence. I would add SpagoBI official docker files to the official library repository of Docker. You can retrieve information of SpagoBI project from these sites:
web site: http://www.spagobi.org
github project: https://github.com/EngineeringSPA/SpagoBI
forge project: http://forge.ow2.org/projects/spagobi
Fiware catalogue : http://catalogue.fiware.org/enablers/data-visualization-spagobi

thanks