### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.21: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
-10.0: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
-10: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
-latest: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 10.0
+10.0.21: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
+10.0: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
+10: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
+latest: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
 
-5.5.45: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5
-5.5: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5
-5: git://github.com/docker-library/mariadb@eb767c72883d3a79d07e27614233e73988f6fad3 5.5
+5.5.45: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5
+5.5: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5
+5: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,14 +4,14 @@
 6.0: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
 6: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
 
-7.0.8: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 7.0
-7.0: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 7.0
-7: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 7.0
+7.0.10: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
+7.0: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
+7: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
 
-8.0.6: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.0
-8.0: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.0
+8.0.8: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.0
+8.0: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.0
 
-8.1.1: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.1
-8.1: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.1
-8: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.1
-latest: git://github.com/docker-library/owncloud@4596b4e046d6895d4d832637aa08fc723198a511 8.1
+8.1.3: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
+8.1: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
+8: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
+latest: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1

--- a/library/percona
+++ b/library/percona
@@ -3,7 +3,7 @@
 5.5.45: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
 5.5: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
 
-5.6.25: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
-5.6: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
-5: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
-latest: git://github.com/docker-library/percona@d0357504f95ce16892001f2ea4199ae21cd64185 5.6
+5.6.26: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
+5.6: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
+5: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
+latest: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.3.0-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-4.3.0: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-4.3-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-4.3: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-4-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-apache: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-4: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
-latest: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af apache
+4.3.1-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4.3.1: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4.3-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4.3: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+latest: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
 
-4.3.0-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
-4.3-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
-4-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
-fpm: git://github.com/docker-library/wordpress@3447b0ea9c1eccf1e00feb8e2e70c311690763af fpm
+4.3.1-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
+4.3-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
+4-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
+fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm


### PR DESCRIPTION
- `mariadb`: pass options on first run (docker-library/mariadb#23)
- `owncloud`: 8.1.3, 8.0.8, and 7.0.10
- `percona`: 5.6.26-74.0-1.jessie
- `wordpress`: 4.3.1