### PR TITLE
fix node:0 alias tag and add node:4 alias tag

### DIFF
--- a/library/node
+++ b/library/node
@@ -14,32 +14,36 @@
 
 0.12.7: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
 0.12: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
+0: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
 
 0.12.7-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
 
 0.12.7-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
 0.12-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
 
 0.12.7-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 
 4.0.0: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
 4.0: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
-0: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
+4: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
 latest: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
 
 4.0.0-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
 4.0-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
 onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
 
 4.0.0-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
 4.0-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
-0-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
+4-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
 slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
 
 4.0.0-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
 4.0-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
 wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy


### PR DESCRIPTION
This fixes an issue with the node:0 tag was pointing to 4.0.0 when is should point to 0.12.7. This also introduces node:4 which points to node:4.0.0