### PR TITLE
Updated Oracle Linux 7.1 image

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,16 +1,16 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/7.1
-7: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/7.1
-7.1: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/7.1
-7.0: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/7.0
+latest: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
+7: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
+7.1: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
+7.0: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/6.7
-6.7: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/6.7
-6.6: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/6.6
+6: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.7
+6.7: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.7
+6.6: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/5.11
-5.11: git://github.com/oracle/docker.git@b7ebd0e94eb2abc4932a9e1d27cf1ba9645e0d5c OracleLinux/5.11
+5: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/5.11
+5.11: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/5.11


### PR DESCRIPTION
Tiny update to the base Oracle Linux 7 image to include Oracle-specific RPM macros for build purposes. This change was already made to the OL6 image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>