### PR TITLE
Update Node.js to v4.1.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,22 +28,22 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 
-4.0.0: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
-4.0: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
-4: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
-latest: git://github.com/nodejs/docker-node@c2a8075f1e3155577c071bf1178c59370bb76d1a 4.0
+4.1.0: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1
+4.1: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1
+4: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1
+latest: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1
 
-4.0.0-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
-4.0-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
-onbuild: git://github.com/nodejs/docker-node@e763a1065077c580aab4d73945597c0b160b4ee2 4.0/onbuild
+4.1.0-onbuild: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/onbuild
+4.1-onbuild: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/onbuild
+onbuild: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/onbuild
 
-4.0.0-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
-4.0-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
-4-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
-slim: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/slim
+4.1.0-slim: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/slim
+4.1-slim: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/slim
+4-slim: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/slim
+slim: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/slim
 
-4.0.0-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
-4.0-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
-wheezy: git://github.com/nodejs/docker-node@abade3a2ce359068516dc4f84ec0824b2393cfbb 4.0/wheezy
+4.1.0-wheezy: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/wheezy
+4.1-wheezy: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/wheezy
+wheezy: git://github.com/nodejs/docker-node@cfc9c3b0dbcbbd3211aec6d525b80ca5e7d1e9ad 4.1/wheezy


### PR DESCRIPTION
This updates Node.js to v4.1.0 per https://github.com/nodejs/docker-node/pull/45