### PR TITLE
add solr

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,0 +1,7 @@
+# maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
+# maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
+
+5.3.0: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
+5.3: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
+5: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
+latest: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3

--- a/library/solr
+++ b/library/solr
@@ -1,7 +1,7 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.0: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
-5.3: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
-5: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
-latest: git://github.com/docker-solr/docker-solr@39b20393652644fc5e0fe2a34d4bda1c257f8ed6 5.3
+5.3.1: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
+5.3: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
+5: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
+latest: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3

--- a/library/solr
+++ b/library/solr
@@ -1,7 +1,7 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.1: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
-5.3: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
-5: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
-latest: git://github.com/docker-solr/docker-solr@9a0cda7b3142c6b5f63642e9c8669cf15dad8b3a 5.3
+5.3.1: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
+5.3: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
+5: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
+latest: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3

--- a/library/solr
+++ b/library/solr
@@ -1,7 +1,7 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.1: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
-5.3: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
-5: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
-latest: git://github.com/docker-solr/docker-solr@d716be08247ec27461d1d22c21d9909edfa46bbd 5.3
+5.3.1: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
+5.3: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
+5: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
+latest: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3


### PR DESCRIPTION
This is a PR to add a Dockerfile for Solr.

Solr is the popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.

This image is based on the popular makuk66/docker-solr image, which it will replace.