### PR TITLE
Update cassandra, golang, redmine

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,7 +1,7 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.16: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
-2.0: git://github.com/docker-library/cassandra@ebbf1631a1d8fb4072bf61a0451a5f7b901e81ab 2.0
+2.0.17: git://github.com/docker-library/cassandra@5d31a1e20371873affd9ce8ea630aedb94618471 2.0
+2.0: git://github.com/docker-library/cassandra@5d31a1e20371873affd9ce8ea630aedb94618471 2.0
 
 2.1.9: git://github.com/docker-library/cassandra@c7d43443c2e80ee9edd0814c8e8332781f7d93ae 2.1
 2.1: git://github.com/docker-library/cassandra@c7d43443c2e80ee9edd0814c8e8332781f7d93ae 2.1

--- a/library/golang
+++ b/library/golang
@@ -1,17 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
 
-1.4.2: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.4
-1.4: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.4
+1.4.3: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4
+1.4: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4
 
-1.4.2-onbuild: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/onbuild
+1.4.3-onbuild: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/onbuild
 1.4-onbuild: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/onbuild
 
-1.4.2-cross: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/cross
+1.4.3-cross: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/cross
 1.4-cross: git://github.com/docker-library/golang@3427e88341de17a4d8921b859180a2649e1ab96e 1.4/cross
 
-1.4.2-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.4/wheezy
-1.4-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.4/wheezy
+1.4.3-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
+1.4-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
 
 1.5.1: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
 1.5: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5

--- a/library/redmine
+++ b/library/redmine
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.6: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
-2.6: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
-2: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 2.6
+2.6.7: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
+2.6: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
+2: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
 
-2.6.6-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
+2.6.7-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
 2.6-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
 2-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
 
-3.0.4: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
-3.0: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
-3: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
-latest: git://github.com/docker-library/redmine@bcd0f77f268bb86dafd4afba0a0b36f478cf767f 3.0
+3.0.5: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
+3.0: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
+3: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
+latest: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 
-3.0.4-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
+3.0.5-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
 3.0-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
 3-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
 passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger


### PR DESCRIPTION
- `cassandra` bump to 2.0.17
- `golang` bump to 1.4.3
- `redmine` bump to 3.0.5 and 2.6.7