### PR TITLE
Support for Erlang OTP on Docker

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,0 +1,10 @@
+# maintainer: denc716@gmail.com (@c0b)
+
+18.1.3: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
+18.1:   git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
+18:     git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
+latest: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
+
+17.5.6.4: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
+17.5:     git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
+17:       git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17

--- a/test/config.sh
+++ b/test/config.sh
@@ -42,6 +42,9 @@ imageTests+=(
 	[elasticsearch]='
 		elasticsearch-basics
 	'
+	[erlang]='
+		erlang-hello-world
+	'
 	[gcc]='
 		gcc-c-hello-world
 		gcc-cpp-hello-world

--- a/test/tests/erlang-hello-world/expected-std-out.txt
+++ b/test/tests/erlang-hello-world/expected-std-out.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/test/tests/erlang-hello-world/hello-world.erl
+++ b/test/tests/erlang-hello-world/hello-world.erl
@@ -1,0 +1,6 @@
+#!/usr/bin/env escript
+
+-module('hello-world').
+
+main(_) ->
+  io:format("Hello World!~n").

--- a/test/tests/erlang-hello-world/run.sh
+++ b/test/tests/erlang-hello-world/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+image="$1"
+dirTest="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+dirContainer='/usr/src/erlang'
+
+docker run --rm -v "$dirTest":"$dirContainer":ro -w "$dirContainer" "$image" escript hello-world.erl


### PR DESCRIPTION
There is no [official erlang images](https://hub.docker.com/_/erlang/) yet, I'm trying to make it happen; please let me know if any additional work need to do

+This is used as docker base image for Erlang OTP.
+
+One latest version for each of Last four major version: 18, 17, R16, R15 will be supported.

### http://www.erlang.org/download.html
Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability.