### PR TITLE
Update docker-library images

### DIFF
--- a/library/owncloud
+++ b/library/owncloud
@@ -1,17 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.9: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
-6.0: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
-6: git://github.com/docker-library/owncloud@d691efbe821094e710340aa025ff98788a7464ed 6.0
+6.0.9: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
+6.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
+6: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
 
-7.0.10: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
-7.0: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
-7: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 7.0
+7.0.10: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
+7.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
+7: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
 
-8.0.8: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.0
-8.0: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.0
+8.0.8: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.0
+8.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.0
 
-8.1.3: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
-8.1: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
-8: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
-latest: git://github.com/docker-library/owncloud@229e1b831dbe7342f0c34bc4a9b5385f55b2989d 8.1
+8.1.3: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
+8.1: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
+8: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
+latest: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.4: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf
-3.5: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf
-3: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf
-latest: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf
+3.5.5: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
+3.5: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
+3: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
+latest: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
 
-3.5.4-management: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf management
-3.5-management: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf management
-3-management: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf management
-management: git://github.com/docker-library/rabbitmq@bb91e64b5664a4ab5cd681b7501a2830edbe9ddf management
+3.5.5-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
+3.5-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
+3-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
+management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management

--- a/library/redmine
+++ b/library/redmine
@@ -4,16 +4,16 @@
 2.6: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
 2: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
 
-2.6.7-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 2.6/passenger
+2.6.7-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
 
 3.0.5: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 3.0: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 3: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 latest: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 
-3.0.5-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
-passenger: git://github.com/docker-library/redmine@5941e7f2d55015dc90df0224c4cc4199e1f6a83d 3.0/passenger
+3.0.5-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
+passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger


### PR DESCRIPTION
- `owncloud`: PHP 5.6 + opcache (docker-library/owncloud#27)
- `rabbitmq`: 3.5.5, remove `tini`, switch to jessie (docker-library/rabbitmq#41, docker-library/rabbitmq#42)
- `redmine`: passenger 5.0.20