### PR TITLE
Official docker image for Source Mage GNU/Linux

### DIFF
--- a/library/sourcemage
+++ b/library/sourcemage
@@ -1,4 +1,4 @@
 # maintainer: Vlad Glagolev <stealth@sourcemage.org> (@vaygr)
 
-latest: git://github.com/vaygr/docker-sourcemage@9f3fb9798195f0a294bfb3a5c41f9affccece740 stable
-0.61: git://github.com/vaygr/docker-sourcemage@9f3fb9798195f0a294bfb3a5c41f9affccece740 stable
+latest: git://github.com/vaygr/docker-sourcemage@6cba47f6e2abffc361d940ac46ba3e846a5ff6c8 stable
+0.61: git://github.com/vaygr/docker-sourcemage@6cba47f6e2abffc361d940ac46ba3e846a5ff6c8 stable

--- a/library/sourcemage
+++ b/library/sourcemage
@@ -1,0 +1,4 @@
+# maintainer: Vlad Glagolev <stealth@sourcemage.org> (@vaygr)
+
+latest: git://github.com/vaygr/docker-sourcemage@9f3fb9798195f0a294bfb3a5c41f9affccece740 stable
+0.61: git://github.com/vaygr/docker-sourcemage@9f3fb9798195f0a294bfb3a5c41f9affccece740 stable

--- a/library/sourcemage
+++ b/library/sourcemage
@@ -1,4 +1,4 @@
 # maintainer: Vlad Glagolev <stealth@sourcemage.org> (@vaygr)
 
-latest: git://github.com/vaygr/docker-sourcemage@6cba47f6e2abffc361d940ac46ba3e846a5ff6c8 stable
-0.61: git://github.com/vaygr/docker-sourcemage@6cba47f6e2abffc361d940ac46ba3e846a5ff6c8 stable
+latest: git://github.com/vaygr/docker-sourcemage@2d7efdca5633554194e2b12fae334ac4b6804b25 stable
+0.61: git://github.com/vaygr/docker-sourcemage@2d7efdca5633554194e2b12fae334ac4b6804b25 stable


### PR DESCRIPTION
Here's a request for inclusion of our official "sourcemage" image into official docker group.

[Source Mage GNU/Linux](http://www.sourcemage.org) is some super-flexible source-based Linux distro ([upcoming beta site](http://beta.sourcemage.ru)). It is one of the [oldest](http://beta.sourcemage.ru/linux-timeline.png) distros available, and even while being not so popular, it still takes [its niche](http://beta.sourcemage.ru/About) quite well.

These images are based on our chroot images and have been tested from [my own repository](https://hub.docker.com/r/vaygr/sourcemage/) at the Hub. The tarballs for these images are GPG-signed and available for check via our public key distributed on all general PGP public directories. They can be accessed directly [on some](http://www.sourcemage.ru/image/official/) of our mirrors as well.

The request for docs is also in-place from [this repository](https://github.com/vaygr/docker-library-docs/tree/sourcemage).

[Intro page](http://beta.sourcemage.ru/Intro) is there if you need some more information on how our system works.
You can also find us lurking on #sourcemage at Freenode IRC network and ask a question!

Thanks!