### PR TITLE
Add Couchbase Server 4.0.0

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,21 +1,25 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
-enterprise: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
+latest: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
+enterprise: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
+community: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/4.0.0
 
-3.1.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
-enterprise-3.1.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.1.0
+4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
+enterprise-4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
+community-4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/4.0.0
 
-3.0.3: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.3
-enterprise-3.0.3: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.3
+3.1.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.1.0
+enterprise-3.1.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.1.0
 
-3.0.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.2
-enterprise-3.0.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/3.0.2
+3.0.3: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.3
+enterprise-3.0.3: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.3
 
-community: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/3.0.1
-community-3.0.1: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/3.0.1
+3.0.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.2
+enterprise-3.0.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.2
 
-2.5.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/2.5.2
-enterprise-2.5.2: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c enterprise/couchbase-server/2.5.2
+community-3.0.1: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/3.0.1
 
-community-2.2.0: git://github.com/couchbase/docker@dcf715fcfdc88225700ee76e437d1d4522ae150c community/couchbase-server/2.2.0
+2.5.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/2.5.2
+enterprise-2.5.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/2.5.2
+
+community-2.2.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/2.2.0


### PR DESCRIPTION
This updates our tags to include 4.0.0 enterprise and community, and resets the generic "enterprise" and "community" tags to point to 4.0.0.

It also includes one minor change to the Dockerfile compared to the previous official version - adding LD_LIBRARY_PATH to the environment.