### PR TITLE
Update the registry official image to point to a go1.4.3-built registry

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -7,6 +7,6 @@ latest: git://github.com/docker/docker-registry@0.9.1
 0.8.1: git://github.com/docker/docker-registry@0.8.1
 0.9.1: git://github.com/docker/docker-registry@0.9.1
 
-2: git://github.com/docker/distribution-library-image@0258654c749c96ca876b1d9ce456bee42b6794de
-2.1: git://github.com/docker/distribution-library-image@0258654c749c96ca876b1d9ce456bee42b6794de
-2.1.1: git://github.com/docker/distribution-library-image@0258654c749c96ca876b1d9ce456bee42b6794de
+2: git://github.com/docker/distribution-library-image@d5f65e019f029d7361be605b14180c93eddaf422
+2.1: git://github.com/docker/distribution-library-image@d5f65e019f029d7361be605b14180c93eddaf422
+2.1.1: git://github.com/docker/distribution-library-image@d5f65e019f029d7361be605b14180c93eddaf422


### PR DESCRIPTION
Signed-off-by: Richard Scothern <richard.scothern@gmail.com>