### PR TITLE
Odoo updates + new image for Odoo 9.0 community

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,5 +1,8 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@0afa334549c20c2a00eb1b8f5540c2f35bd7cac4 8.0
-8: git://github.com/odoo/docker@0afa334549c20c2a00eb1b8f5540c2f35bd7cac4 8.0
-latest: git://github.com/odoo/docker@0afa334549c20c2a00eb1b8f5540c2f35bd7cac4 8.0
+8.0: git://github.com/odoo/docker@6e12a6494782a2aec83346cae9c77d971b0d73b3 8.0
+8: git://github.com/odoo/docker@6e12a6494782a2aec83346cae9c77d971b0d73b3 8.0
+
+9.0: git://github.com/odoo/docker@6e12a6494782a2aec83346cae9c77d971b0d73b3 9.0
+9: git://github.com/odoo/docker@6e12a6494782a2aec83346cae9c77d971b0d73b3 9.0
+latest: git://github.com/odoo/docker@6e12a6494782a2aec83346cae9c77d971b0d73b3 9.0


### PR DESCRIPTION
- Add Odoo 9.0 community, version 20151008
- Update Odoo 8.0 to version 20151008
- Fix an issue with the barcodes not being printed in reports
- Fix access rights issues of /mnt/extra-addons
- Simplify install of lessc
- Fix the priority order of the addons_path in openerp-server.conf

Complete diff: https://github.com/odoo/docker/compare/0afa334549c20c2a00eb1b8f5540c2f35bd7cac4...6e12a6494782a2aec83346cae9c77d971b0d73b3

Regards