### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@91a45111ac40c3e1fc43ad914f7c4e141f84e4b2 7
 latest: git://github.com/docker-library/drupal@91a45111ac40c3e1fc43ad914f7c4e141f84e4b2 7
 
-8.0.0-beta16: git://github.com/docker-library/drupal@88ecb313e0ba12744bc3fc10205f950c85768b11 8
-8.0.0: git://github.com/docker-library/drupal@88ecb313e0ba12744bc3fc10205f950c85768b11 8
-8.0: git://github.com/docker-library/drupal@88ecb313e0ba12744bc3fc10205f950c85768b11 8
-8: git://github.com/docker-library/drupal@88ecb313e0ba12744bc3fc10205f950c85768b11 8
+8.0.0-rc1: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
+8.0.0: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
+8.0: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
+8: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8

--- a/library/mongo
+++ b/library/mongo
@@ -15,5 +15,5 @@
 3: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
 latest: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
 
-3.1.8: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.1
-3.1: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.1
+3.1.9: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1
+3.1: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1

--- a/library/postgres
+++ b/library/postgres
@@ -3,19 +3,19 @@
 9.0.22: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
 9.0: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
 
-9.1.18: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.1
-9.1: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.1
+9.1.19: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.1
+9.1: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.1
 
-9.2.13: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.2
-9.2: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.2
+9.2.14: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.2
+9.2: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.2
 
-9.3.9: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.3
-9.3: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.3
+9.3.10: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.3
+9.3: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.3
 
-9.4.4: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
-9.4: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
-9: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
-latest: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.4
+9.4.5: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
+9.4: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
+9: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
+latest: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
 
-9.5-alpha2: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.5
-9.5: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.5
+9.5-beta1: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.5
+9.5: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.5: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
-3.5: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
-3: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
-latest: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b
+3.5.6: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
+3.5: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
+3: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
+latest: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
 
-3.5.5-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
-3.5-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
-3-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
-management: git://github.com/docker-library/rabbitmq@30315af9719a5531da3d445d0fe1ceff86326d8b management
+3.5.6-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
+3.5-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
+3-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
+management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management


### PR DESCRIPTION
- `drupal`: 8.0.0-rc1 (docker-library/drupal#14)
- `mongo`: 3.1.9
- `postgres`: 9.1.19-1.pgdg80+1, 9.2.14-1.pgdg80+1, 9.3.10-1.pgdg80+1, 9.4.5-1.pgdg80+1, and 9.5~beta1-1.pgdg80+1
- `rabbitmq`: 3.5.6-1