### PR TITLE
Upgrade to node-v4.2.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,22 +28,22 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 
-4.1.2: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1
-4.1: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1
-4: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1
-latest: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1
+4.2.0: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
+4.2: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
+4: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
+latest: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
 
-4.1.2-onbuild: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/onbuild
-4.1-onbuild: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/onbuild
-onbuild: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/onbuild
+4.2.0-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
+onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
 
-4.1.2-slim: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/slim
-4.1-slim: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/slim
-4-slim: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/slim
-slim: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/slim
+4.2.0-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
+slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
 
-4.1.2-wheezy: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/wheezy
-4.1-wheezy: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/wheezy
-wheezy: git://github.com/nodejs/docker-node@0f41e58217f19b7c65161b7850e86df51b75efac 4.1/wheezy
+4.2.0-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
+wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy


### PR DESCRIPTION
node-v4.2.0 'Argon' (LTS)
Reference: https://github.com/nodejs/docker-node/pull/51