### PR TITLE
Revert websphere-liberty to using IBM JRE

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,17 +1,17 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
-kernel: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/kernel
-8.5.5.7-kernel: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/common
-8.5.5.7-common: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.7-webProfile6: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.7-webProfile7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7-javaee7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@9da673b7e3c9d69197e67f9be276a60702674909 websphere-liberty/8.5.5/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@f303dfe190d415776a760e9ccd12de7612d7fa5e websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/kernel
+8.5.5.7-kernel: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/common
+8.5.5.7-common: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.7-webProfile6: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.7-webProfile7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.7-javaee7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/beta


### PR DESCRIPTION
I'm given to understand that export controls are now in place on Docker Hub so we can revert the websphere-liberty image back to using an IBM JRE.