### PR TITLE
Jetty 9.3.5.v20151012

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,14 +1,14 @@
 # maintainer: Mike Dillon <mike@appropriate.io> (@md5)
 # maintainer: Greg Wilkins <gregw@webtide.com> (@gregw)
 
-9.3.3: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-9.3: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-9: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-9.3.3-jre8: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-9.3-jre8: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-latest: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
-jre8: git://github.com/appropriate/docker-jetty@ed49a52a75f5d685edcf3671bf4a2b99987c16ab 9.3-jre8
+9.3.5: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+9.3.5-jre8: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@ef9adff33ab742c6304e19aa2201a6c30118c7df 9.3-jre8
 
 9.2.13: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8
 9.2: git://github.com/appropriate/docker-jetty@8166bf5a7ac46194530d81e0281d0d729fb4b7a8 9.2-jre8

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -27,7 +27,7 @@ _request() {
 }
 
 # Make sure that Jetty is listening on port 8080
-. "$dir/../../retry.sh" --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" = 7 ]'
+. "$dir/../../retry.sh" --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
 
 # Check that we can request /index.jsp with no params
 [ "$(_request GET "/" | tail -1)" = "null" ]


### PR DESCRIPTION
I was seeing some seemingly spurious failures from the `jetty-hello-web` test. Hopefully they don't show up for this PR...

Diff: https://github.com/appropriate/docker-jetty/compare/ed49a52a75f5d685edcf3671bf4a2b99987c16ab...ef9adff33ab742c6304e19aa2201a6c30118c7df