### PR TITLE
Update node to v4.2.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,22 +28,22 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 
-4.2.0: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
-4.2: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
-4: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
-latest: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2
+4.2.1: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
+4.2: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
+4: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
+latest: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
 
-4.2.0-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
-onbuild: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/onbuild
+4.2.1-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
+onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
 
-4.2.0-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
-slim: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/slim
+4.2.1-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
+slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
 
-4.2.0-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
-wheezy: git://github.com/nodejs/docker-node@184653e68db98e20ced684383ef9e3d4d091c381 4.2/wheezy
+4.2.1-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy


### PR DESCRIPTION
Update node to v4.2.1.

Changeset: https://github.com/nodejs/docker-node/compare/184653e68db98e20ced684383ef9e3d4d091c381...04df8682a438b0ced8f530ab562f5197595e0cbb

> We have two significant regressions with v4.2.0. Fixes have landed in master and v4.x. These are significant issues that affect native modules and anything using timers.
>
> [nodejs/node@b3cbd13340] - buffer: fix assertion error in WeakCallback (Fedor Indutny) nodejs/node#3329
> [nodejs/node@c245a199a7] - lib: fix undefined timeout regression (Ryan Graham) nodejs/node#3331

Related: nodejs/docker-node#56 nodejs/node#3337
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>