### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,17 +1,29 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.2: git://github.com/docker-library/docker@bb15fc25bbd4f51a880cf02f91eab447b1083b75 1.8
-1.8: git://github.com/docker-library/docker@bb15fc25bbd4f51a880cf02f91eab447b1083b75 1.8
-1: git://github.com/docker-library/docker@bb15fc25bbd4f51a880cf02f91eab447b1083b75 1.8
-latest: git://github.com/docker-library/docker@bb15fc25bbd4f51a880cf02f91eab447b1083b75 1.8
+1.9.0-rc1: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
+1.9-rc: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
+rc: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
 
-1.8.2-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
-1.8-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
-1-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.8/dind
+1.9.0-rc1-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
+1.9-rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
+rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 
-1.8.2-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
+1.9.0-rc1-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
+1.9-rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
+rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
+
+1.8.3: git://github.com/docker-library/docker@460aea3b5f26709dc58252deb7cf31cd0a26383e 1.8
+1.8: git://github.com/docker-library/docker@460aea3b5f26709dc58252deb7cf31cd0a26383e 1.8
+1: git://github.com/docker-library/docker@460aea3b5f26709dc58252deb7cf31cd0a26383e 1.8
+latest: git://github.com/docker-library/docker@460aea3b5f26709dc58252deb7cf31cd0a26383e 1.8
+
+1.8.3-dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.8/dind
+1.8-dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.8/dind
+1-dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.8/dind
+dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.8/dind
+
+1.8.3-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
 1.8-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
 1-git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
 git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f6332104 1.8/git
@@ -19,8 +31,8 @@ git: git://github.com/docker-library/docker@a2614c9b94d3bae7d8d61a7cf4d56a42f633
 1.7.1: git://github.com/docker-library/docker@6c4acc40ebc56a539fd33e7799187641dc1e27b0 1.7
 1.7: git://github.com/docker-library/docker@6c4acc40ebc56a539fd33e7799187641dc1e27b0 1.7
 
-1.7.1-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.7/dind
-1.7-dind: git://github.com/docker-library/docker@251cf235760a2ba6db1cf1ddc8ccb3d4da5ec99d 1.7/dind
+1.7.1-dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.7/dind
+1.7-dind: git://github.com/docker-library/docker@2e8569cf5c665ef955855e95be475f52a55c0720 1.7/dind
 
 1.7.1-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/git
 1.7-git: git://github.com/docker-library/docker@a98e0c42a96497670c36f4b2dcad2bcc81f18f35 1.7/git

--- a/library/docker-dev
+++ b/library/docker-dev
@@ -1,8 +1,8 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 
-1.8.2: git://github.com/docker/docker@0a8c2e3717cb3a6fe4e8cb10243cb06473052541
-1.8: git://github.com/docker/docker@0a8c2e3717cb3a6fe4e8cb10243cb06473052541
-1: git://github.com/docker/docker@0a8c2e3717cb3a6fe4e8cb10243cb06473052541
+1.8.3: git://github.com/docker/docker@f4bf5c7026816785d9f63c07e87f9450a49f2403
+1.8: git://github.com/docker/docker@f4bf5c7026816785d9f63c07e87f9450a49f2403
+1: git://github.com/docker/docker@f4bf5c7026816785d9f63c07e87f9450a49f2403
 
 # "latest" intentionally missing, since "docker-dev:latest" implies (IMO) the "latest development image", which these builds never will be
 # if that is what you are after, see "dockercore/docker" (https://registry.hub.docker.com/u/dockercore/docker/)

--- a/library/drupal
+++ b/library/drupal
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.39: git://github.com/docker-library/drupal@91a45111ac40c3e1fc43ad914f7c4e141f84e4b2 7
-7: git://github.com/docker-library/drupal@91a45111ac40c3e1fc43ad914f7c4e141f84e4b2 7
-latest: git://github.com/docker-library/drupal@91a45111ac40c3e1fc43ad914f7c4e141f84e4b2 7
+7.39: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
+7: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
+latest: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
 
-8.0.0-rc1: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
-8.0.0: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
-8.0: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
-8: git://github.com/docker-library/drupal@85ddf34ce60bda95e8c7a54fd4e85011da670bfc 8
+8.0.0-rc1: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
+8.0.0: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
+8.0: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
+8: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8

--- a/library/httpd
+++ b/library/httpd
@@ -3,7 +3,7 @@
 2.2.31: git://github.com/docker-library/httpd@756770f69df0b67457c68614670471b8539d0cf5 2.2
 2.2: git://github.com/docker-library/httpd@756770f69df0b67457c68614670471b8539d0cf5 2.2
 
-2.4.16: git://github.com/docker-library/httpd@502ecf54a9db85f556028036973a9bce72eae8e8 2.4
-2.4: git://github.com/docker-library/httpd@502ecf54a9db85f556028036973a9bce72eae8e8 2.4
-2: git://github.com/docker-library/httpd@502ecf54a9db85f556028036973a9bce72eae8e8 2.4
-latest: git://github.com/docker-library/httpd@502ecf54a9db85f556028036973a9bce72eae8e8 2.4
+2.4.17: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
+2.4: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
+2: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
+latest: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.21: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
-10.0: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
-10: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
-latest: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 10.0
+10.0.21: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
+10.0: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
+10: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
+latest: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
 
-5.5.45: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5
-5.5: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5
-5: git://github.com/docker-library/mariadb@2e0954278a2c463162d0721e70687d1477e04799 5.5
+5.5.46: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5
+5.5: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5
+5: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -10,10 +10,10 @@
 2.6: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
 2: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
 
-3.0.6: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
-3.0: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
-3: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
-latest: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 3.0
+3.0.7: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
+3.0: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
+3: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
+latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
 
 3.1.9: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1
 3.1: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,17 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.9: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
-6.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
-6: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 6.0
+6.0.9-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
+6.0.9: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
+6.0-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
+6.0: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
+6-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
+6: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
 
-7.0.10: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
-7.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
-7: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 7.0
+6.0.9-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
+6.0-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
+6-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
 
-8.0.8: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.0
-8.0: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.0
+7.0.10-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
+7.0.10: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
+7.0: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
+7: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
 
-8.1.3: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
-8.1: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
-8: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
-latest: git://github.com/docker-library/owncloud@542c46cd9f35cf124ed5b97fba61184cc00642f0 8.1
+7.0.10-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/fpm
+
+8.0.8-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/apache
+8.0.8: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/apache
+8.0: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/apache
+
+8.0.8-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.0/fpm
+
+8.1.3-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+8.1.3: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+8.1: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+8-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+8: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+latest: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
+
+8.1.3-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
+8-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
+fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
-9.0: git://github.com/docker-library/postgres@cd294bf8dfdf4a74b2077aa6413fa579f9bf07de 9.0
+9.0.22: git://github.com/docker-library/postgres@8f8c0bbc5236e0deedd35595c504e5fd380b1233 9.0
+9.0: git://github.com/docker-library/postgres@8f8c0bbc5236e0deedd35595c504e5fd380b1233 9.0
 
-9.1.19: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.1
-9.1: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.1
+9.1.19: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.1
+9.1: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.1
 
-9.2.14: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.2
-9.2: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.2
+9.2.14: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.2
+9.2: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.2
 
-9.3.10: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.3
-9.3: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.3
+9.3.10: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.3
+9.3: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.3
 
-9.4.5: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
-9.4: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
-9: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
-latest: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.4
+9.4.5: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
+9.4: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
+9: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
+latest: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
 
-9.5-beta1: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.5
-9.5: git://github.com/docker-library/postgres@b9ea5d40cbedf35606ac638950a824f3e97aae5b 9.5
+9.5-beta1: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.5
+9.5: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.5

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre8
 
-8.0.27-jre7: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-jre7: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-8.0.27: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-8.0: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-8: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
-latest: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre7
+8.0.28-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8.0.28: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8.0: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+latest: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
 
-8.0.27-jre8: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre8
-jre8: git://github.com/docker-library/tomcat@df283818c14e8f24c294e2d3cd23099ef92e6643 8-jre8
+8.0.28-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
+jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8


### PR DESCRIPTION
- `docker`: 1.8.3, 1.9.0-rc1
- `docker-dev`: 1.8.3
- `drupal`: add PHP zip extension (docker-library/drupal#7)
- `httpd`: 2.4.17
- `mariadb`: 5.5.46+maria-1~wheezy
- `mongo`: 3.0.7
- `owncloud`: add FPM variants (docker-library/owncloud#28)
- `postgres`: explicit uid/gid (docker-library/postgres#93)
- `tomcat`: 8.0.28