### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -1,8 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.39: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
-7: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
-latest: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 7
+7.40: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
+7: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
+latest: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
 
 8.0.0-rc1: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
 8.0.0: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,23 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.3
-1.3: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.3
+1.3: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.4
-1.4: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.4
+1.4: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.5
-1.5: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.5
+1.5: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.6
-1.6: git://github.com/docker-library/elasticsearch@546a3d48ac776256ab4b78a7136cc57ef0e8ddab 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.6
+1.6: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.6
 
-1.7.2: git://github.com/docker-library/elasticsearch@18527ddda24e2f765c18c925f8970b5570882a3c 1.7
-1.7: git://github.com/docker-library/elasticsearch@18527ddda24e2f765c18c925f8970b5570882a3c 1.7
-1: git://github.com/docker-library/elasticsearch@18527ddda24e2f765c18c925f8970b5570882a3c 1.7
-latest: git://github.com/docker-library/elasticsearch@18527ddda24e2f765c18c925f8970b5570882a3c 1.7
+1.7.3: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
+1.7: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
+1: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
+latest: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
 
-2.0.0-beta2: git://github.com/docker-library/elasticsearch@c6ae6abfc71a4fed1edcec58fafb9aca2cb3449c 2.0
-2.0.0: git://github.com/docker-library/elasticsearch@c6ae6abfc71a4fed1edcec58fafb9aca2cb3449c 2.0
-2.0: git://github.com/docker-library/elasticsearch@c6ae6abfc71a4fed1edcec58fafb9aca2cb3449c 2.0
-2: git://github.com/docker-library/elasticsearch@c6ae6abfc71a4fed1edcec58fafb9aca2cb3449c 2.0
+2.0.0-rc1: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
+2.0.0: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
+2.0: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
+2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0

--- a/library/logstash
+++ b/library/logstash
@@ -11,8 +11,8 @@
 1: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 latest: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 
-2.0.0-beta1-1: git://github.com/docker-library/logstash@62715f69df799b5feff3e42370bbc6d70f92c7d7 2.0
-2.0.0-beta1: git://github.com/docker-library/logstash@62715f69df799b5feff3e42370bbc6d70f92c7d7 2.0
-2.0.0: git://github.com/docker-library/logstash@62715f69df799b5feff3e42370bbc6d70f92c7d7 2.0
-2.0: git://github.com/docker-library/logstash@62715f69df799b5feff3e42370bbc6d70f92c7d7 2.0
-2: git://github.com/docker-library/logstash@62715f69df799b5feff3e42370bbc6d70f92c7d7 2.0
+2.0.0-beta2-1: git://github.com/docker-library/logstash@8f54fa3328ec16bf0c0a7d125a0ec851a1ac38db 2.0
+2.0.0-beta2: git://github.com/docker-library/logstash@8f54fa3328ec16bf0c0a7d125a0ec851a1ac38db 2.0
+2.0.0: git://github.com/docker-library/logstash@8f54fa3328ec16bf0c0a7d125a0ec851a1ac38db 2.0
+2.0: git://github.com/docker-library/logstash@8f54fa3328ec16bf0c0a7d125a0ec851a1ac38db 2.0
+2: git://github.com/docker-library/logstash@8f54fa3328ec16bf0c0a7d125a0ec851a1ac38db 2.0

--- a/library/mongo
+++ b/library/mongo
@@ -15,5 +15,5 @@
 3: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
 latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
 
-3.1.9: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1
-3.1: git://github.com/docker-library/mongo@843e9903cb09320898f126d9be585594576814ae 3.1
+3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
+3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.6: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
-3.5: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
-3: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
-latest: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689
+3.5.6: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86
+3.5: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86
+3: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86
+latest: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86
 
-3.5.6-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
-3.5-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
-3-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
-management: git://github.com/docker-library/rabbitmq@b4f7e6ec02417d3bea10d8718a3e640a2ee2e689 management
+3.5.6-management: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86 management
+3.5-management: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86 management
+3-management: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86 management
+management: git://github.com/docker-library/rabbitmq@74728041378a7f82732f07b04962c3e76909df86 management

--- a/library/redis
+++ b/library/redis
@@ -6,20 +6,20 @@
 2.6.17-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
 2.6-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
 
-2.8.22: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8
-2.8: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8
-2: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8
+2.8.23: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
+2.8: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
+2: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
 
-2.8.22-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 2.8/32bit
+2.8.23-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
 
-3.0.4: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0
-3.0: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0
-3: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0
-latest: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0
+3.0.5: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
+3.0: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
+3: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
+latest: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
 
-3.0.4-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0/32bit
-32bit: git://github.com/docker-library/redis@151ba62d9b6a1485b636d57736f42ed9b26ac50b 3.0/32bit
+3.0.5-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
+32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit


### PR DESCRIPTION
- `drupal`: 7.40 (docker-library/drupal#18)
- `elasticsearch`: 1.7.3, 2.0.0-rc1 (docker-library/elasticsearch#60, docker-library/elasticsearch#59)
- `logstash`: 2.0.0~beta2 (docker-library/logstash#28)
- `mongo`: new PGP key for 3.1
- `rabbitmq`: add 4369 & 25672 to `EXPOSE` (docker-library/rabbitmq#47)
- `redis`: 2.8.23 and 3.0.5