### PR TITLE
Couchbase: Address difficulties with bind-mounts on MacOS

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,25 +1,25 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
-enterprise: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
-community: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/4.0.0
+latest: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/4.0.0
+enterprise: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/4.0.0
+community: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 community/couchbase-server/4.0.0
 
-4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
-enterprise-4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/4.0.0
-community-4.0.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/4.0.0
+4.0.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/4.0.0
+enterprise-4.0.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/4.0.0
+community-4.0.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 community/couchbase-server/4.0.0
 
-3.1.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.1.0
-enterprise-3.1.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.1.0
+3.1.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.1.0
+enterprise-3.1.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.1.0
 
-3.0.3: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.3
-enterprise-3.0.3: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.3
+3.0.3: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.0.3
+enterprise-3.0.3: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.0.3
 
-3.0.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.2
-enterprise-3.0.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/3.0.2
+3.0.2: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.0.2
+enterprise-3.0.2: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/3.0.2
 
-community-3.0.1: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/3.0.1
+community-3.0.1: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 community/couchbase-server/3.0.1
 
-2.5.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/2.5.2
-enterprise-2.5.2: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d enterprise/couchbase-server/2.5.2
+2.5.2: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/2.5.2
+enterprise-2.5.2: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 enterprise/couchbase-server/2.5.2
 
-community-2.2.0: git://github.com/couchbase/docker@e5e03d89aa87176d87ba7c76a01814bf357c921d community/couchbase-server/2.2.0
+community-2.2.0: git://github.com/couchbase/docker@a997f494aae7d8fa572dbc581ab289e8eaa72279 community/couchbase-server/2.2.0


### PR DESCRIPTION
This change ensures the "couchbase" user in the Docker container is UID 1000, to match the "docker" user in the boot2docker VM. It was previously UID 999, which caused failure to start when bind-mounting /opt/couchbase/var on MacOS. This issue is discussed (at great, great length) at https://github.com/boot2docker/boot2docker/issues/581 .

@tianon , @yosifkit - IMHO it'd be a really good idea to add a note to https://docs.docker.com/articles/dockerfile_best-practices/ suggesting that if you are running non-root processes in your container and you expect users to bind-mount volumes that those processes will write to, you should ensure those processes run as UID 1000 to ensure compatibility with boot2docker.

(This change also adds port 8093 to the list of EXPOSEd ports for Couchbase, mostly as a documentation point.)