### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 
-1.21.0-ubuntu: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 ubuntu
-1.21-ubuntu: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 ubuntu
-1-ubuntu: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 ubuntu
-ubuntu: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 ubuntu
+1.21.0-ubuntu: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c ubuntu
+1.21-ubuntu: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c ubuntu
+1-ubuntu: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c ubuntu
+ubuntu: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c ubuntu
 
-1.24.0: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 upstream
-1.24: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 upstream
-1: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 upstream
-latest: git://github.com/docker-library/busybox@17c9ac1c30f32efbf440a62b95814bc82c0abbd6 upstream
+1.24.0: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c upstream
+1.24: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c upstream
+1: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c upstream
+latest: git://github.com/docker-library/busybox@09d77e40ef9b7085ae9a57cabdae6e6926faf87c upstream

--- a/library/cassandra
+++ b/library/cassandra
@@ -3,10 +3,10 @@
 2.0.17: git://github.com/docker-library/cassandra@5d31a1e20371873affd9ce8ea630aedb94618471 2.0
 2.0: git://github.com/docker-library/cassandra@5d31a1e20371873affd9ce8ea630aedb94618471 2.0
 
-2.1.10: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.1
-2.1: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.1
+2.1.11: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.1
+2.1: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.1
 
-2.2.2: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.2
-2.2: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.2
-2: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.2
-latest: git://github.com/docker-library/cassandra@e3c2c360a9c825b450f5442dc064f798f376d9cb 2.2
+2.2.3: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.2
+2.2: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.2
+2: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.2
+latest: git://github.com/docker-library/cassandra@92e84142e864c087420196904ed01de624a3b633 2.2

--- a/library/php
+++ b/library/php
@@ -1,57 +1,57 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.45-cli: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4
-5.4-cli: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4
-5.4.45: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4
-5.4: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4
+5.4.45-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
+5.4-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
+5.4.45: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
+5.4: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
 
-5.4.45-apache: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4/apache
-5.4-apache: git://github.com/docker-library/php@cf1e938f3721632443e01734bcfcbcf1160ea539 5.4/apache
+5.4.45-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/apache
+5.4-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/apache
 
-5.4.45-fpm: git://github.com/docker-library/php@766e3c00431dfb9c4043b8a1c50c2c9195c94b24 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@766e3c00431dfb9c4043b8a1c50c2c9195c94b24 5.4/fpm
+5.4.45-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/fpm
+5.4-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/fpm
 
-5.5.30-cli: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5
-5.5-cli: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5
-5.5.30: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5
-5.5: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5
+5.5.30-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
+5.5-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
+5.5.30: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
+5.5: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
 
-5.5.30-apache: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5/apache
-5.5-apache: git://github.com/docker-library/php@f37a400328dc61daa991a75ad753669f35ee72ef 5.5/apache
+5.5.30-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/apache
+5.5-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/apache
 
-5.5.30-fpm: git://github.com/docker-library/php@58adff408a2576f3e32c8f730eb18736768d88b9 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@58adff408a2576f3e32c8f730eb18736768d88b9 5.5/fpm
+5.5.30-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/fpm
 
-5.6.14-cli: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-5.6-cli: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-5-cli: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-cli: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-5.6.14: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-5.6: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-5: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
-latest: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6
+5.6.14-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+5.6-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+5-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+5.6.14: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+5.6: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+5: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
+latest: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6
 
-5.6.14-apache: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/apache
-5.6-apache: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/apache
-5-apache: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/apache
-apache: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/apache
+5.6.14-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/apache
+5.6-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/apache
+5-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/apache
+apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/apache
 
-5.6.14-fpm: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/fpm
-5-fpm: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/fpm
-fpm: git://github.com/docker-library/php@c05f8260ab4b9371923c409d099f37c9eef863a7 5.6/fpm
+5.6.14-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/fpm
+5-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/fpm
+fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.6/fpm
 
-7.0.0RC5-cli: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
-7.0-cli: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
-7-cli: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
-7.0.0RC5: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
-7.0: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
-7: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0
+7.0.0RC5-cli: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
+7.0-cli: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
+7-cli: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
+7.0.0RC5: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
+7.0: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
+7: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0
 
-7.0.0RC5-apache: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/apache
-7.0-apache: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/apache
-7-apache: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/apache
+7.0.0RC5-apache: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/apache
+7.0-apache: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/apache
+7-apache: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/apache
 
-7.0.0RC5-fpm: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/fpm
-7-fpm: git://github.com/docker-library/php@86875314babcd174d6737be46968c4ce3a8cc858 7.0/fpm
+7.0.0RC5-fpm: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/fpm
+7-fpm: git://github.com/docker-library/php@f751ba0b5b1753ff8486cccdc1c3354d3be49597 7.0/fpm

--- a/library/python
+++ b/library/python
@@ -42,29 +42,27 @@
 
 3.4.3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
 3.4: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
-3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
-latest: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
 
 3.4.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
-3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
 3.4.3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
 3.4-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
-3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
 
 3.4.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
 3.4-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
-3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
 
 3.5.0: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
 3.5: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
+3: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
+latest: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
 
 3.5.0-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
 3.5.0-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
 3.5-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
+3-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
+slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim

--- a/library/ruby
+++ b/library/ruby
@@ -8,9 +8,9 @@
 2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 
-2.0.0-p647-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0/slim
+2.0.0-p647-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
 
 2.1.7: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1
 2.1: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1
@@ -18,8 +18,8 @@
 2.1.7-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.7-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1/slim
+2.1.7-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.1/slim
 
 2.2.3: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
 2.2: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
@@ -31,7 +31,7 @@ latest: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1
 2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.3-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2/slim
-2-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2/slim
-slim: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2/slim
+2.2.3-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
+2-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
+slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim

--- a/library/tomcat
+++ b/library/tomcat
@@ -11,16 +11,16 @@
 6.0-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
 6-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
 
-7.0.64-jre7: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
-7.0.64: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
-7.0: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
-7: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre7
+7.0.65-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7.0.65: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7.0: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
 
-7.0.64-jre8: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@b81ffe88c0bb6d760b6ee7d9c056469d59e68311 7-jre8
+7.0.65-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
 
 8.0.28-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
 8.0-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7


### PR DESCRIPTION
- `busybox`: more explicit builder Dockerfiles (and slightly smaller ubuntu variant image)  
  https://github.com/docker-library/busybox/compare/17c9ac1c30f32efbf440a62b95814bc82c0abbd6...09d77e40ef9b7085ae9a57cabdae6e6926faf87c
- `cassandra`: 2.1.11 and 2.2.3
- `php`: remove invalid `--with-pcre` flag (docker-library/php#142)
- `ruby`: verify checksum in slim variants (docker-library/ruby#54)
- `tomcat`: 7.0.65