### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.40: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
-7: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
-latest: git://github.com/docker-library/drupal@7a95f6b9072c8d2b350225aca69b95e89bd8cf66 7
+7.41: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
+7: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
+latest: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 
-8.0.0-rc1: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
-8.0.0: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
-8.0: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
-8: git://github.com/docker-library/drupal@8108a55ea5ab69f0259c65baa7faa98cec26ebd7 8
+8.0.0-rc2: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
+8.0.0: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
+8.0: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
+8: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.21: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
-10.0: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
-10: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
-latest: git://github.com/docker-library/mariadb@a7be78d954009e2acc47fc5a1cb2e7997b54f594 10.0
+10.0.21: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 10.0
+10.0: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 10.0
+10: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 10.0
+latest: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 10.0
 
-5.5.46: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5
-5.5: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5
-5: git://github.com/docker-library/mariadb@0b799d3cdb39002c665d97eb93c8985e26fb7bd7 5.5
+5.5.46: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5
+5.5: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5
+5: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -1,13 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.46: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.5
-5.5: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.5
+5.5.46: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.5
+5.5: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.5
 
-5.6.27: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.6
-5.6: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.6
-5: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.6
-latest: git://github.com/docker-library/mysql@e892e8c52485535cce5dbadaba2c579fcc805f21 5.6
+5.6.27: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
+5.6: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
 
-5.7.8-rc: git://github.com/docker-library/mysql@5836bc9af9deb67b68c32bebad09a0f7513da36e 5.7
-5.7.8: git://github.com/docker-library/mysql@5836bc9af9deb67b68c32bebad09a0f7513da36e 5.7
-5.7: git://github.com/docker-library/mysql@5836bc9af9deb67b68c32bebad09a0f7513da36e 5.7
+5.7.9: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
+5.7: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
+5: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
+latest: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,15 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.9-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-6.0.9: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-6.0-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-6.0: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-6-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-6: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/apache
-
-6.0.9-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
-6.0-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
-6-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 6.0/fpm
+# https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
 7.0.10-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
 7.0.10: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 7.0/apache
@@ -34,12 +25,20 @@
 8.1.3: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
 8.1-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
 8.1: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
-8-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
-8: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
-apache: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
-latest: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/apache
 
 8.1.3-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
 8.1-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
-8-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
-fpm: git://github.com/docker-library/owncloud@9ccc7fca5bf414af5d8930ed5036ee6ab1f28999 8.1/fpm
+
+8.2.0-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8.2.0: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8.2: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+latest: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+
+8.2.0-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
+fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.45: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
-5.5: git://github.com/docker-library/percona@301bc073bee3e7e89fd96edd324581aabe3b3b73 5.5
+5.5.45: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.5
+5.5: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.5
 
-5.6.26: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
-5.6: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
-5: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
-latest: git://github.com/docker-library/percona@0c94823a5a41d31cbcb4392b85aaf5c00ecf5671 5.6
+5.6.26: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.6
+5.6: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.6
+5: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.6
+latest: git://github.com/docker-library/percona@e453f135fea491f954e7619fa9be6eeff69f66f5 5.6

--- a/library/redmine
+++ b/library/redmine
@@ -4,16 +4,16 @@
 2.6: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
 2: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
 
-2.6.7-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 2.6/passenger
+2.6.7-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
 
 3.0.5: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 3.0: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 3: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 latest: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
 
-3.0.5-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
-passenger: git://github.com/docker-library/redmine@558a0dbd4f88d47d5af8987a4f1dc6a9ba61a49c 3.0/passenger
+3.0.5-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
+passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger


### PR DESCRIPTION
- `drupal`: 8.0.0-rc2 and 7.41 (docker-library/drupal#19, docker-library/drupal#20)
- `mariadb`: minor quoting fixes (docker-library/mariadb#27)
- `mysql`: minor quoting fixes (docker-library/mysql#109)
- `owncloud`: remove EOL 6.0, add new 8.2 release
- `percona`: minor quoting fixes (docker-library/percona#9)
- `redmine`: passenger 5.0.21