### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,15 +1,15 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.0-rc1: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
-1.9-rc: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
-rc: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc
+1.9.0-rc2: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
+1.9-rc: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
+rc: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
 
-1.9.0-rc1-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
+1.9.0-rc2-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 1.9-rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 
-1.9.0-rc1-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
+1.9.0-rc2-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 1.9-rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 

--- a/library/haproxy
+++ b/library/haproxy
@@ -5,5 +5,8 @@
 
 1.5.14: git://github.com/docker-library/haproxy@ba0dc92fc368edb8e1f4928662316435fe782348 1.5
 1.5: git://github.com/docker-library/haproxy@ba0dc92fc368edb8e1f4928662316435fe782348 1.5
-1: git://github.com/docker-library/haproxy@ba0dc92fc368edb8e1f4928662316435fe782348 1.5
-latest: git://github.com/docker-library/haproxy@ba0dc92fc368edb8e1f4928662316435fe782348 1.5
+
+1.6.1: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
+1.6: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
+1: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
+latest: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6

--- a/library/logstash
+++ b/library/logstash
@@ -11,8 +11,8 @@
 1: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 latest: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 
-2.0.0-beta3-1: git://github.com/docker-library/logstash@91855a2ff26267602fea0b6c95e8ec8de6327758 2.0
-2.0.0-beta3: git://github.com/docker-library/logstash@91855a2ff26267602fea0b6c95e8ec8de6327758 2.0
-2.0.0: git://github.com/docker-library/logstash@91855a2ff26267602fea0b6c95e8ec8de6327758 2.0
-2.0: git://github.com/docker-library/logstash@91855a2ff26267602fea0b6c95e8ec8de6327758 2.0
-2: git://github.com/docker-library/logstash@91855a2ff26267602fea0b6c95e8ec8de6327758 2.0
+2.0.0-rc1-1: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
+2.0.0-rc1: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
+2.0.0: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
+2.0: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
+2: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0


### PR DESCRIPTION
- `docker`: 1.9.0-rc2
- `haproxy`: 1.6.1 (docker-library/haproxy#11)
- `logstash`: 2.0.0-rc1