### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.18: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-3.1: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-3: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
-latest: git://github.com/docker-library/celery@a4173ea8c6afb21ce3d3fad90242274e4911f278
+3.1.19: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
+3.1: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
+3: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
+latest: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e

--- a/library/docker
+++ b/library/docker
@@ -1,15 +1,15 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.0-rc2: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
-1.9-rc: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
-rc: git://github.com/docker-library/docker@7f13cd4f8f7448277dff03701703b227cf4f8fc4 1.9-rc
+1.9.0-rc3: git://github.com/docker-library/docker@b6bedcfe457d94764b3ddfd2fe8eaa535f34d021 1.9-rc
+1.9-rc: git://github.com/docker-library/docker@b6bedcfe457d94764b3ddfd2fe8eaa535f34d021 1.9-rc
+rc: git://github.com/docker-library/docker@b6bedcfe457d94764b3ddfd2fe8eaa535f34d021 1.9-rc
 
-1.9.0-rc2-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
+1.9.0-rc3-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 1.9-rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 rc-dind: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/dind
 
-1.9.0-rc2-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
+1.9.0-rc3-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 1.9-rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 rc-git: git://github.com/docker-library/docker@20e81e7474e54f9edbb33c931e4731ef6c5b8335 1.9-rc/git
 

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -15,9 +15,8 @@
 1.7.3: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
 1.7: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
 1: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
-latest: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
 
-2.0.0-rc1: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
-2.0.0: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
-2.0: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
-2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 2.0
+2.0.0: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
+2.0: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
+2: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
+latest: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0

--- a/library/java
+++ b/library/java
@@ -14,19 +14,19 @@ openjdk-6-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736
 6b36-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
 6-jre: git://github.com/docker-library/java@9859b8586dd2511d005c84694736e2121ceb11d7 openjdk-6-jre
 
-openjdk-7u79-jdk: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-openjdk-7u79: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-openjdk-7-jdk: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-openjdk-7: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-7u79-jdk: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-7u79: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-7-jdk: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
-7: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jdk
+openjdk-7u85-jdk: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+openjdk-7u85: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+openjdk-7-jdk: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+openjdk-7: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+7u85-jdk: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+7u85: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+7-jdk: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
+7: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jdk
 
-openjdk-7u79-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
-openjdk-7-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
-7u79-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
-7-jre: git://github.com/docker-library/java@65f4567ed9294e7404b3d2d0c806249946e06210 openjdk-7-jre
+openjdk-7u85-jre: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jre
+openjdk-7-jre: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jre
+7u85-jre: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jre
+7-jre: git://github.com/docker-library/java@cee45bcb0f2d6db2e3e96c5465ebd5dbddcb2aea openjdk-7-jre
 
 openjdk-8u66-jdk: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk
 openjdk-8u66: git://github.com/docker-library/java@6f340724d3bc1f9b4385975c5de6bfe15aac8c85 openjdk-8-jdk

--- a/library/kibana
+++ b/library/kibana
@@ -5,9 +5,8 @@
 
 4.1.2: git://github.com/docker-library/kibana@e39420bcf5bb76cd4a11180532a44978d04cb485 4.1
 4.1: git://github.com/docker-library/kibana@e39420bcf5bb76cd4a11180532a44978d04cb485 4.1
-4: git://github.com/docker-library/kibana@e39420bcf5bb76cd4a11180532a44978d04cb485 4.1
-latest: git://github.com/docker-library/kibana@e39420bcf5bb76cd4a11180532a44978d04cb485 4.1
 
-4.2.0-beta2: git://github.com/docker-library/kibana@3e7b051630e6c765f5e9630e3f7f8948557093ef 4.2
-4.2.0: git://github.com/docker-library/kibana@3e7b051630e6c765f5e9630e3f7f8948557093ef 4.2
-4.2: git://github.com/docker-library/kibana@3e7b051630e6c765f5e9630e3f7f8948557093ef 4.2
+4.2.0: git://github.com/docker-library/kibana@39e433266cc29368b70fd04a84271fe2d3fbb2cb 4.2
+4.2: git://github.com/docker-library/kibana@39e433266cc29368b70fd04a84271fe2d3fbb2cb 4.2
+4: git://github.com/docker-library/kibana@39e433266cc29368b70fd04a84271fe2d3fbb2cb 4.2
+latest: git://github.com/docker-library/kibana@39e433266cc29368b70fd04a84271fe2d3fbb2cb 4.2

--- a/library/logstash
+++ b/library/logstash
@@ -9,10 +9,9 @@
 1.5.4: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 1.5: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 1: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
-latest: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.5
 
-2.0.0-rc1-1: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
-2.0.0-rc1: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
-2.0.0: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
-2.0: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
-2: git://github.com/docker-library/logstash@d559b3f4cb236de21b678e6b2ba9abce507df048 2.0
+2.0.0-1: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
+2.0.0: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
+2.0: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
+2: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
+latest: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0

--- a/library/mysql
+++ b/library/mysql
@@ -6,7 +6,7 @@
 5.6.27: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
 5.6: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
 
-5.7.9: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
-5.7: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
-5: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
-latest: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.7
+5.7.9: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
+5.7: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
+5: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
+latest: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-2.6.1: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2
-2-2.6: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2
-2-2: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2
-2: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2
+2-4.0.0: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
+2-4.0: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
+2-4: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
+2: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
 
-2-2.6.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-2.6-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-4.0.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-2.6.1-slim: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2/slim
-2-2.6-slim: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2/slim
-2-2-slim: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2/slim
-2-slim: git://github.com/docker-library/pypy@f1c1a5dd1248c044dafc52ddff7ff18be77d0ea8 2/slim
+2-4.0.0-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
+2-4.0-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
+2-4-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
+2-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
 3-2.4: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3


### PR DESCRIPTION
- `celery`: 3.1.19
- `docker`: 1.9.0-rc3
- `elasticsearch`: 2.0.0
- `java`: 7u85-2.6.1-5~deb8u1
- `kibana`: 4.2.0
- `logstash`: 2.0.0
- `mysql`: remove `--innodb-read-only` workaround (docker-library/mysql#114)
- `pypy`: 4.0.0