### PR TITLE
Update node to 5.0.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -31,19 +31,39 @@
 4.2.1: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
 4.2: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
 4: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
-latest: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
+argon: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
 
 4.2.1-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
 4.2-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
 4-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
 
 4.2.1-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
 4.2-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
 4-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
+argon-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
 
 4.2.1-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
 4.2-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
 4-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+
+5.0.0: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0
+5.0: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0
+5: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0
+latest: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0
+
+5.0.0-onbuild: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/onbuild
+5.0-onbuild: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/onbuild
+onbuild: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/onbuild
+
+5.0.0-slim: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/slim
+5.0-slim: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/slim
+5-slim: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/slim
+slim: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/slim
+
+5.0.0-wheezy: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/wheezy
+5.0-wheezy: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/wheezy
+wheezy: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0/wheezy


### PR DESCRIPTION
This PR updates the node image to v5.0.0 and adds the long term support version `argon` tag.

Changeset: https://github.com/nodejs/docker-node/compare/04df8682a438b0ced8f530ab562f5197595e0cbb...2445743c1453941f787b0aa22cca51c62a1a3f09

Related: nodejs/docker-node#59 nodejs/node#3466
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>