### PR TITLE
Bump docker-thrift version to 0.9.3

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -2,4 +2,5 @@
 
 0.9: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9
 0.9.2: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9
+0.9.3: git://github.com/ahawkins/docker-thrift@23d022c7b84399794349bf4ba7f5568020911f1d 0.9
 latest: git://github.com/ahawkins/docker-thrift@61c3478ab828d3e610f192b442ac2a7221749c47 0.9


### PR DESCRIPTION
depends on: https://github.com/ahawkins/docker-thrift/pull/1 to be merged.