### PR TITLE
Update node-v4.2.1 (LTS) to node-v4.2.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
 
-4.2.1: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
-4.2: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
-4: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
-argon: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2
+4.2.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
+4.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
+4: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
+argon: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
 
-4.2.1-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/onbuild
+4.2.2-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
 
-4.2.1-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
-argon-slim: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/slim
+4.2.2-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
+argon-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
 
-4.2.1-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@04df8682a438b0ced8f530ab562f5197595e0cbb 4.2/wheezy
+4.2.2-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
 
 5.0.0: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0
 5.0: git://github.com/nodejs/docker-node@2445743c1453941f787b0aa22cca51c62a1a3f09 5.0


### PR DESCRIPTION
References:
- https://github.com/nodejs/node/pull/3588
- https://github.com/nodejs/docker-node/pull/62