### PR TITLE
Updates for django, drupal, haproxy, httpd, mongo, ruby

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.5-python2: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 2.7
-1.8-python2: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 2.7
-1-python2: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 2.7
-python2: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 2.7
+1.8.6-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
+1.8-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
+1-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
+python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
 
 python2-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7/onbuild
 
-1.8.5-python3: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-1.8.5: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-1.8-python3: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-1.8: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-1-python3: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-1: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-python3: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
-latest: git://github.com/docker-library/django@5c1ccfb0b0402f6d45bd65af53179e0c8afcaece 3.4
+1.8.6-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1.8.6: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1.8-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1.8: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+latest: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
 
 python3-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild
 onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 latest: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 
-8.0.0-rc2: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
-8.0.0: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
-8.0: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
-8: git://github.com/docker-library/drupal@176ed927eace897e55946bfdcfa7cfce23468acb 8
+8.0.0-rc3: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
+8.0.0: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
+8.0: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
+8: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8

--- a/library/haproxy
+++ b/library/haproxy
@@ -6,7 +6,7 @@
 1.5.15: git://github.com/docker-library/haproxy@2c73ea45ca3defee81f16ca206d2c2ca8e79f167 1.5
 1.5: git://github.com/docker-library/haproxy@2c73ea45ca3defee81f16ca206d2c2ca8e79f167 1.5
 
-1.6.1: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
-1.6: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
-1: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
-latest: git://github.com/docker-library/haproxy@9fe8247741a38e50cab2910de1c14c36371a265e 1.6
+1.6.2: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
+1.6: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
+1: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
+latest: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.31: git://github.com/docker-library/httpd@756770f69df0b67457c68614670471b8539d0cf5 2.2
-2.2: git://github.com/docker-library/httpd@756770f69df0b67457c68614670471b8539d0cf5 2.2
+2.2.31: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.2
+2.2: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.2
 
-2.4.17: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
-2.4: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
-2: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
-latest: git://github.com/docker-library/httpd@3ea3760ef8d264ac7539ec6db9ce9c0b0665a192 2.4
+2.4.17: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
+2.4: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
+2: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
+latest: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4

--- a/library/mongo
+++ b/library/mongo
@@ -18,7 +18,7 @@ latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c
 3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 
-3.2.0-rc1: git://github.com/docker-library/mongo@d60bff17a6c875054e4d0550d78a7b2522d0bbc9 3.2-rc
-3.2.0: git://github.com/docker-library/mongo@d60bff17a6c875054e4d0550d78a7b2522d0bbc9 3.2-rc
-3.2: git://github.com/docker-library/mongo@d60bff17a6c875054e4d0550d78a7b2522d0bbc9 3.2-rc
-3.2-rc: git://github.com/docker-library/mongo@d60bff17a6c875054e4d0550d78a7b2522d0bbc9 3.2-rc
+3.2.0-rc2: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
+3.2.0: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
+3.2: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
+3.2-rc: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc

--- a/library/ruby
+++ b/library/ruby
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p647: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0
-2.0.0: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0
-2.0: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.0
+2.0.0-p647: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
+2.0.0: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
+2.0: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
 
 2.0.0-p647-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 
-2.0.0-p647-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.0/slim
+2.0.0-p647-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
 
-2.1.7: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1
-2.1: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.1
+2.1.7: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1
+2.1: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1
 
 2.1.7-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.7-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.1/slim
+2.1.7-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1/slim
 
-2.2.3: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
-2.2: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
-2: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
-latest: git://github.com/docker-library/ruby@0cdec78d89e33750a4b796bd2c748f0d5a1ae654 2.2
+2.2.3: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
+2.2: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
+2: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
+latest: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
 
 2.2.3-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.3-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
-2-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
-slim: git://github.com/docker-library/ruby@4cba299a609debea1b81a8da9844e6d27fba5229 2.2/slim
+2.2.3-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
+2-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
+slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim


### PR DESCRIPTION
 - `django` bump to 1.8.6
 - `drupal` bump to 8.0.0-rc3
 - `haproxy` bump to 1.6.2
 - `httpd` fix apxs https://github.com/docker-library/httpd/pull/7
 - `mongo` bump to 3.2.0-rc2
 - `ruby` bump rubygems 2.5.0