### PR TITLE
Adjust "retry.sh" to bail if our container does

### DIFF
--- a/test/retry.sh
+++ b/test/retry.sh
@@ -32,6 +32,11 @@ while ! eval "$@" &> /dev/null; do
 		eval "$@" # to hopefully get a useful error message
 		false
 	fi
+	if [ "$cid" ] && [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" != 'true' ]; then
+		echo >&2 "${image:-the container} stopped unexpectedly!"
+		( set -x && docker logs "$cid" ) >&2 || true
+		false
+	fi
 	echo >&2 -n .
 	sleep "$sleep"
 done


### PR DESCRIPTION
If our container's died, we can be pretty sure our process of testing it for "aliveness" is going to fail. :smile:

This doesn't change pass/fail status, but does make us bail faster for obviously-failing images (like how `mariadb:10.1` segfaults on the first functional line of the entrypoint script...).

After building `mariadb:10.1` manually on my system:
```console
$ ./run.sh mariadb:10.{0,1}
testing mariadb:10.0
	'utc' [1/6]...passed
	'cve-2014--shellshock' [2/6]...passed
	'no-hard-coded-passwords' [3/6]...passed
	'override-cmd' [4/6]...passed
	'mysql-basics' [5/6].......passed
	'mysql-initdb' [6/6]........passed
testing mariadb:10.1
	'utc' [1/6]...passed
	'cve-2014--shellshock' [2/6]...passed
	'no-hard-coded-passwords' [3/6]...passed
	'override-cmd' [4/6]...passed
	'mysql-basics' [5/6]...mariadb:10.1 stopped unexpectedly!
++ docker logs c2a397225474806a9b10051182aaf352fb6e2433f629d0111728ea8aecdf6f19
mkdir: cannot create directory '': No such file or directory
failed
	'mysql-initdb' [6/6]...mariadb:10.1 stopped unexpectedly!
++ docker logs a4c93362eb6e60e31ce03f0a223379834e8d62917eba151ad7a61ada9cd30786
mkdir: cannot create directory '': No such file or directory
failed
```

cc @md5 :smile: