### PR TITLE
Update all the openSUSE images

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,9 +1,13 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.2
-13.2: git://github.com/openSUSE/docker-containers-build@f3c7e8aa49da4c10b3352d56c28d3cea6f3afefa docker
-harlequin: git://github.com/openSUSE/docker-containers-build@f3c7e8aa49da4c10b3352d56c28d3cea6f3afefa docker
-latest: git://github.com/openSUSE/docker-containers-build@f3c7e8aa49da4c10b3352d56c28d3cea6f3afefa docker
+13.2: git://github.com/openSUSE/docker-containers-build@d9e75cd826dffd35984b8c7c9322494810b4e29c docker
+harlequin: git://github.com/openSUSE/docker-containers-build@d9e75cd826dffd35984b8c7c9322494810b4e29c docker
+
+# openSUSE 42.1
+42.1: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
+leap: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
+latest: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@35541028a567a6b797487ec202eb2dc7d469a591 docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@be79ebd1a6640e08fae0e79c1511546da2b58bcd docker


### PR DESCRIPTION
Introduce openSUSE Leap 42.1.
Update openSUSE 13.2 and Tumbleweed images.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>