### PR TITLE
Convert the tests to use "docker build" instead of explicit bind-mounts

### DIFF
--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -186,6 +186,12 @@ for repoTag in "${repos[@]}"; do
 			repoFile="$library/$repo"
 		fi
 		
+		if [ ! -f "$repoFile" ]; then
+			echo >&2 "error: '$repoFile' does not exist!"
+			didFail=1
+			continue
+		fi
+		
 		repoFile="$(readlink -f "$repoFile")"
 		echo "$repoTag ($repoFile)" >> "$logDir/repos.txt"
 		

--- a/test/tests/docker-build.sh
+++ b/test/tests/docker-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# wrapper around "docker build" that creates a temporary directory and copies files into it first so that arbitrary host directories can be copied into containers without bind mounts, but accepts a Dockerfile on stdin
+
+# usage: ./docker-build.sh some-host-directory -t some-new-image:some-tag <<EOD
+#        FROM ...
+#        COPY dir/... /.../
+#        EOD
+#    ie: ./docker-build.sh .../hylang-hello-world -t librarytest/hylang <<EOD
+#        FROM hylang
+#        COPY dir/container.hy /dir/
+#        CMD ["hy", "/dir/container.hy"]
+#        EOD
+
+dir="$1"; shift
+[ -d "$dir" ]
+
+tmp="$(mktemp -t -d docker-library-test-build-XXXXXXXXXX)"
+trap "rm -rf '$tmp'" EXIT
+
+cat > "$tmp/Dockerfile"
+cp -a "$dir" "$tmp/dir"
+docker build "$@" "$tmp" > /dev/null

--- a/test/tests/image-name.sh
+++ b/test/tests/image-name.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# usage: ./image-name.sh librarytest/something some/image:some-tag
+# output: librarytest/something:some-image-some-tag
+
+base="$1"; shift
+tag="$1"; shift
+
+echo "$base:$(echo "$tag" | sed 's![:/]!-!g')"

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -12,7 +12,12 @@ image="$1"
 clientImage="$image"
 
 # Create an instance of the container-under-test
-cid="$(docker run -d -v "$dir/index.jsp":/var/lib/jetty/webapps/ROOT/index.jsp:ro "$image")"
+serverImage="$("$dir/../image-name.sh" librarytest/jetty-hello-web "$image")"
+"$dir/../docker-build.sh" "$dir" -t "$serverImage" <<EOD
+FROM $image
+COPY dir/index.jsp /var/lib/jetty/webapps/ROOT/
+EOD
+cid="$(docker run -d "$serverImage")"
 trap "docker rm -vf $cid > /dev/null" EXIT
 
 _request() {

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -5,6 +5,12 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
+serverImage="$("$dir/../image-name.sh" librarytest/mysql-initdb "$image")"
+"$dir/../docker-build.sh" "$dir" -t "$serverImage" <<EOD
+FROM $image
+COPY dir/initdb.sql /docker-entrypoint-initdb.d/
+EOD
+
 export MYSQL_ROOT_PASSWORD='this is an example test password'
 export MYSQL_USER='0123456789012345' # "ERROR: 1470  String 'my cool mysql user' is too long for user name (should be no longer than 16)"
 export MYSQL_PASSWORD='my cool mysql password'
@@ -18,8 +24,7 @@ cid="$(
 		-e MYSQL_PASSWORD \
 		-e MYSQL_DATABASE \
 		--name "$cname" \
-		-v "$dir/initdb.sql:/docker-entrypoint-initdb.d/test.sql":ro \
-		"$image"
+		"$serverImage"
 )"
 trap "docker rm -vf $cid > /dev/null" EXIT
 

--- a/test/tests/php-fpm-hello-web/run.sh
+++ b/test/tests/php-fpm-hello-web/run.sh
@@ -7,7 +7,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # Build a client image with cgi-fcgi for testing
-clientImage='librarytest/php-fpm-hello-web:fcgi'
+clientImage='librarytest/php-fpm-hello-web:fcgi-client'
 docker build -t "$clientImage" - > /dev/null <<'EOF'
 FROM debian:jessie
 
@@ -16,8 +16,14 @@ RUN set -x && apt-get update && apt-get install -y libfcgi0ldbl && rm -rf /var/l
 ENTRYPOINT ["cgi-fcgi"]
 EOF
 
+serverImage="$("$dir/../image-name.sh" librarytest/php-fpm-hello-web "$image")"
+"$dir/../docker-build.sh" "$dir" -t "$serverImage" <<EOD
+FROM $image
+COPY dir/index.php /var/www/html/
+EOD
+
 # Create an instance of the container-under-test
-cid="$(docker run -d -v "$dir/index.php":/var/www/html/index.php:ro "$image")"
+cid="$(docker run -d "$serverImage")"
 trap "docker rm -vf $cid > /dev/null" EXIT
 
 # RACY TESTS ARE RACY

--- a/test/tests/postgres-initdb/run.sh
+++ b/test/tests/postgres-initdb/run.sh
@@ -5,6 +5,12 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
+serverImage="$("$dir/../image-name.sh" librarytest/postgres-initdb "$image")"
+"$dir/../docker-build.sh" "$dir" -t "$serverImage" <<EOD
+FROM $image
+COPY dir/initdb.sql /docker-entrypoint-initdb.d/
+EOD
+
 export POSTGRES_USER='my cool postgres user'
 export POSTGRES_PASSWORD='my cool postgres password'
 export POSTGRES_DB='my cool postgres database'
@@ -16,8 +22,7 @@ cid="$(
 		-e POSTGRES_PASSWORD \
 		-e POSTGRES_DB \
 		--name "$cname" \
-		-v "$dir/initdb.sql:/docker-entrypoint-initdb.d/test.sql":ro \
-		"$image"
+		"$serverImage"
 )"
 trap "docker rm -vf $cid > /dev/null" EXIT
 


### PR DESCRIPTION
Also, convert "test-pr.sh" to use a two-stage containerized approach to actually check out the tests from the PR we're testing (especially nice for PRs that contain image changes and test updates, so we can fix tests in the PR that changes the associated images, for example).

cc @md5 (welcome to the crazy ideas I've been mulling over :smiling_imp:)

This also adds a special case to "test-pr.sh" such that we can test our local directory contents as if it were a PR already:

To illustrate, `./test-pr.sh 0 hylang` results in:

Build test of #0; FAKE (`hylang`):

```console
$ bashbrew build "hylang"
Cloning hylang (git://github.com/hylang/hy) ...
Processing hylang:latest ...
Processing hylang:0 ...
Processing hylang:0.11 ...
Processing hylang:0.11.0 ...
$ bashbrew list --uniq "$url" | xargs test/run.sh
testing hylang:latest
	'utc' [1/6]...passed
	'cve-2014--shellshock' [2/6]...passed
	'no-hard-coded-passwords' [3/6]...passed
	'override-cmd' [4/6]...passed
	'hylang-sh' [5/6]...passed
	'hylang-hello-world' [6/6]...passed
```