### PR TITLE
Update Neo4j to 2.3.1

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -1,7 +1,7 @@
 # maintainer: Ben Butler-Cole <ben@neotechnology.com> (@benbc)
 
-2.3.0: git://github.com/neo4j/docker-neo4j@f424f2e0bbe0efca3608ffdc031e27c746da275d 2.3.0
-latest: git://github.com/neo4j/docker-neo4j@f424f2e0bbe0efca3608ffdc031e27c746da275d 2.3.0
+2.3.1: git://github.com/neo4j/docker-neo4j@026fcee712c5fd2596c7d41e14c2981404d94df2 2.3.1
+latest: git://github.com/neo4j/docker-neo4j@026fcee712c5fd2596c7d41e14c2981404d94df2 2.3.1
 
-2.3.0-enterprise: git://github.com/neo4j/docker-neo4j@f424f2e0bbe0efca3608ffdc031e27c746da275d 2.3.0-enterprise
-enterprise: git://github.com/neo4j/docker-neo4j@f424f2e0bbe0efca3608ffdc031e27c746da275d 2.3.0-enterprise
+2.3.1-enterprise: git://github.com/neo4j/docker-neo4j@026fcee712c5fd2596c7d41e14c2981404d94df2 2.3.1-enterprise
+enterprise: git://github.com/neo4j/docker-neo4j@026fcee712c5fd2596c7d41e14c2981404d94df2 2.3.1-enterprise


### PR DESCRIPTION
We've just released a new version of Neo4j, so we'd like to update the official image.

There are two other change to the image here, apart from the updated binary:
* constrain default heap size (https://github.com/neo4j/docker-neo4j/commit/d1b51e7416dc39240f7e9696513cbde84342ea08)
*  it is no longer necesary to provide all config files when overriding just one of them (https://github.com/neo4j/docker-neo4j/commit/026fcee712c5fd2596c7d41e14c2981404d94df2)

All the other commits since then are documentation-only or for publishing tags for other Neo4j version to our own repo.