### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.11: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 2.1
-2.1: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 2.1
+2.1.11: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.1
+2.1: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.1
 
-2.2.3: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 2.2
-2.2: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 2.2
-2: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 2.2
+2.2.3: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
+2.2: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
+2: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
 
-3.0.0: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 3.0
-3.0: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 3.0
-3: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 3.0
-latest: git://github.com/docker-library/cassandra@b72500bc9b75278301abcc14f86fe52a48e0ce5f 3.0
+3.0.0: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
+3.0: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
+3: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
+latest: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.6-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
-1.8-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
-1-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
-python2: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 2.7
+1.8.6-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
+1.8-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
+1-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
+python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
 
-python2-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 2.7/onbuild
+python2-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 2.7/onbuild
 
-1.8.6-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-1.8.6: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-1.8-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-1.8: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-1-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-1: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-python3: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
-latest: git://github.com/docker-library/django@b4ec88e57f86855901d74dc47558d95b549a2b31 3.4
+1.8.6-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1.8.6: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1.8-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1.8: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+latest: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
 
-python3-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild
-onbuild: git://github.com/docker-library/django@a918e5b9ac643924bfd987700a89dc52abfb782a 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 3.4/onbuild
+onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -4,7 +4,7 @@
 7: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 latest: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 
-8.0.0-rc3: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
-8.0.0: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
-8.0: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
-8: git://github.com/docker-library/drupal@9dbd2c70f08e7cef12c6780031647f9456dae0be 8
+8.0.0-rc4: git://github.com/docker-library/drupal@df294406ed259f02e721b7cf78560b21bdf88a1a 8
+8.0.0: git://github.com/docker-library/drupal@df294406ed259f02e721b7cf78560b21bdf88a1a 8
+8.0: git://github.com/docker-library/drupal@df294406ed259f02e721b7cf78560b21bdf88a1a 8
+8: git://github.com/docker-library/drupal@df294406ed259f02e721b7cf78560b21bdf88a1a 8

--- a/library/golang
+++ b/library/golang
@@ -13,6 +13,9 @@
 1.4.3-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
 1.4-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
 
+1.4.3-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
+1.4-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
+
 1.5.1: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
 1.5: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
 1: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
@@ -27,3 +30,8 @@ onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e
 1.5-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
 1-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
 wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
+
+1.5.1-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
+1.5-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
+1-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
+alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine


### PR DESCRIPTION
- `cassandra`: allow `rpc_address` and `start_rpc` configuration via env (docker-library/cassandra#35)
- `django`: add GNU `gettext` for `makemessages` (docker-library/django#12)
- `drupal`: 8.0.0-rc4 (docker-library/drupal#22)
- `golang`: add new `alpine` variant (docker-library/golang#68)