### PR TITLE
[ROS] Fixing entry point script

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,17 +1,17 @@
 # maintainer: Dirk Thomas <dthomas+buildfarm@osrfoundation.org> (@dirk-thomas)
 
-indigo-ros-core:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
-latest:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
+indigo-ros-core:    git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-ros-core
+indigo-ros-base:    git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-ros-base
+indigo-robot:       git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-robot
+indigo-perception:  git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-perception
+indigo:             git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-ros-base
+latest:             git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/indigo/indigo-ros-base
 # Docker EOL: 2019-04
 # LTS
 
-jade-ros-core:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
+jade-ros-core:    git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@f3acbc5ab3092a5d8e888f15046a01620ba3538f ros/jade/jade-ros-base
 # Docker EOL: 2017-04


### PR DESCRIPTION
Removing quotes to avoid exec attempting to find a command named as the entire string, thus braking commands with given arguments. 
Found this when testing [example compose file](https://github.com/docker-library/docs/pull/394).
See changes: https://github.com/osrf/docker_images/commit/f3acbc5ab3092a5d8e888f15046a01620ba3538f