### PR TITLE
Refresh long-neglected Mono images

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -3,31 +3,38 @@
 3.10.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
 3.10: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
 
-3.10.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0/onbuild
-3.10-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0/onbuild
+3.10.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
+3.10-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
 
-3.12.1: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
-3.12.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
-3.12: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
-3: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0
+3.12.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
+3.12.0: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
+3.12: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
 
-3.12.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
-3.12-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
-3-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.12.0/onbuild
+3.12.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
+3.12.0-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
+3.12-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
 
 3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 
-3.8.0-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild
-3.8-onbuild: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0/onbuild
+3.8.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
+3.8-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
 
-4.0.1: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
-4.0.0: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
-4.0: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
-4: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
-4.0.0-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
-4.0-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
-4-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
+4.0.5.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
+4.0.5: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
+4.0: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
 
-latest: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0
-onbuild: git://github.com/mono/docker@0d3556995aa47043059d60c42321e8ccaf173363 4.0.0/onbuild
+4.0.5.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
+4.0.5-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
+4.0-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
+
+4.2.1.102: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
+4.2.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
+4.2: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
+latest: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
+
+4.2.1.102-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
+4.2.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
+4.2-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
+onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
+


### PR DESCRIPTION
These are now more strictly versioned upstream, allowing for Docker to track more versions without automatic upgrades.

Have dropped the "3" and "4" version links, which were meaningless.

Moving forwards, there will be a 4-part version for each upstream release (but possibly containing package-specific bugfixes), plus 3-part and 2-part links to the latest versions thereof.