### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -5,7 +5,7 @@
 1-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
 python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
 
-python2-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 2.7/onbuild
+python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
 1.8.6-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
 1.8.6: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
@@ -16,5 +16,5 @@ python2-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a41
 python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
 latest: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
 
-python3-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 3.4/onbuild
-onbuild: git://github.com/docker-library/django@0dafa76e4892ff9effd97a414f0fb4f78f87332e 3.4/onbuild
+python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
+onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.3
-1.3: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.3
+1.3: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.4
-1.4: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.4
+1.4: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.5
-1.5: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.5
+1.5: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.6
-1.6: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
+1.6: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
 
-1.7.3: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
-1.7: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
-1: git://github.com/docker-library/elasticsearch@c0cc86cddec0de3bd8fa01bcca5ef0c36fc7d255 1.7
+1.7.3: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
+1.7: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
+1: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
 
-2.0.0: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
-2.0: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
-2: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
-latest: git://github.com/docker-library/elasticsearch@5b69bc2cf03614d2afafa1f6a85ed15e1c20a423 2.0
+2.0.0: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 2.0
+2.0: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 2.0
+2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 2.0
+latest: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 2.0

--- a/library/kibana
+++ b/library/kibana
@@ -3,7 +3,6 @@
 4.0.3: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
 4.0: git://github.com/docker-library/kibana@0ffeed9bb61036fca3f23fa4f9208b90a484f150 4.0
 
-
 4.1.3: git://github.com/docker-library/kibana@c05e1e821fcda0ca1908653c00adae04eeb95548 4.1
 4.1: git://github.com/docker-library/kibana@c05e1e821fcda0ca1908653c00adae04eeb95548 4.1
 

--- a/library/mongo
+++ b/library/mongo
@@ -18,7 +18,7 @@ latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c
 3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 
-3.2.0-rc2: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
-3.2.0: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
-3.2: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
-3.2-rc: git://github.com/docker-library/mongo@8b9f19b2dfa7a2d90e2c4152ca33c8879a88c872 3.2-rc
+3.2.0-rc3: git://github.com/docker-library/mongo@329c84e093c37d12c3099ad8e34d72461e54b451 3.2-rc
+3.2.0: git://github.com/docker-library/mongo@329c84e093c37d12c3099ad8e34d72461e54b451 3.2-rc
+3.2: git://github.com/docker-library/mongo@329c84e093c37d12c3099ad8e34d72461e54b451 3.2-rc
+3.2-rc: git://github.com/docker-library/mongo@329c84e093c37d12c3099ad8e34d72461e54b451 3.2-rc

--- a/library/owncloud
+++ b/library/owncloud
@@ -29,16 +29,16 @@
 8.1.4-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/fpm
 8.1-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/fpm
 
-8.2.0-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-8.2.0: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-8.2: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-8: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-apache: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
-latest: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/apache
+8.2.1-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8.2.1: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8.2: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+latest: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
 
-8.2.0-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
-fpm: git://github.com/docker-library/owncloud@ccce5969ff2cc416538fe4813b1a7f6350194ce8 8.2/fpm
+8.2.1-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
+fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-4.0.0: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
-2-4.0: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
-2-4: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
-2: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2
+2-4.0.1: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
+2-4.0: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
+2-4: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
+2: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
 
-2-4.0.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-4.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-4.0.0-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
-2-4.0-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
-2-4-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
-2-slim: git://github.com/docker-library/pypy@ad1dd1553b569ab2f53451f89513ba0ccca06ff2 2/slim
+2-4.0.1-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
+2-4.0-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
+2-4-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
+2-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
 3-2.4: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3

--- a/library/redmine
+++ b/library/redmine
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.7: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
-2.6: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
-2: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 2.6
+2.6.8: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
+2.6: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
+2: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
 
-2.6.7-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
+2.6.8-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
 2.6-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
 2-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
 
-3.0.5: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
-3.0: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
-3: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
-latest: git://github.com/docker-library/redmine@b1ee49aa86501363e5832fad93938cf40428c5b7 3.0
+3.0.6: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
+3.0: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
+3: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
+latest: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
 
-3.0.5-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
+3.0.6-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
 3.0-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
 3-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
 passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.3.1-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-4.3.1: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-4.3-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-4.3: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-4-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-apache: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-4: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
-latest: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 apache
+4.3.1-apache: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+4.3.1: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+4.3-apache: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+4.3: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+4-apache: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+apache: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+4: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
+latest: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e apache
 
-4.3.1-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
-4.3-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
-4-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
-fpm: git://github.com/docker-library/wordpress@4823a04099579f2aafb118ae8177449425cc84d2 fpm
+4.3.1-fpm: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e fpm
+4.3-fpm: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e fpm
+4-fpm: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e fpm
+fpm: git://github.com/docker-library/wordpress@4c69e958dac3fc28183093ed79931f34c2d1d67e fpm


### PR DESCRIPTION
- `django`: fix onbuild Dockerfile whitespace
- `elasticsearch`: fix 2.0.0 to listen on 0.0.0.0 instead of 127.0.0.1 by default (docker-library/elasticsearch#65)
- `kibana`: 4.1.3
- `mongo`: 3.2.0-rc3
- `owncloud`: 8.2.1
- `pypy`: 4.0.1
- `redmine`: 2.6.8 and 3.0.6
- `wordpress`: use provided MySQL root user only as a last resort in auto-configuration (docker-library/wordpress#104)