### PR TITLE
add latest 2.7.1; re-add 2.6 release series.

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,6 +4,9 @@
 2.5.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
 2.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
 
-2.7: git://github.com/arangodb/arangodb-docker@9a21f8fb32b497315b9420028945b6d8be111455 jessie/2.7.0
-2.7.0: git://github.com/arangodb/arangodb-docker@9a21f8fb32b497315b9420028945b6d8be111455 jessie/2.7.0
-latest: git://github.com/arangodb/arangodb-docker@9a21f8fb32b497315b9420028945b6d8be111455 jessie/2.7.0
+2.6: git://github.com/arangodb/arangodb-docker@803663b157696616d70e2bb44ce6e256f912e3a6 jessie/2.6.10
+2.6.10: git://github.com/arangodb/arangodb-docker@803663b157696616d70e2bb44ce6e256f912e3a6 jessie/2.6.10
+
+2.7: git://github.com/arangodb/arangodb-docker@313c56491780cc1835ab842fea425c73f7803f46 jessie/2.7.1
+2.7.1: git://github.com/arangodb/arangodb-docker@313c56491780cc1835ab842fea425c73f7803f46 jessie/2.7.1
+latest: git://github.com/arangodb/arangodb-docker@313c56491780cc1835ab842fea425c73f7803f46 jessie/2.7.1


### PR DESCRIPTION
Mixed up versions in the bot script.  Fixed, plus made actual releases.