### PR TITLE
bump erlang version to 18.1.4

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,9 +1,14 @@
 # maintainer: denc716@gmail.com (@c0b)
 
-18.1.3: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
-18.1:   git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
-18:     git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
-latest: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 18
+18.1.4: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
+18.1:   git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
+18:     git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
+latest: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
+
+18.1.4-onbuild: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
+18.1-onbuild:   git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
+18-onbuild:     git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
+onbuild:        git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
 
 17.5.6.4: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
 17.5:     git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17


### PR DESCRIPTION
also with changes:
1) add rebar3 version 3.0.0-beta.4
    https://github.com/rebar/rebar3/releases
2) onbuild image with default run rebar3 shell

https://github.com/c0b/docker-erlang-otp/commit/c5474e9