### PR TITLE
Update Mono to correct onbuild Dockerfile mistake

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -6,13 +6,15 @@
 3.10.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
 3.10-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
 
-3.12.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
-3.12.0: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
-3.12: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1
+3.12.1: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1
+3.12.0: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1
+3.12: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1
+3: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1
 
-3.12.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
-3.12.0-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
-3.12-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 3.12.1/onbuild
+3.12.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3.12.0-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3.12-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
 
 3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
@@ -20,21 +22,22 @@
 3.8.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
 3.8-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
 
-4.0.5.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
-4.0.5: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
-4.0: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1
+4.0.5.1: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1
+4.0.5: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1
+4.0: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1
 
-4.0.5.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
-4.0.5-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
-4.0-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.0.5.1/onbuild
+4.0.5.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
+4.0.5-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
+4.0-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
 
-4.2.1.102: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
-4.2.1: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
-4.2: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
-latest: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102
+4.2.1.102: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
+4.2.1: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
+4.2: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
+4: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
+latest: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
 
-4.2.1.102-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
-4.2.1-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
-4.2-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
-onbuild: git://github.com/mono/docker@4f0929a7cea6ab9e17a67e07ee7176c0446a5adb 4.2.1.102/onbuild
-
+4.2.1.102-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
+4.2.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
+4.2-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
+4-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
+onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild


### PR DESCRIPTION
We discovered that the -onbuild Dockerfile for 4.2.1.102 pointed to the wrong tag.
Additionally, we didn't have a tag for '3' and '4' versions.