### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.6-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
-1.8-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
-1-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
-python2: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 2.7
+1.8.7-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
+1.8-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
+1-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
+python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.8.6-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-1.8.6: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-1.8-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-1.8: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-1-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-1: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-python3: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
-latest: git://github.com/docker-library/django@3adb41cebc4b862de62409226d4631d8e6defec9 3.4
+1.8.7-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1.8.7: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1.8-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1.8: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+latest: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/owncloud
+++ b/library/owncloud
@@ -13,32 +13,32 @@
 7.0-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/fpm
 7-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/fpm
 
-8.0.9-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/apache
-8.0.9: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/apache
-8.0: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/apache
+8.0.9-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
+8.0.9: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
+8.0: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
 
-8.0.9-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.0/fpm
+8.0.9-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/fpm
 
-8.1.4-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/apache
-8.1.4: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/apache
-8.1: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/apache
+8.1.4-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
+8.1.4: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
+8.1: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
 
-8.1.4-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 8.1/fpm
+8.1.4-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/fpm
 
-8.2.1-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-8.2.1: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-8.2: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-8: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-apache: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
-latest: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/apache
+8.2.1-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8.2.1: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8.2: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+latest: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
 
-8.2.1-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
-fpm: git://github.com/docker-library/owncloud@9678a4ff060c8e5aa961af4e9966856daa96b600 8.2/fpm
+8.2.1-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
+fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
 
-8.0.28-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-jre7: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-8.0.28: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-8.0: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
-latest: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre7
+8.0.29-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8.0.29: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8.0: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+latest: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
 
-8.0.28-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
-jre8: git://github.com/docker-library/tomcat@bd58c7237bff0357e76c9c9ee22deac77a2860cb 8-jre8
+8.0.29-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
+jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8


### PR DESCRIPTION
- `django`: 1.8.7
- `owncloud`: switch from "ACPu-beta" to just "APCu" since "-beta" is now PHP-7-only (docker-library/owncloud#36)
- `tomcat`: 8.0.29