### PR TITLE
Update Node.js to 0.12.8

### DIFF
--- a/library/node
+++ b/library/node
@@ -12,21 +12,21 @@
 0.10.40-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/wheezy
 0.10-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/wheezy
 
-0.12.7: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
-0.12: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
-0: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12
+0.12.8: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
+0.12: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
+0: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
 
-0.12.7-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@701976f243b4bd08bc0b70e0a452eaa187363372 0.12/onbuild
+0.12.8-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
 
-0.12.7-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/slim
+0.12.8-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
 
-0.12.7-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.12/wheezy
+0.12.8-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
 
 4.2.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
 4.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2


### PR DESCRIPTION
This updates the Node.js 0.12 version to 0.12.8 and also updates npm to 3.4.1.

Reference:

- nodejs/node#2806
- https://nodejs.org/en/blog/release/v0.12.8/
