### PR TITLE
Add Oracle Linux 7.2

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,16 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
-7: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
-7.1: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.1
-7.0: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.7
-6.7: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.7
-6.6: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/5.11
-5.11: git://github.com/oracle/docker.git@cd11b463dcf97128b5472d33d6c1fdd6a8099e23 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/5.11

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@6bde6629b2b777b4ad2c67a2e99845b1d89e2683 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/5.11


### PR DESCRIPTION
Hopefully this should pass Travis CI. This PR adds the Oracle Linux 7.2 base image.