### PR TITLE
ZDOCK-4 - replace expired license in php-zendserver:7.0-php-5.4

### DIFF
--- a/library/php-zendserver
+++ b/library/php-zendserver
@@ -7,8 +7,8 @@
 8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 8.5/5.6
 8.5: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 8.5/5.6
 
-5.4: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 7.0/5.4
-7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 7.0/5.4
+5.4: git://github.com/zendtech/php-zendserver-docker@1aacbda2e70ecd7c004c7c44df47bfe4e3466632 7.0/5.4
+7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@1aacbda2e70ecd7c004c7c44df47bfe4e3466632 7.0/5.4
 
 8.6-preview-php7.0: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 8.6/7.0
 8.6: git://github.com/zendtech/php-zendserver-docker@e29b830b4a40fd40ae5a8229da8e9106358a8f75 8.6/7.0


### PR DESCRIPTION
This ammends PR 1222 - replace the license in php-zendserver:7.0-php-5.4 with a valid one.