### PR TITLE
Updates for django drupal golang mongo mysql php

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,17 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.8.7-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
-1.8-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
-1-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
-python2: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 2.7
+1.9-python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
+1-python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
+python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.8.7-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-1.8.7: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-1.8-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-1.8: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-1-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-1: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-python3: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
-latest: git://github.com/docker-library/django@55ab84ddbf16db89defb54925a0ebcab8b8f4209 3.4
+1.9-python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+1.9: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+1-python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+1: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+latest: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -3,7 +3,7 @@
 7.41: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 7: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
 
-8.0.0: git://github.com/docker-library/drupal@898b3178e7d1737347fe0602726b38c4bb300330 8
-8.0: git://github.com/docker-library/drupal@898b3178e7d1737347fe0602726b38c4bb300330 8
-8: git://github.com/docker-library/drupal@898b3178e7d1737347fe0602726b38c4bb300330 8
-latest: git://github.com/docker-library/drupal@898b3178e7d1737347fe0602726b38c4bb300330 8
+8.0.1: git://github.com/docker-library/drupal@ca201ee97093e5407f14f6cdad875cb5ea64e08a 8
+8.0: git://github.com/docker-library/drupal@ca201ee97093e5407f14f6cdad875cb5ea64e08a 8
+8: git://github.com/docker-library/drupal@ca201ee97093e5407f14f6cdad875cb5ea64e08a 8
+latest: git://github.com/docker-library/drupal@ca201ee97093e5407f14f6cdad875cb5ea64e08a 8

--- a/library/golang
+++ b/library/golang
@@ -16,22 +16,22 @@
 1.4.3-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
 1.4-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
 
-1.5.1: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
-1.5: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
-1: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
-latest: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5
+1.5.2: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
+1.5: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
+1: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
+latest: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
 
-1.5.1-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
+1.5.2-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 1.5-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 1-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 
-1.5.1-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
-1.5-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
-1-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
-wheezy: git://github.com/docker-library/golang@51d6eacd41fe80d41105142b9ad32f575082970f 1.5/wheezy
+1.5.2-wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
+1.5-wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
+1-wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
+wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
 
-1.5.1-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
-1.5-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
-1-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.5/alpine
+1.5.2-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
+1.5-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
+1-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
+alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -18,7 +18,7 @@ latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c
 3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 
-3.2.0-rc4: git://github.com/docker-library/mongo@8bad644787fba5b30d91f6d86931821deaa69989 3.2-rc
-3.2.0: git://github.com/docker-library/mongo@8bad644787fba5b30d91f6d86931821deaa69989 3.2-rc
-3.2: git://github.com/docker-library/mongo@8bad644787fba5b30d91f6d86931821deaa69989 3.2-rc
-3.2-rc: git://github.com/docker-library/mongo@8bad644787fba5b30d91f6d86931821deaa69989 3.2-rc
+3.2.0-rc6: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
+3.2.0: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
+3.2: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
+3.2-rc: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.46: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.5
-5.5: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.5
+5.5.46: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.5
+5.5: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.5
 
-5.6.27: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
-5.6: git://github.com/docker-library/mysql@4797ba77f07cb8ccd650a888b072f1d9de89f439 5.6
+5.6.27: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.6
+5.6: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.6
 
-5.7.9: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
-5.7: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
-5: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
-latest: git://github.com/docker-library/mysql@7dea35524a41992ed669858e80c07c5d666d5426 5.7
+5.7.9: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
+5.7: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
+5: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
+latest: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7

--- a/library/php
+++ b/library/php
@@ -25,33 +25,33 @@
 5.6.16-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 5.6-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 5-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 5.6.16: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 5.6: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 5: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-latest: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
 
 5.6.16-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
 5.6-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
 5-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
 
 5.6.16-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
 5.6-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
 5-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
 
-7.0.0RC8-cli: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
-7.0-cli: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
-7-cli: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
-7.0.0RC8: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
-7.0: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
-7: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0
+7.0.0-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7.0-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7.0.0: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7.0: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+latest: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
 
-7.0.0RC8-apache: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/apache
-7.0-apache: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/apache
-7-apache: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/apache
+7.0.0-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
+7.0-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
+7-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
+apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
 
-7.0.0RC8-fpm: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/fpm
-7-fpm: git://github.com/docker-library/php@e7762b5057d8b6dcf96abe16d4bd7d152784c68f 7.0/fpm
+7.0.0-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
+7-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
+fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm


### PR DESCRIPTION
- `django` bump to 1.9
- `drupal` bump to 8.0.1
- `golang` bump 1.5.2
- `mongo` bump to 3.2.0-rc6
- `mysql` see https://github.com/docker-library/mysql/pull/119
- `php` PHP 7.0 GA