### PR TITLE
Update Node.js to 0.10.41, 0.12.9, 4.2.3 and 5.1.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.40: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10
-0.10: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10
+0.10.41: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10
+0.10: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10
 
-0.10.40-onbuild: git://github.com/nodejs/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@9c93908dfcdc140c14aa78cbb4830850bcf99012 0.10/onbuild
+0.10.41-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
 
-0.10.40-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/slim
+0.10.41-slim: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/slim
 
-0.10.40-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@d798690bdae91174715ac083e31198674f044b68 0.10/wheezy
+0.10.41-wheezy: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/wheezy
 
-0.12.8: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
-0.12: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
-0: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12
+0.12.9: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
+0.12: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
+0: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
 
-0.12.8-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@79a29e6a4cb63f6e11824e21123e280a7345990f 0.12/onbuild
+0.12.9-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
 
-0.12.8-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/slim
+0.12.9-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
 
-0.12.8-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@e3ebe31f6cd0d61d2756c08e232d3583e2543079 0.12/wheezy
+0.12.9-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
 
-4.2.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
-4.2: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
-4: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
-argon: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2
+4.2.3: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
+4.2: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
+4: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
+argon: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
 
-4.2.2-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/onbuild
+4.2.3-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
 
-4.2.2-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
-argon-slim: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/slim
+4.2.3-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
+argon-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
 
-4.2.2-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@9992908b275546d9dc1b6063a4d0b7bc500e8b3b 4.2/wheezy
+4.2.3-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
 
-5.1.0: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1
-5.1: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1
-5: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1
-latest: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1
+5.1.1: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
+5.1: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
+5: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
+latest: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
 
-5.1.0-onbuild: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/onbuild
-5.1-onbuild: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/onbuild
-onbuild: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/onbuild
+5.1.1-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
+5.1-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
+onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
 
-5.1.0-slim: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/slim
-5.1-slim: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/slim
-5-slim: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/slim
-slim: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/slim
+5.1.1-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
+5.1-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
+5-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
+slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
 
-5.1.0-wheezy: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/wheezy
-5.1-wheezy: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/wheezy
-wheezy: git://github.com/nodejs/docker-node@3622304ad09a84826521e81cb7ddf253c020d89e 5.1/wheezy
+5.1.1-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
+5.1-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
+wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy


### PR DESCRIPTION
This Updates the various versions of node to:

- 0.10.41
- 0.12.9
- 4.2.3
- 5.1.1

Per: https://nodejs.org/en/blog/vulnerability/december-2015-security-releases/