### PR TITLE
Update ubuntu (especially for CVE-2015-3193 and friends)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 3c35594 Update tarballs
-#    - `ubuntu:precise`: 20151028
-#    - `ubuntu:trusty`: 20151028
-#    - `ubuntu:vivid`: 20151111
-#    - `ubuntu:wily`: 20151019
+#  - 3852ef7 Update tarballs
+#    - `ubuntu:precise`: 20151208
+#    - `ubuntu:trusty`: 20151208
+#    - `ubuntu:vivid`: 20151208
+#    - `ubuntu:wily`: 20151208
 
-# 20151028
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 precise
-precise-20151028: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 precise
+# 20151208
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 precise
+precise-20151208: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 precise
 
-# 20151028
-14.04.3: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 trusty
-trusty-20151028: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 trusty
+# 20151208
+14.04.3: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 trusty
+trusty-20151208: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 trusty
 
-# 20151111
-15.04: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 vivid
-vivid-20151111: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 vivid
-vivid: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 vivid
+# 20151208
+15.04: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 vivid
+vivid-20151208: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 vivid
+vivid: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 vivid
 
-# 20151019
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 wily
-wily-20151019: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@3c355946fd5164da3f31063a5c5f249c826f7071 wily
+# 20151208
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 wily
+wily-20151208: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@3852ef7c7e841ea8c126c9b00e64eeca61fe5ab0 wily


### PR DESCRIPTION
- `ubuntu:precise`: 20151208
- `ubuntu:trusty`: 20151208
- `ubuntu:vivid`: 20151208
- `ubuntu:wily`: 20151208

See https://github.com/docker-library/official-images/issues/1235.