### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.11: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.1
-2.1: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.1
+2.1.12: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.1
+2.1: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.1
 
-2.2.3: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
-2.2: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
-2: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 2.2
+2.2.4: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
+2.2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
+2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
 
-3.0.0: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
-3.0: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
-3: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
-latest: git://github.com/docker-library/cassandra@9062e0160e3a24ec0acb368c69d85153a43bfdb1 3.0
+3.0.1: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
+3.0: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
+3: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
+latest: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.31: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.2
-2.2: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.2
+2.2.31: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
+2.2: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
 
-2.4.17: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
-2.4: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
-2: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
-latest: git://github.com/docker-library/httpd@5b81416f52f626f087a4a08b50adaa65271ee69c 2.4
+2.4.17: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
+2.4: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
+2: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
+latest: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.4.1: git://github.com/docker-library/julia@52b372536c3dd5d01a7aacdd90a7246c5bf85a3d
-0.4: git://github.com/docker-library/julia@52b372536c3dd5d01a7aacdd90a7246c5bf85a3d
-latest: git://github.com/docker-library/julia@52b372536c3dd5d01a7aacdd90a7246c5bf85a3d
+0.4.2: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e
+0.4: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e
+latest: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e

--- a/library/logstash
+++ b/library/logstash
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.5-1-a2bacae: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.4
-1.4.5-1: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.4
-1.4.5: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.4
-1.4: git://github.com/docker-library/logstash@0b9134f8c83f58120bee00efd41f4b5867930016 1.4
+1.4.5-1-a2bacae: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
+1.4.5-1: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
+1.4.5: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
+1.4: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
 
-1.5.5-1: git://github.com/docker-library/logstash@a250673f3f3a6dec5176041f805d41d6e7fd90b0 1.5
-1.5.5: git://github.com/docker-library/logstash@a250673f3f3a6dec5176041f805d41d6e7fd90b0 1.5
-1.5: git://github.com/docker-library/logstash@a250673f3f3a6dec5176041f805d41d6e7fd90b0 1.5
-1: git://github.com/docker-library/logstash@a250673f3f3a6dec5176041f805d41d6e7fd90b0 1.5
+1.5.6-1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
+1.5.6: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
+1.5: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
+1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
 
-2.0.0-1: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
-2.0.0: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
-2.0: git://github.com/docker-library/logstash@c218eb120f20b4c8f19e2afb235ff012a5173794 2.0
+2.0.0-1: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
+2.0.0: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
+2.0: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
 
-2.1.0-1: git://github.com/docker-library/logstash@a50f6cf48fe5c16ba2c628fffa03733732135e55 2.1
-2.1.0: git://github.com/docker-library/logstash@a50f6cf48fe5c16ba2c628fffa03733732135e55 2.1
-2.1: git://github.com/docker-library/logstash@a50f6cf48fe5c16ba2c628fffa03733732135e55 2.1
-2: git://github.com/docker-library/logstash@a50f6cf48fe5c16ba2c628fffa03733732135e55 2.1
-latest: git://github.com/docker-library/logstash@a50f6cf48fe5c16ba2c628fffa03733732135e55 2.1
+2.1.1-1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 2.1
+2.1.1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 2.1
+2.1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 2.1
+2: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 2.1
+latest: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 2.1

--- a/library/mongo
+++ b/library/mongo
@@ -12,13 +12,11 @@
 
 3.0.7: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
 3.0: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
-3: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
-latest: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
 
 3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 
-3.2.0-rc6: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
-3.2.0: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
-3.2: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
-3.2-rc: git://github.com/docker-library/mongo@9cb4efe1d35b38a23e745d3aa3c9e8f87eaa7f5e 3.2-rc
+3.2.0: git://github.com/docker-library/mongo@fcb9584617e63f1d3db8dc730fb8abb83653c7ad 3.2
+3.2: git://github.com/docker-library/mongo@fcb9584617e63f1d3db8dc730fb8abb83653c7ad 3.2
+3: git://github.com/docker-library/mongo@fcb9584617e63f1d3db8dc730fb8abb83653c7ad 3.2
+latest: git://github.com/docker-library/mongo@fcb9584617e63f1d3db8dc730fb8abb83653c7ad 3.2

--- a/library/mysql
+++ b/library/mysql
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.46: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.5
-5.5: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.5
+5.5.47: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
+5.5: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
 
-5.6.27: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.6
-5.6: git://github.com/docker-library/mysql@6871ce6cdd55ecf09f81cf8f00dfac30b8c3ab1f 5.6
+5.6.28: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.6
+5.6: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.6
 
 5.7.9: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
 5.7: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7

--- a/library/python
+++ b/library/python
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.10: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
-2.7: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
-2: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7
+2.7.11: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
+2.7: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
+2: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
 
-2.7.10-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
+2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.10-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
-2.7-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
-2-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
+2.7-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
+2-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
 
-2.7.10-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
 
 3.2.6: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
 3.2: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
@@ -52,17 +52,17 @@
 3.4.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
 3.4-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
 
-3.5.0: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
-3.5: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
-3: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
-latest: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5
+3.5.1: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
+3.5: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
+3: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
+latest: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
 
-3.5.0-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.0-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
-3.5-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
-3-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
-slim: git://github.com/docker-library/python@e4a0ed26c086a48a75e9ea2b163c8262dcdff2af 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
+3.5-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
+3-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
+slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim

--- a/library/redmine
+++ b/library/redmine
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.8: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
-2.6: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
-2: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 2.6
+2.6.9: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
+2.6: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
+2: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
 
-2.6.8-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 2.6/passenger
+2.6.9-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
 
-3.0.6: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
-3.0: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
-3: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
-latest: git://github.com/docker-library/redmine@f0cccc5bda49bc605402ff4d633ea2bef9496cd6 3.0
+3.0.7: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
+3.0: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
+3: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
+latest: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
 
-3.0.6-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
-passenger: git://github.com/docker-library/redmine@e33c6a05d1828d5704509cb1e5e1aac4e7aa6d96 3.0/passenger
+3.0.7-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
+passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
 
-8.0.29-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-jre7: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-8.0.29: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-8.0: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
-latest: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre7
+8.0.30-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8.0.30: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8.0: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+latest: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
 
-8.0.29-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
-jre8: git://github.com/docker-library/tomcat@4e9726eb5182dd6fe93402485b9db4aae22177e1 8-jre8
+8.0.30-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
+jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8


### PR DESCRIPTION
- `cassandra`: 2.1.12 and 2.2.4
- `httpd`: enable "most" mods on 2.2 (docker-library/httpd#8)
- `julia`: 0.4.2
- `logstash`: 1.5.6 and 2.1.1
- `mongo`: 3.2.0 GA
- `mysql`: 5.5.47 and 5.6.28-1debian8
- `python`: 2.7.11 and 3.5.1 (note: `python-hy` currently fails on 3.5.1; see hylang/hy#995 for details)
- `redmine`: 2.6.9 and 3.0.7; passenger 5.0.22; remove `redmine.pid` (docker-library/redmine#5)
- `tomcat`: 8.0.30