### PR TITLE
Remove php:5.4; end of life

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,16 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.4.45-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
-5.4-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
-5.4.45: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
-5.4: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4
-
-5.4.45-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/apache
-5.4-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/apache
-
-5.4.45-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/fpm
-5.4-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.4/fpm
-
 5.5.30-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
 5.5-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
 5.5.30: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5


### PR DESCRIPTION
See https://secure.php.net/supported-versions.php for details.