### PR TITLE
Update Node.js to v5.2.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca
 4-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
 
-5.1.1: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
-5.1: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
-5: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
-latest: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1
+5.2.0: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
+5.2: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
+5: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
+latest: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
 
-5.1.1-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
-5.1-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
-onbuild: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/onbuild
+5.2.0-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
+5.2-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
+onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
 
-5.1.1-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
-5.1-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
-5-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
-slim: git://github.com/nodejs/docker-node@444da1d3492d12d1e174b2764b7c06105c0e407a 5.1/slim
+5.2.0-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
+5.2-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
+5-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
+slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
 
-5.1.1-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
-5.1-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 5.1/wheezy
+5.2.0-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
+5.2-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
+wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy


### PR DESCRIPTION
This PR updates the latest `node` Docker Image to v5.2.0 of Node.js.

Changeset: https://github.com/nodejs/docker-node/compare/444da1d3492d12d1e174b2764b7c06105c0e407a...5d433ece4d221fac7e38efbec25ffea2dea56286

Related: nodejs/node#4181
Related: nodejs/docker-node#76

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>