### PR TITLE
Update openSUSE images to fix security issues

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,13 +1,13 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.2
-13.2: git://github.com/openSUSE/docker-containers-build@d9e75cd826dffd35984b8c7c9322494810b4e29c docker
-harlequin: git://github.com/openSUSE/docker-containers-build@d9e75cd826dffd35984b8c7c9322494810b4e29c docker
+13.2: git://github.com/openSUSE/docker-containers-build@3bbe87081f5d8f89e56fdca093ea24c3ab8b2992 docker
+harlequin: git://github.com/openSUSE/docker-containers-build@3bbe87081f5d8f89e56fdca093ea24c3ab8b2992 docker
 
 # openSUSE 42.1
-42.1: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
-leap: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
-latest: git://github.com/openSUSE/docker-containers-build@da3cf11b9e96b61ffbe92de846e77075bc11e326 docker
+42.1: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
+leap: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
+latest: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@be79ebd1a6640e08fae0e79c1511546da2b58bcd docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@9afc04abd28f91bb954057bc32d7b2687adc9f03 docker


### PR DESCRIPTION
Fix openSSL CVE-2015-3193, CVE-2015-3194, CVE-2015-3195, CVE-2015-3196 https://github.com/docker-library/official-images/issues/1235