### PR TITLE
Jenkins 1.625.3 LTS

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -2,6 +2,6 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 # maintainer: Carlos Sanchez <csanchez@cloudbees.com> (@carlossg)
 
-latest: git://github.com/jenkinsci/jenkins-ci.org-docker@4fa9ebc13069fa8186728622cd63702cddf11162
-1.625.2: git://github.com/jenkinsci/jenkins-ci.org-docker@4fa9ebc13069fa8186728622cd63702cddf11162
+latest: git://github.com/jenkinsci/jenkins-ci.org-docker@83ce6f6070f1670563a00d0f61d04edd62b78f4f
+1.625.3: git://github.com/jenkinsci/jenkins-ci.org-docker@83ce6f6070f1670563a00d0f61d04edd62b78f4f
 


### PR DESCRIPTION
BTW seems that the 1.625.1 tag was removed from https://hub.docker.com/r/library/jenkins/tags/ 
why would that be?