### PR TITLE
Updates to mariadb, php, tomcat

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -5,6 +5,6 @@
 10: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
 latest: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
 
-5.5.46: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5
-5.5: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5
-5: git://github.com/docker-library/mariadb@fe52f7ab9f0a4f827394ba65f5c7f51def1959c1 5.5
+5.5.47: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
+5.5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
+5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5

--- a/library/php
+++ b/library/php
@@ -1,46 +1,46 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.30-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
-5.5-cli: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
-5.5.30: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
-5.5: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5
+5.5.30-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5
+5.5-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5
+5.5.30: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5
+5.5: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5
 
-5.5.30-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/apache
-5.5-apache: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/apache
+5.5.30-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5/apache
+5.5-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5/apache
 
-5.5.30-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@fec7f537f049aafd2102202519c3ca9cb9576707 5.5/fpm
+5.5.30-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.5/fpm
 
-5.6.16-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-5.6-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-5-cli: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-5.6.16: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-5.6: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
-5: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6
+5.6.16-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
+5.6-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
+5-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
+5.6.16: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
+5.6: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
+5: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6
 
-5.6.16-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
-5.6-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
-5-apache: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/apache
+5.6.16-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/apache
+5.6-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/apache
+5-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/apache
 
-5.6.16-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
-5-fpm: git://github.com/docker-library/php@12d7a6644a420a6e74e2bd57ebaa1c5f014984a3 5.6/fpm
+5.6.16-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/fpm
+5-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/fpm
 
-7.0.0-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-7.0-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-7-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-cli: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-7.0.0: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-7.0: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-7: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
-latest: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0
+7.0.0-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7.0-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7.0.0: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7.0: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+latest: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
 
-7.0.0-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
-7.0-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
-7-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
-apache: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/apache
+7.0.0-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
+7.0-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
+7-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
+apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
 
-7.0.0-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
-7-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
-fpm: git://github.com/docker-library/php@ff9dcb42c09b89869d854a0ba642a28a4b8ea00e 7.0/fpm
+7.0.0-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
+7-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
+fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm

--- a/library/tomcat
+++ b/library/tomcat
@@ -11,16 +11,16 @@
 6.0-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
 6-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
 
-7.0.65-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
-7.0.65: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
-7.0: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
-7: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre7
+7.0.67-jre7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
+7.0.67: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
+7.0: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
+7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
 
-7.0.65-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@8c174e038fe911fecc1a920a56afc10fd343bce2 7-jre8
+7.0.67-jre8: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre8
 
 8.0.30-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
 8.0-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7


### PR DESCRIPTION
- `mariadb` bump to `5.5.46`
- `php` add `--jobs` to docker-php-ext-install, see https://github.com/docker-library/php/pull/159
- `tomcat` bump `7.0.67`