### PR TITLE
Update Solr to 5.4.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -3,5 +3,8 @@
 
 5.3.1: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
 5.3: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
-5: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
-latest: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
+
+5.4.0: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
+5.4: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
+5: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
+latest: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4


### PR DESCRIPTION
Apache Solr 5.4.0 was released on 14th December 2015.

Link to the official announcement is at the announce@apache.org archives: https://mail-archives.apache.org/mod_mbox/www-announce/201512.mbox/%3C1450102801.3270143.466926913.41C0F29D%40webmail.messagingengine.com%3E