### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -12,9 +12,9 @@
 1.6.2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
 1.6: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
 
-1.7.3: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
-1.7: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
-1: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.7
+1.7.4: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
+1.7: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
+1: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
 
 2.0.1: git://github.com/docker-library/elasticsearch@730ed65afd6f61ffc39c3b4832458e378b49312a 2.0
 2.0: git://github.com/docker-library/elasticsearch@730ed65afd6f61ffc39c3b4832458e378b49312a 2.0

--- a/library/gcc
+++ b/library/gcc
@@ -19,6 +19,11 @@
 # Last Modified: 2015-07-16
 5.2.0: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
 5.2: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
-5: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
-latest: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
 # Docker EOL: 2016-07-16
+
+# Last Modified: 2015-12-04
+5.3.0: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
+5.3: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
+5: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
+latest: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
+# Docker EOL: 2016-12-04

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.2: git://github.com/docker-library/ghost@0e550c2109f6fdf35cc5fc11cd3563d89f7f45bb
-0.7: git://github.com/docker-library/ghost@0e550c2109f6fdf35cc5fc11cd3563d89f7f45bb
-0: git://github.com/docker-library/ghost@0e550c2109f6fdf35cc5fc11cd3563d89f7f45bb
-latest: git://github.com/docker-library/ghost@0e550c2109f6fdf35cc5fc11cd3563d89f7f45bb
+0.7.3: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
+0.7: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
+0: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
+latest: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40

--- a/library/httpd
+++ b/library/httpd
@@ -3,7 +3,7 @@
 2.2.31: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
 2.2: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
 
-2.4.17: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
-2.4: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
-2: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
-latest: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.4
+2.4.18: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
+2.4: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
+2: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
+latest: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4

--- a/library/java
+++ b/library/java
@@ -45,16 +45,16 @@ openjdk-8-jre: git://github.com/docker-library/java@200ecf22e5a23cb48cbb3ce47aa0
 8-jre: git://github.com/docker-library/java@200ecf22e5a23cb48cbb3ce47aa08aa3b49a0d2d openjdk-8-jre
 jre: git://github.com/docker-library/java@200ecf22e5a23cb48cbb3ce47aa08aa3b49a0d2d openjdk-8-jre
 
-openjdk-9-b94-jdk: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-openjdk-9-b94: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-openjdk-9-jdk: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-openjdk-9: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-9-b94-jdk: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-9-b94: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-9-jdk: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
-9: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jdk
+openjdk-9-b96-jdk: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+openjdk-9-b96: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+openjdk-9-jdk: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+openjdk-9: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+9-b96-jdk: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+9-b96: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+9-jdk: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
+9: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jdk
 
-openjdk-9-b94-jre: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jre
-openjdk-9-jre: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jre
-9-b94-jre: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jre
-9-jre: git://github.com/docker-library/java@5ed8eb2445b2ff267a9c88c9ddaaa7dd9e384134 openjdk-9-jre
+openjdk-9-b96-jre: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jre
+openjdk-9-jre: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jre
+9-b96-jre: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jre
+9-jre: git://github.com/docker-library/java@e2f1ab45666ee26160609c4b32517488d52d1428 openjdk-9-jre

--- a/library/mongo
+++ b/library/mongo
@@ -10,8 +10,8 @@
 2.6: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
 2: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
 
-3.0.7: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
-3.0: git://github.com/docker-library/mongo@35d3a11dd6cee3675fb149593e7a20e42c76fa86 3.0
+3.0.8: git://github.com/docker-library/mongo@d9b96ad7dfac1bb5203b549a676535351ee48d4d 3.0
+3.0: git://github.com/docker-library/mongo@d9b96ad7dfac1bb5203b549a676535351ee48d4d 3.0
 
 3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
 3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1

--- a/library/mysql
+++ b/library/mysql
@@ -3,10 +3,10 @@
 5.5.47: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
 5.5: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
 
-5.6.28: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.6
-5.6: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.6
+5.6.27: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.6
+5.6: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.6
 
-5.7.9: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
-5.7: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
-5: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
-latest: git://github.com/docker-library/mysql@141b713b8c973a7a2592b5f6bf9c44693fedea36 5.7
+5.7.10: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
+5.7: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
+5: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
+latest: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.6: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43
-3.5: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43
-3: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43
-latest: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43
+3.5.7: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
+3.5: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
+3: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
+latest: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
 
-3.5.6-management: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43 management
-3.5-management: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43 management
-3-management: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43 management
-management: git://github.com/docker-library/rabbitmq@60e5665854131f7fcb9ab0285d7d52ac932efb43 management
+3.5.7-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
+3.5-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
+3-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
+management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management

--- a/library/ruby
+++ b/library/ruby
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p647: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
-2.0.0: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
-2.0: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0
+2.0.0-p648: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
+2.0.0: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
+2.0: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
 
-2.0.0-p647-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
+2.0.0-p648-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 
-2.0.0-p647-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.0/slim
+2.0.0-p648-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
 
-2.1.7: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1
-2.1: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1
+2.1.8: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1
+2.1: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1
 
-2.1.7-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
+2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.7-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.1/slim
+2.1.8-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1/slim
 
-2.2.3: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
-2.2: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
-2: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
-latest: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2
+2.2.4: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
+2.2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
+2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
+latest: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
 
-2.2.3-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
+2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.3-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
-2-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
-slim: git://github.com/docker-library/ruby@74ee8aec9c17ea2134db8a8ef199cf092c829576 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.4.0-apache: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-4.4.0: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-4.4-apache: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-4.4: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-4-apache: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-apache: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-4: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
-latest: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d apache
+4.4.0-apache: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+4.4.0: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+4.4-apache: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+4.4: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+4-apache: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+apache: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+4: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
+latest: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b apache
 
-4.4.0-fpm: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d fpm
-4.4-fpm: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d fpm
-4-fpm: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d fpm
-fpm: git://github.com/docker-library/wordpress@4cae1f357818979b3a493d3cefbe55d69d9c765d fpm
+4.4.0-fpm: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b fpm
+4.4-fpm: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b fpm
+4-fpm: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b fpm
+fpm: git://github.com/docker-library/wordpress@d0638d3fc8aab0453fadb3d314420bf3ab0e899b fpm


### PR DESCRIPTION
- `elasticsearch`: 1.7.4
- `gcc`: 5.3.0 (docker-library/gcc#24)
- `ghost`: 0.7.3
- `httpd`: 2.4.18
- `java`: 9~b96-1
- `mongo`: 3.0.8
- `mysql`: 5.7.10-1debian8 and 5.6.27-1debian8
- `rabbitmq`: 3.5.7-1
- `ruby`: 2.2.4, 2.1.8, and 2.0.0-p648; bundler 1.11.2, rubygems 2.5.1
- `wordpress`: enable `mod_expires` (docker-library/wordpress#111), add `WORDPRESS_DEBUG` env (docker-library/wordpress#108)