### PR TITLE
Update Node.js to v5.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca
 4-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
 
-5.2.0: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
-5.2: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
-5: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
-latest: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2
+5.3.0: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3
+5.3: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3
+5: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3
+latest: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3
 
-5.2.0-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
-5.2-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
-onbuild: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/onbuild
+5.3.0-onbuild: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/onbuild
+5.3-onbuild: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/onbuild
+onbuild: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/onbuild
 
-5.2.0-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
-5.2-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
-5-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
-slim: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/slim
+5.3.0-slim: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/slim
+5.3-slim: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/slim
+5-slim: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/slim
+slim: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/slim
 
-5.2.0-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
-5.2-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
-wheezy: git://github.com/nodejs/docker-node@5d433ece4d221fac7e38efbec25ffea2dea56286 5.2/wheezy
+5.3.0-wheezy: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/wheezy
+5.3-wheezy: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/wheezy
+wheezy: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3/wheezy


### PR DESCRIPTION
This PR updates the latest `node` Docker Image to v5.3.0 of Node.js.

Changeset: https://github.com/nodejs/docker-node/compare/5d433ece4d221fac7e38efbec25ffea2dea56286...87993b5bb5b47a6dfc9f27b553406a4cb60f7050

Related: nodejs/node#4281
Related: nodejs/docker-node#79

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>