### PR TITLE
Updated Oracle Linux 7.2 image

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@46bea8247257750039951e1bcd892f56181f02b3 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/5.11


### PR DESCRIPTION
New OpenSSL packages re #1235 and fix CVE-2015-3193, CVE-2015-3194, CVE-2015-3195, CVE-2015-3196.

Signed-off-by: Avi Miller <avi.miller@gmail.com>