### PR TITLE
Add CouchDB

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -1,0 +1,10 @@
+# maintainer: Clemens Stolle <klaemo@apache.org> (@klaemo)
+
+latest: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1
+1.6.1: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1
+1.6: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1
+1: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1
+
+1.6.1-couchperuser: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1-couchperuser
+1.6-couchperuser: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1-couchperuser
+1-couchperuser: git://github.com/klaemo/docker-couchdb@fe82d8781f99cefb4b5efbaa319b30fd4f80a73f 1.6.1-couchperuser


### PR DESCRIPTION
Hey there,

I'm the CouchDB Docker person and I'd like to add an official CouchDB image to the registry.
It is based on the popular [klaemo/couchdb](https://hub.docker.com/r/klaemo/couchdb/) image.
Let me know, if you need me to change anything.

Thanks for reviewing.