### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -35,3 +35,15 @@ wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827
 1.5-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
 1-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
 alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
+
+1.6beta1: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6
+1.6: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6
+
+1.6beta1-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
+1.6-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
+
+1.6beta1-wheezy: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/wheezy
+1.6-wheezy: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/wheezy
+
+1.6beta1-alpine: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/alpine
+1.6-alpine: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.26: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
-1.4: git://github.com/docker-library/haproxy@e06675f0670414932e659db5ba8f98f8a430a1d1 1.4
+1.4.26: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.4
+1.4: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.4
 
-1.5.15: git://github.com/docker-library/haproxy@2c73ea45ca3defee81f16ca206d2c2ca8e79f167 1.5
-1.5: git://github.com/docker-library/haproxy@2c73ea45ca3defee81f16ca206d2c2ca8e79f167 1.5
+1.5.15: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
+1.5: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
 
-1.6.2: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
-1.6: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
-1: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
-latest: git://github.com/docker-library/haproxy@dbb1a9e1991643c64785dd359f67daa4201c034f 1.6
+1.6.2: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
+1.6: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
+1: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
+latest: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.0.22: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
-10.0: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
-10: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
-latest: git://github.com/docker-library/mariadb@034c283be05caa5e465047ce19f1770647eadd74 10.0
+10.0.23: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
+10.0: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
+10: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
+latest: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
 
 5.5.47: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
 5.5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -3,8 +3,8 @@
 5.5.47: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
 5.5: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
 
-5.6.27: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.6
-5.6: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.6
+5.6.28: git://github.com/docker-library/mysql@a1a948c19137b7843ff0c7de0c95d22b74ecfefd 5.6
+5.6: git://github.com/docker-library/mysql@a1a948c19137b7843ff0c7de0c95d22b74ecfefd 5.6
 
 5.7.10: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
 5.7: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7

--- a/library/php
+++ b/library/php
@@ -26,21 +26,21 @@
 5.6-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/fpm
 5-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 5.6/fpm
 
-7.0.0-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-7.0-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-7-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-cli: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-7.0.0: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-7.0: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-7: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
-latest: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0
+7.0.1-cli: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+7.0-cli: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+7-cli: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+cli: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+7.0.1: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+7.0: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+7: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
+latest: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0
 
-7.0.0-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
-7.0-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
-7-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
-apache: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/apache
+7.0.1-apache: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/apache
+7.0-apache: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/apache
+7-apache: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/apache
+apache: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/apache
 
-7.0.0-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
-7-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
-fpm: git://github.com/docker-library/php@a9f7fed15bc6bb03aa3648560ef4cb0ac79fb612 7.0/fpm
+7.0.1-fpm: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/fpm
+7-fpm: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/fpm
+fpm: git://github.com/docker-library/php@914f1fc040ed55d6fca2af602bdf0bb6f6b3b319 7.0/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -17,5 +17,5 @@
 9: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
 latest: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
 
-9.5-beta2: git://github.com/docker-library/postgres@8a9fbcb40f13ccc7762f278b9df611cabe22d300 9.5
-9.5: git://github.com/docker-library/postgres@8a9fbcb40f13ccc7762f278b9df611cabe22d300 9.5
+9.5-rc1: git://github.com/docker-library/postgres@d74474439c5ce1b0d7a2e17a310e53ae975e519b 9.5
+9.5: git://github.com/docker-library/postgres@d74474439c5ce1b0d7a2e17a310e53ae975e519b 9.5

--- a/library/redis
+++ b/library/redis
@@ -14,12 +14,12 @@
 2.8-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
 2-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
 
-3.0.5: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
-3.0: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
-3: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
-latest: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0
+3.0.6: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
+3.0: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
+3: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
+latest: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
 
-3.0.5-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 3.0/32bit
+3.0.6-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
+32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit


### PR DESCRIPTION
- `golang`: 1.6beta1 (docker-library/golang#72)
- `haproxy`: switch to `debian:jessie` (docker-library/haproxy#14)
- `mariadb`: 10.0.23+maria-1~jessie
- `mysql`: 5.6.28-1debian8
- `php`: 7.0.1 (docker-library/php#164)
- `postgres`: 9.5~rc1-1.pgdg80+1
- `redis`: 3.0.6