### PR TITLE
Updates to websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,17 +1,17 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
-kernel: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/kernel
-8.5.5.7-kernel: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/common
-8.5.5.7-common: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.7-webProfile6: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.7-webProfile7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7-javaee7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@975e98caeaf81eb0648832d54778e0d6b079e4b4 websphere-liberty/8.5.5/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@a985ec807ce260337a36875a76a57d9a8eed9d40 websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
+8.5.5.7-kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
+8.5.5.7-common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.7-webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.7-webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.7-javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/beta


### PR DESCRIPTION
A roll-up of changes from the last week:

 - Removal of license acceptance environment variable
 - Update to WebSphere Liberty 8.5.5.8 (includes fix for Apache
   Commons Vulnerability (CVE-2015-7450)
 - Separate Liberty configuration and output using the
   WLP_OUTPUT_DIR environment variable; create symlink shortcuts
   /config and /output
 - Separate out Liberty logs to /logs using LOG_DIR