### PR TITLE
Add Varnish

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,0 +1,7 @@
+# maintainer: Eric Lewis <eric.lewis@nytimes.com> (@ericandrewlewis)
+# maintainer: Eric Buth <eric.buth@nytimes.com> (@buth)
+
+4.1.0: git://github.com/newsdev/docker-varnish@2338063953894a2b812712b75c48e0e4fd31a5c9
+4.1: git://github.com/newsdev/docker-varnish@2338063953894a2b812712b75c48e0e4fd31a5c9
+4: git://github.com/newsdev/docker-varnish@2338063953894a2b812712b75c48e0e4fd31a5c9
+latest: git://github.com/newsdev/docker-varnish@2338063953894a2b812712b75c48e0e4fd31a5c9


### PR DESCRIPTION
Hi,

we've open sourced our Varnish Dockerfile and would like to contribute it to the community :smile:
# Checklist for Review
- [ ] associated with or contacted upstream?
  - https://www.varnish-cache.org/lists/pipermail/varnish-misc/2015-December/024747.html :cry:
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
- [ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [ ] 2+ dockerization review?
- [ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
