### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -7,7 +7,7 @@
 2.2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
 2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
 
-3.0.1: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
-3.0: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
-3: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
-latest: git://github.com/docker-library/cassandra@95facd11ffa7048dbde8cefa8b1847a1d6a613f3 3.0
+3.0.2: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
+3.0: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
+3: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
+latest: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0

--- a/library/owncloud
+++ b/library/owncloud
@@ -2,43 +2,43 @@
 
 # https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
-7.0.11-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
-7.0.11: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
-7.0: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
-7: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/apache
+7.0.12-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7.0.12: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7.0: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
 
-7.0.11-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@4e2e35d39456479193a9aa5984be69bd90a3b5aa 7.0/fpm
+7.0.12-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
 
-8.0.9-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
-8.0.9: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
-8.0: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/apache
+8.0.10-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
+8.0.10: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
+8.0: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
 
-8.0.9-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.0/fpm
+8.0.10-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/fpm
 
-8.1.4-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
-8.1.4: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
-8.1: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/apache
+8.1.5-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
+8.1.5: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
+8.1: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
 
-8.1.4-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.1/fpm
+8.1.5-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/fpm
 
-8.2.1-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-8.2.1: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-8.2: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-8: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-apache: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
-latest: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/apache
+8.2.2-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8.2.2: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8.2: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+latest: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
 
-8.2.1-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
-fpm: git://github.com/docker-library/owncloud@1729d80aabfd0d9a7d345991dbf80cc4b8a00c7f 8.2/fpm
+8.2.2-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
+fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm

--- a/library/python
+++ b/library/python
@@ -40,17 +40,17 @@
 3.3.6-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
 3.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
 
-3.4.3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
-3.4: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4
+3.4.4: git://github.com/docker-library/python@f9739c6da575c450aaed8628c1e0bfa97bf1ba18 3.4
+3.4: git://github.com/docker-library/python@f9739c6da575c450aaed8628c1e0bfa97bf1ba18 3.4
 
-3.4.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
+3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
-3.4-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/slim
+3.4-slim: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/slim
 
-3.4.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/wheezy
 
 3.5.1: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
 3.5: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5

--- a/library/redmine
+++ b/library/redmine
@@ -4,16 +4,16 @@
 2.6: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
 2: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
 
-2.6.9-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 2.6/passenger
+2.6.9-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
 
 3.0.7: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
 3.0: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
 3: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
 latest: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
 
-3.0.7-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
-passenger: git://github.com/docker-library/redmine@f8d57eb52d315683ad75d07dd7429ba26b8e7963 3.0/passenger
+3.0.7-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
+3-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
+passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger


### PR DESCRIPTION
- `cassandra`: 3.0.2
- `owncloud`: 7.0.12, 8.1.5, 8.2.2; fix APCu build failure (docker-library/owncloud#40)
- `python`: 3.4.4
- `redmine`: passenger 5.0.23