### PR TITLE
Update websphere-liberty tags to 8.5.5.8

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,16 +2,16 @@
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
 kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
-8.5.5.7-kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
+8.5.5.8-kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
 common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
-8.5.5.7-common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
+8.5.5.8-common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
 webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.7-webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.8-webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
 webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.7-webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.8-webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
 javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7-javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.8-javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.8: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
 8.5.5: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
 latest: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
 beta: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/beta


### PR DESCRIPTION
This should have been included in my last pull request. Let me know if you think that we should re-build the 8.5.5.7 images as they would have been previously first. Personally I am not encouraging people to use those version tagged images and am only using them as a (mostly correct) indicator of the current image content.