### PR TITLE
Update node to 4.2.4

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
 
-4.2.3: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
-4.2: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
-4: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
-argon: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2
+4.2.4: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
+4.2: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
+4: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
+argon: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
 
-4.2.3-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/onbuild
+4.2.4-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
 
-4.2.3-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
-argon-slim: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/slim
+4.2.4-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
+argon-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
 
-4.2.3-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@bb89224e0f2572e4894c50abfa8174ca65d6b28f 4.2/wheezy
+4.2.4-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
 
 5.3.0: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3
 5.3: git://github.com/nodejs/docker-node@87993b5bb5b47a6dfc9f27b553406a4cb60f7050 5.3


### PR DESCRIPTION
This PR updates v4 variants of the `node` Docker Image to v4.2.4 of Node.js.

Changeset: https://github.com/nodejs/docker-node/compare/bb89224e0f2572e4894c50abfa8174ca65d6b28f...7cbea391f22678de5d828b1a38c27a25c951795f

Related: nodejs/node#4336
Related: nodejs/docker-node#81

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>