### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -50,3 +50,9 @@ wily-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a7498841773
 wily-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wily/scm
 
 wily: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 wily
+
+xenial-curl: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/curl
+
+xenial-scm: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/scm
+
+xenial: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.3: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
-0.7: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
-0: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
-latest: git://github.com/docker-library/ghost@fd8e24cd72cb47288f5dcde08713284b8fac6d40
+0.7.4: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
+0.7: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
+0: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
+latest: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0

--- a/library/haproxy
+++ b/library/haproxy
@@ -6,7 +6,7 @@
 1.5.15: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
 1.5: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
 
-1.6.2: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
-1.6: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
-1: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
-latest: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.6
+1.6.3: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
+1.6: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
+1: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
+latest: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,9 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
+10.1.10: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
+10.1: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
+10: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
+latest: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
+
 10.0.23: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
 10.0: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
-10: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
-latest: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
 
 5.5.47: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
 5.5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5

--- a/library/python
+++ b/library/python
@@ -1,68 +1,68 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
-2.7: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
-2: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7
+2.7.11: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
+2.7: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
+2: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
-2.7-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
-2-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
+2.7-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
+2-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
 
-2.7.11-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
-3.2: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2
+3.2.6: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2
+3.2: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/slim
-3.2-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/slim
+3.2-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3
-3.3: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3
+3.3.6: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3
+3.3: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/slim
-3.3-slim: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/slim
+3.3-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@15798abb6cfb145344462a345db4b572227fb859 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@f9739c6da575c450aaed8628c1e0bfa97bf1ba18 3.4
-3.4: git://github.com/docker-library/python@f9739c6da575c450aaed8628c1e0bfa97bf1ba18 3.4
+3.4.4: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4
+3.4: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/slim
-3.4-slim: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/slim
+3.4-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/slim
 
-3.4.4-wheezy: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@00c226b82eee61c6c68adf813d9f7177d2efa52a 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
-3.5: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
-3: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
-latest: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5
+3.5.1: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5
+3.5: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5
+3: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5
+latest: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
-3.5-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
-3-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
-slim: git://github.com/docker-library/python@5909006206b117a7e9d1a329abdde6031e7342c5 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5/slim
+3.5-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5/slim
+3-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5/slim
+slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.5/slim

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.5.7: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
-3.5: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
-3: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
-latest: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a
+3.6.0: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3
+3.6: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3
+3: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3
+latest: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3
 
-3.5.7-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
-3.5-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
-3-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
-management: git://github.com/docker-library/rabbitmq@9444464ce885bc73b315b4f83c37ee56ed15180a management
+3.6.0-management: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3 management
+3.6-management: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3 management
+3-management: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3 management
+management: git://github.com/docker-library/rabbitmq@ec1f618a64a518ba54ea9e9511b4dad444bda8f3 management

--- a/library/redis
+++ b/library/redis
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.6
-2.6: git://github.com/docker-library/redis@94e9dcaaa93312651e91815fe7e4c5ef0f266408 2.6
+2.6.17: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6
+2.6: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6
 
-2.6.17-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
-2.6-32bit: git://github.com/docker-library/redis@5e3f74f3edbbf8311b86e40e7ebe47f602981387 2.6/32bit
+2.6.17-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6/32bit
+2.6-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6/32bit
 
-2.8.23: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
-2.8: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
-2: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8
+2.8.23: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
+2.8: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
+2: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
 
-2.8.23-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@8929846148513a1e35e4212003965758112f8b55 2.8/32bit
+2.8.23-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
 
-3.0.6: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
-3.0: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
-3: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
-latest: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0
+3.0.6: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
+3.0: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
+3: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
+latest: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
 
-3.0.6-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
-32bit: git://github.com/docker-library/redis@59416b013c78ab027fac81ec11c285a228b149c7 3.0/32bit
+3.0.6-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
+32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit

--- a/library/ruby
+++ b/library/ruby
@@ -23,15 +23,24 @@
 
 2.2.4: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
 2.2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
-2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
-latest: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
-2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
 2.2.4-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
 2.2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
-2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+
+2.3.0: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
+2.3: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
+2: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
+latest: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
+
+2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+
+2.3.0-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
+2-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
+slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim


### PR DESCRIPTION
- `buildpack-deps`: add xenial (docker-library/buildpack-deps#39)
- `ghost`: 0.7.4
- `haproxy`: 1.6.3
- `mariadb`: 10.1.10 (finally, 10.1!)
- `python`: add `-f` to `curl` invocations (docker-library/python#73)
- `rabbitmq`: 3.6.0-1
- `redis`: add `-f` to `curl` invocations (docker-library/redis#37), switch to jessie (docker-library/redis#38)
- `ruby`: 2.3 :tada: (docker-library/ruby#59)