### PR TITLE
Add the notion of "explicit variants" to our test suite

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -8,6 +8,14 @@ globalTests+=(
 	override-cmd
 )
 
+# for "explicit" images, only run tests that are explicitly specified for that image/variant
+explicitTests+=(
+	[:onbuild]=1
+)
+imageTests[:onbuild]+='
+	override-cmd
+'
+
 testAlias+=(
 	[iojs]='node'
 	[jruby]='ruby'
@@ -157,4 +165,3 @@ globalExcludeTests+=(
 	[ruby:slim_ruby-bundler]=1
 	[ruby:slim_ruby-gems]=1
 )
-

--- a/test/tests/remove-onbuild.sh
+++ b/test/tests/remove-onbuild.sh
@@ -47,8 +47,10 @@ mkdir -p "$tmp/$newId"
 echo "$jsonString" > "$tmp/$newId/json"
 echo -n '1.0' > "$tmp/$newId/VERSION"
 dd if=/dev/zero of="$tmp/$newId/layer.tar" bs=1k count=1 &> /dev/null # empty tar file
+
 cat > "$tmp/repositories" <<EOF
 {"$outImage":{"$outTag":"$newId"}}
 EOF
+
 docker rmi -f "$out" &> /dev/null || true # avoid "already exists, renaming the old one" from "docker load"
 tar -cC "$tmp" . | docker load


### PR DESCRIPTION
For an "explicit variant", only the tests specified _explicitly_ for that variant will be executed -- the initial target of this is to not run quite so many tests on ":onbuild" variants, thus no longer requiring our hacky remove-onbuild logic (since the ":onbuild" variants are usually just extra metadata and sometimes a few extra packages on top of the standard variant).