### PR TITLE
bump erlang versions to 18.2.1 & 17.5.6.7

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,15 +1,15 @@
 # maintainer: denc716@gmail.com (@c0b)
 
-18.1.4: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
-18.1:   git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
-18:     git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
-latest: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18
+18.2.1: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
+18.2:   git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
+18:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
+latest: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
 
-18.1.4-onbuild: git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
-18.1-onbuild:   git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
-18-onbuild:     git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
-onbuild:        git://github.com/c0b/docker-erlang-otp@20e41464075dc0fc76709be77701530eddb6fe33 18/onbuild
+18.2.1-onbuild: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
+18.2-onbuild:   git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
+18-onbuild:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
+onbuild:        git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
 
-17.5.6.4: git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
-17.5:     git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
-17:       git://github.com/c0b/docker-erlang-otp@70fd1e32745cbc68e894d340b105f30b387966c8 17
+17.5.6.7: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17
+17.5:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17
+17:       git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17


### PR DESCRIPTION
bump versions.