### PR TITLE
Fix python-hy to not use bash

### DIFF
--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 pip install -q hy

--- a/test/tests/python-hy/run.sh
+++ b/test/tests/python-hy/run.sh
@@ -1,1 +1,1 @@
-../run-bash-in-container.sh
+../run-sh-in-container.sh

--- a/test/tests/run-sh-in-container.sh
+++ b/test/tests/run-sh-in-container.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
+runDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+source "$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh


### PR DESCRIPTION
The python alpine variant does not ship bash so we use /bin/sh instead.