### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,5 +9,8 @@
 
 3.0.2: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
 3.0: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
-3: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
-latest: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
+
+3.1.1: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
+3.1: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
+3: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
+latest: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1

--- a/library/django
+++ b/library/django
@@ -1,17 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9-python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
-1-python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
-python2: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 2.7
+1.9.1-python2: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 2.7
+1.9-python2: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 2.7
+1-python2: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 2.7
+python2: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.9-python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
-1.9: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
-1-python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
-1: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
-python3: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
-latest: git://github.com/docker-library/django@dcfc8240410bd423516832e16b4d69f21be082ee 3.4
+1.9.1-python3: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+1.9.1: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+1.9-python3: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+1.9: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+1-python3: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+1: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+python3: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
+latest: git://github.com/docker-library/django@72cb89ce2a563a495619de41b2b5bb0cb52b28dc 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/golang
+++ b/library/golang
@@ -13,8 +13,8 @@
 1.4.3-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
 1.4-wheezy: git://github.com/docker-library/golang@a4f3927494b48c7bdb6ea6edac8f89818853b45b 1.4/wheezy
 
-1.4.3-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
-1.4-alpine: git://github.com/docker-library/golang@63a33bf151190592eaf0540dd4b7027a9ca13f9b 1.4/alpine
+1.4.3-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.4/alpine
+1.4-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.4/alpine
 
 1.5.2: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
 1.5: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5
@@ -31,10 +31,10 @@ onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e
 1-wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
 wheezy: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/wheezy
 
-1.5.2-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
-1.5-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
-1-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
-alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827b85f69e 1.5/alpine
+1.5.2-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.5/alpine
+1.5-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.5/alpine
+1-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.5/alpine
+alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.5/alpine
 
 1.6beta1: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6
 1.6: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6
@@ -45,5 +45,5 @@ alpine: git://github.com/docker-library/golang@e5ff96b1ab32db028f608f89eacf2b827
 1.6beta1-wheezy: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/wheezy
 1.6-wheezy: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/wheezy
 
-1.6beta1-alpine: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/alpine
-1.6-alpine: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/alpine
+1.6beta1-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.6/alpine
+1.6-alpine: git://github.com/docker-library/golang@5fc9acac9ae394e055cdc2e80400bf78e360cd2c 1.6/alpine

--- a/library/redis
+++ b/library/redis
@@ -1,11 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.17: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6
-2.6: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6
-
-2.6.17-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6/32bit
-2.6-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.6/32bit
-
 2.8.23: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
 2.8: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
 2: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8


### PR DESCRIPTION
- `cassandra`: add 3.1 (docker-library/cassandra#44)
- `django`: 1.9.1
- `golang`: update to Alpine 3.3 (docker-library/golang#74)
- `redis`: remove 2.6 (docker-library/redis#39)