### PR TITLE
Replace readline test with sqlite and ssl

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -1,5 +1,6 @@
 import curses
-import readline
+import sqlite3
+import ssl
 
 import bz2
 assert(bz2.decompress(bz2.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')


### PR DESCRIPTION
The alpine image does not have readline, so we test for sqlite3 and ssl
instead.