### PR TITLE
Fix ruby-bundler and ruby-gems tests to not use bash

### DIFF
--- a/test/tests/ruby-bundler/container.sh
+++ b/test/tests/ruby-bundler/container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 dir="$(mktemp -d)"
@@ -9,6 +9,6 @@ cp Gemfile "$dir"
 # make sure that running "bundle" twice doesn't change Gemfile.lock the second time
 cd "$dir"
 BUNDLE_FROZEN=0 bundle install
-cp Gemfile.lock{,.orig}
+cp Gemfile.lock Gemfile.lock.orig
 BUNDLE_FROZEN=1 bundle install
-diff -u Gemfile.lock{.orig,} >&2
+diff -u Gemfile.lock.orig Gemfile.lock >&2

--- a/test/tests/ruby-bundler/run.sh
+++ b/test/tests/ruby-bundler/run.sh
@@ -1,1 +1,1 @@
-../run-bash-in-container.sh
+../run-sh-in-container.sh

--- a/test/tests/ruby-gems/container.sh
+++ b/test/tests/ruby-gems/container.sh
@@ -1,20 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # list taken from https://rubygems.org/stats
-gems=(
-	thor
-	rake
-	rails
-	rack
-	activesupport
-	activerecord
-	actionpack
-	json
-	actionmailer
+for gem in \
+	thor \
+	rake \
+	rails \
+	rack \
+	activesupport \
+	activerecord \
+	actionpack \
+	json \
+	actionmailer \
 	activeresource
-)
+	do
 
-for gem in "${gems[@]}"; do
 	gem install "$gem"
 done

--- a/test/tests/ruby-gems/run.sh
+++ b/test/tests/ruby-gems/run.sh
@@ -1,1 +1,1 @@
-../run-bash-in-container.sh
+../run-sh-in-container.sh


### PR DESCRIPTION
Don't assume that bash is available. Alpine does not ship bash by
default, so use the ligher /bin/sh instead.