### PR TITLE
Update docker-library/postgres images

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@8f8c0bbc5236e0deedd35595c504e5fd380b1233 9.0
-9.0: git://github.com/docker-library/postgres@8f8c0bbc5236e0deedd35595c504e5fd380b1233 9.0
+9.0.22: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.0
+9.0: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.0
 
-9.1.19: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.1
-9.1: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.1
+9.1.19: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.1
+9.1: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.1
 
-9.2.14: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.2
-9.2: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.2
+9.2.14: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.2
+9.2: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.2
 
-9.3.10: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.3
-9.3: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.3
+9.3.10: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.3
+9.3: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.3
 
-9.4.5: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
-9.4: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
-9: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
-latest: git://github.com/docker-library/postgres@ed23320582f4ec5b0e5e35c99d98966dacbc6ed8 9.4
+9.4.5: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
+9.4: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
+9: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
+latest: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
 
-9.5-rc1: git://github.com/docker-library/postgres@d74474439c5ce1b0d7a2e17a310e53ae975e519b 9.5
-9.5: git://github.com/docker-library/postgres@d74474439c5ce1b0d7a2e17a310e53ae975e519b 9.5
+9.5-rc1: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.5
+9.5: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.5
+


### PR DESCRIPTION
The images now `chmod 700 PGDATA` to allow mounting volumes to PGDATA (which get permissions of 755 instead of 700).