### PR TITLE
Add VMware Photon as official image

### DIFF
--- a/library/photon
+++ b/library/photon
@@ -1,0 +1,11 @@
+# maintainer: Fabio Rapposelli <fabio@vmware.com> (@frapposelli)
+
+# commits: (master..dist)
+#  - ef1d8be updated tarballs
+
+# release-dockerfiles/1.0RC
+1.0RC: git://github.com/frapposelli/photon-docker-image@ef1d8be98877d927b6058c09364834692b7aa0fc 1.0RC
+latest: git://github.com/frapposelli/photon-docker-image@ef1d8be98877d927b6058c09364834692b7aa0fc 1.0RC
+
+# release-dockerfiles/1.0TP2
+1.0TP2: git://github.com/frapposelli/photon-docker-image@ef1d8be98877d927b6058c09364834692b7aa0fc 1.0TP2


### PR DESCRIPTION
Tried with `vmwarephoton` but I believe just `photon` would work better.