### PR TITLE
Update ghost, percona, postgres, python, and redis

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.4: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
-0.7: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
-0: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
-latest: git://github.com/docker-library/ghost@16a6fd356668cb69086eddd6e2d62addcbc8bca0
+0.7.5: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
+0.7: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
+0: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
+latest: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.46: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.5
-5.5: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.5
+5.5.47: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.5
+5.5: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.5
 
-5.6.27: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.6
-5.6: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.6
-5: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.6
-latest: git://github.com/docker-library/percona@ee41cc830ff124c4a5c9de605b1a7e338ca6db91 5.6
+5.6.28: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
+5.6: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
+5: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
+latest: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.0
-9.0: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.0
+9.0.22: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.0
+9.0: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.0
 
-9.1.19: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.1
-9.1: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.1
+9.1.19: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.1
+9.1: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.1
 
-9.2.14: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.2
-9.2: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.2
+9.2.14: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.2
+9.2: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.2
 
-9.3.10: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.3
-9.3: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.3
+9.3.10: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
+9.3: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
 
-9.4.5: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
-9.4: git://github.com/docker-library/postgres@d1644850949964935c418a73e0a7dc36f4f12dd9 9.4
+9.4.5: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.4
+9.4: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.4
 
-9.5.0: git://github.com/docker-library/postgres@2c72165e4f9dc66a61998111f69b5eba0b6b71f4 9.5
-9.5: git://github.com/docker-library/postgres@2c72165e4f9dc66a61998111f69b5eba0b6b71f4 9.5
-9: git://github.com/docker-library/postgres@2c72165e4f9dc66a61998111f69b5eba0b6b71f4 9.5
-latest: git://github.com/docker-library/postgres@2c72165e4f9dc66a61998111f69b5eba0b6b71f4 9.5
+9.5.0: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
+9.5: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
+9: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
+latest: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5

--- a/library/python
+++ b/library/python
@@ -1,16 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
-2.7: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
-2: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7
+2.7.11: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
+2.7: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
+2: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
-2.7-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
-2-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
+2.7-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
+2-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
+
+2.7.11-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
+2-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
 
 2.7.11-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
 2.7-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
@@ -52,22 +56,22 @@
 3.4.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
 3.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5
-3.5: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5
-3: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5
-latest: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5
+3.5.1: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
+3.5: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
+3: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
+latest: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/slim
-3.5-slim: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/slim
-3-slim: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/slim
-slim: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
+3.5-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
+3-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
+slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@5980eb7c3975e3a56235bae6ed116f0f2d85cb3c 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@5980eb7c3975e3a56235bae6ed116f0f2d85cb3c 3.5/alpine
-3-alpine: git://github.com/docker-library/python@5980eb7c3975e3a56235bae6ed116f0f2d85cb3c 3.5/alpine
-alpine: git://github.com/docker-library/python@5980eb7c3975e3a56235bae6ed116f0f2d85cb3c 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
+3-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
+alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine

--- a/library/redis
+++ b/library/redis
@@ -17,3 +17,8 @@ latest: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f
 3.0-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
 3-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
 32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
+
+3.0.6-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
+3-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
+alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine


### PR DESCRIPTION
- `ghost` `0.7.5`
- `percona` `5.5.47` `5.6.28`
- `postgres` https://github.com/docker-library/postgres/pull/113
- `python` add some `alpine` variants
- `redis` add `3.0.6-alpine`