### PR TITLE
Add GlassFish 4.1.1 image from Oracle

### DIFF
--- a/library/glassfish
+++ b/library/glassfish
@@ -1,8 +1,12 @@
-# maintainer: Amazon Web Services <https://aws.amazon.com/contact-us/> (@aws)
+# Maintainer: Bruno Borges <bruno.borges@oracle.com> (@brunoborges)
 
+latest: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1
+4.1.1: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1
+4.1.1-web: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1-web
+
+# Deprecated images
 4.0-jdk7: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.0-jdk7
 4.0: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.0-jdk7
 
 4.1-jdk8: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.1-jdk8
 4.1: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.1-jdk8
-latest: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.1-jdk8

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,10 +3,3 @@
 latest: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1
 4.1.1: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1
 4.1.1-web: git://github.com/oracle/docker-images@5ce9431c6ebe5777924c29acdfc79758c42ca9f3 GlassFish/4.1.1-web
-
-# Deprecated images
-4.0-jdk7: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.0-jdk7
-4.0: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.0-jdk7
-
-4.1-jdk8: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.1-jdk8
-4.1: git://github.com/aws/aws-eb-glassfish@aafcfc5e812dfb9b998105d3ca9da1b7f10664e1 4.1-jdk8

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,0 +1,6 @@
+# Maintainer: Bruno Borges <bruno.borges@oracle.com> (@brunoborges)
+java-6: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-6
+java-7: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-7
+java-8: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-8
+java-8u65: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-8u65
+latest: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/latest

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,6 +1,0 @@
-# Maintainer: Bruno Borges <bruno.borges@oracle.com> (@brunoborges)
-java-6: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-6
-java-7: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-7
-java-8: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-8
-java-8u65: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/java-8u65
-latest: git://github.com/oracle/docker-images@95b399d6103367de6f9afad5b4e29d1b02767fe8 OpenJDK/latest


### PR DESCRIPTION
The AWS team received a request to add GlassFish 4.1.1 on December 9th, 2015 but until now the image is not available. A PR exists:

- https://github.com/aws/aws-eb-glassfish-dockerfiles/issues/3
- https://github.com/aws/aws-eb-glassfish-dockerfiles/pull/2

Oracle folks would like to start maintaining the top-level GlassFish image based on OpenJDK and Oracle Linux. This PR adds 4.1.1 version and directs 'latest' tag to this new version.