### PR TITLE
Update Node to v5.4.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25
 4-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
 
-5.4.0: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4
-5.4: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4
-5: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4
-latest: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4
+5.4.1: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
+5.4: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
+5: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
+latest: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
 
-5.4.0-onbuild: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/onbuild
-5.4-onbuild: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/onbuild
-onbuild: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/onbuild
+5.4.1-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
+5.4-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
+onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
 
-5.4.0-slim: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/slim
-5.4-slim: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/slim
-5-slim: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/slim
-slim: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/slim
+5.4.1-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
+5.4-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
+5-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
+slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
 
-5.4.0-wheezy: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/wheezy
-5.4-wheezy: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/wheezy
-wheezy: git://github.com/nodejs/docker-node@c4868ce25f75d47e3ec75e6479664d8c46fc990e 5.4/wheezy
+5.4.1-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
+5.4-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
+wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy


### PR DESCRIPTION
This PR updates the latest `node` Docker Image to v5.4.1 of Node.js.

Changeset: https://github.com/nodejs/docker-node/compare/c4868ce25f75d47e3ec75e6479664d8c46fc990e...4bc77d4335b66f9c7dbc6ad791f38faabf535662

Related: nodejs/node#4626
Related: nodejs/docker-node#86

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>