### PR TITLE
Replace "awk" with "cut" for greater compatibility

### DIFF
--- a/test/tests/no-hard-coded-passwords/run.sh
+++ b/test/tests/no-hard-coded-passwords/run.sh
@@ -2,10 +2,10 @@
 set -e
 
 IFS=$'\n'
-userPasswds=( $(docker run --rm --user 0:0 --entrypoint awk "$1" -F ':' '{ print $1 ":" $2 }' /etc/passwd) )
+userPasswds=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/passwd) )
 userShadows=()
 if echo "${userPasswds[*]}" | grep -qE ':x$'; then
-	userShadows=( $(docker run --rm --user 0:0 --entrypoint awk "$1" -F ':' '{ print $1 ":" $2 }' /etc/shadow || true) )
+	userShadows=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/shadow || true) )
 fi
 unset IFS
 


### PR DESCRIPTION
Some really bizarre distributions don't include "awk" in the absolute minimum set, believe it or not! (I'm having a hard time believing it myself!)

This was first realized while build-testing #1332 (VMware Photon), but in looking at how to fix it I realized we were using "awk" as a really overblown and unnecessary "cut" implementation. :smile: