### PR TITLE
Update sentry 8.0.1

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -4,12 +4,12 @@
 7.7: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 7.7
 7: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 7.7
 
-8.0.0: git://github.com/getsentry/docker-sentry@6f4de0ef8a6ce0d12c34c14f6f0788d632685712 8.0
-8.0: git://github.com/getsentry/docker-sentry@6f4de0ef8a6ce0d12c34c14f6f0788d632685712 8.0
-8: git://github.com/getsentry/docker-sentry@6f4de0ef8a6ce0d12c34c14f6f0788d632685712 8.0
-latest: git://github.com/getsentry/docker-sentry@6f4de0ef8a6ce0d12c34c14f6f0788d632685712 8.0
+8.0.1: git://github.com/getsentry/docker-sentry@c134a81cacf5f83a28842d4b7b09472d97bcb6ef 8.0
+8.0: git://github.com/getsentry/docker-sentry@c134a81cacf5f83a28842d4b7b09472d97bcb6ef 8.0
+8: git://github.com/getsentry/docker-sentry@c134a81cacf5f83a28842d4b7b09472d97bcb6ef 8.0
+latest: git://github.com/getsentry/docker-sentry@c134a81cacf5f83a28842d4b7b09472d97bcb6ef 8.0
 
-8.0.0-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
+8.0.1-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
 8.0-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
 8-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
 onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild


### PR DESCRIPTION
Sorry for the back to back. :)

Was going to just do 8.0.1, but I wanted to also get a tag for 8.0.0 so it wasn't missing.