### PR TITLE
Update busybox with three variants instead of two

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,12 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 
-1.21.0-ubuntu: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 ubuntu
-1.21-ubuntu: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 ubuntu
-1-ubuntu: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 ubuntu
-ubuntu: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 ubuntu
+1.24.1-glibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 glibc
+1.24-glibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 glibc
+1-glibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 glibc
+glibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 glibc
 
-1.24.1: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 upstream
-1.24: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 upstream
-1: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 upstream
-latest: git://github.com/docker-library/busybox@b783e409ecd7f7d3682bd18d27d9ea4668fb3cd0 upstream
+1.24.1-musl: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 musl
+1.24-musl: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 musl
+1-musl: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 musl
+musl: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 musl
+
+1.24.1-uclibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+1.24.1: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+1.24-uclibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+1.24: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+1-uclibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+1: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+uclibc: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc
+latest: git://github.com/docker-library/busybox@81c593a39bec858e92bfa2c239aa57e7b988ba37 uclibc


### PR DESCRIPTION
See https://github.com/docker-library/busybox/pull/7 for more context; the short of it is that we were really differentiating based on "libc variant" anyhow, so this makes that more explicit and adds a new "musl" variant too (because why not).