### PR TITLE
Updates to golang, julia, mysql, postgres, python, and rabbitmq

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -31,10 +31,10 @@ onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e
 1-wheezy: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/wheezy
 wheezy: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/wheezy
 
-1.5.3-alpine: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/alpine
-1.5-alpine: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/alpine
-1-alpine: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/alpine
-alpine: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9dced4cbd 1.5/alpine
+1.5.3-alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.5/alpine
+1.5-alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.5/alpine
+1-alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.5/alpine
+alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.5/alpine
 
 1.6beta2: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6
 1.6: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6
@@ -45,5 +45,5 @@ alpine: git://github.com/docker-library/golang@1eab0db63794152b4516dbcb70270eb9d
 1.6beta2-wheezy: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6/wheezy
 1.6-wheezy: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6/wheezy
 
-1.6beta2-alpine: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6/alpine
-1.6-alpine: git://github.com/docker-library/golang@7f3d1ad6f1b658af7df616f9fd9b1fc90fd69402 1.6/alpine
+1.6beta2-alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.6/alpine
+1.6-alpine: git://github.com/docker-library/golang@1689df433a45bd787990f2982fb28345ec27f733 1.6/alpine

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.4.2: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e
-0.4: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e
-latest: git://github.com/docker-library/julia@a408dd5869f54f0adfc6b6950200f6781284d15e
+0.4.3: git://github.com/docker-library/julia@5747284971cda96c8c784d17be6b5aaa782307ba
+0.4: git://github.com/docker-library/julia@5747284971cda96c8c784d17be6b5aaa782307ba
+latest: git://github.com/docker-library/julia@5747284971cda96c8c784d17be6b5aaa782307ba

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
-5.5: git://github.com/docker-library/mysql@ac05512a1b788e8ae658d0f4a980ff7a01a51c93 5.5
+5.5.47: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.5
+5.5: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.5
 
-5.6.28: git://github.com/docker-library/mysql@a1a948c19137b7843ff0c7de0c95d22b74ecfefd 5.6
-5.6: git://github.com/docker-library/mysql@a1a948c19137b7843ff0c7de0c95d22b74ecfefd 5.6
+5.6.28: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.6
+5.6: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.6
 
-5.7.10: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
-5.7: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
-5: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
-latest: git://github.com/docker-library/mysql@ee6ac037ab647e0de9dbeb4e064610a95cb6df4a 5.7
+5.7.10: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
+5.7: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
+5: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
+latest: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7

--- a/library/postgres
+++ b/library/postgres
@@ -12,8 +12,8 @@
 9.3.10: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
 9.3: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
 
-9.4.5: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.4
-9.4: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.4
+9.4.5: git://github.com/docker-library/postgres@762e07937086fb43082ab1523ac9d0191c2c347f 9.4
+9.4: git://github.com/docker-library/postgres@762e07937086fb43082ab1523ac9d0191c2c347f 9.4
 
 9.5.0: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
 9.5: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5

--- a/library/python
+++ b/library/python
@@ -12,49 +12,55 @@
 2.7-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
 2-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
-2-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
+2-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2
-3.2: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2
+3.2.6: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2
+3.2: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2
 
 3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
 
-3.2.6-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/slim
-3.2-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/slim
+3.2.6-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/slim
+3.2-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/slim
 
-3.2.6-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.2/wheezy
+3.2.6-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/wheezy
+3.2-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/wheezy
 
-3.3.6: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3
-3.3: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3
+3.3.6: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
+3.3: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/slim
-3.3-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/slim
+3.3-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/slim
 
-3.3.6-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.3/wheezy
+3.3.6-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/alpine
 
-3.4.4: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4
-3.4: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4
+3.3.6-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/wheezy
+
+3.4.4: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4
+3.4: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/slim
-3.4-slim: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/slim
+3.4-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/slim
 
-3.4.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@033320b278e78732e5739f19bca5f8f29573b553 3.4/wheezy
+3.4.4-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/alpine
+
+3.4.4-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/wheezy
 
 3.5.1: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
 3.5: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.0: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086
-3.6: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086
-3: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086
-latest: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086
+3.6.0: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
+3.6: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
+3: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
+latest: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
 
-3.6.0-management: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086 management
-3.6-management: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086 management
-3-management: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086 management
-management: git://github.com/docker-library/rabbitmq@27b93617e5741a6da21589d9db1acca3758e0086 management
+3.6.0-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
+3.6-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
+3-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
+management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management


### PR DESCRIPTION
- `golang` make alpine variant a little smaller https://github.com/docker-library/golang/pull/78
- `julia` bump `0.4.3`
- `mysql` https://github.com/docker-library/mysql/pull/126
- `postgres` `9.4.5-2`
- `python` https://github.com/docker-library/python/pull/82
- `rabbitmq` https://github.com/docker-library/rabbitmq/pull/58