### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.3
-1.3: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.3
+1.3: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.4
-1.4: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.4
+1.4: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.5
-1.5: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.5
+1.5: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
-1.6: git://github.com/docker-library/elasticsearch@7b3badaa502c496462ebad7f45eac45a8fb44030 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.6
+1.6: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.6
 
-1.7.4: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
-1.7: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
-1: git://github.com/docker-library/elasticsearch@e2982f617a25c891a50192fb26b48c7c3b367e81 1.7
+1.7.4: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.7
+1.7: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.7
+1: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 1.7
 
-2.0.2: git://github.com/docker-library/elasticsearch@190ea87fad5f126918020111da4e1723e741e6b7 2.0
-2.0: git://github.com/docker-library/elasticsearch@190ea87fad5f126918020111da4e1723e741e6b7 2.0
+2.0.2: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.0
+2.0: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.0
 
-2.1.1: git://github.com/docker-library/elasticsearch@7d08b8e82fb8ca19745dab75ee32ba5a746ac999 2.1
-2.1: git://github.com/docker-library/elasticsearch@7d08b8e82fb8ca19745dab75ee32ba5a746ac999 2.1
-2: git://github.com/docker-library/elasticsearch@7d08b8e82fb8ca19745dab75ee32ba5a746ac999 2.1
-latest: git://github.com/docker-library/elasticsearch@7d08b8e82fb8ca19745dab75ee32ba5a746ac999 2.1
+2.1.1: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.1
+2.1: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.1
+2: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.1
+latest: git://github.com/docker-library/elasticsearch@a3f8e658da60bf58e97e18a78d85815a896f9eed 2.1

--- a/library/java
+++ b/library/java
@@ -45,16 +45,16 @@ openjdk-8-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3
 8-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-8-jre
 jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-8-jre
 
-openjdk-9-b96-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-openjdk-9-b96: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-openjdk-9-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-openjdk-9: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-9-b96-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-9-b96: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-9-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
-9: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-9-jdk
+openjdk-9-b101-jdk: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+openjdk-9-b101: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+openjdk-9-jdk: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+openjdk-9: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+9-b101-jdk: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+9-b101: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+9-jdk: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
+9: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jdk
 
-openjdk-9-b96-jre: git://github.com/docker-library/java@5552e0cd8db55b834a0d26ab200d19cee54b09f3 openjdk-9-jre
-openjdk-9-jre: git://github.com/docker-library/java@5552e0cd8db55b834a0d26ab200d19cee54b09f3 openjdk-9-jre
-9-b96-jre: git://github.com/docker-library/java@5552e0cd8db55b834a0d26ab200d19cee54b09f3 openjdk-9-jre
-9-jre: git://github.com/docker-library/java@5552e0cd8db55b834a0d26ab200d19cee54b09f3 openjdk-9-jre
+openjdk-9-b101-jre: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jre
+openjdk-9-jre: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jre
+9-b101-jre: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jre
+9-jre: git://github.com/docker-library/java@56a204b2096324ffc854725cb83eeaa22325d9d2 openjdk-9-jre

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.12.1: git://github.com/RocketChat/Docker.Official.Image@72ee51eb8543be869f38f2669581ccddbf25b329
-0.12: git://github.com/RocketChat/Docker.Official.Image@72ee51eb8543be869f38f2669581ccddbf25b329
-0: git://github.com/RocketChat/Docker.Official.Image@72ee51eb8543be869f38f2669581ccddbf25b329
-latest: git://github.com/RocketChat/Docker.Official.Image@72ee51eb8543be869f38f2669581ccddbf25b329
+0.14.0: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
+0.14: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
+0: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
+latest: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4


### PR DESCRIPTION
- `elasticsearch`: allow `--user` (docker-library/elasticsearch#77)
- `java`: 9~b101-2
- `rocket.chat`: 0.14.0 (and reorder a bit; https://github.com/RocketChat/Docker.Official.Image/compare/72ee51eb8543be869f38f2669581ccddbf25b329...af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4)

cc @pierreozoux