### PR TITLE
Update Node LTS to 4.2.5

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.41: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10
-0.10: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10
+0.10.41: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10
+0.10: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10
 
 0.10.41-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
 
-0.10.41-slim: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/slim
+0.10.41-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/slim
 
-0.10.41-wheezy: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@1e28b4b6a0c2d20469829f70115851ce92ab75c3 0.10/wheezy
+0.10.41-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/wheezy
 
-0.12.9: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
-0.12: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
-0: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12
+0.12.9: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
+0.12: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
+0: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
 
 0.12.9-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
 
-0.12.9-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/slim
+0.12.9-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
 
-0.12.9-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/wheezy
+0.12.9-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
 
-4.2.4: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
-4.2: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
-4: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
-argon: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2
+4.2.5: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2
+4.2: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2
+4: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2
+argon: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2
 
-4.2.4-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/onbuild
+4.2.5-onbuild: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/onbuild
+4.2-onbuild: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/onbuild
 
-4.2.4-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
-argon-slim: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/slim
+4.2.5-slim: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/slim
+4.2-slim: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/slim
+4-slim: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/slim
+argon-slim: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/slim
 
-4.2.4-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@7cbea391f22678de5d828b1a38c27a25c951795f 4.2/wheezy
+4.2.5-wheezy: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/wheezy
+4.2-wheezy: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@36abbd4f4bf2e7d5f17f894b69d6c80ca876d311 4.2/wheezy
 
-5.4.1: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
-5.4: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
-5: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
-latest: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4
+5.4.1: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4
+5.4: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4
+5: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4
+latest: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4
 
 5.4.1-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
 5.4-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
 5-onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
 onbuild: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/onbuild
 
-5.4.1-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
-5.4-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
-5-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
-slim: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/slim
+5.4.1-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/slim
+5.4-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/slim
+5-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/slim
+slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/slim
 
-5.4.1-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
-5.4-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
-wheezy: git://github.com/nodejs/docker-node@4bc77d4335b66f9c7dbc6ad791f38faabf535662 5.4/wheezy
+5.4.1-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/wheezy
+5.4-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/wheezy
+wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 5.4/wheezy


### PR DESCRIPTION
The other images' hashes were changed too, because of nodejs/docker-node#85 which adds two new release keys.

Related: nodejs/docker-node#89
Related: nodejs/node#4768
Related: nodejs/docker-node#85