### PR TITLE
Update Solr to 5.3.2 and 5.4.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,10 +1,10 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.1: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
-5.3: git://github.com/docker-solr/docker-solr@d722c55dd320a812e278a23c60a5d5616515df0b 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@5d6039fb7019b08d420b7bb90f76e8958dc32548 5.3
+5.3: git://github.com/docker-solr/docker-solr@5d6039fb7019b08d420b7bb90f76e8958dc32548 5.3
 
-5.4.0: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
-5.4: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
-5: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
-latest: git://github.com/docker-solr/docker-solr@3e61ef877ca9d04e7f005cd40ba726abd1f74259 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
+5.4: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
+5: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
+latest: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4


### PR DESCRIPTION
This update is for Solr to 5.3.2 and 5.4.1. See their respective announcement emails for more details:

- [Apache Solr 5.3.2 released](http://mail-archives.apache.org/mod_mbox/lucene-dev/201601.mbox/%3cCAKiERN62XhEwC0VSK20b-R5wat_h3EyLojjaNyt5j8juQEBiwg@mail.gmail.com%3e)
- [Apache Solr 5.4.1 released](http://mail-archives.apache.org/mod_mbox/lucene-dev/201601.mbox/%3cCAPsWd+N2A0rQLMKfAsm-kGO7ihscPOMxrQQqHCCBOirhq82xkw@mail.gmail.com%3e)

Note in particular: "If you are on 5.4.0 and using BINARY, SORTED_NUMERIC or SORTED_SET doc values, upgrading to 5.4.1 is strongly recommended."

This update also includes a few changes to the docker-solr repository:

- Set DNS TTLs (see https://github.com/docker-solr/docker-solr/commit/ecbadb16e68d187a470f383c7c8ae0b6d9316508)
- Uncomment SOLR_PORT=8983 in solr.in.sh (fixes https://github.com/docker-solr/docker-solr/issues/6)
- New FAQ [Can I run ZooKeeper and Solr clusters under Docker?](https://github.com/docker-solr/docker-solr/blob/master/Docker-FAQ.md#can-i-run-zookeeper-and-solr-clusters-under-docker)
- New [Example of Zookeeper and Solr cluster with Docker networking](https://github.com/docker-solr/docker-solr/blob/master/docs/docker-networking.md) for the upcoming Docker 1.10.