### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,16 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.12: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.1
-2.1: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.1
+2.1.12: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 2.1
+2.1: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 2.1
 
-2.2.4: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
-2.2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
-2: git://github.com/docker-library/cassandra@e42689e24fa459f8a417931a5cd6b22b9bf1f31c 2.2
+2.2.4: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 2.2
+2.2: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 2.2
+2: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 2.2
 
-3.0.2: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
-3.0: git://github.com/docker-library/cassandra@8daf9e78e24d741e37d8c9c2ee12ba2e70057c6e 3.0
+3.0.2: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.0
+3.0: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.0
 
-3.1.1: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
-3.1: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
-3: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
-latest: git://github.com/docker-library/cassandra@f61f8951219708e3d17819a0833db2927bc76330 3.1
+3.1.1: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.1
+3.1: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.1
+
+3.2: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.2
+3: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.2
+latest: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.2

--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.19: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
-3.1: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
-3: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
-latest: git://github.com/docker-library/celery@e2bc6ae91c1b584fd6c2b65976e0ccb42c17db4e
+3.1.20: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
+3.1: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
+3: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
+latest: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.10: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
-10.1: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
-10: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
-latest: git://github.com/docker-library/mariadb@d960d3cd750accc47d620886cff901d87a600d37 10.1
+10.1.10: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
+10.1: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
+10: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
+latest: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
 
-10.0.23: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
-10.0: git://github.com/docker-library/mariadb@2a8c48a54d8210241861740ea76b5aedf4da681f 10.0
+10.0.23: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.0
+10.0: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.0
 
-5.5.47: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
-5.5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
-5: git://github.com/docker-library/mariadb@de4c20ffb8cb11baa7a522f8e0d98316dc95f2cb 5.5
+5.5.47: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5
+5.5: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5
+5: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.25: git://github.com/docker-library/memcached@1944b045661a2fabcf2b9677f7edaa07e04f8d8d
-1.4: git://github.com/docker-library/memcached@1944b045661a2fabcf2b9677f7edaa07e04f8d8d
-1: git://github.com/docker-library/memcached@1944b045661a2fabcf2b9677f7edaa07e04f8d8d
-latest: git://github.com/docker-library/memcached@1944b045661a2fabcf2b9677f7edaa07e04f8d8d
+1.4.25: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
+1.4: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
+1: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
+latest: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa

--- a/library/mongo
+++ b/library/mongo
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.2
-2.2: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.2
+2.2.7: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.2
+2.2: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.2
 
-2.4.14: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.4
-2.4: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.4
+2.4.14: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.4
+2.4: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.4
 
-2.6.11: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
-2.6: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
-2: git://github.com/docker-library/mongo@982328582c74dd2f0a9c8c77b84006f291f974c3 2.6
+2.6.11: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.6
+2.6: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.6
+2: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 2.6
 
-3.0.8: git://github.com/docker-library/mongo@d9b96ad7dfac1bb5203b549a676535351ee48d4d 3.0
-3.0: git://github.com/docker-library/mongo@d9b96ad7dfac1bb5203b549a676535351ee48d4d 3.0
+3.0.9: git://github.com/docker-library/mongo@890eccb3cb0ddd402c7c13862182914746bfaa56 3.0
+3.0: git://github.com/docker-library/mongo@890eccb3cb0ddd402c7c13862182914746bfaa56 3.0
 
-3.1.9: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
-3.1: git://github.com/docker-library/mongo@5216cf8aedcf7634172e607b0c9718cc332e0d71 3.1
+3.1.9: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.1
+3.1: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.1
 
-3.2.1: git://github.com/docker-library/mongo@358d9eb62895be2c9fd4290595573c93b79d47d4 3.2
-3.2: git://github.com/docker-library/mongo@358d9eb62895be2c9fd4290595573c93b79d47d4 3.2
-3: git://github.com/docker-library/mongo@358d9eb62895be2c9fd4290595573c93b79d47d4 3.2
-latest: git://github.com/docker-library/mongo@358d9eb62895be2c9fd4290595573c93b79d47d4 3.2
+3.2.1: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.2
+3.2: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.2
+3: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.2
+latest: git://github.com/docker-library/mongo@0edfc5e01d2699dd781f25a6b1ee76dcf7e41e31 3.2

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.5
-5.5: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.5
+5.5.47: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.5
+5.5: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.5
 
-5.6.28: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.6
-5.6: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.6
+5.6.28: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.6
+5.6: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.6
 
-5.7.10: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
-5.7: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
-5: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
-latest: git://github.com/docker-library/mysql@2e80e5ff6aa7d3a09723ad40f5954a0563dbac29 5.7
+5.7.10: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
+5.7: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
+5: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
+latest: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.5
-5.5: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.5
+5.5.47: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.5
+5.5: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.5
 
-5.6.28: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
-5.6: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
-5: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
-latest: git://github.com/docker-library/percona@f4735d6bded2f34cbcac18341d7fde8fa8757b2d 5.6
+5.6.28: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
+5.6: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
+5: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
+latest: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6

--- a/library/php
+++ b/library/php
@@ -1,46 +1,46 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.31-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5
-5.5-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5
-5.5.31: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5
-5.5: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5
+5.5.31-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5
+5.5-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5
+5.5.31: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5
+5.5: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5
 
-5.5.31-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5/apache
-5.5-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5/apache
+5.5.31-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5/apache
+5.5-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.5/apache
 
-5.5.31-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 5.5/fpm
+5.5.31-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 5.5/fpm
 
-5.6.17-cli: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
-5.6-cli: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
-5-cli: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
-5.6.17: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
-5.6: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
-5: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6
+5.6.17-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
+5.6-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
+5-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
+5.6.17: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
+5.6: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
+5: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6
 
-5.6.17-apache: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/apache
-5.6-apache: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/apache
-5-apache: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/apache
+5.6.17-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6/apache
+5.6-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6/apache
+5-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 5.6/apache
 
-5.6.17-fpm: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/fpm
-5-fpm: git://github.com/docker-library/php@7122ec89a73c7b1213f53c6a6807ab06e7deead9 5.6/fpm
+5.6.17-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 5.6/fpm
+5-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 5.6/fpm
 
-7.0.2-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-7.0-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-7-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-cli: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-7.0.2: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-7.0: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-7: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
-latest: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0
+7.0.2-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+7.0-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+7-cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+cli: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+7.0.2: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+7.0: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+7: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
+latest: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0
 
-7.0.2-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/apache
-7.0-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/apache
-7-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/apache
-apache: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/apache
+7.0.2-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0/apache
+7.0-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0/apache
+7-apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0/apache
+apache: git://github.com/docker-library/php@85447ff6a554f05b1cb893e5edf2a2cbba848332 7.0/apache
 
-7.0.2-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/fpm
-7-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/fpm
-fpm: git://github.com/docker-library/php@cd075c9d4e53b255b4af6691a7ee10354d7fbb8d 7.0/fpm
+7.0.2-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 7.0/fpm
+7-fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 7.0/fpm
+fpm: git://github.com/docker-library/php@e1292bb6ec9c0939abd0b8878bf6f7b8d29595d8 7.0/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.0.22: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.0
-9.0: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.0
+9.1.19: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.1
+9.1: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.1
 
-9.1.19: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.1
-9.1: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.1
+9.2.14: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.2
+9.2: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.2
 
-9.2.14: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.2
-9.2: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.2
+9.3.10: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.3
+9.3: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.3
 
-9.3.10: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
-9.3: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.3
+9.4.5: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.4
+9.4: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.4
 
-9.4.5: git://github.com/docker-library/postgres@762e07937086fb43082ab1523ac9d0191c2c347f 9.4
-9.4: git://github.com/docker-library/postgres@762e07937086fb43082ab1523ac9d0191c2c347f 9.4
-
-9.5.0: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
-9.5: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
-9: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
-latest: git://github.com/docker-library/postgres@9737ce4eeb7d580de8bd6831d8144ba08c316197 9.5
+9.5.0: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
+9.5: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
+9: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
+latest: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5

--- a/library/python
+++ b/library/python
@@ -20,18 +20,6 @@
 2.7-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
 2-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
 
-3.2.6: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2
-3.2: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2
-
-3.2.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
-3.2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.2/onbuild
-
-3.2.6-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/slim
-3.2-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/slim
-
-3.2.6-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/wheezy
-3.2-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.2/wheezy
-
 3.3.6: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
 3.3: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.0: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
-3.6: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
-3: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
-latest: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40
+3.6.0: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9
+3.6: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9
+3: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9
+latest: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9
 
-3.6.0-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
-3.6-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
-3-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
-management: git://github.com/docker-library/rabbitmq@f9b15d74ffafa31e028d9218aebfc9b3eac45e40 management
+3.6.0-management: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9 management
+3.6-management: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9 management
+3-management: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9 management
+management: git://github.com/docker-library/rabbitmq@d9c4635649edacf6728bd2a28aedc97c77ac47f9 management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.5: git://github.com/docker-library/rails@1d9e5d95eaff6030dd28be4de0b415cc415e0497
-4.2: git://github.com/docker-library/rails@1d9e5d95eaff6030dd28be4de0b415cc415e0497
-4: git://github.com/docker-library/rails@1d9e5d95eaff6030dd28be4de0b415cc415e0497
-latest: git://github.com/docker-library/rails@1d9e5d95eaff6030dd28be4de0b415cc415e0497
+4.2.5.1: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
+4.2.5: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
+4.2: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
+4: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
+latest: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
 
 onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild

--- a/library/redmine
+++ b/library/redmine
@@ -1,19 +1,31 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.9: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
-2.6: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
-2: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 2.6
+2.6.9: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
+2.6: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
+2: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
 
 2.6.9-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
 2.6-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
 2-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 2.6/passenger
 
-3.0.7: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
-3.0: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
-3: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
-latest: git://github.com/docker-library/redmine@0b1bd12df7afc21ec18dd2abfc263f28a0eded4a 3.0
+3.0.7: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.0
+3.0: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.0
 
 3.0.7-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
 3.0-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
-3-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
-passenger: git://github.com/docker-library/redmine@5baaf21e90656d3db14574577de99a87527a1d58 3.0/passenger
+
+3.1.3: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.1
+3.1: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.1
+
+3.1.3-passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.1/passenger
+3.1-passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.1/passenger
+
+3.2.0: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
+3.2: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
+3: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
+latest: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
+
+3.2.0-passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.2/passenger
+3.2-passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.2/passenger
+3-passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.2/passenger
+passenger: git://github.com/docker-library/redmine@34418b897eb0e71c65e48b7eb01e8cc867140eea 3.2/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.14.0: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
-0.14: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
-0: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
-latest: git://github.com/RocketChat/Docker.Official.Image@af3284fc689b3cbf4a6e8d2a9ee6a1042bb120e4
+0.15.0: git://github.com/RocketChat/Docker.Official.Image@07e464de780898cf3af56151033c82e2f4e8ea18
+0.15: git://github.com/RocketChat/Docker.Official.Image@07e464de780898cf3af56151033c82e2f4e8ea18
+0: git://github.com/RocketChat/Docker.Official.Image@07e464de780898cf3af56151033c82e2f4e8ea18
+latest: git://github.com/RocketChat/Docker.Official.Image@07e464de780898cf3af56151033c82e2f4e8ea18

--- a/library/ruby
+++ b/library/ruby
@@ -1,46 +1,46 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p648: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
-2.0.0: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
-2.0: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0
+2.0.0-p648: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0
+2.0.0: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0
+2.0: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0
 
 2.0.0-p648-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 
-2.0.0-p648-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.0/slim
+2.0.0-p648-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.0/slim
 
-2.1.8: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1
-2.1: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1
+2.1.8: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1
+2.1: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1
 
 2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.8-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.1/slim
+2.1.8-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1/slim
 
-2.2.4: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
-2.2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
+2.2.4: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2
+2.2: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2/slim
 
-2.3.0: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
-2.3: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
-2: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
-latest: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3
+2.3.0: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
+2.3: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
+2: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
+latest: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
 
 2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
-2-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
-slim: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/slim
+2.3.0-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
+2-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
+slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim


### PR DESCRIPTION
- `cassandra`: 3.2 (docker-library/cassandra#47)
- `celery`: 3.1.20
- `mariadb`: resync entrypoint with MySQL (docker-library/mariadb#37, docker-library/mariadb#34)
- `memcached`: fix SHA1 checking (docker-library/memcached#6)
- `mongo`: 3.0.9, conditional chown, configdb (docker-library/mariadb#78)
- `mysql`: fix init failure a bit (docker-library/mysql#134)
- `percona`: resync entrypoint with MySQL (docker-library/percona#12)
- `php`: update FPM to use `php-fpm.d` for config (docker-library/php#184)
- `postgres`: remove EOL 9.0 (docker-library/postgres#122)
- `python`: remove EOL 3.2 (docker-library/python#87)
- `rabbitmq`: allow for `--user` to work (docker-library/rabbitmq#60)
- `rails`: 4.2.5.1
- `redmine`: add SCMs (docker-library/redmine#9)
- `rocket.chat`: 0.15.0 (RocketChat/Docker.Official.Image#13)
- `ruby`: silence `root` warning (docker-library/ruby#63)

cc @engelgabriel @pierreozoux (for `rocket.chat`)