### PR TITLE
bump Erlang images for versions 18.2.2 & 17.5.6.8

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,15 +1,22 @@
 # maintainer: denc716@gmail.com (@c0b)
 
-18.2.1: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
-18.2:   git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
-18:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
-latest: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18
+18.2.2: git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
+18.2:   git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
+18:     git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
+latest: git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
 
-18.2.1-onbuild: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
-18.2-onbuild:   git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
-18-onbuild:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
-onbuild:        git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 18/onbuild
+18.2-slim: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
+18-slim:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
+slim:      git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
 
-17.5.6.7: git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17
-17.5:     git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17
-17:       git://github.com/c0b/docker-erlang-otp@4ccaeb1b709c227bea0a712c25f974350242d6d6 17
+18.2.2-onbuild: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
+18.2-onbuild:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
+18-onbuild:     git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
+onbuild:        git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
+
+17.5.6.8: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
+17.5:     git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
+17:       git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
+
+17.5-slim: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17/slim
+17-slim:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17/slim


### PR DESCRIPTION
add slim versions as well for storage constrained environments

the slim versions will be good to use as base images for elixir #1171 ? @vovimayhem @ivan-kolmychek