### PR TITLE
Update registry:latest to point to registry 2.x

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,10 +3,7 @@
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
-latest: git://github.com/docker/docker-registry@0.9.1
-0.8.1: git://github.com/docker/docker-registry@0.8.1
-0.9.1: git://github.com/docker/docker-registry@0.9.1
-
 2: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
 2.2: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
 2.2.1: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
+latest: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65


### PR DESCRIPTION
The registry:latest tag currently points to registry 0.9.1. It has been
pointing to this old version for awhile to avoid breaking users
following outdated legacy registry documentation. Registry 2.x is
well-established now, and the time has come to change the latest tag.
Change it so that registry:latest is synonymous with registry:2.

Remove old 0.8.1 and 0.9.1 tags from the file.

cc @docker/distribution-maintainers