### PR TITLE
Update Mono to latest 4.2.2.30

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -1,43 +1,49 @@
 # maintainer: Jo Shields <jo.shields@xamarin.com> (@directhex)
 
-3.10.0: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.10.0
-3.10: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.10.0
+3.10.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
+3.10: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
 
-3.10.0-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.10.0/onbuild
-3.10-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.10.0/onbuild
+3.10.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
+3.10-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
 
 3.12.1: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1
 3.12.0: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1
 3.12: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1
 3: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1
 
-3.12.1-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1/onbuild
-3.12.0-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1/onbuild
-3.12-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1/onbuild
-3-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.12.1/onbuild
+3.12.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3.12.0-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3.12-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
+3-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
 
-3.8.0: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.8.0
-3.8: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.8.0
+3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
+3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
 
-3.8.0-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.8.0/onbuild
-3.8-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 3.8.0/onbuild
+3.8.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
+3.8-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
 
 4.0.5.1: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1
 4.0.5: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1
 4.0: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1
 
-4.0.5.1-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1/onbuild
-4.0.5-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1/onbuild
-4.0-onbuild: git://github.com/mono/docker@810b0cd85839b4b62706935a804fee63d2eb3285 4.0.5.1/onbuild
+4.0.5.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
+4.0.5-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
+4.0-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.0.5.1/onbuild
 
 4.2.1.102: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
 4.2.1: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
-4.2: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
-4: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
-latest: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102
 
 4.2.1.102-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
 4.2.1-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
-4.2-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
-4-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 4.2.1.102/onbuild
+
+4.2.2.30: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30
+4.2.2: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30
+4.2: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30
+4: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30
+latest: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30
+
+4.2.2.30-onbuild: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30/onbuild
+4.2.2-onbuild: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30/onbuild
+4.2-onbuild: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30/onbuild
+4-onbuild: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30/onbuild
+onbuild: git://github.com/mono/docker@d1aafcdae56ae9ceaf013294d3c74c4183a80281 4.2.2.30/onbuild


### PR DESCRIPTION
Point 4 and 4.2 to this version.

The changes to older tags seem to be because in https://github.com/docker-library/official-images/pull/1247 the commit sha was updated to the same for all tags.

I ran generate-stackbrew-library.sh which updated the hashes to the last modified version which is correct in these cases.

/cc @tianon 