### PR TITLE
Correct removal of websphere-liberty .classCache

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,17 +1,17 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
-kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
-8.5.5.8-kernel: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
-8.5.5.8-common: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.8-webProfile6: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.8-webProfile7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.8-javaee7: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.8: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@086dcba5e235a1c87b11742c833aeb41c6ac11a8 websphere-liberty/8.5.5/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@c201526abbe14137dde7e2f9eed03375343d2783 websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/kernel
+8.5.5.8-kernel: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/common
+8.5.5.8-common: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.8-webProfile6: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.8-webProfile7: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.8-javaee7: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.8: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/8.5.5/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@c0ccc06d923102c8a8cb5eb7fe70d79fe3a48a72 websphere-liberty/beta


### PR DESCRIPTION
The last update changed the paths that various files are written to when server commands are invoked. This meant that the remove of the generated .classCache created during the build was failing to actual remove anything and the images all grew by ~60 MB for no good reason...