### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.10: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
-10.1: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
-10: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
-latest: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.1
+10.1.11: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
+10.1: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
+10: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
+latest: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
 
-10.0.23: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.0
-10.0: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 10.0
+10.0.23: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 10.0
+10.0: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 10.0
 
-5.5.47: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5
-5.5: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5
-5: git://github.com/docker-library/mariadb@5d17b854fb2963edbd1affa3867cdbc8d5e1933f 5.5
+5.5.47: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5
+5.5: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5
+5: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.5
-5.5: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.5
+5.5.47: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.5
+5.5: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.5
 
-5.6.28: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
-5.6: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
-5: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
-latest: git://github.com/docker-library/percona@8d37b2f07db1ffab3696a2c2411ddca05809018c 5.6
+5.6.28: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
+5.6: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
+5: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
+latest: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6

--- a/library/redis
+++ b/library/redis
@@ -8,17 +8,17 @@
 2.8-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
 2-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
 
-3.0.6: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
-3.0: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
-3: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
-latest: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0
+3.0.7: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
+3.0: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
+3: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
+latest: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
 
-3.0.6-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 3.0/32bit
+3.0.7-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
+32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
 
-3.0.6-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
-3-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
-alpine: git://github.com/docker-library/redis@18e13f767bd396c53aa1f0071b218816110060ac 3.0/alpine
+3.0.7-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
+3-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
+alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -21,6 +21,9 @@
 2.1.8-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1/slim
 2.1-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.1/slim
 
+2.1.8-alpine: git://github.com/docker-library/ruby@a4b7790875c2b2d2b65752c3b324313bc31f0c5e 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@a4b7790875c2b2d2b65752c3b324313bc31f0c5e 2.1/alpine
+
 2.2.4: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2
 2.2: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2
 
@@ -29,6 +32,9 @@
 
 2.2.4-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2/slim
 2.2-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.2/slim
+
+2.2.4-alpine: git://github.com/docker-library/ruby@a4b7790875c2b2d2b65752c3b324313bc31f0c5e 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@a4b7790875c2b2d2b65752c3b324313bc31f0c5e 2.2/alpine
 
 2.3.0: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
 2.3: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3
@@ -44,3 +50,8 @@ onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126
 2.3-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
 2-slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
 slim: git://github.com/docker-library/ruby@4810c0687d6b47c27f3a4011131baff18d2ed34e 2.3/slim
+
+2.3.0-alpine: git://github.com/docker-library/ruby@43d4d172fb47045982234d3820a4bb7d8f4aefda 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@43d4d172fb47045982234d3820a4bb7d8f4aefda 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@43d4d172fb47045982234d3820a4bb7d8f4aefda 2.3/alpine
+alpine: git://github.com/docker-library/ruby@43d4d172fb47045982234d3820a4bb7d8f4aefda 2.3/alpine


### PR DESCRIPTION
- `mariadb`: 10.1.11+maria-1~jessie, fix `pwgen` (docker-library/mariadb#40)
- `percona`: fix `pwgen` (docker-library/percona#13)
- `redis`: 3.0.7
- `ruby`: add new `alpine` variants (docker-library/ruby#60, docker-library/ruby#65)