### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -25,14 +25,14 @@ git: git://github.com/docker-library/docker@7a61b09b70b0aba202019c63258214379811
 1.8.3-git: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.8/git
 1.8-git: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.8/git
 
-1.10.0-rc2: git://github.com/docker-library/docker@abd4b429d8479c35ef05bca4eb52faf8ea49dba0 1.10-rc
-1.10-rc: git://github.com/docker-library/docker@abd4b429d8479c35ef05bca4eb52faf8ea49dba0 1.10-rc
-rc: git://github.com/docker-library/docker@abd4b429d8479c35ef05bca4eb52faf8ea49dba0 1.10-rc
+1.10.0-rc3: git://github.com/docker-library/docker@edfcc36da8e217d9c7b1ee6cd467a586756e6bb1 1.10-rc
+1.10-rc: git://github.com/docker-library/docker@edfcc36da8e217d9c7b1ee6cd467a586756e6bb1 1.10-rc
+rc: git://github.com/docker-library/docker@edfcc36da8e217d9c7b1ee6cd467a586756e6bb1 1.10-rc
 
-1.10.0-rc2-dind: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/dind
+1.10.0-rc3-dind: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/dind
 1.10-rc-dind: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/dind
 rc-dind: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/dind
 
-1.10.0-rc2-git: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/git
+1.10.0-rc3-git: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/git
 1.10-rc-git: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/git
 rc-git: git://github.com/docker-library/docker@945f73423dd843ee587567712b6657d5780307da 1.10-rc/git

--- a/library/drupal
+++ b/library/drupal
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.41: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
-7: git://github.com/docker-library/drupal@9e1ff6c719c7a6dec88b1089f9128dab428c4eed 7
+7.42: git://github.com/docker-library/drupal@e1b4c2b894645c6919849de16d82a2a0da2ea5c3 7
+7: git://github.com/docker-library/drupal@e1b4c2b894645c6919849de16d82a2a0da2ea5c3 7
 
-8.0.2: git://github.com/docker-library/drupal@58c575506a269f099b5578b76249101763e31ae7 8
-8.0: git://github.com/docker-library/drupal@58c575506a269f099b5578b76249101763e31ae7 8
-8: git://github.com/docker-library/drupal@58c575506a269f099b5578b76249101763e31ae7 8
-latest: git://github.com/docker-library/drupal@58c575506a269f099b5578b76249101763e31ae7 8
+8.0.3: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
+8.0: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
+8: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
+latest: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.5: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
-0.7: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
-0: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
-latest: git://github.com/docker-library/ghost@6b6ffbf7830d24bd5fa144e9c835a1f2f09df3c9
+0.7.6: git://github.com/docker-library/ghost@1e4098ce8840142afb2b95e63acdfc7aa329b61b
+0.7: git://github.com/docker-library/ghost@1e4098ce8840142afb2b95e63acdfc7aa329b61b
+0: git://github.com/docker-library/ghost@1e4098ce8840142afb2b95e63acdfc7aa329b61b
+latest: git://github.com/docker-library/ghost@1e4098ce8840142afb2b95e63acdfc7aa329b61b

--- a/library/java
+++ b/library/java
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-openjdk-6b36-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-openjdk-6b36: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-openjdk-6-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-openjdk-6: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-6b36-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-6b36: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-6-jdk: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
-6: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jdk
+openjdk-6b38-jdk: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+openjdk-6b38: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+openjdk-6-jdk: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+openjdk-6: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+6b38-jdk: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+6b38: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+6-jdk: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+6: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
 
-openjdk-6b36-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jre
-openjdk-6-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jre
-6b36-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jre
-6-jre: git://github.com/docker-library/java@c046a7da2ac56f0ee5b870590de3e5a1cce569a7 openjdk-6-jre
+openjdk-6b38-jre: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
+openjdk-6-jre: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
+6b38-jre: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
+6-jre: git://github.com/docker-library/java@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
 
 openjdk-7u95-jdk: git://github.com/docker-library/java@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
 openjdk-7u95: git://github.com/docker-library/java@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.4.1-apache: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-4.4.1: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-4.4-apache: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-4.4: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-4-apache: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-apache: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-4: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
-latest: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa apache
+4.4.2-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4.4.2: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4.4-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4.4: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+latest: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
 
-4.4.1-fpm: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa fpm
-4.4-fpm: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa fpm
-4-fpm: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa fpm
-fpm: git://github.com/docker-library/wordpress@2877506644eec86186d32e5aac19d6737f113efa fpm
+4.4.2-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
+4.4-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
+4-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
+fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm


### PR DESCRIPTION
- `docker`: 1.10.0-rc3
- `drupal`: 7.42, 8.0.3 (docker-library/drupal#33)
- `ghost`: 0.7.6
- `java`: 6b38-1.13.10-1~deb7u1
- `wordpress`: 4.4.2