### PR TITLE
bump erlang otp 18.2.3 release

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,22 +1,22 @@
 # maintainer: denc716@gmail.com (@c0b)
 
-18.2.2: git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
-18.2:   git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
-18:     git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
-latest: git://github.com/c0b/docker-erlang-otp@a44b506d60f417c1135257789244f9c3f7941118 18
+18.2.3: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18
+18.2:   git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18
+18:     git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18
+latest: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18
 
-18.2-slim: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
-18-slim:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
-slim:      git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/slim
+18.2-slim: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/slim
+18-slim:   git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/slim
+slim:      git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/slim
 
-18.2.2-onbuild: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
-18.2-onbuild:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
-18-onbuild:     git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
-onbuild:        git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 18/onbuild
+18.2.3-onbuild: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/onbuild
+18.2-onbuild:   git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/onbuild
+18-onbuild:     git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/onbuild
+onbuild:        git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 18/onbuild
 
-17.5.6.8: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
-17.5:     git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
-17:       git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17
+17.5.6.8: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
+17.5:     git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
+17:       git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
 
-17.5-slim: git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17/slim
-17-slim:   git://github.com/c0b/docker-erlang-otp@5deb27b20bb30e0ff5c3d8d8c96df06462ed5909 17/slim
+17.5-slim: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17/slim
+17-slim:   git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17/slim


### PR DESCRIPTION
also fixed an issue c0b/docker-erlang-otp#8 that many images here unable
to start crypto / odbc apps.