### PR TITLE
Registry release v2.3

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,10 +3,6 @@
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
-latest: git://github.com/docker/docker-registry@0.9.1
-0.8.1: git://github.com/docker/docker-registry@0.8.1
-0.9.1: git://github.com/docker/docker-registry@0.9.1
-
-2: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
-2.2: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
-2.2.1: git://github.com/docker/distribution-library-image@3aadce6abde20374ff286d444b24a0ac8949ba65
+2: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c
+2.3: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c
+2.3.0: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c


### PR DESCRIPTION
Update 2, 2.3 and latest to point to the this version.

Depends on #1391 

Signed-off-by: Richard Scothern <richard.scothern@docker.com>