### PR TITLE
[security] Update to Jetty 9.3.7

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,14 +1,14 @@
 # maintainer: Mike Dillon <mike@appropriate.io> (@md5)
 # maintainer: Greg Wilkins <gregw@webtide.com> (@gregw)
 
-9.3.6: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-9.3: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-9: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-9.3.6-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-9.3-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-latest: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.3-jre8
+9.3.7: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9.3.7-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
 
 9.2.14: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8
 9.2: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8


### PR DESCRIPTION
Contains a fix for the SLOTH vulnerability.

See https://github.com/appropriate/docker-jetty/issues/25