### PR TITLE
[security] Update Node.js to v0.10.42, v0.12.10 v4.3.0 and v5.6.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.41: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10
-0.10: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10
+0.10.42: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10
+0.10: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10
 
-0.10.41-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@17a074bda5b6030dbba648ee66a2ab1be3759bcc 0.10/onbuild
+0.10.42-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
 
-0.10.41-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/slim
+0.10.42-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/slim
 
-0.10.41-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.10/wheezy
+0.10.42-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/wheezy
 
-0.12.9: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
-0.12: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
-0: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12
+0.12.10: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
+0.12: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
+0: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
 
-0.12.9-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@78c217133fdefd3afe44526a3957835be844c1ad 0.12/onbuild
+0.12.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 
-0.12.9-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/slim
+0.12.10-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
 
-0.12.9-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@4b1b5052db3d6bc462103fac2671175d447b102e 0.12/wheezy
+0.12.10-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
 
-4.2.6: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2
-4.2: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2
-4: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2
-argon: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2
+4.3.0: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
+4.3: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
+4: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
+argon: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
 
-4.2.6-onbuild: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/onbuild
-4.2-onbuild: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/onbuild
+4.3.0-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
+4.3-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
 
-4.2.6-slim: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/slim
-4.2-slim: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/slim
-4-slim: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/slim
-argon-slim: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/slim
+4.3.0-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
+4.3-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
+4-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
+argon-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
 
-4.2.6-wheezy: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/wheezy
-4.2-wheezy: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@c161bc491adf9efd1ccea40d9cd4c239a497bfc4 4.2/wheezy
+4.3.0-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
+4.3-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
 
-5.5.0: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5
-5.5: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5
-5: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5
-latest: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5
+5.6.0: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
+5.6: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
+5: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
+latest: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
 
-5.5.0-onbuild: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/onbuild
-5.5-onbuild: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/onbuild
-onbuild: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/onbuild
+5.6.0-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
+5.6-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
+onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
 
-5.5.0-slim: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/slim
-5.5-slim: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/slim
-5-slim: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/slim
-slim: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/slim
+5.6.0-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
+5.6-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
+5-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
+slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
 
-5.5.0-wheezy: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/wheezy
-5.5-wheezy: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/wheezy
-wheezy: git://github.com/nodejs/docker-node@31bb0d89ab3d67ddb9a998e4bf655c3cd98f445c 5.5/wheezy
+5.6.0-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
+5.6-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
+wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy


### PR DESCRIPTION
This updates Node.js to  v0.10.42, v0.12.10 v4.3.0 and v5.6.0.

Reference:

https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/

Relevant issues/pull requests from our repo:
https://github.com/nodejs/docker-node/issues/97
https://github.com/nodejs/docker-node/pull/98
https://github.com/nodejs/docker-node/pull/99
https://github.com/nodejs/docker-node/pull/100