### PR TITLE
Add new arangodb 2.8.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -10,6 +10,6 @@
 2.7: git://github.com/arangodb/arangodb-docker@dbfcc5f3edb37f622a2acd221b58106547b05fae jessie/2.7.5
 2.7.5: git://github.com/arangodb/arangodb-docker@dbfcc5f3edb37f622a2acd221b58106547b05fae jessie/2.7.5
 
-2.8: git://github.com/arangodb/arangodb-docker@694aacf25b43e79ad3be658fe33f4ee9455e17cf jessie/2.8.1
-2.8.1: git://github.com/arangodb/arangodb-docker@694aacf25b43e79ad3be658fe33f4ee9455e17cf jessie/2.8.1
-latest: git://github.com/arangodb/arangodb-docker@694aacf25b43e79ad3be658fe33f4ee9455e17cf jessie/2.8.1
+2.8: git://github.com/arangodb/arangodb-docker@344a0f230bda0b944bfd46a19a638e7d54a0dc8e jessie/2.8.2
+2.8.2: git://github.com/arangodb/arangodb-docker@344a0f230bda0b944bfd46a19a638e7d54a0dc8e jessie/2.8.2
+latest: git://github.com/arangodb/arangodb-docker@344a0f230bda0b944bfd46a19a638e7d54a0dc8e jessie/2.8.2


### PR DESCRIPTION
Normally a bot is creating an automated pull request here whenever we release a new version. 

However we are trying to get rid of our special arangodb/arangodb image and merged the differences into the official Docker image here.

Notable differences:

1. The old official image did not do any authentication (our special image had authentication enabled by default)

I had a look at the official mysql Dockerfile and what was happening there (use environment vars to determine password policy) seemed very useful and we adapted it to arangodb.

2. The old official image did run as root

The official mysql image is running with its own uid. So we changed that as well (this is also how our old special image worked)

I hope the changes make sense :) (and I hope I didn"t miss anything what our bot is normally doing) :S