### PR TITLE
Bump Rakudo Star dockerfile

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,5 +1,5 @@
 # maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
 
-2016.01:  git://github.com/perl6/docker@ee6c27fe526dd73e2531ba3888ac3bfdcd0f4078
+2016.01:  git://github.com/perl6/docker@11c13fc1aab1d3973ec4e751985d257fabc9a3c7
 
-latest:  git://github.com/perl6/docker@ee6c27fe526dd73e2531ba3888ac3bfdcd0f4078
+latest:  git://github.com/perl6/docker@11c13fc1aab1d3973ec4e751985d257fabc9a3c7

--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,5 +1,5 @@
 # maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
 
-2016.01:  git://github.com/perl6/docker@11c13fc1aab1d3973ec4e751985d257fabc9a3c7
+2016.01:  git://github.com/perl6/docker@68589fca92aaad50e7beb3da100e399ad41df17e
 
-latest:  git://github.com/perl6/docker@11c13fc1aab1d3973ec4e751985d257fabc9a3c7
+latest:  git://github.com/perl6/docker@68589fca92aaad50e7beb3da100e399ad41df17e


### PR DESCRIPTION
Diff: https://github.com/perl6/docker/compare/ee6c27fe52...11c13fc

This change sets up PATH so that scripts installed via Panda (a
Perl 6 package manager) are directly invokable via the command line.