### PR TITLE
Add OrientDB to official images

### DIFF
--- a/library/orientdb
+++ b/library/orientdb
@@ -4,4 +4,8 @@
 
 2.1.10: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1
 
-latest: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1
+2.1.12: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.1
+
+2.2.0-beta: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.2
+
+latest: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.1

--- a/library/orientdb
+++ b/library/orientdb
@@ -2,10 +2,8 @@
 
 2.0.18: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.0
 
-2.1.10: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1
-
-2.1.12: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.1
+2.1.14: git://github.com/orientechnologies/orientdb-docker@031dae09937615329b22dc7805a5114dd3510734 2.1
 
 2.2.0-beta: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.2
 
-latest: git://github.com/orientechnologies/orientdb-docker@60ea1215c2c9c1204a8add48b18295dde8392991 2.1
+latest: git://github.com/orientechnologies/orientdb-docker@031dae09937615329b22dc7805a5114dd3510734 2.1

--- a/library/orientdb
+++ b/library/orientdb
@@ -1,5 +1,7 @@
 # maintainer: Roberto Franchini <r.franchini@orientdb.com> (@robfrank)
 
+2.0.18: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.0
+
 2.1.10: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1
 
-2.0.18: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.0
+latest: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1

--- a/library/orientdb
+++ b/library/orientdb
@@ -1,0 +1,5 @@
+# maintainer: Roberto Franchini <r.franchini@orientdb.com> (@robfrank)
+
+2.1.10: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.1
+
+2.0.18: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.0


### PR DESCRIPTION
Add OrientDB to official images.
At the moment only versions 2.0.18, 2.1.10 and latest (same of 2.1.10) are tagged.