### PR TITLE
Adds an official image for Consul.

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,5 +1,4 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
-0.6.3: git://github.com/hashicorp/docker-consul@bdbf63901c464fa7798eda1d19301be39e6069bb 0.6
-0.6.4: git://github.com/hashicorp/docker-consul@b1097f34f5b244eacfc6e05d1daf2c6e046afc39 0.6
-latest: git://github.com/hashicorp/docker-consul@b1097f34f5b244eacfc6e05d1daf2c6e046afc39 0.6
+0.6.4: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6
+latest: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6

--- a/library/consul
+++ b/library/consul
@@ -1,0 +1,4 @@
+# maintainer: James Phillips <james@hashicorp.com> (@slackpad)
+
+0.6.3: git://github.com/hashicorp/docker-consul@a452edd59700226b2df33d43046226baf574b5e0 0.6
+latest: git://github.com/hashicorp/docker-consul@a452edd59700226b2df33d43046226baf574b5e0 0.6

--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,4 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
-0.6.3: git://github.com/hashicorp/docker-consul@a452edd59700226b2df33d43046226baf574b5e0 0.6
-latest: git://github.com/hashicorp/docker-consul@a452edd59700226b2df33d43046226baf574b5e0 0.6
+0.6.3: git://github.com/hashicorp/docker-consul@bdbf63901c464fa7798eda1d19301be39e6069bb 0.6
+latest: git://github.com/hashicorp/docker-consul@bdbf63901c464fa7798eda1d19301be39e6069bb 0.6

--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,4 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
-v0.6.4: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6
-latest: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6
+v0.6.4: git://github.com/hashicorp/docker-consul@9a59dc1a87adc164b72ac67bc9e4364a3fc4138d 0.6
+latest: git://github.com/hashicorp/docker-consul@9a59dc1a87adc164b72ac67bc9e4364a3fc4138d 0.6

--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,4 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
-0.6.4: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6
+v0.6.4: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6
 latest: git://github.com/hashicorp/docker-consul@d442f03c754b6faf1fc85c73e2713411ad0a2788 0.6

--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,5 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
 0.6.3: git://github.com/hashicorp/docker-consul@bdbf63901c464fa7798eda1d19301be39e6069bb 0.6
-latest: git://github.com/hashicorp/docker-consul@bdbf63901c464fa7798eda1d19301be39e6069bb 0.6
+0.6.4: git://github.com/hashicorp/docker-consul@b1097f34f5b244eacfc6e05d1daf2c6e046afc39 0.6
+latest: git://github.com/hashicorp/docker-consul@b1097f34f5b244eacfc6e05d1daf2c6e046afc39 0.6


### PR DESCRIPTION
Hi - I'm an employee at HashiCorp and we'd like to propose an official image for [Consul](https://www.consul.io/). The repo referenced here has some details about the tools we used:

https://github.com/hashicorp/docker-consul/tree/master/0.6

We've also got a first cut at our docs PR content here:

https://github.com/slackpad/docs/blob/official-consul-image/consul/content.md

Thanks for your feedback!

/cc @psftw