### PR TITLE
Update images to use xz compression

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.42: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10
-0.10: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10
+0.10.42: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10
+0.10: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10
 
 0.10.42-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
 
-0.10.42-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/slim
+0.10.42-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/slim
 
-0.10.42-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/wheezy
+0.10.42-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/wheezy
 
-0.12.10: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
-0.12: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
-0: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12
+0.12.10: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
+0.12: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
+0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
 
 0.12.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 
-0.12.10-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/slim
+0.12.10-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
 
-0.12.10-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/wheezy
+0.12.10-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
 
-4.3.0: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
-4.3: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
-4: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
-argon: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3
+4.3.0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
+4.3: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
+4: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
+argon: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
 
 4.3.0-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
 4.3-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
 4-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
 argon-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
 
-4.3.0-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
-4.3-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
-4-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
-argon-slim: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/slim
+4.3.0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
+4.3-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
+4-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
+argon-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
 
-4.3.0-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
-4.3-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/wheezy
+4.3.0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
+4.3-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
 
-5.6.0: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
-5.6: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
-5: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
-latest: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6
+5.6.0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
+5.6: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
+5: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
+latest: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
 
 5.6.0-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
 5.6-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
 5-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
 onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
 
-5.6.0-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
-5.6-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
-5-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
-slim: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/slim
+5.6.0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
+5.6-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
+5-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
+slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
 
-5.6.0-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
-5.6-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
-wheezy: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/wheezy
+5.6.0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
+5.6-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
+wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy


### PR DESCRIPTION
This updates all the Node.js Docker images to use xz compressed packages when installing Node.

See https://github.com/nodejs/docker-node/issues/77