### PR TITLE
Update to Jetty 9.2.15

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,21 +1,21 @@
 # maintainer: Mike Dillon <mike@appropriate.io> (@md5)
 # maintainer: Greg Wilkins <gregw@webtide.com> (@gregw)
 
-9.3.7: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-9.3: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-9: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-9.3.7-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-9.3-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-9-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-latest: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
-jre8: git://github.com/appropriate/docker-jetty@f8673606d5bc9fc0414220ea4b4917dffbf10bbf 9.3-jre8
+9.3.7: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+9.3: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+9: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+9.3.7-jre8: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+9.3-jre8: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+9-jre8: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+latest: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
+jre8: git://github.com/appropriate/docker-jetty@696c58ef8e85ad491dd07457036f55a0eb84ed95 9.3-jre8
 
-9.2.14: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8
-9.2: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8
-9.2.14-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8
-9.2-jre8: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre8
+9.2.15: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre8
+9.2: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre8
+9.2.15-jre8: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre8
+9.2-jre8: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre8
 
-9.2.14-jre7: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre7
-9.2-jre7: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre7
-9-jre7: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre7
-jre7: git://github.com/appropriate/docker-jetty@072c632652b4c13ceb78db302411d57d612086b9 9.2-jre7
+9.2.15-jre7: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre7
+9.2-jre7: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre7
+9-jre7: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre7
+jre7: git://github.com/appropriate/docker-jetty@10f05b129dfd6caa03dc3038a19fab44fb6dcf67 9.2-jre7


### PR DESCRIPTION
Also includes GPG updates from https://github.com/appropriate/docker-jetty/pull/27