### PR TITLE
Update library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -33,12 +33,6 @@ trusty-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912
 
 trusty: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 trusty
 
-vivid-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 vivid/curl
-
-vivid-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f vivid/scm
-
-vivid: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 vivid
-
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wheezy/scm

--- a/library/drupal
+++ b/library/drupal
@@ -1,9 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.42: git://github.com/docker-library/drupal@e1b4c2b894645c6919849de16d82a2a0da2ea5c3 7
-7: git://github.com/docker-library/drupal@e1b4c2b894645c6919849de16d82a2a0da2ea5c3 7
+7.42-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
+7.42: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
+7-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
+7: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
 
-8.0.3: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
-8.0: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
-8: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
-latest: git://github.com/docker-library/drupal@3b7218a46cdd867a93b6ab7dde514555c05a8018 8
+7.42-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/fpm
+7-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/fpm
+
+8.0.3-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8.0.3: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8.0-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8.0: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+latest: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+
+8.0.3-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
+8.0-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
+8-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
+fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm

--- a/library/kibana
+++ b/library/kibana
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.3: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.0
-4.0: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.0
+4.0.3: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
+4.0: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
 
-4.1.4: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.1
-4.1: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.1
+4.1.4: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.1
+4.1: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.1
 
 4.2.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2
 4.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,6 +8,6 @@ latest: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a9952
 10.0.23: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 10.0
 10.0: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 10.0
 
-5.5.47: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5
-5.5: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5
-5: git://github.com/docker-library/mariadb@4a577108e44be5a7482dc98f163f6d3ac453fc76 5.5
+5.5.48: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5
+5.5: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5
+5: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.5
-5.5: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.5
+5.5.48: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.5
+5.5: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.5
 
-5.6.28: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.6
-5.6: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.6
+5.6.29: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.6
+5.6: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.6
 
-5.7.10: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
-5.7: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
-5: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
-latest: git://github.com/docker-library/mysql@ed198ce2e8aa78613c615f20c5c4dd09fa450f66 5.7
+5.7.11: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
+5.7: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
+5: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
+latest: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.19: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.1
-9.1: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.1
+9.1.20: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.1
+9.1: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.1
 
-9.2.14: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.2
-9.2: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.2
+9.2.15: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.2
+9.2: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.2
 
-9.3.10: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.3
-9.3: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.3
+9.3.11: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.3
+9.3: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.3
 
-9.4.5: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.4
-9.4: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.4
+9.4.6: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.4
+9.4: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.4
 
-9.5.0: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
-9.5: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
-9: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
-latest: git://github.com/docker-library/postgres@916a840510b481e7d3f0f74fa04fde3edfdfbd04 9.5
+9.5.1: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
+9.5: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
+9: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
+latest: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.44-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
-6.0.44: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
-6.0: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
-6: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre7
+6.0.45-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6.0-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6.0.45: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6.0: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
 
-6.0.44-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
-6.0-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
-6-jre8: git://github.com/docker-library/tomcat@3b05667011a600a2f46422dd533467eff8e7fecf 6-jre8
+6.0.45-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
+6.0-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
+6-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
 
 7.0.67-jre7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
 7.0-jre7: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre7
@@ -22,16 +22,16 @@
 7.0-jre8: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre8
 7-jre8: git://github.com/docker-library/tomcat@7d7d6256214d54613930ab2200be159aff49cac5 7-jre8
 
-8.0.30-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-jre7: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-8.0.30: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-8.0: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
-latest: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre7
+8.0.32-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8.0.32: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8.0: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+latest: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
 
-8.0.30-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
-jre8: git://github.com/docker-library/tomcat@e36c4044b7ece1361f124aaf3560c2efd888b62f 8-jre8
+8.0.32-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
+jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8


### PR DESCRIPTION
- `buildpack-deps` drop EOL vivid
- `drupal` add `fpm` variant https://github.com/docker-library/drupal/pull/32
- `kibana` resync Dockerfile changes https://github.com/docker-library/kibana/pull/33
- `mariadb` bump `5.5.48` https://github.com/docker-library/mariadb/commit/1f29c307ee5a37127cf8a636aabe374829f10b76
- `mysql` version bumps https://github.com/docker-library/mysql/pull/138
- `postgres` version bumps https://github.com/docker-library/postgres/pull/123
- `tomcat` bump to 8 and 6 https://github.com/docker-library/tomcat/compare/7d7d6256...31289