### PR TITLE
Update kibana 4.4.1, 4.3.2, 4.1.5 and logstash 2.2.1

### DIFF
--- a/library/kibana
+++ b/library/kibana
@@ -3,16 +3,16 @@
 4.0.3: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
 4.0: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
 
-4.1.4: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.1
-4.1: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.1
+4.1.5: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.1
+4.1: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.1
 
 4.2.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2
 4.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2
 
-4.3.1: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.3
-4.3: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.3
+4.3.2: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.3
+4.3: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.3
 
-4.4.0: git://github.com/docker-library/kibana@559199ccb087316815bb65283841e6f42ce221a6 4.4
-4.4: git://github.com/docker-library/kibana@559199ccb087316815bb65283841e6f42ce221a6 4.4
-4: git://github.com/docker-library/kibana@559199ccb087316815bb65283841e6f42ce221a6 4.4
-latest: git://github.com/docker-library/kibana@559199ccb087316815bb65283841e6f42ce221a6 4.4
+4.4.1: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
+4.4: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
+4: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
+latest: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4

--- a/library/logstash
+++ b/library/logstash
@@ -18,8 +18,8 @@
 2.1.2: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.1
 2.1: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.1
 
-2.2.0-1: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.2
-2.2.0: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.2
-2.2: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.2
-2: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.2
-latest: git://github.com/docker-library/logstash@b0506df9000e2289f8c378523e9d5afdc42617dd 2.2
+2.2.1-1: git://github.com/docker-library/logstash@aa2e1c7fa0d9eb98974d0785db701a51643240c1 2.2
+2.2.1: git://github.com/docker-library/logstash@aa2e1c7fa0d9eb98974d0785db701a51643240c1 2.2
+2.2: git://github.com/docker-library/logstash@aa2e1c7fa0d9eb98974d0785db701a51643240c1 2.2
+2: git://github.com/docker-library/logstash@aa2e1c7fa0d9eb98974d0785db701a51643240c1 2.2
+latest: git://github.com/docker-library/logstash@aa2e1c7fa0d9eb98974d0785db701a51643240c1 2.2


### PR DESCRIPTION
kibana PR: docker-library/kibana/pull/36
logstash PR: docker-library/logstash/pull/37