### PR TITLE
Bump Alpine edge for musl 1.1.13 and remove EOL 2.x images

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,9 +1,7 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-2.6: git://github.com/gliderlabs/docker-alpine@356f821e086d189fb1e052fd2cb79363454fda71 versions/library-2.6
-2.7: git://github.com/gliderlabs/docker-alpine@d73b633bf4ede2872ce72d8c3dc63af093bde454 versions/library-2.7
-3.1: git://github.com/gliderlabs/docker-alpine@9bd05ed23c4bbfd63ad4dfc2944e561f20ac060f versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@769f9a3432028eb1b306bcc807514d2358f0d691 versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@9ad8b8d1bb062e54ed8d71f351a60dd01341ae1a versions/library-3.3
-latest: git://github.com/gliderlabs/docker-alpine@9ad8b8d1bb062e54ed8d71f351a60dd01341ae1a versions/library-3.3
-edge: git://github.com/gliderlabs/docker-alpine@309793a38f9b677f6a869d9c840cf45cfb53bc9f versions/library-edge
+3.1: git://github.com/gliderlabs/docker-alpine@daa57aebea0d12d469beda41143084f930eb3f64 versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@5ab72a9d820624cc5c74467bcb5ebad03d2b82c3 versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@e69683d6c10fe2944d75ccd56e56117503a2518b versions/library-3.3
+latest: git://github.com/gliderlabs/docker-alpine@e69683d6c10fe2944d75ccd56e56117503a2518b versions/library-3.3
+edge: git://github.com/gliderlabs/docker-alpine@5168f3bf32153a4c471e2f712146658a9062325d versions/library-edge


### PR DESCRIPTION
This bumps the Alpine builds for musl 1.1.13 on edge and removes EOL 2.x images. The edge has some new DNS stuff for gliderlabs/docker-alpine#8.