### PR TITLE
Update debian (especially for CVE-2015-7547)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -2,41 +2,41 @@
 # maintainer: Paul Tagliamonte <paultag@debian.org> (@paultag)
 
 # commits: (master..dist)
-#  - 0a2d20c 2016-01-25 debootstraps
+#  - 7d44cfc 2016-02-16 debootstraps (CVE-2015-7547, glibc)
 
-8.3: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 jessie
-8: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 jessie
-jessie: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 jessie
-latest: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 jessie
+8.3: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 jessie
+8: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 jessie
+jessie: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 jessie
+latest: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 jessie
 
-jessie-backports: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 jessie/backports
+jessie-backports: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 jessie/backports
 
-oldstable: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 oldstable
+oldstable: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 oldstable
 
-oldstable-backports: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 oldstable/backports
+oldstable-backports: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 oldstable/backports
 
-sid: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 sid
+sid: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 sid
 
-6.0.10: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 squeeze
-6.0: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 squeeze
-6: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 squeeze
-squeeze: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 squeeze
+6.0.10: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 squeeze
+6.0: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 squeeze
+6: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 squeeze
+squeeze: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 squeeze
 
-stable: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 stable
+stable: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 stable
 
-stable-backports: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 stable/backports
+stable-backports: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 stable/backports
 
-stretch: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 stretch
+stretch: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 stretch
 
-testing: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 testing
+testing: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 testing
 
-unstable: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 unstable
+unstable: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 unstable
 
-7.9: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 wheezy
-7: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 wheezy
-wheezy: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 wheezy
+7.9: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 wheezy
+7: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 wheezy
+wheezy: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 wheezy
 
-wheezy-backports: git://github.com/tianon/docker-brew-debian@0a2d20ca8e26f7bf6a5cc3ce2727eb6cc1894ef9 wheezy/backports
+wheezy-backports: git://github.com/tianon/docker-brew-debian@7d44cfcf679a8cd9803482305c22c7e1af3fee15 wheezy/backports
 
 rc-buggy: git://github.com/tianon/dockerfiles@22a998f815d55217afa0075411b810b8889ceac1 debian/rc-buggy
 experimental: git://github.com/tianon/dockerfiles@22a998f815d55217afa0075411b810b8889ceac1 debian/experimental


### PR DESCRIPTION
See https://github.com/docker-library/official-images/issues/1448