### PR TITLE
Update Node.js to v4.3.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
 
-4.3.0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
-4.3: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
-4: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
-argon: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3
+4.3.1: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
+4.3: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
+4: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
+argon: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
 
-4.3.0-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
-4.3-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@555e351a259a6f278cfccfb5213e69d8feb4769c 4.3/onbuild
+4.3.1-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
+4.3-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
 
-4.3.0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
-4.3-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
-4-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
-argon-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/slim
+4.3.1-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
+4.3-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
+4-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
+argon-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
 
-4.3.0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
-4.3-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 4.3/wheezy
+4.3.1-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
+4.3-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
 
 5.6.0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
 5.6: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6


### PR DESCRIPTION
Updates Npde.js 4.x.x to v4.3.1.

Reference:

- https://nodejs.org/en/blog/release/v4.3.1/
- https://github.com/nodejs/docker-node/pull/103