### PR TITLE
Updated Oracle Linux 7.2 and 6.7 images to resolve CVE-2015-7547.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@051054d1c799a07ca9999f7232d357f97d50ce24 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/5.11


### PR DESCRIPTION
Signed-off-by: Avi Miller <avi.miller@oracle.com>