### PR TITLE
Update ubuntu (especially for CVE-2015-7547)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - e406914 Update tarballs
-#    - `ubuntu:precise`: 20160108
-#    - `ubuntu:trusty`: 20160119
-#    - `ubuntu:wily`: 20160121
-#    - `ubuntu:xenial`: 20160125
+#  - 8d4f361 Update tarballs
+#    - `ubuntu:precise`: 20160217
+#    - `ubuntu:trusty`: 20160217
+#    - `ubuntu:wily`: 20160217
+#    - `ubuntu:xenial`: 20160217.2
 
-# 20160108
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c precise
-precise-20160108: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c precise
+# 20160217
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 precise
+precise-20160217: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 precise
 
-# 20160119
-14.04.3: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c trusty
-trusty-20160119: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c trusty
+# 20160217
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 trusty
+trusty-20160217: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 trusty
 
-# 20160121
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c wily
-wily-20160121: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c wily
+# 20160217
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 wily
+wily-20160217: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 wily
 
-# 20160125
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c xenial
-xenial-20160125: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@e406914e5f648003dfe8329b512c30c9ad0d2f9c xenial
+# 20160217.2
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 xenial
+xenial-20160217.2: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@8d4f361dc880f933d28962313571bbb9177130a9 xenial


### PR DESCRIPTION
- `ubuntu:precise`: 20160217
- `ubuntu:trusty`: 20160217
- `ubuntu:wily`: 20160217
- `ubuntu:xenial`: 20160217.2

See also https://github.com/docker-library/official-images/issues/1448