### PR TITLE
Update openSUSE 42.1 and tumbleweed

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -5,9 +5,9 @@
 harlequin: git://github.com/openSUSE/docker-containers-build@3bbe87081f5d8f89e56fdca093ea24c3ab8b2992 docker
 
 # openSUSE 42.1
-42.1: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
-leap: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
-latest: git://github.com/openSUSE/docker-containers-build@70d5db31fd5357d4d36170570d215120800b4f3c docker
+42.1: git://github.com/openSUSE/docker-containers-build@c41c1924ae1087905a4f0626d5a4b1e116251be5 docker
+leap: git://github.com/openSUSE/docker-containers-build@c41c1924ae1087905a4f0626d5a4b1e116251be5 docker
+latest: git://github.com/openSUSE/docker-containers-build@c41c1924ae1087905a4f0626d5a4b1e116251be5 docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@9afc04abd28f91bb954057bc32d7b2687adc9f03 docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@98e187793067fcd23010c89d4688fb9c8245a4f1 docker


### PR DESCRIPTION
Fixes glibc and libssl issues (see issue #1448).

The fix for openSUSE 13.2 is still being processed. I'll open a dedicated PR for it.