### PR TITLE
Introducing changes in tags in nginx official docker images

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,6 +1,14 @@
 # maintainer: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 
-latest: git://github.com/nginxinc/docker-nginx@e82e776e7507868a887178bc7eaae5c1ed7aa47f
-1: git://github.com/nginxinc/docker-nginx@e82e776e7507868a887178bc7eaae5c1ed7aa47f
-1.9: git://github.com/nginxinc/docker-nginx@e82e776e7507868a887178bc7eaae5c1ed7aa47f
-1.9.11: git://github.com/nginxinc/docker-nginx@e82e776e7507868a887178bc7eaae5c1ed7aa47f
+latest: git://github.com/nginxinc/docker-nginx@f48d943038eaafd1f69cb14d86db95b3044bd4d8 mainline/jessie
+1: git://github.com/nginxinc/docker-nginx@f48d943038eaafd1f69cb14d86db95b3044bd4d8 mainline/jessie
+1.9: git://github.com/nginxinc/docker-nginx@f48d943038eaafd1f69cb14d86db95b3044bd4d8 mainline/jessie
+1.9.12: git://github.com/nginxinc/docker-nginx@f48d943038eaafd1f69cb14d86db95b3044bd4d8 mainline/jessie
+
+stable: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae stable/jessie
+1.8: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae stable/jessie
+1.8.1: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae stable/jessie
+
+stable-alpine: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae stable/alpine
+mainline-alpine: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae mainline/alpine
+alpine: git://github.com/nginxinc/docker-nginx@14c1b938737cf4399a6bb039bc506957dce562ae mainline/alpine


### PR DESCRIPTION
latest: based on debian 8 jessie with a current build from mainline
branch  (stays the same as it was)

stable: based on debian 8 jessie with a current build from stable branch

mainline-$distro: based on $distro with a current build from mainline
branch

stable-$distro: based on $distro with a current build from stable branch

$distro: based on $distro with a current build from mainline branch

Obviously this scheme promotes usage of mainline branch and Debian 8,
but the user can choose the preferred distro and use stable version if
preferred.

The list of supported distros for now is:

- Alpine
- CentOS 5
- CentOS 6
- CentOS 7
- Debian 7 "Wheezy"
- Debian 8 "Jessie"
- Ubuntu 12.04 "Precise"
- Ubuntu 14.04 "Trusty"

The plan is to add Debian and Ubuntu LTS releases as they are
introduced.