### PR TITLE
Update Mageia 5 (especially for CVE-2015-7547)

### DIFF
--- a/library/mageia
+++ b/library/mageia
@@ -1,5 +1,4 @@
 # maintainer: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 
-latest: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 5
-4: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 4
-5: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 5
+latest: git://github.com/juanluisbaptiste/docker-brew-mageia@4da7cfe586ac0ef3fe3856d48d0410bf83c0cbe2 5
+5: git://github.com/juanluisbaptiste/docker-brew-mageia@4da7cfe586ac0ef3fe3856d48d0410bf83c0cbe2 5


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/issues/1448.

This also removes Mageia 4 (which was EOL on September 19th, 2015; https://www.mageia.org/en/support/#lifecycle).

cc @juanluisbaptiste -- it looks good; I just rebased your "dist" branch on master and squashed the two tarball-touching commits into a single one :+1: (https://github.com/juanluisbaptiste/docker-brew-mageia/commit/4da7cfe586ac0ef3fe3856d48d0410bf83c0cbe2)