### PR TITLE
Updated images glibc: CVE-2015-7547 #1448

### DIFF
--- a/library/mageia
+++ b/library/mageia
@@ -1,5 +1,4 @@
 # maintainer: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 
-latest: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 5
-4: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 4
-5: git://github.com/juanluisbaptiste/docker-brew-mageia@0de4791998e295f9b71ff4d079dea424fe397853 5
+latest: git://github.com/juanluisbaptiste/docker-brew-mageia@4da7cfe586ac0ef3fe3856d48d0410bf83c0cbe2 5
+5: git://github.com/juanluisbaptiste/docker-brew-mageia@4da7cfe586ac0ef3fe3856d48d0410bf83c0cbe2 5


### PR DESCRIPTION
Updated images for glibc: CVE-2015-7547 #1448 and removed mageia 4 as it is EOL.