### PR TITLE
Update to v5.7.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945c
 4-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
 
-5.6.0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
-5.6: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
-5: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
-latest: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6
+5.7.0: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
+5.7: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
+5: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
+latest: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
 
-5.6.0-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
-5.6-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
-onbuild: git://github.com/nodejs/docker-node@28986afcb607a3506b8c43e1f2e23d9cceb4b853 5.6/onbuild
+5.7.0-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
+5.7-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
+onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
 
-5.6.0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
-5.6-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
-5-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/slim
+5.7.0-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
+5.7-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
+5-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
+slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
 
-5.6.0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
-5.6-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 5.6/wheezy
+5.7.0-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
+5.7-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
+wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy


### PR DESCRIPTION
This updates the Docker Node.js image with v5.7.0.

Reference:

- https://github.com/nodejs/docker-node/issues/105
- https://github.com/nodejs/docker-node/pull/106
- https://github.com/nodejs/node/pull/5295
- https://nodejs.org/en/blog/release/v5.7.0/
