### PR TITLE
Update Solr to 5.5.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,5 +6,8 @@
 
 5.4.1: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
 5.4: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
-5: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
-latest: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
+
+5.5.0: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
+5.5: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
+5: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
+latest: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5


### PR DESCRIPTION
This update is for Solr to 5.5.0. See the announcement email for more details:

- [Apache Solr 5.5.0 released](http://mail-archives.apache.org/mod_mbox/lucene-dev/201602.mbox/%3cCAL8Pwkbe1QgwidXSJK0KAdNs+YFGsOo_h33RZTpO+hF0dAQr8w@mail.gmail.com%3e)