### PR TITLE
Add simple test for MySQL --log-bin

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -90,6 +90,7 @@ imageTests+=(
 	[mysql]='
 		mysql-basics
 		mysql-initdb
+		mysql-log-bin
 	'
 	[node]='
 		node-hello-world

--- a/test/tests/mysql-log-bin/run.sh
+++ b/test/tests/mysql-log-bin/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+cname="mysql-container-$RANDOM-$RANDOM"
+cid="$(
+	docker run -d \
+		-e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+		--name "$cname" \
+		"$image" \
+		--log-bin="foo-$RANDOM" \
+		--server-id="$RANDOM"
+)"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+mysql() {
+	docker run --rm -i \
+		--link "$cname":mysql \
+		--entrypoint mysql \
+		"$image" \
+		-hmysql \
+		--silent \
+		"$@"
+}
+
+. "$dir/../../retry.sh" --tries 20 "echo 'SELECT 1' | mysql"
+
+# yay, must be OK


### PR DESCRIPTION
This will help ensure we don't accidentally have a resurgence of https://github.com/docker-library/mysql/issues/136, and that we catch it for other implementations (like MariaDB; https://github.com/docker-library/mariadb/pull/43).