### PR TITLE
Add an official image for Traefik

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,0 +1,5 @@
+# maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
+# maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
+
+v1.0.0-beta.392: git://github.com/containous/traefik-library-image@7f7b1e2c7d8ca00ae07e37e64a0e305f7422f6aa
+latest: git://github.com/containous/traefik-library-image@7f7b1e2c7d8ca00ae07e37e64a0e305f7422f6aa


### PR DESCRIPTION
Hi!

I'm the maintainer of [Træfɪk](http://traefik.io) and I would like to propose an official Docker image.
Another PR has been created for the doc: docker-library/docs#501

Thanks for your feedback!
/cc @tianon @jpetazzo @vdemeester