### PR TITLE
Update images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -1,23 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-7.42-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
-7.42: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
-7-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
-7: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/apache
+7.43-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
+7.43: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
+7-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
+7: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
 
-7.42-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/fpm
-7-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 7/fpm
+7.43-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
+7-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
 
-8.0.3-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-8.0.3: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-8.0-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-8.0: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-8-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-8: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-apache: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
-latest: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/apache
+8.0.4-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8.0.4: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8.0-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8.0: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+latest: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
 
-8.0.3-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
-8.0-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
-8-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
-fpm: git://github.com/docker-library/drupal@44f7abcf1c2f77165c02818708d3bd722c51a602 8/fpm
+8.0.4-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
+8.0-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
+8-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
+fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm

--- a/library/redis
+++ b/library/redis
@@ -1,24 +1,24 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.8.23: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
-2.8: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
-2: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8
+2.8.23: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
+2.8: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
+2: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
 
-2.8.23-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@7d9f53256f8e13aa4dff2112145c69c22f8ce394 2.8/32bit
+2.8.23-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
 
-3.0.7: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
-3.0: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
-3: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
-latest: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0
+3.0.7: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
+3.0: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
+3: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
+latest: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
 
-3.0.7-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
-32bit: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/32bit
+3.0.7-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
+32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
 
-3.0.7-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
-3-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
-alpine: git://github.com/docker-library/redis@b375650fb69b7db819e90c0033433c705b28656e 3.0/alpine
+3.0.7-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
+3-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
+alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine


### PR DESCRIPTION
- `drupal` version bumps for security fixes (closes https://github.com/docker-library/drupal/issues/36)
- `redis` https://github.com/docker-library/redis/pull/48