### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.11: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
-10.1: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
-10: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
-latest: git://github.com/docker-library/mariadb@7a476703349000ba14919175256a99520da42c1e 10.1
+10.1.12: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
+10.1: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
+10: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
+latest: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
 
-10.0.24: git://github.com/docker-library/mariadb@97e98960f11fd8fb71e942367f0a67e7fd0b6583 10.0
-10.0: git://github.com/docker-library/mariadb@97e98960f11fd8fb71e942367f0a67e7fd0b6583 10.0
+10.0.24: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 10.0
+10.0: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 10.0
 
-5.5.48: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5
-5.5: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5
-5: git://github.com/docker-library/mariadb@1f29c307ee5a37127cf8a636aabe374829f10b76 5.5
+5.5.48: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5
+5.5: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5
+5: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5

--- a/library/percona
+++ b/library/percona
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.5
-5.5: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.5
+5.5.47: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.5
+5.5: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.5
 
-5.6.28: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
-5.6: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
-5: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
-latest: git://github.com/docker-library/percona@b6f99e07367c193d96b29ac720fe9bfff231fde8 5.6
+5.6.28: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
+5.6: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
+5: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
+latest: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6


### PR DESCRIPTION
- `mariadb`: 10.1.12, `--log-bin` workaround (docker-library/mariadb#44)
- `percona`: `--log-bin` workaround (docker-library/percona#14)