### PR TITLE
Swap irssi to use new GitHub releases (since irssi.org no longer hosts the tarballs)

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -1,7 +1,7 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.17: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
-0.8: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
-0: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
-latest: git://github.com/jfrazelle/irssi@18b53336a61b495c2f76f9a71d433de4792395c6
+0.8.17: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
+0.8: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
+0: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
+latest: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57


### PR DESCRIPTION
See jfrazelle/irssi#3