### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.13: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 2.1
-2.1: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 2.1
+2.1.13: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.1
+2.1: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.1
 
-2.2.5: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 2.2
-2.2: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 2.2
-2: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 2.2
+2.2.5: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
+2.2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
+2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
 
-3.0.3: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 3.0
-3.0: git://github.com/docker-library/cassandra@d0a316423d957077b59f5d37ace76b5f4cc84a4c 3.0
+3.0.3: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.0
+3.0: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.0
 
-3.1.1: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.1
-3.1: git://github.com/docker-library/cassandra@e57caf5f7dc58160846753096016f81224bc0a80 3.1
+3.1.1: git://github.com/docker-library/cassandra@453a8dff57e4a34a3c12d8800d307483e877a531 3.1
+3.1: git://github.com/docker-library/cassandra@453a8dff57e4a34a3c12d8800d307483e877a531 3.1
 
-3.2.1: git://github.com/docker-library/cassandra@59ea86ef4380e2ad76f0b7a3c46019046b445ada 3.2
-3.2: git://github.com/docker-library/cassandra@59ea86ef4380e2ad76f0b7a3c46019046b445ada 3.2
+3.2.1: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.2
+3.2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.2
 
-3.3: git://github.com/docker-library/cassandra@13a08c6fb1f02a68060d632ac75b2caed92500e7 3.3
-3: git://github.com/docker-library/cassandra@13a08c6fb1f02a68060d632ac75b2caed92500e7 3.3
-latest: git://github.com/docker-library/cassandra@13a08c6fb1f02a68060d632ac75b2caed92500e7 3.3
+3.3: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3
+3: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3
+latest: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3

--- a/library/percona
+++ b/library/percona
@@ -5,5 +5,8 @@
 
 5.6.28: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
 5.6: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
-5: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
-latest: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
+
+5.7.10: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
+5.7: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
+5: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
+latest: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-4.0.1: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
-2-4.0: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
-2-4: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
-2: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2
+2-4.0.1: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
+2-4.0: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
+2-4: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
+2: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
 
 2-4.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-4.0.1-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
-2-4.0-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
-2-4-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
-2-slim: git://github.com/docker-library/pypy@3826e2d8095e0dda578aca3fa7fb72c3e7aaa47e 2/slim
+2-4.0.1-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
+2-4.0-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
+2-4-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
+2-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
-3-2.4: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
-3-2: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
-3: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
-latest: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3
+3-2.4.0: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
+3-2.4: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
+3-2: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
+3: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
+latest: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb717074
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
-3-2-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
-3-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
-slim: git://github.com/docker-library/pypy@528795c882a9cb55e713586aeb3eb71707438c69 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
+3-2-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
+3-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
+slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
-2.7: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
-2: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7
+2.7.11: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
+2.7: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
+2: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
-2.7-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
-2-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
+2.7-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
+2-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
-2-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
+2-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
-3.3: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3
+3.3.6: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3
+3.3: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/slim
-3.3-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/slim
+3.3-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4
-3.4: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4
+3.4.4: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4
+3.4: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/slim
-3.4-slim: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/slim
+3.4-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@12db3f7b07f9704719657a0652357a3ae4cdc1c1 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
-3.5: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
-3: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
-latest: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5
+3.5.1: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
+3.5: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
+3: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
+latest: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
-3.5-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
-3-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
-slim: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
+3.5-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
+3-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
+slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
-3-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
-alpine: git://github.com/docker-library/python@326d146f38fd2bbdaed8c37442a81d6486b5bf2b 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
+3-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
+alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -1,57 +1,57 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p648: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0
-2.0.0: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0
-2.0: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0
+2.0.0-p648: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
+2.0.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
+2.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
 
 2.0.0-p648-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
 
-2.0.0-p648-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.0/slim
+2.0.0-p648-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
+2.0.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
+2.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
 
-2.1.8: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1
-2.1: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1
+2.1.8: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1
+2.1: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1
 
 2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.8-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1/slim
+2.1.8-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/slim
 
-2.1.8-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.1/alpine
+2.1.8-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/alpine
 
-2.2.4: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2
-2.2: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2
+2.2.4: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2
+2.2: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/slim
 
-2.2.4-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.2/alpine
+2.2.4-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/alpine
 
-2.3.0: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3
-2.3: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3
-2: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3
-latest: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3
+2.3.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
+2.3: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
+2: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
+latest: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
 
 2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/slim
-2-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/slim
-slim: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/slim
+2.3.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
+2-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
+slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
 
-2.3.0-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/alpine
-alpine: git://github.com/docker-library/ruby@9b1f77c11d663930f4175c683b1c5f268d4d8191 2.3/alpine
+2.3.0-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
+alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine


### PR DESCRIPTION
- `cassandra`: chown logs (docker-library/cassandra#49)
- `percona`: 5.7 (docker-library/percona#16, docker-library/percona#17)
- `python`: pip 8! (docker-library/python#83)
- `pypy`: pip 8
- `ruby`: rubygems 2.6.0