### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.13: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.1
-2.1: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.1
+2.1.13: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
+2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
 
-2.2.5: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
-2.2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
-2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 2.2
+2.2.5: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
 
-3.0.3: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.0
-3.0: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.0
+3.0.3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.0
+3.0: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.0
 
-3.1.1: git://github.com/docker-library/cassandra@453a8dff57e4a34a3c12d8800d307483e877a531 3.1
-3.1: git://github.com/docker-library/cassandra@453a8dff57e4a34a3c12d8800d307483e877a531 3.1
+3.1.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1
+3.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1
 
-3.2.1: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.2
-3.2: git://github.com/docker-library/cassandra@2f08d4a6eb283d0ff81785cf1c6745ceb5535e72 3.2
+3.2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.2
+3.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.2
 
-3.3: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3
-3: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3
-latest: git://github.com/docker-library/cassandra@d93f3ec5c720277d9258a5bf3cbc24fe0e800fba 3.3
+3.3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3
+3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3
+latest: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.2-python2: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 2.7
-1.9-python2: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 2.7
-1-python2: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 2.7
-python2: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 2.7
+1.9.3-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
+1.9-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
+1-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
+python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.9.2-python3: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-1.9.2: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-1.9-python3: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-1.9: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-1-python3: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-1: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-python3: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
-latest: git://github.com/docker-library/django@c5e6eb31208f4645a5c01c4bb6f602b8bd0b2bfe 3.4
+1.9.3-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1.9.3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1.9-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1.9: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+latest: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -8,16 +8,16 @@
 7.43-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
 7-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
 
-8.0.4-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-8.0.4: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-8.0-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-8.0: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-8-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-8: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
-latest: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/apache
+8.0.4-apache: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+8.0.4: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+8.0-apache: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+8.0: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+8-apache: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+8: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+apache: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
+latest: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/apache
 
-8.0.4-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
-8.0-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
-8-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 8/fpm
+8.0.4-fpm: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/fpm
+8.0-fpm: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/fpm
+8-fpm: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/fpm
+fpm: git://github.com/docker-library/drupal@bbf0fdcd33e2167af133d4bcea0e72604c9bd3ba 8/fpm

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,28 +1,28 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.3
-1.3: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.3
+1.3: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.4
-1.4: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.4
+1.4: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.5
-1.5: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.5
+1.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.6
-1.6: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.6
+1.6: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.6
 
-1.7.5: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.7
-1.7: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.7
-1: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 1.7
+1.7.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
+1.7: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
+1: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
 
-2.0.2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.0
-2.0: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.0
+2.0.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.0
+2.0: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.0
 
-2.1.2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.1
-2.1: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.1
+2.1.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.1
+2.1: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.1
 
-2.2.0: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.2
-2.2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.2
-2: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.2
-latest: git://github.com/docker-library/elasticsearch@c3d6d0417654c4e19b4e9e3308dddca321325cd2 2.2
+2.2.0: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
+2.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
+2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
+latest: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2

--- a/library/gcc
+++ b/library/gcc
@@ -1,29 +1,29 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
 # Last Modified: 2015-06-23
-4.8.5: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.8
-4.8: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.8
+4.8.5: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.8
+4.8: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.8
 # Docker EOL: 2016-06-23
 
 # Last Modified: 2015-06-26
-4.9.3: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
-4.9: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
-4: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 4.9
+4.9.3: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
+4.9: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
+4: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
 # Docker EOL: 2016-06-26
 
 # Last Modified: 2015-04-22
-5.1.0: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 5.1
-5.1: git://github.com/docker-library/gcc@d7108b41b79e9cdfee2d59bcd84b8bb65ae424d5 5.1
+5.1.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.1
+5.1: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.1
 # Docker EOL: 2016-04-22
 
 # Last Modified: 2015-07-16
-5.2.0: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
-5.2: git://github.com/docker-library/gcc@2db1810f653d5a2b6135f81ed0d1f7659e462d7b 5.2
+5.2.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
+5.2: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
 # Docker EOL: 2016-07-16
 
 # Last Modified: 2015-12-04
-5.3.0: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
-5.3: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
-5: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
-latest: git://github.com/docker-library/gcc@aeeaf564ad8cbce6eb1d6e7749d8394475e7d345 5.3
+5.3.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
+5.3: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
+5: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
+latest: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
 # Docker EOL: 2016-12-04

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.8: git://github.com/docker-library/ghost@bb7274f3cc712ecc1997fd96b5994d08af4ebf46
-0.7: git://github.com/docker-library/ghost@bb7274f3cc712ecc1997fd96b5994d08af4ebf46
-0: git://github.com/docker-library/ghost@bb7274f3cc712ecc1997fd96b5994d08af4ebf46
-latest: git://github.com/docker-library/ghost@bb7274f3cc712ecc1997fd96b5994d08af4ebf46
+0.7.8: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
+0.7: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
+0: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
+latest: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.31: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
-2.2: git://github.com/docker-library/httpd@01b9f786daeace767c57c82d7289f4a8490d1035 2.2
+2.2.31: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.2
+2.2: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.2
 
-2.4.18: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
-2.4: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
-2: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
-latest: git://github.com/docker-library/httpd@1f1f7d39d5fe5aebeedea6872786b4e3ce0ebcc9 2.4
+2.4.18: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.4
+2.4: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.4
+2: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.4
+latest: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.4

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.4.3: git://github.com/docker-library/julia@ff730c9c2ddf959311a071af9fef5ae15f5125a0
-0.4: git://github.com/docker-library/julia@ff730c9c2ddf959311a071af9fef5ae15f5125a0
-latest: git://github.com/docker-library/julia@ff730c9c2ddf959311a071af9fef5ae15f5125a0
+0.4.3: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e
+0.4: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e
+latest: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e

--- a/library/kibana
+++ b/library/kibana
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.3: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
-4.0: git://github.com/docker-library/kibana@d7600122303543f39b8fb8d2af10d2b5ebee59ef 4.0
+4.0.3: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.0
+4.0: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.0
 
-4.1.5: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.1
-4.1: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.1
+4.1.5: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.1
+4.1: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.1
 
-4.2.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2
-4.2: git://github.com/docker-library/kibana@cc8525104d855645462ad1a2b502b5f589eeec19 4.2
+4.2.2: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.2
+4.2: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.2
 
-4.3.2: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.3
-4.3: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.3
+4.3.2: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.3
+4.3: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.3
 
-4.4.1: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
-4.4: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
-4: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
-latest: git://github.com/docker-library/kibana@279f41998ff62b33fc5ce2b348fe297b4231854b 4.4
+4.4.1: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.4
+4.4: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.4
+4: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.4
+latest: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.4

--- a/library/logstash
+++ b/library/logstash
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.5-1-a2bacae: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
-1.4.5-1: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
-1.4.5: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
-1.4: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 1.4
+1.4.5-1-a2bacae: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
+1.4.5-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
+1.4.5: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
+1.4: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
 
-1.5.6-1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
-1.5.6: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
-1.5: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
-1: git://github.com/docker-library/logstash@1005054d7dbda0a68dffd55540dabd03649d7d9e 1.5
+1.5.6-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
+1.5.6: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
+1.5: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
+1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
 
-2.0.0-1: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
-2.0.0: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
-2.0: git://github.com/docker-library/logstash@33bd21c3d91a54456606ebc950028af554c82aa7 2.0
+2.0.0-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
+2.0.0: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
+2.0: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
 
-2.1.3-1: git://github.com/docker-library/logstash@6640b3dc91110c65e30a715a07bfec00d1f32999 2.1
-2.1.3: git://github.com/docker-library/logstash@6640b3dc91110c65e30a715a07bfec00d1f32999 2.1
-2.1: git://github.com/docker-library/logstash@6640b3dc91110c65e30a715a07bfec00d1f32999 2.1
+2.1.3-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
+2.1.3: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
+2.1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
 
-2.2.2-1: git://github.com/docker-library/logstash@242021957eed6d4fa8c6b4ee10bc07e705641e72 2.2
-2.2.2: git://github.com/docker-library/logstash@242021957eed6d4fa8c6b4ee10bc07e705641e72 2.2
-2.2: git://github.com/docker-library/logstash@242021957eed6d4fa8c6b4ee10bc07e705641e72 2.2
-2: git://github.com/docker-library/logstash@242021957eed6d4fa8c6b4ee10bc07e705641e72 2.2
-latest: git://github.com/docker-library/logstash@242021957eed6d4fa8c6b4ee10bc07e705641e72 2.2
+2.2.2-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
+2.2.2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
+2.2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
+2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
+latest: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2

--- a/library/mongo
+++ b/library/mongo
@@ -1,22 +1,22 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.2
-2.2: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.2
+2.2.7: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.2
+2.2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.2
 
-2.4.14: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.4
-2.4: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.4
+2.4.14: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
+2.4: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
 
-2.6.11: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.6
-2.6: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.6
-2: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 2.6
+2.6.11: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
+2.6: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
+2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
 
-3.0.9: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 3.0
-3.0: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 3.0
+3.0.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.0
+3.0: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.0
 
-3.1.9: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 3.1
-3.1: git://github.com/docker-library/mongo@7da0e6d6520607c99d40cf71a2e4b0a2da0beca9 3.1
+3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
+3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 
-3.2.3: git://github.com/docker-library/mongo@8db153365063d518bbb23e9420b39798d2947222 3.2
-3.2: git://github.com/docker-library/mongo@8db153365063d518bbb23e9420b39798d2947222 3.2
-3: git://github.com/docker-library/mongo@8db153365063d518bbb23e9420b39798d2947222 3.2
-latest: git://github.com/docker-library/mongo@8db153365063d518bbb23e9420b39798d2947222 3.2
+3.2.3: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
+3.2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
+3: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
+latest: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2

--- a/library/mysql
+++ b/library/mysql
@@ -1,7 +1,7 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.5
-5.5: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.5
+5.5.48: git://github.com/docker-library/mysql@496aaa6c7a888360410b625fc709b3acfb78587f 5.5
+5.5: git://github.com/docker-library/mysql@496aaa6c7a888360410b625fc709b3acfb78587f 5.5
 
 5.6.29: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.6
 5.6: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.6

--- a/library/owncloud
+++ b/library/owncloud
@@ -2,43 +2,43 @@
 
 # https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
-7.0.12-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
-7.0.12: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
-7.0: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
-7: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/apache
+7.0.12-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7.0.12: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7.0: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
 
-7.0.12-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 7.0/fpm
+7.0.12-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
 
-8.0.10-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
-8.0.10: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
-8.0: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/apache
+8.0.10-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
+8.0.10: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
+8.0: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
 
-8.0.10-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.0/fpm
+8.0.10-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/fpm
 
-8.1.5-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
-8.1.5: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
-8.1: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/apache
+8.1.5-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
+8.1.5: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
+8.1: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
 
-8.1.5-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.1/fpm
+8.1.5-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/fpm
 
-8.2.2-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-8.2.2: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-8.2: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-8: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-apache: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
-latest: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/apache
+8.2.2-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8.2.2: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8.2: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+latest: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
 
-8.2.2-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
-fpm: git://github.com/docker-library/owncloud@bd378401607bc61274b8beb460d1b2b11797ef8e 8.2/fpm
+8.2.2-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
+fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm

--- a/library/php
+++ b/library/php
@@ -1,58 +1,58 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.32-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5
-5.5-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5
-5.5.32: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5
-5.5: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5
+5.5.32-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
+5.5-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
+5.5.32: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
+5.5: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
 
-5.5.32-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/apache
-5.5-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/apache
+5.5.32-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/apache
+5.5-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/apache
 
-5.5.32-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/fpm
+5.5.32-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/fpm
 
-5.5.32-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/zts
-5.5-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.5/zts
+5.5.32-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/zts
+5.5-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/zts
 
-5.6.18-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
-5.6-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
-5-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
-5.6.18: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
-5.6: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
-5: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6
+5.6.18-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5.6-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5.6.18: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5.6: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
 
-5.6.18-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/apache
-5.6-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/apache
-5-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/apache
+5.6.18-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
+5.6-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
+5-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
 
-5.6.18-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/fpm
-5-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/fpm
+5.6.18-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
+5-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
 
-5.6.18-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/zts
-5.6-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/zts
-5-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 5.6/zts
+5.6.18-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
+5.6-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
+5-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
 
-7.0.3-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-7.0-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-7-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-cli: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-7.0.3: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-7.0: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-7: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
-latest: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0
+7.0.3-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7.0-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7.0.3: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7.0: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+latest: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
 
-7.0.3-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/apache
-7.0-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/apache
-7-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/apache
-apache: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/apache
+7.0.3-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
+7.0-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
+7-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
+apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
 
-7.0.3-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/fpm
-7-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/fpm
-fpm: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/fpm
+7.0.3-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
+7-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
+fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
 
-7.0.3-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/zts
-7.0-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/zts
-7-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/zts
-zts: git://github.com/docker-library/php@7bd5c38db974ee629a815896add1ec568a1cc88c 7.0/zts
+7.0.3-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
+7.0-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
+7-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
+zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.20: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.1
-9.1: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.1
+9.1.20: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.1
+9.1: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.1
 
-9.2.15: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.2
-9.2: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.2
+9.2.15: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.2
+9.2: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.2
 
-9.3.11: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.3
-9.3: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.3
+9.3.11: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.3
+9.3: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.3
 
-9.4.6: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.4
-9.4: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.4
+9.4.6: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.4
+9.4: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.4
 
-9.5.1: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
-9.5: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
-9: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
-latest: git://github.com/docker-library/postgres@443c7947d548b1c607e06f7a75ca475de7ff3284 9.5
+9.5.1: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
+9.5: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
+9: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
+latest: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
-2.7: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
-2: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7
+2.7.11: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
+2.7: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
+2: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
-2.7-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
-2-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
+2.7-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
+2-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
-2-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
+2-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3
-3.3: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3
+3.3.6: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3
+3.3: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/slim
-3.3-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/slim
+3.3-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4
-3.4: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4
+3.4.4: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4
+3.4: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/slim
-3.4-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/slim
+3.4-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
-3.5: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
-3: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
-latest: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5
+3.5.1: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
+3.5: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
+3: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
+latest: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
-3.5-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
-3-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
-slim: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
+3.5-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
+3-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
+slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
-3-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
-alpine: git://github.com/docker-library/python@8f0e46ad31990230f00d85e4b2df58da49043d36 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
+3-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
+alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.0: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68
-3.6: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68
-3: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68
-latest: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68
+3.6.1: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
+3.6: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
+3: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
+latest: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
 
-3.6.0-management: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68 management
-3.6-management: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68 management
-3-management: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68 management
-management: git://github.com/docker-library/rabbitmq@90918b05b23b85014454c24782518ccfd9fc4c68 management
+3.6.1-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
+3.6-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
+3-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
+management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management

--- a/library/rails
+++ b/library/rails
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.5.1: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
-4.2.5: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
-4.2: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
-4: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
-latest: git://github.com/docker-library/rails@e2b37f7c245ecf9a34b9d99462c081599897b370
+4.2.5.2: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
+4.2.5: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
+4.2: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
+4: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
+latest: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
 
 onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild

--- a/library/redis
+++ b/library/redis
@@ -1,24 +1,24 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.8.23: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
-2.8: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
-2: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8
+2.8.23: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
+2.8: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
+2: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
 
-2.8.23-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 2.8/32bit
+2.8.23-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
 
-3.0.7: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
-3.0: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
-3: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
-latest: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0
+3.0.7: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
+3.0: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
+3: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
+latest: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
 
-3.0.7-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
-32bit: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/32bit
+3.0.7-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
+32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
 
-3.0.7-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
-3-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
-alpine: git://github.com/docker-library/redis@b9756ce368687678d48613989c7bbac93830ca1f 3.0/alpine
+3.0.7-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
+3-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
+alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -1,31 +1,31 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.9: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
-2.6: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
-2: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 2.6
+2.6.9: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
+2.6: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
+2: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
 
-2.6.9-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 2.6/passenger
+2.6.9-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
 
-3.0.7: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.0
-3.0: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.0
+3.0.7: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
+3.0: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
 
-3.0.7-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.0/passenger
+3.0.7-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.0/passenger
 
-3.1.3: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.1
-3.1: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.1
+3.1.3: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.1
+3.1: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.1
 
-3.1.3-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.1/passenger
-3.1-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.1/passenger
+3.1.3-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.1/passenger
+3.1-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.1/passenger
 
-3.2.0: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
-3.2: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
-3: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
-latest: git://github.com/docker-library/redmine@eca5b843e275dc5fb69c2f37854ceffe0ec994a0 3.2
+3.2.0: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
+3.2: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
+3: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
+latest: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
 
-3.2.0-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.2/passenger
-3.2-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.2/passenger
-3-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.2/passenger
-passenger: git://github.com/docker-library/redmine@dc88af734019b7f8590a5d5044a845f0cf6073fa 3.2/passenger
+3.2.0-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
+3.2-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
+3-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
+passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.19.0: git://github.com/RocketChat/Docker.Official.Image@83593d8f74f453983492a7181102250b9ea6b2ba
-0.19: git://github.com/RocketChat/Docker.Official.Image@83593d8f74f453983492a7181102250b9ea6b2ba
-0: git://github.com/RocketChat/Docker.Official.Image@83593d8f74f453983492a7181102250b9ea6b2ba
-latest: git://github.com/RocketChat/Docker.Official.Image@83593d8f74f453983492a7181102250b9ea6b2ba
+0.20.0: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
+0.20: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
+0: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
+latest: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77

--- a/library/ruby
+++ b/library/ruby
@@ -1,57 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.0.0-p648: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
-2.0.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
-2.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0
-
-2.0.0-p648-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
-2.0.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
-2.0-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.0/onbuild
-
-2.0.0-p648-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
-2.0.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
-2.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.0/slim
-
-2.1.8: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1
-2.1: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1
+2.1.8: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1
+2.1: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1
 
 2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.8-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/slim
+2.1.8-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/slim
 
-2.1.8-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.1/alpine
+2.1.8-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/alpine
 
-2.2.4: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2
-2.2: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2
+2.2.4: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2
+2.2: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/slim
 
-2.2.4-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.2/alpine
+2.2.4-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/alpine
 
-2.3.0: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
-2.3: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
-2: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
-latest: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3
+2.3.0: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
+2.3: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
+2: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
+latest: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
 
 2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
-2-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
-slim: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/slim
+2.3.0-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
+2-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
+slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
 
-2.3.0-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
-alpine: git://github.com/docker-library/ruby@c387c6c3a2505060514e31c247cb37d22c944e55 2.3/alpine
+2.3.0-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
+alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,37 +1,37 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.45-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
-6.0.45: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
-6.0: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
-6: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre7
+6.0.45-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6.0.45: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
 
-6.0.45-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
-6.0-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
-6-jre8: git://github.com/docker-library/tomcat@31289c61ce9a5ad829ca9ad8adabf0e3160f16e8 6-jre8
+6.0.45-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
+6.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
+6-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
 
-7.0.68-jre7: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
-7.0.68: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
-7.0: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
-7: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre7
+7.0.68-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7.0.68: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
 
-7.0.68-jre8: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@a55c4f55b74edcf25c7a7cb8feb2b934d4724e8d 7-jre8
+7.0.68-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
+7.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
+7-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
 
-8.0.32-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-jre7: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-8.0.32: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-8.0: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
-latest: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre7
+8.0.32-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8.0.32: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+latest: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
 
-8.0.32-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
-jre8: git://github.com/docker-library/tomcat@7da0fe6d6ba425faf5706ad13f1b6970a5192dd5 8-jre8
+8.0.32-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
+8.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
+8-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
+jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8


### PR DESCRIPTION
Unless otherwise specified, these are just updates due to https://github.com/docker-library/official-images/pull/1420#ref-pullrequest-136851424.

- `drupal`: use PHP 7 for 8+ (docker-library/drupal#35)
- `ghost`: copy all themes explicitly (docker-library/ghost#31)
- ~~`java`: 9~b107-1~~
- `rails`: 4.2.5.2
- `rocket.chat`: 0.20.0
- `ruby`: remove 2.0 (EOL; docker-library/ruby#71)