### PR TITLE
Sentry 8.2

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,21 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-7.7.4: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 7.7
-7.7: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 7.7
-7: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 7.7
-
-8.0.6: git://github.com/getsentry/docker-sentry@2b4e8b3b6eafe9c0b44e5c21eee2918e45ebb84e 8.0
-8.0: git://github.com/getsentry/docker-sentry@2b4e8b3b6eafe9c0b44e5c21eee2918e45ebb84e 8.0
-
-8.0.6-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
-8.0-onbuild: git://github.com/getsentry/docker-sentry@e60211c46e9fd4b4f9ee679946bc9915ae2bf0c0 8.0/onbuild
-
 8.1.2: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
 8.1: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
-8: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
-latest: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
 
-8.1.2-onbuild: git://github.com/getsentry/docker-sentry@07e387f3a5644638ca3e2f8235a1f8f647b3f03c 8.1/onbuild
-8.1-onbuild: git://github.com/getsentry/docker-sentry@07e387f3a5644638ca3e2f8235a1f8f647b3f03c 8.1/onbuild
-8-onbuild: git://github.com/getsentry/docker-sentry@07e387f3a5644638ca3e2f8235a1f8f647b3f03c 8.1/onbuild
-onbuild: git://github.com/getsentry/docker-sentry@07e387f3a5644638ca3e2f8235a1f8f647b3f03c 8.1/onbuild
+8.1.2-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
+8.1-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
+
+8.2.0: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
+8.2: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
+8: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
+latest: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
+
+8.2.0-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+8.2-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+8-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild


### PR DESCRIPTION
Also removes older 7.7 and 8.0 and maintain a trailing 2 versions only. :tada:

/cc @yosifkit @tianon 