### PR TITLE
Switch to new Alpine package CDN repository URL

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,7 +1,7 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-3.1: git://github.com/gliderlabs/docker-alpine@4b5f449eab427be1ce0401a1cafbb6bce97729d8 versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@96151f5a1c45525d7ce1dea0f5dccc6a8882a5e1 versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@bb49d343acb07f77b2ee123af4a2c331291a4069 versions/library-3.3
-latest: git://github.com/gliderlabs/docker-alpine@bb49d343acb07f77b2ee123af4a2c331291a4069 versions/library-3.3
-edge: git://github.com/gliderlabs/docker-alpine@35a0be9f9c6d7959830072b40ae3536da160d7db versions/library-edge
+3.1: git://github.com/gliderlabs/docker-alpine@14843c6a7f1a2c43450490dcd7dbe4842b8683b0 versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@df6f51eceabaeee4e2f04187403e0e816ca8736e versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@20f23b86a518687f33eee4e3adc5ef8bddccf712 versions/library-3.3
+latest: git://github.com/gliderlabs/docker-alpine@20f23b86a518687f33eee4e3adc5ef8bddccf712 versions/library-3.3
+edge: git://github.com/gliderlabs/docker-alpine@0e6430bd43bb658afe0e95dbdbd472a90745bf68 versions/library-edge


### PR DESCRIPTION
This switches the default Alpine package repository to a new CDN backed by Fastly. Package installs now stream from a CDN pop closest to the end user and will be much faster.

Reference gliderlabs/docker-alpine#146.