### PR TITLE
Sentry 8.1.3 & 8.2.1

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-8.1.2: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
-8.1: git://github.com/getsentry/docker-sentry@1e5786a158efb11c826410a9533ad7819e647a75 8.1
+8.1.3: git://github.com/getsentry/docker-sentry@136c05ff0ed9b17b06d4edb9806eea2a975398cc 8.1
+8.1: git://github.com/getsentry/docker-sentry@136c05ff0ed9b17b06d4edb9806eea2a975398cc 8.1
 
-8.1.2-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
+8.1.3-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
 8.1-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
 
-8.2.0: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
-8.2: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
-8: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
-latest: git://github.com/getsentry/docker-sentry@eac97b7e2f1b7aadc7fa281100b89f3b0425c8fb 8.2
+8.2.1: git://github.com/getsentry/docker-sentry@f5431a4c7254749487e8c25f54d2bad07f8e5e75 8.2
+8.2: git://github.com/getsentry/docker-sentry@f5431a4c7254749487e8c25f54d2bad07f8e5e75 8.2
+8: git://github.com/getsentry/docker-sentry@f5431a4c7254749487e8c25f54d2bad07f8e5e75 8.2
+latest: git://github.com/getsentry/docker-sentry@f5431a4c7254749487e8c25f54d2bad07f8e5e75 8.2
 
-8.2.0-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+8.2.1-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 8.2-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 8-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild


### PR DESCRIPTION
Turns out, this was sadly a result of https://github.com/docker-library/python/pull/83 :(

https://github.com/getsentry/sentry/releases/tag/8.2.1
https://github.com/getsentry/sentry/releases/tag/8.1.3

/cc @yosifkit @tianon 