### PR TITLE
[security] Update to Node.js v4.3.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.42: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10
-0.10: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10
+0.10.42: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10
+0.10: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10
 
 0.10.42-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
 
-0.10.42-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/slim
+0.10.42-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/slim
 
-0.10.42-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.10/wheezy
+0.10.42-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/wheezy
 
-0.12.10: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
-0.12: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
-0: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12
+0.12.10: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
+0.12: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
+0: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
 
 0.12.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
 
-0.12.10-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/slim
+0.12.10-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
 
-0.12.10-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@0c722500f66fb5f606a57824babe9798ae98667b 0.12/wheezy
+0.12.10-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
 
-4.3.1: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
-4.3: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
-4: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
-argon: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3
+4.3.2: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
+4.3: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
+4: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
+argon: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
 
-4.3.1-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
-4.3-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/onbuild
+4.3.2-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
+4.3-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
 
-4.3.1-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
-4.3-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
-4-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
-argon-slim: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/slim
+4.3.2-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
+4.3-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
+4-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
+argon-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
 
-4.3.1-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
-4.3-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@0f898d6da852108defeab98780f1945cecce9465 4.3/wheezy
+4.3.2-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
+4.3-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
 
-5.7.0: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
-5.7: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
-5: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
-latest: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7
+5.7.0: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
+5.7: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
+5: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
+latest: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
 
 5.7.0-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
 5.7-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
 5-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
 onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
 
-5.7.0-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
-5.7-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
-5-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
-slim: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/slim
+5.7.0-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
+5.7-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
+5-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
+slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
 
-5.7.0-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
-5.7-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
-wheezy: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/wheezy
+5.7.0-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
+5.7-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
+wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy


### PR DESCRIPTION
Also includes improved gpg usage when verifying packages

I've flagged this as [security] because of the OpenSSL update although I don't believe it's considered to be a significant issue (hence no heads-up email).

Reference:

- https://nodejs.org/en/blog/release/v4.3.2/
- https://github.com/nodejs/node/pull/5526
