### PR TITLE
[security] Update to Node.js v5.7.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe4
 4-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
 
-5.7.0: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
-5.7: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
-5: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
-latest: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7
+5.7.1: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
+5.7: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
+5: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
+latest: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
 
-5.7.0-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
-5.7-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
-onbuild: git://github.com/nodejs/docker-node@9cc089891d4c303c699e05fbafa36997394c4060 5.7/onbuild
+5.7.1-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
+5.7-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
+onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
 
-5.7.0-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
-5.7-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
-5-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/slim
+5.7.1-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
+5.7-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
+5-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
+slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
 
-5.7.0-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
-5.7-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 5.7/wheezy
+5.7.1-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
+5.7-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
+wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy


### PR DESCRIPTION
Sorry about this, I should have grouped this with the v4.3.2 update.

This update also includes an OpenSSL upgrade.

Reference:

- https://nodejs.org/en/blog/release/v5.7.1/
- https://github.com/nodejs/node/pull/5464