### PR TITLE
Updated Oracle Linux images to address OpenSSL CVEs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@af6d1843d74bcf878ed635795cde39eb41cc1c17 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@ee52bc16ff50164dfd9a9b0924f5c04cd65b00a2 OracleLinux/5.11


### PR DESCRIPTION
Resolves #1490 for OL6 and OL7. Work on updating OL5 is still in progress and will be addressed in another PR.

Signed-off-by: Avi Miller <avi.miller@oracle.com>