### PR TITLE
Update ubuntu (especially for CVE-2016-0705, CVE-2016-0798, CVE-2016-0797, CVE-2016-0702, CVE-2016-0799)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 143625e Update tarballs
-#    - `ubuntu:precise`: 20160225
-#    - `ubuntu:trusty`: 20160226
-#    - `ubuntu:wily`: 20160217
-#    - `ubuntu:xenial`: 20160226
+#  - d9c519a Update tarballs
+#    - `ubuntu:precise`: 20160303
+#    - `ubuntu:trusty`: 20160302
+#    - `ubuntu:wily`: 20160302
+#    - `ubuntu:xenial`: 20160303.1
 
-# 20160225
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad precise
-precise-20160225: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad precise
+# 20160303
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 precise
+precise-20160303: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 precise
 
-# 20160226
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad trusty
-trusty-20160226: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad trusty
+# 20160302
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 trusty
+trusty-20160302: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 trusty
 
-# 20160217
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad wily
-wily-20160217: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad wily
+# 20160302
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 wily
+wily-20160302: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 wily
 
-# 20160226
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad xenial
-xenial-20160226: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@143625e7827e51ac1894c5677006c4461feff5ad xenial
+# 20160303.1
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 xenial
+xenial-20160303.1: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@d9c519ae8a2b1cde77e94328d4f1ec0fd85ccd17 xenial


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/issues/1490

- `ubuntu:precise`: 20160303
- `ubuntu:trusty`: 20160302
- `ubuntu:wily`: 20160302
- `ubuntu:xenial`: 20160303.1