### PR TITLE
[security] Update for Node.js v0.10.43 and v0.12.11

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,32 +1,32 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.42: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10
-0.10: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10
+0.10.43: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10
+0.10: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10
 
-0.10.42-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.10/onbuild
+0.10.43-onbuild: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/onbuild
 
-0.10.42-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/slim
+0.10.43-slim: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/slim
 
-0.10.42-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.10/wheezy
+0.10.43-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
 
-0.12.10: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
-0.12: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
-0: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12
+0.12.11: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
+0.12: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
+0: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
 
-0.12.10-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@337bc9daf4553cc2392acbeebbd65234f959d154 0.12/onbuild
+0.12.11-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
 
-0.12.10-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/slim
+0.12.11-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
 
-0.12.10-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@3626d29b1e3e0f9d0c62ce9e261e57dd1b785356 0.12/wheezy
+0.12.11-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
 
 4.3.2: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
 4.3: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3


### PR DESCRIPTION
This is an update for Node.js v0.10.43 and v0.12.11. Both releases contain an OpenSSL upgrade.

Reference:

- https://nodejs.org/en/blog/release/v0.10.43/
- https://nodejs.org/en/blog/release/v0.12.11/
- https://github.com/nodejs/node/pull/5404
- https://github.com/nodejs/node/pull/5403
- https://github.com/nodejs/docker-node/pull/112