### PR TITLE
update rawhide, 23, and latest for openssl CVE-a-thon

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,10 +1,10 @@
 # maintainer: Adam Miller <maxamillion@fedoraproject.org> (@maxamillion)
 # maintainer: Patrick Uiterwijk <puiterwijk@gmail.com> (@puiterwijk)
 
-latest: git://github.com/fedora-cloud/docker-brew-fedora@76072d0b3bda55cccb43473f5e0506efce1531d6
-23: git://github.com/fedora-cloud/docker-brew-fedora@76072d0b3bda55cccb43473f5e0506efce1531d6
+latest: git://github.com/fedora-cloud/docker-brew-fedora@39d5e72640cefb5e6923afd255dd51a2eb06e146
+23: git://github.com/fedora-cloud/docker-brew-fedora@39d5e72640cefb5e6923afd255dd51a2eb06e146
 22: git://github.com/fedora-cloud/docker-brew-fedora@bccd42bf4e9102ef10eff372488167948fdd0430
 21: git://github.com/fedora-cloud/docker-brew-fedora@e32493b9601c3535cd6e0d0a8ff61d8fa95afb83
-rawhide: git://github.com/fedora-cloud/docker-brew-fedora@0529934ba1be5b86bd6dc63357839a8f7ca84475
+rawhide: git://github.com/fedora-cloud/docker-brew-fedora@d5c60b14647267a280a56cc71c6630d8df61644b
 20: git://github.com/fedora-cloud/docker-brew-fedora@10ada29063147fde9e39190f4c2344b6e6e659e6
 heisenbug: git://github.com/fedora-cloud/docker-brew-fedora@10ada29063147fde9e39190f4c2344b6e6e659e6


### PR DESCRIPTION
Fedora 23/latest and rawhide both updated by Fedora docker base image's new co-maintainer @puiterwijk 