### PR TITLE
Registry release v2.3.1

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,6 +3,6 @@
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
-2: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c
-2.3: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c
-2.3.0: git://github.com/docker/distribution-library-image@93b4a90b491342c3906980192826adeabe59a34c
+2: git://github.com/docker/distribution-library-image@b518c35ff6498b007bfccb13d03519d188125689
+2.3: git://github.com/docker/distribution-library-image@b518c35ff6498b007bfccb13d03519d188125689
+2.3.1: git://github.com/docker/distribution-library-image@b518c35ff6498b007bfccb13d03519d188125689


### PR DESCRIPTION
Update 2, 2.3 to point to the this version.

Remove images which are no longer required to be rebuilt.

Signed-off-by: Richard Scothern <richard.scothern@docker.com>