### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -7,8 +7,8 @@
 2.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
 2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
 
-3.0.3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.0
-3.0: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.0
+3.0.4: git://github.com/docker-library/cassandra@952709b74d43657bd19b131f81364386edc5e373 3.0
+3.0: git://github.com/docker-library/cassandra@952709b74d43657bd19b131f81364386edc5e373 3.0
 
 3.1.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1
 3.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1

--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.20: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
-3.1: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
-3: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
-latest: git://github.com/docker-library/celery@22c9fed4bb5d41ba5ec7a52294c85a44c6b4dc34
+3.1.22: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
+3.1: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
+3: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
+latest: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39

--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.3-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
-1.9-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
-1-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
-python2: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 2.7
+1.9.4-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
+1.9-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
+1-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
+python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.9.3-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-1.9.3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-1.9-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-1.9: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-1-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-1: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-python3: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
-latest: git://github.com/docker-library/django@aa2b1ed0a9a3acc194a76d673d1a091a45948931 3.4
+1.9.4-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1.9.4: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1.9-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1.9: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+latest: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -8,27 +8,27 @@
 7.43-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
 7-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
 
-8.0.5-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-8.0.5: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-8.0-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-8.0: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-8-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-8: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
-latest: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/apache
+8.0.5-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+8.0.5: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+8.0-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+8.0: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+8-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+8: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
+latest: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/apache
 
-8.0.5-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/fpm
-8.0-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/fpm
-8-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/fpm
-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.0/fpm
+8.0.5-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/fpm
+8.0-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/fpm
+8-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/fpm
+fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.0/fpm
 
-8.1.0-beta1-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
-8.1.0-beta1: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
-8.1.0-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
-8.1.0: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
-8.1-apache: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
-8.1: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/apache
+8.1.0-beta1-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
+8.1.0-beta1: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
+8.1.0-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
+8.1.0: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
+8.1-apache: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
+8.1: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/apache
 
-8.1.0-beta1-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/fpm
-8.1.0-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/fpm
-8.1-fpm: git://github.com/docker-library/drupal@4fe7a837c7de5ea753070be21e64f0cb971493a7 8.1/fpm
+8.1.0-beta1-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/fpm
+8.1.0-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/fpm
+8.1-fpm: git://github.com/docker-library/drupal@907aa1ebada751931dde5b23666b60bbeb39de09 8.1/fpm

--- a/library/irssi
+++ b/library/irssi
@@ -1,7 +1,7 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.17: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
-0.8: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
-0: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
-latest: git://github.com/jfrazelle/irssi@187c976470c1371b47cfed29cde9811a2d143b57
+0.8.17: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
+0.8: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
+0: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
+latest: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63

--- a/library/mongo
+++ b/library/mongo
@@ -10,13 +10,13 @@
 2.6: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
 2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
 
-3.0.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.0
-3.0: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.0
+3.0.10: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.0
+3.0: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.0
 
 3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 
-3.2.3: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
-3.2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
-3: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
-latest: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.2
+3.2.4: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
+3.2: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
+3: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
+latest: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2

--- a/library/owncloud
+++ b/library/owncloud
@@ -2,43 +2,54 @@
 
 # https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
-7.0.12-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
-7.0.12: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
-7.0: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
-7: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/apache
+7.0.13-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7.0.13: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7.0: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
 
-7.0.12-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 7.0/fpm
+7.0.13-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
 
-8.0.10-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
-8.0.10: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
-8.0: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/apache
+8.0.11-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
+8.0.11: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
+8.0: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
 
-8.0.10-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.0/fpm
+8.0.11-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/fpm
 
-8.1.5-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
-8.1.5: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
-8.1: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/apache
+8.1.6-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
+8.1.6: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
+8.1: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
 
-8.1.5-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.1/fpm
+8.1.6-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/fpm
 
-8.2.2-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-8.2.2: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-8.2: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-8: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-apache: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
-latest: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/apache
+8.2.3-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8.2.3: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8.2: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
 
-8.2.2-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
-fpm: git://github.com/docker-library/owncloud@b318418b76633d0e4a057f68c966213fb11ae2c8 8.2/fpm
+8.2.3-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
+
+9.0.0-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9.0.0: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9.0-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9.0: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+latest: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+
+9.0.0-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
+9.0-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
+9-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
+fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm

--- a/library/percona
+++ b/library/percona
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.47: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.5
-5.5: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.5
+5.5.48: git://github.com/docker-library/percona@7fc9a7b58e5f1f2544800b4f16e97291a5e2deea 5.5
+5.5: git://github.com/docker-library/percona@7fc9a7b58e5f1f2544800b4f16e97291a5e2deea 5.5
 
-5.6.28: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
-5.6: git://github.com/docker-library/percona@ddfe76ce541e9855464d522feb137b22a0971515 5.6
+5.6.29: git://github.com/docker-library/percona@e781d097467d1ce415b01ac9086fbfc5973b762c 5.6
+5.6: git://github.com/docker-library/percona@e781d097467d1ce415b01ac9086fbfc5973b762c 5.6
 
 5.7.10: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
 5.7: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7

--- a/library/php
+++ b/library/php
@@ -1,58 +1,58 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.32-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
-5.5-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
-5.5.32: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
-5.5: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5
+5.5.33-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5
+5.5-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5
+5.5.33: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5
+5.5: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5
 
-5.5.32-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/apache
-5.5-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/apache
+5.5.33-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/apache
+5.5-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/apache
 
-5.5.32-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/fpm
+5.5.33-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/fpm
 
-5.5.32-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/zts
-5.5-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.5/zts
+5.5.33-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/zts
+5.5-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.5/zts
 
-5.6.18-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
-5.6-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
-5-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
-5.6.18: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
-5.6: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
-5: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6
+5.6.19-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
+5.6-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
+5-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
+5.6.19: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
+5.6: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
+5: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6
 
-5.6.18-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
-5.6-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
-5-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/apache
+5.6.19-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/apache
+5.6-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/apache
+5-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/apache
 
-5.6.18-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
-5-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/fpm
+5.6.19-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/fpm
+5-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/fpm
 
-5.6.18-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
-5.6-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
-5-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 5.6/zts
+5.6.19-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/zts
+5.6-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/zts
+5-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 5.6/zts
 
-7.0.3-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-7.0-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-7-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-cli: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-7.0.3: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-7.0: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-7: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
-latest: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0
+7.0.4-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+7.0-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+7-cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+cli: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+7.0.4: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+7.0: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+7: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
+latest: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0
 
-7.0.3-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
-7.0-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
-7-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
-apache: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/apache
+7.0.4-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/apache
+7.0-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/apache
+7-apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/apache
+apache: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/apache
 
-7.0.3-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
-7-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
-fpm: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/fpm
+7.0.4-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/fpm
+7-fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/fpm
+fpm: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/fpm
 
-7.0.3-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
-7.0-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
-7-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
-zts: git://github.com/docker-library/php@8943e1e6a930768994fbc29f4df89d0a3fd65e12 7.0/zts
+7.0.4-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/zts
+7.0-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/zts
+7-zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/zts
+zts: git://github.com/docker-library/php@cdebaa8f318d4d20a492da372d24cb496041fe56 7.0/zts

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.20: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.1
-9.1: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.1
+9.1.20: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.1
+9.1: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.1
 
-9.2.15: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.2
-9.2: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.2
+9.2.15: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.2
+9.2: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.2
 
-9.3.11: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.3
-9.3: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.3
+9.3.11: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.3
+9.3: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.3
 
-9.4.6: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.4
-9.4: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.4
+9.4.6: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.4
+9.4: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.4
 
-9.5.1: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
-9.5: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
-9: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
-latest: git://github.com/docker-library/postgres@35a09c34b04019c3942d13d78b99eab66bc4b3ad 9.5
+9.5.1: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
+9.5: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
+9: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
+latest: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-4.0.1: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
-2-4.0: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
-2-4: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
-2: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2
+2-4.0.1: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
+2-4.0: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
+2-4: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
+2: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
 
 2-4.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-4.0.1-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
-2-4.0-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
-2-4-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
-2-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 2/slim
+2-4.0.1-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
+2-4.0-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
+2-4-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
+2-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
-3-2.4: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
-3-2: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
-3: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
-latest: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3
+3-2.4.0: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
+3-2.4: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
+3-2: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
+3: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
+latest: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501b
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
-3-2-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
-3-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
-slim: git://github.com/docker-library/pypy@b6c28180538193e56aef132bb4a42e9501bf6334 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3/slim
+3-2-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3/slim
+3-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3/slim
+slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3/slim

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
-2.7: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
-2: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7
+2.7.11: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7
+2.7: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7
+2: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
-2.7-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
-2-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/slim
+2.7-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/slim
+2-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
-2-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/alpine
+2-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3
-3.3: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3
+3.3.6: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3
+3.3: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/slim
-3.3-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/slim
+3.3-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4
-3.4: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4
+3.4.4: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4
+3.4: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/slim
-3.4-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/slim
+3.4-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
-3.5: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
-3: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
-latest: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5
+3.5.1: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5
+3.5: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5
+3: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5
+latest: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
-3.5-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
-3-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
-slim: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/slim
+3.5-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/slim
+3-slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/slim
+slim: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
-3-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
-alpine: git://github.com/docker-library/python@93dd2037ba9de1e80e8c17b65649485d7b7112f5 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/alpine
+3-alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/alpine
+alpine: git://github.com/docker-library/python@d2b679d44bcfc2cbc2c1f483b1b8c2a6e5452c80 3.5/alpine

--- a/library/rails
+++ b/library/rails
@@ -1,9 +1,8 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.2.5.2: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
-4.2.5: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
-4.2: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
-4: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
-latest: git://github.com/docker-library/rails@db9122c0525e0a9f76ed47dbfb26e8e25ca0af70
+4.2.6: git://github.com/docker-library/rails@09ca1187b57df26d1ba3fb04874806bdd47109f8
+4.2: git://github.com/docker-library/rails@09ca1187b57df26d1ba3fb04874806bdd47109f8
+4: git://github.com/docker-library/rails@09ca1187b57df26d1ba3fb04874806bdd47109f8
+latest: git://github.com/docker-library/rails@09ca1187b57df26d1ba3fb04874806bdd47109f8
 
 onbuild: git://github.com/docker-library/rails@9fb5d2b7e0f2e7029855028e07e86ab7ec54abaa onbuild

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.20.0: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
-0.20: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
-0: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
-latest: git://github.com/RocketChat/Docker.Official.Image@b82f6b3e479f2166343018574bf8420998c17e77
+0.21.0: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
+0.21: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
+0: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
+latest: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de


### PR DESCRIPTION
- `cassandra`: 3.0.4
- `celery`: 3.1.22
- `django`: 1.9.4
- `drupal`: explicit `FROM php:7.0` instead of `php:7` (safer in the future event of PHP 7.1 incompat)
- `irssi`: fix GPG usage (docker-library/irssi#5)
- `mongo`: 3.2.4 and 3.0.10
- `owncloud`: 9.0 GA, 8.2.3, 8.1.6, 8.0.11, and 7.0.13
- `percona`: 5.6.29-76.2-1.jessie
- `php`: 7.0.4, 5.6.19, and 5.5.33 (docker-library/php#199)
- `postgres`: `sql.gz` enablement (docker-library/postgres#131)
- `pypy`: pip 8.1.0
- `python`: pip 8.1.0 (docker-library/python#94)
- `rails`: 4.2.6
- `rocket.chat`: 0.21.0