### PR TITLE
Update to Node.js v0.12.12 and v4.4.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
 
-4.3.2: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
-4.3: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
-4: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
-argon: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
+4.4.0: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
+4.4: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
+4: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
+argon: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
 
-4.3.2-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
-4.3-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/onbuild
+4.4.0-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
 
-4.3.2-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
-4.3-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
-4-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
-argon-slim: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/slim
+4.4.0-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
 
-4.3.2-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
-4.3-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3/wheezy
+4.4.0-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
 
 5.7.1: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
 5.7: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7

--- a/library/node
+++ b/library/node
@@ -12,21 +12,21 @@
 0.10.43-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
 0.10-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
 
-0.12.11: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
-0.12: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
-0: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12
+0.12.12: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
+0.12: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
+0: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
 
-0.12.11-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/onbuild
+0.12.12-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
 
-0.12.11-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/slim
+0.12.12-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
 
-0.12.11-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@fa1d51c9b9bfab27e48f8c6c740fb702661089e8 0.12/wheezy
+0.12.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
 
 4.3.2: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3
 4.3: git://github.com/nodejs/docker-node@5934cfb183f13fec7ef17c5d185dbfe444d1da0f 4.3


### PR DESCRIPTION
Updates Node.js to v0.12.12 and v4.4.0 ( I did a follow up commit to include v4.4.0)

Reference:

- https://nodejs.org/en/blog/release/v0.12.12/
- https://github.com/nodejs/docker-node/pull/116
- https://github.com/nodejs/node/pull/5301