### PR TITLE
Update for Node.js v5.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a240
 4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
 
-5.7.1: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
-5.7: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
-5: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
-latest: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7
+5.8.0: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
+5.8: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
+5: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
+latest: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
 
-5.7.1-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
-5.7-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
-onbuild: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/onbuild
+5.8.0-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
+5.8-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
+onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
 
-5.7.1-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
-5.7-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
-5-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
-slim: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/slim
+5.8.0-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
+5.8-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
+5-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
+slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
 
-5.7.1-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
-5.7-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
-wheezy: git://github.com/nodejs/docker-node@b2c7f6e357359b7b8f30caada05f1d412d926d7b 5.7/wheezy
+5.8.0-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
+5.8-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
+wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy


### PR DESCRIPTION
This is an update for Node.js v5.8.0.

Reference:

- https://github.com/nodejs/docker-node/issues/119
- https://github.com/nodejs/node/pull/5559
- https://nodejs.org/en/blog/release/v5.8.0/