### PR TITLE
Update elasticsearch and pypy

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,28 +1,28 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.3
-1.3: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.3
+1.3.9: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.3
+1.3: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.3
 
-1.4.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.4
-1.4: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.4
+1.4.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
+1.4: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
 
-1.5.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.5
-1.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.5
+1.5.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.5
+1.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.5
 
-1.6.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.6
-1.6: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.6
+1.6.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.6
+1.6: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.6
 
-1.7.5: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
-1.7: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
-1: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 1.7
+1.7.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
+1.7: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
+1: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
 
-2.0.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.0
-2.0: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.0
+2.0.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.0
+2.0: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.0
 
-2.1.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.1
-2.1: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.1
+2.1.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
+2.1: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
 
-2.2.0: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
-2.2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
-2: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
-latest: git://github.com/docker-library/elasticsearch@8a74bd1f706af238e2cb9d8063d5067338e5d388 2.2
+2.2.0: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.2
+2.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.2
+2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.2
+latest: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.2

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-4.0.1: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
-2-4.0: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
-2-4: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
-2: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2
+2-5.0.0: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2
+2-5.0: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2
+2-5: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2
+2: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2
 
-2-4.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.0.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-4.0.1-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
-2-4.0-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
-2-4-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
-2-slim: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 2/slim
+2-5.0.0-slim: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2/slim
+2-5.0-slim: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2/slim
+2-5-slim: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2/slim
+2-slim: git://github.com/docker-library/pypy@90b51282fdf1387585e1d6d2fdd41627e7f19e4f 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3
 3-2.4: git://github.com/docker-library/pypy@7663c0dfad945ebc6b6b2fc07d09a1ebca619f8c 3


### PR DESCRIPTION
- `elasticsearch` https://github.com/docker-library/elasticsearch/pull/88
- `pypy` bump to `5.0.0`