### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.1.22: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
-3.1: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
-3: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
-latest: git://github.com/docker-library/celery@3a598dfe1b9cbe9adde5f8c4d28009d295dcbc39
+3.1.23: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
+3.1: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
+3: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
+latest: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291

--- a/library/docker
+++ b/library/docker
@@ -1,17 +1,17 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.10.2: git://github.com/docker-library/docker@8d8a46bbe4c018a262df473d844d548689787d6e 1.10
-1.10: git://github.com/docker-library/docker@8d8a46bbe4c018a262df473d844d548689787d6e 1.10
-1: git://github.com/docker-library/docker@8d8a46bbe4c018a262df473d844d548689787d6e 1.10
-latest: git://github.com/docker-library/docker@8d8a46bbe4c018a262df473d844d548689787d6e 1.10
+1.10.3: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
+1.10: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
+1: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
+latest: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
 
-1.10.2-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
+1.10.3-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
 1.10-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
 1-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
 dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
 
-1.10.2-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
+1.10.3-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
 1.10-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
 1-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
 git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git

--- a/library/java
+++ b/library/java
@@ -1,60 +1,91 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-openjdk-6b38-jdk: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-openjdk-6b38: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-openjdk-6-jdk: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-openjdk-6: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-6b38-jdk: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-6b38: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-6-jdk: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
-6: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jdk
+openjdk-6b38-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+openjdk-6b38: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+openjdk-6-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+openjdk-6: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+6b38-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+6b38: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+6-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+6: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
 
-openjdk-6b38-jre: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
-openjdk-6-jre: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
-6b38-jre: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
-6-jre: git://github.com/docker-library/openjdk@193df6f21c76adb7bf23c0a6791fcbc28f6ec5fc openjdk-6-jre
+openjdk-6b38-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
+openjdk-6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
+6b38-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
+6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
 
-openjdk-7u95-jdk: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-openjdk-7u95: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-openjdk-7-jdk: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-openjdk-7: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-7u95-jdk: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-7u95: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-7-jdk: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
-7: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jdk
+openjdk-7u95-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+openjdk-7u95: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+openjdk-7-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+openjdk-7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+7u95-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+7u95: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+7-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
 
-openjdk-7u95-jre: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jre
-openjdk-7-jre: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jre
-7u95-jre: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jre
-7-jre: git://github.com/docker-library/openjdk@f71d77ba3fe01cbfc625e38c1841531870f0538c openjdk-7-jre
+openjdk-7u95-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+openjdk-7u95-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+openjdk-7-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+openjdk-7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7u95-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7u95-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 
-openjdk-8u72-jdk: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-openjdk-8u72: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-openjdk-8-jdk: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-openjdk-8: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-8u72-jdk: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-8u72: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-8-jdk: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-8: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-jdk: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
-latest: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jdk
+openjdk-7u95-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
+openjdk-7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
+7u95-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
+7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
 
-openjdk-8u72-jre: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jre
-openjdk-8-jre: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jre
-8u72-jre: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jre
-8-jre: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jre
-jre: git://github.com/docker-library/openjdk@2dd0496901a9c01c78895d0e6618b36c08f78bde openjdk-8-jre
+openjdk-7u95-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
+openjdk-7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
+7u95-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
+7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 
-openjdk-9-b102-jdk: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-openjdk-9-b102: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-9-b102-jdk: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-9-b102: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-9-jdk: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
-9: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jdk
+openjdk-8u72-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+openjdk-8u72: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+openjdk-8-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+openjdk-8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+8u72-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+8u72: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+8-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+latest: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
 
-openjdk-9-b102-jre: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jre
-9-b102-jre: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jre
-9-jre: git://github.com/docker-library/openjdk@0235b70854cf9251ab4a1479696975412320a9bd openjdk-9-jre
+openjdk-8u72-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+openjdk-8u72-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+openjdk-8-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+8u72-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+8u72-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+8-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+8-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+
+openjdk-8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+
+openjdk-8u72-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+8u72-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+8-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+
+openjdk-9-b107-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+openjdk-9-b107: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+9-b107-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+9-b107: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+9: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+
+openjdk-9-b107-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
+9-b107-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
+9-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.12: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
-10.1: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
-10: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
-latest: git://github.com/docker-library/mariadb@9430efcac9f75793dd2e368bc9517c21a96c07ef 10.1
+10.1.12: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
+10.1: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
+10: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
+latest: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
 
-10.0.24: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 10.0
-10.0: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 10.0
+10.0.24: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0
+10.0: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0
 
-5.5.48: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5
-5.5: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5
-5: git://github.com/docker-library/mariadb@a3da203091c235a827467d5bcb10bc4b06903295 5.5
+5.5.48: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5
+5.5: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5
+5: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/mysql@496aaa6c7a888360410b625fc709b3acfb78587f 5.5
-5.5: git://github.com/docker-library/mysql@496aaa6c7a888360410b625fc709b3acfb78587f 5.5
+5.5.48: git://github.com/docker-library/mysql@a93628500589d5a584f523fd168360ec16d81655 5.5
+5.5: git://github.com/docker-library/mysql@a93628500589d5a584f523fd168360ec16d81655 5.5
 
-5.6.29: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.6
-5.6: git://github.com/docker-library/mysql@ace4c65b8e97f0145616386916aabaec518d4e08 5.6
+5.6.29: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.6
+5.6: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.6
 
-5.7.11: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
-5.7: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
-5: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
-latest: git://github.com/docker-library/mysql@4e022c06314ff6047dabc4abee2f222ae9ce564d 5.7
+5.7.11: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
+5.7: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
+5: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
+latest: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7

--- a/library/percona
+++ b/library/percona
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/percona@7fc9a7b58e5f1f2544800b4f16e97291a5e2deea 5.5
-5.5: git://github.com/docker-library/percona@7fc9a7b58e5f1f2544800b4f16e97291a5e2deea 5.5
+5.5.48: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.5
+5.5: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.5
 
-5.6.29: git://github.com/docker-library/percona@e781d097467d1ce415b01ac9086fbfc5973b762c 5.6
-5.6: git://github.com/docker-library/percona@e781d097467d1ce415b01ac9086fbfc5973b762c 5.6
+5.6.29: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
+5.6: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
 
-5.7.10: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
-5.7: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
-5: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
-latest: git://github.com/docker-library/percona@b4999fd228678f88c972bcff1f4532da1bb443a4 5.7
+5.7.10: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
+5.7: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
+5: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
+latest: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7


### PR DESCRIPTION
- `celery`: 3.1.23
- `docker`: 1.10.3
- `java`: add `alpine` variants for 7 and 8 (docker-library/openjdk#62), add `bzip2` and `xz` (docker-library/openjdk#70)
- `mariadb`: skip setup for `--help` (docker-library/mariadb#45)
- `mysql`: skip setup for `--help` (docker-library/mysql#147)
- `percona`: skip setup for `--help` (docker-library/percona#15)