### PR TITLE
library: opensuse: update OpenSUSE images

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,13 +1,13 @@
 # maintainer: Flavio Castelli <fcastelli@suse.com> (@flavio)
 
 # openSUSE 13.2
-13.2: git://github.com/openSUSE/docker-containers-build@ed3df5e41110e93de7cba6f1cc11f0a2fc2271b4 docker
-harlequin: git://github.com/openSUSE/docker-containers-build@ed3df5e41110e93de7cba6f1cc11f0a2fc2271b4 docker
+13.2: git://github.com/openSUSE/docker-containers-build@6bcc5f50a8eac7b37d9d55d905e72d986b727436 docker
+harlequin: git://github.com/openSUSE/docker-containers-build@6bcc5f50a8eac7b37d9d55d905e72d986b727436 docker
 
 # openSUSE 42.1
-42.1: git://github.com/openSUSE/docker-containers-build@8363237ea4c474de56f71efa80b1e58de6e46499 docker
-leap: git://github.com/openSUSE/docker-containers-build@8363237ea4c474de56f71efa80b1e58de6e46499 docker
-latest: git://github.com/openSUSE/docker-containers-build@8363237ea4c474de56f71efa80b1e58de6e46499 docker
+42.1: git://github.com/openSUSE/docker-containers-build@d529ec4ff604e41997fd98b6ade9715ab20cf75c docker
+leap: git://github.com/openSUSE/docker-containers-build@d529ec4ff604e41997fd98b6ade9715ab20cf75c docker
+latest: git://github.com/openSUSE/docker-containers-build@d529ec4ff604e41997fd98b6ade9715ab20cf75c docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@7ccafe3786633dfcc420d5e8ffcc0bf097fab0af docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@9ae47a56a87fb66aa29e2a46e1979855c1c1bdde docker


### PR DESCRIPTION
Due to a bug in kiwi, all OpenSUSE images had their extended attributes
stripped (which caused issues with tools like `ping`). This update
includes rebuilt images that fixes this problem.

Signed-off-by: Aleksa Sarai <asarai@suse.de>

/cc @flavio @tianon 