### PR TITLE
Update busybox (2016-03-15 tarballs)

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,21 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 # maintainer: Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 
-1.24.1-glibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 glibc
-1.24-glibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 glibc
-1-glibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 glibc
-glibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 glibc
+1.24.1-glibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d glibc
+1.24-glibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d glibc
+1-glibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d glibc
+glibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d glibc
 
-1.24.1-musl: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 musl
-1.24-musl: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 musl
-1-musl: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 musl
-musl: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 musl
+1.24.1-musl: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d musl
+1.24-musl: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d musl
+1-musl: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d musl
+musl: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d musl
 
-1.24.1-uclibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-1.24.1: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-1.24-uclibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-1.24: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-1-uclibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-1: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-uclibc: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
-latest: git://github.com/docker-library/busybox@1cf3ff5b2bdf332e6ecff8c4aaaa94172f693332 uclibc
+1.24.1-uclibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+1.24.1: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+1.24-uclibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+1.24: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+1-uclibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+1: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+uclibc: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc
+latest: git://github.com/docker-library/busybox@e333c2a49992959d77e3792a04dfccebdd97981d uclibc


### PR DESCRIPTION
Especially for https://github.com/docker-library/busybox/pull/11, which fixes our ability to use more than three DNS search paths.