### PR TITLE
Update haproxy, percona, postgres, redmine, and ruby

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.26: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.4
-1.4: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.4
+1.4.27: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
+1.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
 
-1.5.15: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
-1.5: git://github.com/docker-library/haproxy@2c1ab61d9ba298a8b40164ed91d8d0a797e7bb1c 1.5
+1.5.16: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
+1.5: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
 
-1.6.3: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
-1.6: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
-1: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
-latest: git://github.com/docker-library/haproxy@7998146d9fb15e16c0550d978064e82619bf7702 1.6
+1.6.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
+1.6: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
+1: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
+latest: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6

--- a/library/percona
+++ b/library/percona
@@ -6,7 +6,7 @@
 5.6.29: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
 5.6: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
 
-5.7.10: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
-5.7: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
-5: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
-latest: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.7
+5.7.11: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
+5.7: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
+5: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
+latest: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.20: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.1
-9.1: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.1
+9.1.20: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.1
+9.1: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.1
 
-9.2.15: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.2
-9.2: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.2
+9.2.15: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.2
+9.2: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.2
 
-9.3.11: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.3
-9.3: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.3
+9.3.11: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.3
+9.3: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.3
 
-9.4.6: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.4
-9.4: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.4
+9.4.6: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.4
+9.4: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.4
 
-9.5.1: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
-9.5: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
-9: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
-latest: git://github.com/docker-library/postgres@48d6cd0f57ea3f7de4a3d02d7b0ca8f2f9d6e991 9.5
+9.5.1: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
+9.5: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
+9: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
+latest: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5

--- a/library/redmine
+++ b/library/redmine
@@ -1,10 +1,10 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.6.9: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
-2.6: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
-2: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 2.6
+2.6.10: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
+2.6: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
+2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
 
-2.6.9-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
+2.6.10-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
 2.6-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
 2-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 2.6/passenger
 
@@ -14,18 +14,18 @@
 3.0.7-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.0/passenger
 3.0-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.0/passenger
 
-3.1.3: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.1
-3.1: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.1
+3.1.4: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
+3.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
 
-3.1.3-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.1/passenger
+3.1.4-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.1/passenger
 3.1-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.1/passenger
 
-3.2.0: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
-3.2: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
-3: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
-latest: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.2
+3.2.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
+3.2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
+3: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
+latest: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
 
-3.2.0-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
+3.2.1-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
 3.2-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
 3-passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger
 passenger: git://github.com/docker-library/redmine@4bc61432ba8c03b6f3044ac73947c2d425ebf662 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.8: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1
-2.1: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1
+2.1.8: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1
+2.1: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1
 
 2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.8-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/slim
+2.1.8-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/slim
 
-2.1.8-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.1/alpine
+2.1.8-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/alpine
 
-2.2.4: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2
-2.2: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2
+2.2.4: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2
+2.2: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/slim
 
-2.2.4-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.2/alpine
+2.2.4-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/alpine
 
-2.3.0: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
-2.3: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
-2: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
-latest: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3
+2.3.0: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
+2.3: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
+2: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
+latest: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
 
 2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
-2-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
-slim: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/slim
+2.3.0-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
+2-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
+slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
 
-2.3.0-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
-alpine: git://github.com/docker-library/ruby@4a3fdc3eed98346362a62b5d53e56f7f4e4e6d63 2.3/alpine
+2.3.0-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/alpine
+alpine: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/alpine


### PR DESCRIPTION
- `haproxy` Update to 1.6.4, 1.5.16, and 1.4.27
- `percona` Update to 5.7.11-4-1.jessie
- `postgres` https://github.com/docker-library/postgres/pull/132
- `redmine` Update to 3.2.1, 3.1.4, and 2.6.10
- `ruby` Update rubygems to 2.6.2