### PR TITLE
Update HAProxy and Rocket.Chat

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -3,10 +3,21 @@
 1.4.27: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
 1.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
 
+1.4.27-alpine: git://github.com/docker-library/haproxy@60d34669b97c528199d3b372ea8347aaf308de8a 1.4/alpine
+1.4-alpine: git://github.com/docker-library/haproxy@60d34669b97c528199d3b372ea8347aaf308de8a 1.4/alpine
+
 1.5.16: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
 1.5: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
+
+1.5.16-alpine: git://github.com/docker-library/haproxy@48ab27a7ce0ec802aff02ed789f1195fcafd9558 1.5/alpine
+1.5-alpine: git://github.com/docker-library/haproxy@48ab27a7ce0ec802aff02ed789f1195fcafd9558 1.5/alpine
 
 1.6.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
 1.6: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
 1: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
 latest: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
+
+1.6.4-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
+1.6-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
+1-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
+alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.21.0: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
-0.21: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
-0: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
-latest: git://github.com/RocketChat/Docker.Official.Image@a59723b313dbdf190e104d8590cb9c015cfae6de
+0.22.0: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
+0.22: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
+0: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
+latest: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00


### PR DESCRIPTION
- `haproxy`: add Alpine variants (docker-library/haproxy#16)
- `rocket.chat`: 0.22.0