### PR TITLE
Add "reload" support to HAProxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,23 +1,23 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.27: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
-1.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.4
+1.4.27: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
+1.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
 
-1.4.27-alpine: git://github.com/docker-library/haproxy@60d34669b97c528199d3b372ea8347aaf308de8a 1.4/alpine
-1.4-alpine: git://github.com/docker-library/haproxy@60d34669b97c528199d3b372ea8347aaf308de8a 1.4/alpine
+1.4.27-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
+1.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
 
-1.5.16: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
-1.5: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.5
+1.5.16: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5
+1.5: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5
 
-1.5.16-alpine: git://github.com/docker-library/haproxy@48ab27a7ce0ec802aff02ed789f1195fcafd9558 1.5/alpine
-1.5-alpine: git://github.com/docker-library/haproxy@48ab27a7ce0ec802aff02ed789f1195fcafd9558 1.5/alpine
+1.5.16-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5/alpine
+1.5-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5/alpine
 
-1.6.4: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
-1.6: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
-1: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
-latest: git://github.com/docker-library/haproxy@dddcbc797defcdad1189931986851572d3b5894e 1.6
+1.6.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
+1.6: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
+1: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
+latest: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
 
-1.6.4-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
-1.6-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
-1-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
-alpine: git://github.com/docker-library/haproxy@88fddd524fdd36baf040fa686a2c02a49be88d43 1.6/alpine
+1.6.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
+1.6-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
+1-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
+alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine


### PR DESCRIPTION
This allows us to send `SIGHUP` for having HAProxy reload the config, and `SIGTERM` should now work for graceful shutdown (docker-library/haproxy#17, docker-library/haproxy#22).