### PR TITLE
Update to Node.js v5.9.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -50,15 +50,23 @@ argon-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2
 
 5.9.0: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
 5.9: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
+5: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
+latest: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
 
 5.9.0-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
 5.9-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
+onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
 
 5.9.0-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
 5.9-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
+5-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
+slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
 
 5.9.0-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
 5.9-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
+wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
 
 docs: git://github.com/nodejs/docker-node@0e0c74ad89870df855ecb8fa4e440c1bf030a0e3 docs
 

--- a/library/node
+++ b/library/node
@@ -67,11 +67,3 @@ slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b030
 5.9-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
 5-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
 wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
-
-docs: git://github.com/nodejs/docker-node@0e0c74ad89870df855ecb8fa4e440c1bf030a0e3 docs
-
-docs-onbuild: git://github.com/nodejs/docker-node@ docs/onbuild
-
-docs-slim: git://github.com/nodejs/docker-node@ docs/slim
-
-docs-wheezy: git://github.com/nodejs/docker-node@ docs/wheezy

--- a/library/node
+++ b/library/node
@@ -48,22 +48,22 @@ argon-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a240
 4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
 
-5.8.0: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
-5.8: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
-5: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
-latest: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8
+5.9.0: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
+5.9: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
 
-5.8.0-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
-5.8-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
-onbuild: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/onbuild
+5.9.0-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
+5.9-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
 
-5.8.0-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
-5.8-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
-5-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
-slim: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/slim
+5.9.0-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
+5.9-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
 
-5.8.0-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
-5.8-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
-wheezy: git://github.com/nodejs/docker-node@a0e795b24770de9a72c2054ac0a8244c0fee015c 5.8/wheezy
+5.9.0-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
+5.9-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
+
+docs: git://github.com/nodejs/docker-node@0e0c74ad89870df855ecb8fa4e440c1bf030a0e3 docs
+
+docs-onbuild: git://github.com/nodejs/docker-node@ docs/onbuild
+
+docs-slim: git://github.com/nodejs/docker-node@ docs/slim
+
+docs-wheezy: git://github.com/nodejs/docker-node@ docs/wheezy


### PR DESCRIPTION
This updates Node.js to v5.9.0.

Reference:

- https://nodejs.org/en/blog/release/v5.9.0/
- https://github.com/nodejs/node/pull/5702
- https://github.com/nodejs/docker-node/issues/123