### PR TITLE
Update ubuntu (especially for libpam vulnerability)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 30d456f Update tarballs
-#    - `ubuntu:precise`: 20160311
-#    - `ubuntu:trusty`: 20160315
-#    - `ubuntu:wily`: 20160302
-#    - `ubuntu:xenial`: 20160314.4
+#  - fae14e7 Update tarballs
+#    - `ubuntu:precise`: 20160318
+#    - `ubuntu:trusty`: 20160317
+#    - `ubuntu:wily`: 20160316
+#    - `ubuntu:xenial`: 20160317
 
-# 20160311
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 precise
-precise-20160311: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 precise
+# 20160318
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 precise
+precise-20160318: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 precise
 
-# 20160315
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 trusty
-trusty-20160315: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 trusty
+# 20160317
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 trusty
+trusty-20160317: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 trusty
 
-# 20160302
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 wily
-wily-20160302: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 wily
+# 20160316
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 wily
+wily-20160316: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 wily
 
-# 20160314.4
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 xenial
-xenial-20160314.4: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@30d456fb9b0b00f204f30a4ef84217bf59620b17 xenial
+# 20160317
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 xenial
+xenial-20160317: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@fae14e72201e4411a7e04c70150238dc79242b29 xenial


### PR DESCRIPTION
- `ubuntu:precise`: 20160318
- `ubuntu:trusty`: 20160317
- `ubuntu:wily`: 20160316
- `ubuntu:xenial`: 20160317