### PR TITLE
Update Node.js to v4.4.1 and v5.9.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,42 +28,42 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
 
-4.4.0: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
-4.4: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
-4: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
-argon: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4
+4.4.1: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
+4.4: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
+4: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
+argon: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
 
-4.4.0-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/onbuild
+4.4.1-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
 
-4.4.0-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/slim
+4.4.1-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
 
-4.4.0-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@12b7be1a82f2366a798c618f40c0a2402dd5b509 4.4/wheezy
+4.4.1-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
 
-5.9.0: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
-5.9: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
-5: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
-latest: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9
+5.9.1: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
+5.9: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
+5: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
+latest: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
 
-5.9.0-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
-5.9-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
-onbuild: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/onbuild
+5.9.1-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
+5.9-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
+onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
 
-5.9.0-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
-5.9-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
-5-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
-slim: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/slim
+5.9.1-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
+5.9-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
+5-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
+slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
 
-5.9.0-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
-5.9-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
-wheezy: git://github.com/nodejs/docker-node@c415d0802c101079f10e1da3518d2555e4b03013 5.9/wheezy
+5.9.1-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
+5.9-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
+wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy


### PR DESCRIPTION
This updates Node.js to v4.4.1 and v5.9.1

Reference:

- https://github.com/nodejs/docker-node/issues/128
- https://github.com/nodejs/node/pull/5835
- https://github.com/nodejs/node/pull/5831
- https://nodejs.org/en/blog/release/v4.4.1/
- https://nodejs.org/en/blog/release/v5.9.1/