### PR TITLE
added NEM

### DIFF
--- a/library/nem
+++ b/library/nem
@@ -1,0 +1,5 @@
+# maintainer: rb2nem@gmail.com (@rb2nem)
+nis: git://github.com/rb2nem/docker-hub-nem@a0398ea3b132ee245ee0cbfa0f4f79cbab21190f nis
+ncc: git://github.com/rb2nem/docker-hub-nem@a0398ea3b132ee245ee0cbfa0f4f79cbab21190f ncc
+nis-0.6.74: git://github.com/rb2nem/docker-hub-nem@a0398ea3b132ee245ee0cbfa0f4f79cbab21190f nis
+ncc-0.6.74: git://github.com/rb2nem/docker-hub-nem@a0398ea3b132ee245ee0cbfa0f4f79cbab21190f ncc


### PR DESCRIPTION
This PR add docker config file for running [NEM](http://nem.io)'s server (nis) and client (ncc).
NEM is number 12 of http://coinmarketcap.com/ and growing.
This work is based on unofficial images maintained at https://hub.docker.com/u/rb2nem/ , but with 
changes to follow the oficial images guidelines.
NEM is developed in Java and this image reuses the official Java images.
The images run only one process and each expose one port: 8989 for client and 7890 for server.
The main focus of these images is to make it easy to run a NIS node, and lower the barrier of
entry for developers interested in NEM.