### PR TITLE
Security: Sentry 8.1.5 & 8.2.4

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-8.1.4: git://github.com/getsentry/docker-sentry@642b1b8906851708cc309ac2af71033ac260f32e 8.1
-8.1: git://github.com/getsentry/docker-sentry@642b1b8906851708cc309ac2af71033ac260f32e 8.1
+8.1.5: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.1
+8.1: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.1
 
-8.1.4-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
+8.1.5-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
 8.1-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
 
-8.2.3: git://github.com/getsentry/docker-sentry@445f76edb8edacfa8e0010df7b2881119a29b4a5 8.2
-8.2: git://github.com/getsentry/docker-sentry@445f76edb8edacfa8e0010df7b2881119a29b4a5 8.2
-8: git://github.com/getsentry/docker-sentry@445f76edb8edacfa8e0010df7b2881119a29b4a5 8.2
-latest: git://github.com/getsentry/docker-sentry@445f76edb8edacfa8e0010df7b2881119a29b4a5 8.2
+8.2.4: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
+8.2: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
+8: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
+latest: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
 
-8.2.3-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+8.2.4-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 8.2-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 8-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild


### PR DESCRIPTION
See:
  https://github.com/getsentry/sentry/releases/tag/8.2.4
  https://github.com/getsentry/sentry/releases/tag/8.1.5

/cc @yosifkit 