### PR TITLE
Update elasticsearch v2.3.0/v2.2.2, logstash v2.3.0/v2.2.3, kibana v4.5.0

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -22,7 +22,10 @@
 2.1.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
 2.1: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
 
-2.2.1: git://github.com/docker-library/elasticsearch@dce83166a2636abfac110a4555cdf17fd554ae91 2.2
-2.2: git://github.com/docker-library/elasticsearch@dce83166a2636abfac110a4555cdf17fd554ae91 2.2
-2: git://github.com/docker-library/elasticsearch@dce83166a2636abfac110a4555cdf17fd554ae91 2.2
-latest: git://github.com/docker-library/elasticsearch@dce83166a2636abfac110a4555cdf17fd554ae91 2.2
+2.2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
+2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
+
+2.3.0: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
+2.3: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
+2: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
+latest: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3

--- a/library/kibana
+++ b/library/kibana
@@ -14,5 +14,8 @@
 
 4.4.2: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
 4.4: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
-4: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
-latest: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
+
+4.5.0: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
+4.5: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
+4: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
+latest: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5

--- a/library/logstash
+++ b/library/logstash
@@ -18,8 +18,12 @@
 2.1.3: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
 2.1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
 
-2.2.2-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
-2.2.2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
-2.2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
-2: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
-latest: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.2
+2.2.3-1: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
+2.2.3: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
+2.2: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
+
+2.3.0-1: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
+2.3.0: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
+2.3: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
+2: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
+latest: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3


### PR DESCRIPTION
PR elasticsearch: docker-library/elasticsearch/pull/94
PR logstash: docker-library/logstash/pull/42
PR kibana: docker-library/kibana/pull/39