### PR TITLE
[security] Update for Node.js v0.10.44, v0.12.13, v4.4.2 and v5.10.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.43: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10
-0.10: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10
+0.10.44: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10
+0.10: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10
 
-0.10.43-onbuild: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/onbuild
+0.10.44-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
 
-0.10.43-slim: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/slim
+0.10.44-slim: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10/slim
 
-0.10.43-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@03d0a92fc4a52087d3bd414b49a977325a7ac4ff 0.10/wheezy
+0.10.44-wheezy: git://github.com/nodejs/docker-node@9d0a1897a95b6a50660e993119608b41e3060969 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@9d0a1897a95b6a50660e993119608b41e3060969 0.10/wheezy
 
-0.12.12: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
-0.12: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
-0: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12
+0.12.13: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
+0.12: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
+0: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
 
-0.12.12-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/onbuild
+0.12.13-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 
-0.12.12-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/slim
+0.12.13-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
 
-0.12.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@bbdb1dc2ed5e1a0e57ec9d59f9a0cbdd104ff090 0.12/wheezy
+0.12.13-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
 
-4.4.1: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
-4.4: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
-4: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
-argon: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4
+4.4.2: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
+4.4: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
+4: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
+argon: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
 
-4.4.1-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/onbuild
+4.4.2-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
 
-4.4.1-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/slim
+4.4.2-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
 
-4.4.1-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@88077364f7612b1f0e4bdd81db286886cf516958 4.4/wheezy
+4.4.2-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
 
-5.9.1: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
-5.9: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
-5: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
-latest: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9
+5.10.0: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10
+5.10: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10
+5: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10
+latest: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10
 
-5.9.1-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
-5.9-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
-onbuild: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/onbuild
+5.10.0-onbuild: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/onbuild
+5.10-onbuild: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/onbuild
+onbuild: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/onbuild
 
-5.9.1-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
-5.9-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
-5-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
-slim: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/slim
+5.10.0-slim: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/slim
+5.10-slim: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/slim
+5-slim: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/slim
+slim: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/slim
 
-5.9.1-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
-5.9-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
-wheezy: git://github.com/nodejs/docker-node@9dfa3cbd5ca0133d3c111e4624e3452169b4fef9 5.9/wheezy
+5.10.0-wheezy: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/wheezy
+5.10-wheezy: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/wheezy
+wheezy: git://github.com/nodejs/docker-node@78c9ef30b3ddb81464ffd04d3df95c51224029a1 5.10/wheezy


### PR DESCRIPTION
This is a security update for npm in each Node.js image per https://nodejs.org/en/blog/vulnerability/npm-tokens-leak-march-2016/.

Also note that the v0.10.44  binary now includes the latest version of npm so we are no longer updating npm in the Dockerfile of the v0.10 image.

Reference:

- https://github.com/nodejs/docker-node/issues/132
- https://github.com/nodejs/docker-node/issues/133
- https://github.com/nodejs/docker-node/issues/134

