### PR TITLE
Bump Alpine for Ruby base image musl fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,7 +1,7 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-3.1: git://github.com/gliderlabs/docker-alpine@14843c6a7f1a2c43450490dcd7dbe4842b8683b0 versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@df6f51eceabaeee4e2f04187403e0e816ca8736e versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@20f23b86a518687f33eee4e3adc5ef8bddccf712 versions/library-3.3
-latest: git://github.com/gliderlabs/docker-alpine@20f23b86a518687f33eee4e3adc5ef8bddccf712 versions/library-3.3
-edge: git://github.com/gliderlabs/docker-alpine@0e6430bd43bb658afe0e95dbdbd472a90745bf68 versions/library-edge
+3.1: git://github.com/gliderlabs/docker-alpine@15b474abe9efb3140468010c8c264e8ad20757f6 versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@8d8e867fa7a829d898224a60041412060236a104 versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@d59b1d8ffd48d19c574bdd88c25b031bc83dfaad versions/library-3.3
+latest: git://github.com/gliderlabs/docker-alpine@d59b1d8ffd48d19c574bdd88c25b031bc83dfaad versions/library-3.3
+edge: git://github.com/gliderlabs/docker-alpine@f523d0089492f0ef38b96fc9a4062b1882748819 versions/library-edge


### PR DESCRIPTION
Should fix docker-library/ruby#77.