### PR TITLE
Sentry 8.3

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-8.1.5: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.1
-8.1: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.1
-
-8.1.5-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
-8.1-onbuild: git://github.com/getsentry/docker-sentry@6870e0f6469f2c17f00d25324311df5d46a2791c 8.1/onbuild
-
 8.2.4: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
 8.2: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
-8: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
-latest: git://github.com/getsentry/docker-sentry@3ec1dafe76069627d9a1f2fe2bca149026ce9576 8.2
 
 8.2.4-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
 8.2-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
-8-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
+
+8.3.0: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3
+8.3: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3
+8: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3
+latest: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3
+
+8.3.0-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
+8.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
+8-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
+onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.3.0