### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.4-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
-1.9-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
-1-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
-python2: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 2.7
+1.9.5-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
+1.9-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
+1-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
+python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.9.4-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-1.9.4: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-1.9-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-1.9: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-1-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-1: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-python3: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
-latest: git://github.com/docker-library/django@ed24424d84ec19a4d9e71401ce4d895c97a7e352 3.4
+1.9.5-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1.9.5: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1.9-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1.9: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+latest: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/docker
+++ b/library/docker
@@ -1,15 +1,27 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
+1.11.0-rc3: git://github.com/docker-library/docker@412c6bd4ebcfa9d2131c1691f01cdcd6c1018d1e 1.11-rc
+1.11-rc: git://github.com/docker-library/docker@412c6bd4ebcfa9d2131c1691f01cdcd6c1018d1e 1.11-rc
+rc: git://github.com/docker-library/docker@412c6bd4ebcfa9d2131c1691f01cdcd6c1018d1e 1.11-rc
+
+1.11.0-rc3-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
+1.11-rc-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
+rc-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
+
+1.11.0-rc3-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
+1.11-rc-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
+rc-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
+
 1.10.3: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
 1.10: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
 1: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
 latest: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
 
-1.10.3-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
-1.10-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
-1-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
-dind: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/dind
+1.10.3-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
+1.10-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
+1-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
+dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
 
 1.10.3-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
 1.10-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
@@ -19,8 +31,8 @@ git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601
 1.9.1: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9
 1.9: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9
 
-1.9.1-dind: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9/dind
-1.9-dind: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9/dind
+1.9.1-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.9/dind
+1.9-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.9/dind
 
 1.9.1-git: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9/git
 1.9-git: git://github.com/docker-library/docker@7a61b09b70b0aba202019c6325821437981126f4 1.9/git

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -25,7 +25,7 @@
 2.2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 
-2.3.0: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
-2.3: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
-2: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
-latest: git://github.com/docker-library/elasticsearch@bceef593300c241757fe93737f0e4502a269f122 2.3
+2.3.1: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
+2.3: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
+2: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
+latest: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3

--- a/library/golang
+++ b/library/golang
@@ -28,7 +28,7 @@ onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f
 1-wheezy: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/wheezy
 wheezy: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/wheezy
 
-1.6.0-alpine: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/alpine
-1.6-alpine: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/alpine
-1-alpine: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/alpine
-alpine: git://github.com/docker-library/golang@3cdd85183c0f3f6608588166410d24260cd8cb2f 1.6/alpine
+1.6.0-alpine: git://github.com/docker-library/golang@0f3ab4a3d2eba38991ab7b41941f1dc99f13dc3f 1.6/alpine
+1.6-alpine: git://github.com/docker-library/golang@0f3ab4a3d2eba38991ab7b41941f1dc99f13dc3f 1.6/alpine
+1-alpine: git://github.com/docker-library/golang@0f3ab4a3d2eba38991ab7b41941f1dc99f13dc3f 1.6/alpine
+alpine: git://github.com/docker-library/golang@0f3ab4a3d2eba38991ab7b41941f1dc99f13dc3f 1.6/alpine

--- a/library/irssi
+++ b/library/irssi
@@ -10,7 +10,7 @@ latest: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4
 0-debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
 debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
 
-0.8.19-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
-0.8-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
-0-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
+0.8.19-alpine: git://github.com/jfrazelle/irssi@7194b9bc0429d26d097f7486f61ac874a0920365 alpine
+0.8-alpine: git://github.com/jfrazelle/irssi@7194b9bc0429d26d097f7486f61ac874a0920365 alpine
+0-alpine: git://github.com/jfrazelle/irssi@7194b9bc0429d26d097f7486f61ac874a0920365 alpine
+alpine: git://github.com/jfrazelle/irssi@7194b9bc0429d26d097f7486f61ac874a0920365 alpine

--- a/library/irssi
+++ b/library/irssi
@@ -1,7 +1,16 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.17: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
-0.8: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
-0: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
-latest: git://github.com/jfrazelle/irssi@00fe42ab059f8f92a02ad3c6d73a09558eb0aa63
+0.8.19: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+0.8: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+0: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+latest: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+0.8.19-debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+0.8-debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+0-debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+debian: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b debian
+
+0.8.19-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
+0.8-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
+0-alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine
+alpine: git://github.com/jfrazelle/irssi@2065fe5f6c9656d34b301bbfd0643dcdbc17bd4b alpine

--- a/library/java
+++ b/library/java
@@ -23,12 +23,12 @@ openjdk-7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379
 7-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
 7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
 
-openjdk-7u95-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
-openjdk-7u95-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+openjdk-7u91-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+openjdk-7u91-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 openjdk-7-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 openjdk-7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
-7u95-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
-7u95-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7u91-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
+7u91-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 7-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 
@@ -37,9 +37,9 @@ openjdk-7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102
 7u95-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
 7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
 
-openjdk-7u95-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
+openjdk-7u91-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 openjdk-7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
-7u95-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
+7u91-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 
 openjdk-8u72-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
@@ -53,16 +53,16 @@ openjdk-8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379
 jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
 latest: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
 
-openjdk-8u72-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-openjdk-8u72-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-openjdk-8-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-8u72-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-8u72-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-8-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-8-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jdk/alpine
+openjdk-8u77-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+openjdk-8u77-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+openjdk-8-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+8u77-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+8u77-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+8-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+8-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
 
 openjdk-8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
@@ -70,22 +70,22 @@ openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102
 8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 
-openjdk-8u72-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
-openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
-8u72-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
-8-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 8-jre/alpine
+openjdk-8u77-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
+openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
+8u77-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
+8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
+jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 
-openjdk-9-b107-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-openjdk-9-b107: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-9-b107-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-9-b107: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
-9: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jdk
+openjdk-9-b112-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+openjdk-9-b112: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+9-b112-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+9-b112: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+9: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
 
-openjdk-9-b107-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
-9-b107-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
-9-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 9-jre
+openjdk-9-b112-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
+9-b112-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
+9-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.4.3: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e
-0.4: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e
-latest: git://github.com/docker-library/julia@4c64514dc0f1aa0aed906af3a9a135d684c7d49e
+0.4.5: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57
+0.4: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57
+latest: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.12: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
-10.1: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
-10: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
-latest: git://github.com/docker-library/mariadb@c64262339972ac2a8dadaf8141e012aa8ddb8c23 10.1
+10.1.13: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
+10.1: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
+10: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
+latest: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
 
 10.0.24: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0
 10.0: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -6,12 +6,12 @@
 2.4.14: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
 2.4: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
 
-2.6.11: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
-2.6: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
-2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.6
+2.6.12: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
+2.6: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
+2: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
 
-3.0.10: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.0
-3.0: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.0
+3.0.11: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
+3.0: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
 
 3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/mysql@a93628500589d5a584f523fd168360ec16d81655 5.5
-5.5: git://github.com/docker-library/mysql@a93628500589d5a584f523fd168360ec16d81655 5.5
+5.5.48: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.5
+5.5: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.5
 
-5.6.29: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.6
-5.6: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.6
+5.6.29: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.6
+5.6: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.6
 
-5.7.11: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
-5.7: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
-5: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
-latest: git://github.com/docker-library/mysql@3288a66368f16deb6f2768ce373ab36f92553cfa 5.7
+5.7.11: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.7
+5.7: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.7
+5: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.7
+latest: git://github.com/docker-library/mysql@5b1a6a2b50efceac44579df0936facfee654a805 5.7

--- a/library/owncloud
+++ b/library/owncloud
@@ -2,54 +2,54 @@
 
 # https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
-7.0.13-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
-7.0.13: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
-7.0: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
-7: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/apache
+7.0.13-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7.0.13: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7.0: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
 
-7.0.13-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 7.0/fpm
+7.0.13-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
 
-8.0.11-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
-8.0.11: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
-8.0: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/apache
+8.0.11-apache: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
+8.0.11: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
+8.0: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
 
-8.0.11-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.0/fpm
+8.0.11-fpm: git://github.com/docker-library/owncloud@0aacd0ef10b4bd0d7a9e29433ab38376324d2667 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@0aacd0ef10b4bd0d7a9e29433ab38376324d2667 8.0/fpm
 
-8.1.6-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
-8.1.6: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
-8.1: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/apache
+8.1.6-apache: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
+8.1.6: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
+8.1: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
 
-8.1.6-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.1/fpm
+8.1.6-fpm: git://github.com/docker-library/owncloud@49f10ce1af40883e9499b8e7613375bbfb11476f 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@49f10ce1af40883e9499b8e7613375bbfb11476f 8.1/fpm
 
-8.2.3-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
-8.2.3: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
-8.2: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
-8: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/apache
+8.2.3-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8.2.3: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8.2: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
 
-8.2.3-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@0c315f16a8ad0a836de7fd1227a905b2617c81ee 8.2/fpm
+8.2.3-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
 
-9.0.0-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-9.0.0: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-9.0-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-9.0: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-9-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-9: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-apache: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
-latest: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/apache
+9.0.0-apache: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+9.0.0: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+9.0-apache: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+9.0: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+9-apache: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+9: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+apache: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
+latest: git://github.com/docker-library/owncloud@45bd528f6449d0c1d8cbb46ff3fd187026626679 9.0/apache
 
-9.0.0-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
-9.0-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
-9-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
-fpm: git://github.com/docker-library/owncloud@ad0926eb01118dde31ca6d96bc218a73d1d6ab83 9.0/fpm
+9.0.0-fpm: git://github.com/docker-library/owncloud@173904c6b5278b2c7515737ff4c6a13f9857ddbb 9.0/fpm
+9.0-fpm: git://github.com/docker-library/owncloud@173904c6b5278b2c7515737ff4c6a13f9857ddbb 9.0/fpm
+9-fpm: git://github.com/docker-library/owncloud@173904c6b5278b2c7515737ff4c6a13f9857ddbb 9.0/fpm
+fpm: git://github.com/docker-library/owncloud@173904c6b5278b2c7515737ff4c6a13f9857ddbb 9.0/fpm

--- a/library/php
+++ b/library/php
@@ -1,94 +1,94 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.33-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5
-5.5-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5
-5.5.33: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5
-5.5: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5
+5.5.34-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
+5.5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
+5.5.34: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
+5.5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
 
-5.5.33-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/alpine
+5.5.34-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/alpine
+5.5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/alpine
 
-5.5.33-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/apache
-5.5-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/apache
+5.5.34-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/apache
+5.5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/apache
 
-5.5.33-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/fpm
+5.5.34-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm
 
-5.5.33-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/fpm/alpine
+5.5.34-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm/alpine
+5.5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm/alpine
 
-5.5.33-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/zts
-5.5-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/zts
+5.5.34-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts
+5.5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts
 
-5.5.33-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.5/zts/alpine
+5.5.34-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts/alpine
+5.5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts/alpine
 
-5.6.19-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
-5.6-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
-5-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
-5.6.19: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
-5.6: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
-5: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6
+5.6.20-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5.6-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5.6.20: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5.6: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
 
-5.6.19-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/alpine
-5-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/alpine
+5.6.20-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
+5.6-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
+5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
 
-5.6.19-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/apache
-5.6-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/apache
-5-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/apache
+5.6.20-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
+5.6-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
+5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
 
-5.6.19-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm
-5-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm
+5.6.20-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
+5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
 
-5.6.19-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/fpm/alpine
+5.6.20-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
+5.6-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
+5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
 
-5.6.19-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts
-5.6-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts
-5-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts
+5.6.20-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
+5.6-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
+5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
 
-5.6.19-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 5.6/zts/alpine
+5.6.20-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
+5.6-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
+5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
 
-7.0.4-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-7.0-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-7-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-cli: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-7.0.4: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-7.0: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-7: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
-latest: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0
+7.0.5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7.0-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7.0.5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7.0: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+latest: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
 
-7.0.4-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/alpine
-7-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/alpine
-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/alpine
+7.0.5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
+7.0-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
+7-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
+alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
 
-7.0.4-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/apache
-7.0-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/apache
-7-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/apache
-apache: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/apache
+7.0.5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
+7.0-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
+7-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
+apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
 
-7.0.4-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm
-7-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm
-fpm: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm
+7.0.5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
+7-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
+fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
 
-7.0.4-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/fpm/alpine
+7.0.5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
+7.0-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
+7-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
+fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
 
-7.0.4-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts
-7.0-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts
-7-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts
-zts: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts
+7.0.5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
+7.0-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
+7-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
+zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
 
-7.0.4-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@0d23b3d08770889c6cb31e8e5374334879103f92 7.0/zts/alpine
+7.0.5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
+7.0-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
+7-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
+zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,18 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.20: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.1
-9.1: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.1
+9.1.21: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.1
+9.1: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.1
 
-9.2.15: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.2
-9.2: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.2
+9.2.16: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.2
+9.2: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.2
 
-9.3.11: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.3
-9.3: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.3
+9.3.12: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.3
+9.3: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.3
 
-9.4.6: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.4
-9.4: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.4
+9.4.7: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.4
+9.4: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.4
 
-9.5.1: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
-9.5: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
-9: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
-latest: git://github.com/docker-library/postgres@3f8e9784438c8fe54f831c301a45f4d55f6fa453 9.5
+9.5.2: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
+9.5: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
+9: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
+latest: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-5.0.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2
-2-5.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2
-2-5: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2
-2: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2
+2-5.0.1: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
+2-5.0: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
+2-5: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
+2: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
 
-2-5.0.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-5.0.0-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2/slim
-2-5.0-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2/slim
-2-5-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2/slim
-2-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 2/slim
+2-5.0.1-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
+2-5.0-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
+2-5-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
+2-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
 3-2.4: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3

--- a/library/python
+++ b/library/python
@@ -20,52 +20,52 @@
 2.7-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/wheezy
 2-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3
-3.3: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3
+3.3.6: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3
+3.3: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/slim
-3.3-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/slim
+3.3-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4
-3.4: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4
+3.4.4: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4
+3.4: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/slim
-3.4-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/slim
+3.4-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5
-3.5: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5
-3: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5
-latest: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5
+3.5.1: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
+3.5: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
+3: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
+latest: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/slim
-3.5-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/slim
-3-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/slim
-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
+3.5-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
+3-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
+slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/alpine
-3-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/alpine
-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
+3-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
+alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.22.0: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
-0.22: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
-0: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
-latest: git://github.com/RocketChat/Docker.Official.Image@68b00c2c9eabe0addbbc42bb573a108fd366ba00
+0.24.0: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
+0.24: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
+0: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
+latest: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9

--- a/library/ruby
+++ b/library/ruby
@@ -1,16 +1,16 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.8: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1
-2.1: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1
+2.1.9: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1
+2.1: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1
 
-2.1.8-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
+2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.8-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/slim
 
-2.1.8-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/alpine
 
 2.2.4: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2
 2.2: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2


### PR DESCRIPTION
- `django`: 1.9.5
- `docker`: 1.11.0-rc3, add tune2fs and mkfs.xfs (docker-library/docker#10)
- `elasticsearch`: 2.3.1
- `golang`: force-enable `-fno-PIC` in Alpine (docker-library/golang#91)
- `irssi`: 0.8.19 (jfrazelle/irssi#6), add Alpine variant (jfrazelle/irssi#7)
- `java`: 9~b112-2 (still fails to build), Alpine to 8.77.03-r0 (8u77), fix Alpine tags to reference the proper version
- `julia`: 0.4.5
- `mariadb`: 10.1.13+maria-1~jessie
- `mongo`: 3.0.11
- `mysql`: `ENTRYPOINT` consistency (`docker-entrypoint.sh` with a compatibility symlink)
- `owncloud`: add `exif` module (docker-library/owncloud#53)
- `php`: 7.0.5, 5.6.20, 5.5.34, always enable `mbstring` (docker-library/php#211)
- `postgres`: 9.5.2-1.pgdg80+1, 9.4.7-1.pgdg80+1, 9.3.12-1.pgdg80+1, 9.2.16-1.pgdg80+1, 9.1.21-1.pgdg80+1, local interfaces during init (docker-library/postgres#136)
- `pypy`: 5.0.1
- `python`: fix `python-config` symlink (docker-library/python#99)
- `rocket.chat`: 0.24.0
- `ruby`: 2.1.9, switch `libedit` to `readline` for `irb` (docker-library/ruby#76)