### PR TITLE
Update docker-library images

### DIFF
--- a/library/java
+++ b/library/java
@@ -76,16 +76,16 @@ openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604
 8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 
-openjdk-9-b112-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-openjdk-9-b112: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-9-b112-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-9-b112: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
-9: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jdk
+openjdk-9-b112-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+openjdk-9-b112: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+9-b112-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+9-b112: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+9: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
 
-openjdk-9-b112-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
-9-b112-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
-9-jre: git://github.com/docker-library/openjdk@30b27d0b3b16ae395859ba47610b858076324508 9-jre
+openjdk-9-b112-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
+9-b112-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
+9-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.24.0: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
-0.24: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
-0: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
-latest: git://github.com/RocketChat/Docker.Official.Image@b88232f71aa3399c849fc0e06545f98bcc51f1b9
+0.25.0: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
+0.25: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
+0: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
+latest: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1
-2.1: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1
+2.1.9: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1
+2.1: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@350b92c0d8324ad70d282539cfb1f5d7f2dd027e 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
 
-2.2.4: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2
-2.2: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2
+2.2.4: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2
+2.2: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.2/slim
+2.2.4-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/slim
 
-2.2.4-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.2/alpine
+2.2.4-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/alpine
 
-2.3.0: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
-2.3: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
-2: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
-latest: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3
+2.3.0: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
+2.3: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
+2: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
+latest: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
 
 2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
-2-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
-slim: git://github.com/docker-library/ruby@c88f3a67da720bfa9fb1717960d90fd5db11c757 2.3/slim
+2.3.0-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
+2-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
+slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
 
-2.3.0-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.3/alpine
-alpine: git://github.com/docker-library/ruby@8185fd390fb283e0eef9e1687d652ef8b5d9c52e 2.3/alpine
+2.3.0-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
+alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,37 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.45-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
-6.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
-6-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
-6.0.45: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
-6.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
-6: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre7
+6.0.45-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6.0.45: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
 
-6.0.45-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
-6.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
-6-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 6-jre8
+6.0.45-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
+6.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
+6-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
 
-7.0.68-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
-7.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
-7-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
-7.0.68: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
-7.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
-7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre7
+7.0.68-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7.0.68: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
 
-7.0.68-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
-7.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
-7-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 7-jre8
+7.0.68-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
+7.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
+7-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
 
-8.0.32-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-8.0-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-8-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-jre7: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-8.0.32: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-8.0: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
-latest: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre7
+8.0.33-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8.0.33: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+latest: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
 
-8.0.32-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
-8.0-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
-8-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
-jre8: git://github.com/docker-library/tomcat@ed98c30c1cd42c53831f64dffa78a0abf7db8e9a 8-jre8
+8.0.33-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
+8.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
+8-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
+
+8.5.0-jre8: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
+8.5-jre8: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
+8.5.0: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
+8.5: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
+
+9.0.0.M4-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0.0-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0.0.M4: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0.0: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8


### PR DESCRIPTION
- `java`: remove `ca-certificates-java` workaround for `:9*` and switch `9-jdk` to use the new headless JDK package
- `rocket.chat`: 0.25.0
- `ruby`: rubygems 2.6.3
- `tomcat`: 8.0.33, 8.5.0 (beta), 9.0.0.M4 (docker-library/tomcat#26, docker-library/tomcat#27)