### PR TITLE
Fix the repositories added to the tumbleweed image

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -10,4 +10,4 @@ leap: git://github.com/openSUSE/docker-containers-build@d529ec4ff604e41997fd98b6
 latest: git://github.com/openSUSE/docker-containers-build@d529ec4ff604e41997fd98b6ade9715ab20cf75c docker
 
 # openSUSE Tumbleweed
-tumbleweed: git://github.com/openSUSE/docker-containers-build@9ae47a56a87fb66aa29e2a46e1979855c1c1bdde docker
+tumbleweed: git://github.com/openSUSE/docker-containers-build@c87d6edb440b0165c07f3e3f474f0effd6f5ba8d docker


### PR DESCRIPTION
This fixes issue
https://github.com/openSUSE/docker-containers-build/issues/11

Signed-off-by: Flavio Castelli <fcastelli@suse.com>