### PR TITLE
Update mongo-express to 0.30.44

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.30.43: git://github.com/mongo-express/mongo-express-docker@3290958fd1ff8218baad0ed85cf3e66123baab84
-0.30: git://github.com/mongo-express/mongo-express-docker@3290958fd1ff8218baad0ed85cf3e66123baab84
-latest: git://github.com/mongo-express/mongo-express-docker@3290958fd1ff8218baad0ed85cf3e66123baab84
+0.30.44: git://github.com/mongo-express/mongo-express-docker@f70899049fd358308c7513a9f4ccd77de5f6c7ec
+0.30: git://github.com/mongo-express/mongo-express-docker@f70899049fd358308c7513a9f4ccd77de5f6c7ec
+latest: git://github.com/mongo-express/mongo-express-docker@f70899049fd358308c7513a9f4ccd77de5f6c7ec


### PR DESCRIPTION
This tidies up the home page HTML, and updates a few dependencies:
* mongodb - 2.1.14 => 2.1.16
* async - 2.0.0-rc.2 => 2.0.0-rc.3

P.S. I wasn't expecting this PR to show the entire commit history here, is that normal or did I make a mistake somewhere?