### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,15 +1,15 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.11.0-rc4: git://github.com/docker-library/docker@29e3162cb1352f261466d98d3507628c3d2092d2 1.11-rc
-1.11-rc: git://github.com/docker-library/docker@29e3162cb1352f261466d98d3507628c3d2092d2 1.11-rc
-rc: git://github.com/docker-library/docker@29e3162cb1352f261466d98d3507628c3d2092d2 1.11-rc
+1.11.0-rc5: git://github.com/docker-library/docker@2816eb6a25ff80eb68f773379162964742047608 1.11-rc
+1.11-rc: git://github.com/docker-library/docker@2816eb6a25ff80eb68f773379162964742047608 1.11-rc
+rc: git://github.com/docker-library/docker@2816eb6a25ff80eb68f773379162964742047608 1.11-rc
 
-1.11.0-rc4-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
+1.11.0-rc5-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
 1.11-rc-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
 rc-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.11-rc/dind
 
-1.11.0-rc4-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
+1.11.0-rc5-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
 1.11-rc-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
 rc-git: git://github.com/docker-library/docker@b4404c1aadf1a09b5216b27fb35499bdcfd4d77a 1.11-rc/git
 

--- a/library/logstash
+++ b/library/logstash
@@ -1,29 +1,29 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.4.5-1-a2bacae: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
-1.4.5-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
-1.4.5: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
-1.4: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.4
+1.4.5-1-a2bacae: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
+1.4.5-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
+1.4.5: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
+1.4: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
 
-1.5.6-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
-1.5.6: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
-1.5: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 1.5
+1.5.6-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
+1.5.6: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
+1.5: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
+1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
 
-2.0.0-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
-2.0.0: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
-2.0: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.0
+2.0.0-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
+2.0.0: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
+2.0: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
 
-2.1.3-1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
-2.1.3: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
-2.1: git://github.com/docker-library/logstash@4f3a81ff0f152003653eecd60d0c4e1f05ce99f0 2.1
+2.1.3-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
+2.1.3: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
+2.1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
 
-2.2.3-1: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
-2.2.3: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
-2.2: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.2
+2.2.4-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
+2.2.4: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
+2.2: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
 
-2.3.0-1: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
-2.3.0: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
-2.3: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
-2: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
-latest: git://github.com/docker-library/logstash@a4b4fccbe65bc485d20508e524133fd1058dd28e 2.3
+2.3.1-1: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+2.3.1: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+2.3: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+2: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+latest: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.25.0: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
-0.25: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
-0: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
-latest: git://github.com/RocketChat/Docker.Official.Image@fedfc2e2ad9f862443cd2fcef8d693121e6c7951
+0.26.0: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
+0.26: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
+0: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
+latest: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8


### PR DESCRIPTION
- `docker`: 1.11.0-rc5
- `logstash`: 2.3.1, 2.2.4 (docker-library/logstash#43), `packages.elastic.co`
- `rocket.chat`: 0.26.0