### PR TITLE
Update for Node.js v4.4.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
 
-4.4.2: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
-4.4: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
-4: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
-argon: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4
+4.4.3: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
+4.4: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
+4: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
+argon: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
 
-4.4.2-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/onbuild
+4.4.3-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
 
-4.4.2-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/slim
+4.4.3-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
 
-4.4.2-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@fd8e6c3434e58796003826fed262071d27a77cc9 4.4/wheezy
+4.4.3-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
 
 5.10.1: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10
 5.10: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10


### PR DESCRIPTION
This is an update for Node.js v4.4.3

Reference:
- https://github.com/nodejs/docker-node/issues/147
- https://nodejs.org/en/blog/release/v4.4.3/