### PR TITLE
Update docker-library images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,11 +6,11 @@
 1.4.27-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
 1.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
 
-1.5.16: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5
-1.5: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5
+1.5.17: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5
+1.5: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5
 
-1.5.16-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5/alpine
-1.5-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.5/alpine
+1.5.17-alpine: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5/alpine
+1.5-alpine: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5/alpine
 
 1.6.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
 1.6: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.4.2-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-4.4.2: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-4.4-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-4.4: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-4-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-apache: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-4: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
-latest: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 apache
+4.5.0-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4.5.0: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4.5-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4.5: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+latest: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
 
-4.4.2-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
-4.4-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
-4-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
-fpm: git://github.com/docker-library/wordpress@df190dc9c5752fd09317d836bd2bdcd09ee379a5 fpm
+4.5.0-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
+4.5-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
+4-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
+fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm


### PR DESCRIPTION
- `haproxy`: 1.5.17
- `wordpress`: 4.5