### PR TITLE
Update Ubuntu Trusty (20160412)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - c390883 Update tarballs
+#  - 028503f Update tarballs
 #    - `ubuntu:precise`: 20160330
-#    - `ubuntu:trusty`: 20160405
+#    - `ubuntu:trusty`: 20160412
 #    - `ubuntu:wily`: 20160329
 #    - `ubuntu:xenial`: 20160331.1
 
 # 20160330
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 precise
-precise-20160330: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 precise
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 precise
+precise-20160330: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 precise
 
-# 20160405
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 trusty
-trusty-20160405: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 trusty
-latest: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 trusty
+# 20160412
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 trusty
+trusty-20160412: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 trusty
+latest: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 trusty
 
 # 20160329
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 wily
-wily-20160329: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 wily
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 wily
+wily-20160329: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 wily
 
 # 20160331.1
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 xenial
-xenial-20160331.1: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@c390883f9aa4a069c48a16dc01d49dc2643eea25 xenial
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 xenial
+xenial-20160331.1: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@028503f527c77921a3eff88216f57025cc611869 xenial


### PR DESCRIPTION
```diff
diff --git a/trusty/ubuntu-trusty-core-cloudimg-amd64.manifest b/trusty/ubuntu-trusty-core-cloudimg-amd64.manifest
index 4a675cd..1bc120c 100644
--- a/trusty/ubuntu-trusty-core-cloudimg-amd64.manifest
+++ b/trusty/ubuntu-trusty-core-cloudimg-amd64.manifest
@@ -1,6 +1,6 @@
 adduser        3.113+nmu3ubuntu3
-apt    1.0.1ubuntu2.11
-apt-utils      1.0.1ubuntu2.11
+apt    1.0.1ubuntu2.12
+apt-utils      1.0.1ubuntu2.12
 base-files     7.2ubuntu5.4
 base-passwd    3.5.33
 bash   4.3-7ubuntu1.5
@@ -47,8 +47,8 @@ klibc-utils   2.0.3-0ubuntu1
 kmod   15-0ubuntu6
 less   458-2
 libacl1:amd64  2.2.52-1
-libapt-inst1.5:amd64   1.0.1ubuntu2.11
-libapt-pkg4.12:amd64   1.0.1ubuntu2.11
+libapt-inst1.5:amd64   1.0.1ubuntu2.12
+libapt-pkg4.12:amd64   1.0.1ubuntu2.12
 libarchive-extract-perl        0.70-1
 libattr1:amd64 1:2.4.47-1ubuntu1
 libaudit-common        1:2.3.2-2ubuntu1
@@ -127,7 +127,7 @@ libtext-iconv-perl  1.7-5build2
 libtext-soundex-perl   3.4-1build1
 libtext-wrapi18n-perl  0.06-7
 libtinfo5:amd64        5.9+20140118-1ubuntu1
-libudev1:amd64 204-5ubuntu20.18
+libudev1:amd64 204-5ubuntu20.19
 libusb-0.1-4:amd64     2:0.1.12-23.3ubuntu1
 libustr-1.0-1:amd64    1.0.4-3ubuntu2
 libuuid1:amd64 2.20.1-5.1ubuntu20.7
@@ -173,7 +173,7 @@ tzdata      2016c-0ubuntu0.14.04
 ubuntu-keyring 2012.05.19
 ubuntu-minimal 1.325
 ucf    3.0027+nmu1
-udev   204-5ubuntu20.18
+udev   204-5ubuntu20.19
 upstart        1.12.1-0ubuntu4.2
 ureadahead     0.100.0-16
 util-linux     2.20.1-5.1ubuntu20.7
```