### PR TITLE
Generate keystore password and tidy logs

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,17 +1,17 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
-kernel: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/kernel
-8.5.5.9-kernel: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/common
-8.5.5.9-common: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.9-webProfile6: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.9-webProfile7: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.9-javaee7: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.9: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@dcd83cc7fed1612949d63b4f40ee8cfffa7cfdb4 websphere-liberty/8.5.5/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@a1b189b7ab85ba4f4270fc34fe7fcd5a6b82c763 websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/kernel
+8.5.5.9-kernel: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/kernel
+common: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/common
+8.5.5.9-common: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/webProfile6
+8.5.5.9-webProfile6: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/webProfile7
+8.5.5.9-webProfile7: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.9-javaee7: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/javaee7
+8.5.5.9: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/javaee7
+8.5.5: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/8.5.5/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@1e57ee36ffb385a11fef647059c2cbb870f0aa26 websphere-liberty/beta


### PR DESCRIPTION
For images other than beta, switch to generating the keystore password on initial start of the container. For all images, create the /logs directory upfront and tidy up logs created elsewhere by installUtility.