### PR TITLE
Backward compatibility fix

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,6 +3,6 @@
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
-2: git://github.com/docker/distribution-library-image@3b41b10642a3c24e2405b8f4cfa1441c54f1c8a2
-2.4: git://github.com/docker/distribution-library-image@3b41b10642a3c24e2405b8f4cfa1441c54f1c8a2
-2.4.0: git://github.com/docker/distribution-library-image@3b41b10642a3c24e2405b8f4cfa1441c54f1c8a2
+2: git://github.com/docker/distribution-library-image@740a307bda231c0bfe24e7ee0c5c731896c26b8a
+2.4: git://github.com/docker/distribution-library-image@740a307bda231c0bfe24e7ee0c5c731896c26b8a
+2.4.0: git://github.com/docker/distribution-library-image@740a307bda231c0bfe24e7ee0c5c731896c26b8a


### PR DESCRIPTION
This update includes a change in the dockerfile for the registry library image.

The 'serve' subcommand is moved from the entrypoint into the cmd.  The cmd now
just includes the default config file.

This retains backward compatibility when the registry is run as follows:

docker run --rm --volume /etc/docker-registry.conf:/etc/docker-registry.conf \
registry:2 /etc/docker-registry.conf

Signed-off-by: Richard Scothern <richard.scothern@docker.com>