### PR TITLE
Update Solr to 6.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,30 +1,30 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3
-5.3: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3
+5.3: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4
-5.4: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4
+5.4: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4/alpine
 
-5.5.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5
-5.5: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5
+5.5.1: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5
+5.5: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5
 
-5.5.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5/alpine
+5.5.1-alpine: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5/alpine
 
-6.0.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
-6.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
-6: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
-latest: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
+6.0.0: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
+6.0: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
+6: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
+latest: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
 
-6.0.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
+6.0.0-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine

--- a/library/solr
+++ b/library/solr
@@ -1,13 +1,30 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@5d6039fb7019b08d420b7bb90f76e8958dc32548 5.3
-5.3: git://github.com/docker-solr/docker-solr@5d6039fb7019b08d420b7bb90f76e8958dc32548 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3
+5.3: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3
 
-5.4.1: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
-5.4: git://github.com/docker-solr/docker-solr@da35a589a6218f8fd0e83d61f8c14b201234c1ae 5.4
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3/alpine
 
-5.5.0: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
-5.5: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
-5: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
-latest: git://github.com/docker-solr/docker-solr@2e1ccd64970c65e7dacfe33203963b315f665cc3 5.5
+5.4.1: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4
+5.4: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4
+
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4/alpine
+
+5.5.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5
+5.5: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5
+
+5.5.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5/alpine
+
+6.0.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
+6.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
+6: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
+latest: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
+
+6.0.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine

--- a/library/solr
+++ b/library/solr
@@ -1,30 +1,30 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3
-5.3: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3
+5.3: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4
-5.4: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4
+5.4: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.4/alpine
 
-5.5.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5
-5.5: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5
+5.5.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5
+5.5: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5
 
-5.5.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 5.5/alpine
+5.5.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 5.5/alpine
 
-6.0.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
-6.0: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
-6: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
-latest: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0
+6.0.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
+6.0: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
+6: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
+latest: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0
 
-6.0.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@8521b45272527088c95744a87ad35232f593b772 6.0/alpine
+6.0.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@1b8908a4c8a6cbcb1ab3d4add2d2952f8c8b9f18 6.0/alpine


### PR DESCRIPTION
This docker-solr release includes:

- Solr 6.0. New features including Parallel SQL, Streaming API features, Graph traversal query, BM25 scoring and more.
  For an overview see:
    - [Official Announcement](http://lucene.apache.org/solr/news.html)
    - [Changelog](https://lucene.apache.org/solr/6_0_0/changes/Changes.html)
    - [Blog](http://yonik.com/solr-6/)
    - [Presentation](https://lucidworks.com/blog/2016/04/08/whats-new-in-apache-solr-6/)

- Solr 5.5.1, which includes [3 bug fixes](https://lucene.apache.org/core/5_5_1/changes/Changes.html) since 5.5.0.

- Alpine image variants. These are 40% smaller than the Debian-based images.

- A new entrypoint script which:
  - can create a core at start time
  - can create a core with demo data
  - has an extension mechanism to run your own scripts before/after Solr.
  See the [README](./README.md) for details

- Various improvements for developing the docker-solr repository itself:
  - ability to override mirror URLs and retain artifacts
  - automated Travis build and run testing

Library team: A heads-up: there have some structural changes to support the above, in particular the alpine sub directories and the COPYs in the Dockerfiles. My assumption is that the docker build executes from the sub-directory the respective Dockerfile is in, in which case all should work fine. If not please let me know. Thanks.