### PR TITLE
Add an official image for Apache Storm

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -2,13 +2,13 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
 
 Tags: 0.9.7, 0.9
-GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+GitCommit: 93746fa3936afb3751565860632d3e49d53e9b0e
 Directory: 0.9.7
 
 Tags: 0.10.2, 0.10
-GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+GitCommit: 93746fa3936afb3751565860632d3e49d53e9b0e
 Directory: 0.10.2
 
 Tags: 1.0.2, 1.0, latest
-GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+GitCommit: 93746fa3936afb3751565860632d3e49d53e9b0e
 Directory: 1.0.2

--- a/library/storm
+++ b/library/storm
@@ -1,0 +1,6 @@
+# maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
+
+0.9.6: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 0.9.6
+0.10.0: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 0.10.0
+1.0.0: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 1.0.0
+latest: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 1.0.0

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 0.9.6
-0.10.1: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 0.10.1
-1.0.1: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 1.0.1
-latest: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 1.0.1
+0.9.6: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 0.9.6
+0.10.1: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 0.10.1
+1.0.1: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 1.0.1
+latest: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 1.0.1

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 0.9.6
-0.10.0: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 0.10.0
-1.0.0: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 1.0.0
-latest: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 1.0.0
+0.9.6: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 0.9.6
+0.10.0: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 0.10.0
+1.0.0: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 1.0.0
+latest: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 1.0.0

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 0.9.6
-0.10.1: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 0.10.1
-1.0.1: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 1.0.1
-latest: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 1.0.1
+0.9.6: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 0.9.6
+0.10.1: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 0.10.1
+1.0.1: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 1.0.1
+latest: git://github.com/31z4/storm-docker@eb42867e8e4f0d09b31c72d51dc31fcdcfac414e 1.0.1

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 0.9.6
-0.10.1: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 0.10.1
-1.0.1: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 1.0.1
-latest: git://github.com/31z4/storm-docker@0f2664748a33162d95825c5f9ecb8444f61682b4 1.0.1
+0.9.6: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 0.9.6
+0.10.1: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 0.10.1
+1.0.2: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 1.0.2
+latest: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 1.0.2

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 0.9.6
-0.10.1: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 0.10.1
-1.0.1: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 1.0.1
-latest: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 1.0.1
+0.9.6: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 0.9.6
+0.10.1: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 0.10.1
+1.0.1: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 1.0.1
+latest: git://github.com/31z4/storm-docker@d71c8addfcc86a38934349c46b28b806ea4c1c42 1.0.1

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,14 @@
-# maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
+Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
+GitRepo: https://github.com/31z4/storm-docker.git
 
-0.9.6: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 0.9.6
-0.10.1: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 0.10.1
-1.0.2: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 1.0.2
-latest: git://github.com/31z4/storm-docker@5fb2661adf5891ac5ccf26f927c73a7bc4b89187 1.0.2
+Tags: 0.9.7, 0.9
+GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+Directory: 0.9.7
+
+Tags: 0.10.2, 0.10
+GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+Directory: 0.10.2
+
+Tags: 1.0.2, 1.0, latest
+GitCommit: f38117c7116512d45f1af04b514e9971e7214de8
+Directory: 1.0.2

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 0.9.6
-0.10.0: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 0.10.0
-1.0.0: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 1.0.0
-latest: git://github.com/31z4/storm-docker@d050a2bd2f4b0aecfa007968e1d54448b15fa94d 1.0.0
+0.9.6: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 0.9.6
+0.10.1: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 0.10.1
+1.0.1: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 1.0.1
+latest: git://github.com/31z4/storm-docker@d57881285dd264f2e194dacc120004c0cb4476d2 1.0.1

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-0.9.6: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 0.9.6
-0.10.0: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 0.10.0
-1.0.0: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 1.0.0
-latest: git://github.com/31z4/storm-docker@ba9faacec10470a4d16a779cdc448279cbf9e4df 1.0.0
+0.9.6: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 0.9.6
+0.10.0: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 0.10.0
+1.0.0: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 1.0.0
+latest: git://github.com/31z4/storm-docker@a138393f9ef35c94e652d7c49c17285fe158c99b 1.0.0


### PR DESCRIPTION
As version 1.0.0 is a [huge milestone](http://storm.apache.org/2016/04/12/storm100-released.html) for Apache Storm it would be great to finally have an official image for it. See corresponding [docs PR](https://github.com/docker-library/docs/pull/550).

# Checklist for Review

- [x] associated with or contacted upstream?
  - https://github.com/docker-library/official-images/pull/1641#issuecomment-219223295
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/550
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)