### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,8 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.3.9: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.3
-1.3: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.3
-
 1.4.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
 1.4: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
 
@@ -29,3 +26,8 @@
 2.3: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
 2: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
 latest: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
+
+5.0.0-alpha1: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
+5.0.0: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
+5.0: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
+5: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.8: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
-0.7: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
-0: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
-latest: git://github.com/docker-library/ghost@8c0d010d4f6c0aa91b16ad1b9dcc09ee2a287549
+0.7.9: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
+0.7: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
+0: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
+latest: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d

--- a/library/java
+++ b/library/java
@@ -76,16 +76,16 @@ openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604
 8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 
-openjdk-9-b112-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-openjdk-9-b112: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-9-b112-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-9-b112: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
-9: git://github.com/docker-library/openjdk@3110fbc370293c071cc995c4a89e4b1814553ad5 9-jdk
+openjdk-9-b113-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+openjdk-9-b113: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+9-b113-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+9-b113: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+9: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
 
-openjdk-9-b112-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
-9-b112-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
-9-jre: git://github.com/docker-library/openjdk@d22a4675dad30274c9ed6cfd9b98bfa0fec9d4a9 9-jre
+openjdk-9-b113-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
+9-b113-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
+9-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre

--- a/library/kibana
+++ b/library/kibana
@@ -19,3 +19,8 @@
 4.5: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
 4: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
 latest: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
+
+5.0.0-alpha1: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
+5.0.0: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
+5.0: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
+5: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -27,3 +27,9 @@
 2.3: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
 2: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
 latest: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+
+5.0.0-alpha1-1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
+5.0.0-alpha1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
+5.0.0: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
+5.0: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
+5: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0

--- a/library/mongo
+++ b/library/mongo
@@ -16,7 +16,7 @@
 3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 
-3.2.4: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
-3.2: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
-3: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
-latest: git://github.com/docker-library/mongo@191cc63288fb44c2fd147eac27ade07ae4b6b0b5 3.2
+3.2.5: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
+3.2: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
+3: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
+latest: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2

--- a/library/tomcat
+++ b/library/tomcat
@@ -11,16 +11,16 @@
 6.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
 6-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
 
-7.0.68-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
-7.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
-7-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
-7.0.68: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
-7.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
-7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre7
+7.0.69-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7.0-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7.0.69: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7.0: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
 
-7.0.68-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
-7.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
-7-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 7/jre8
+7.0.69-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
+7.0-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
+7-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
 
 8.0.33-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
 8.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7


### PR DESCRIPTION
- `elasticsearch`: remove EOL 1.3, add 5.0.0-alpha1 (has some seccomp issues; see docker-library/elasticsearch#98)
- `ghost`: 0.7.9
- `java`: 9~b113-1
- `kibana`: 5.0.0-alpha1
- `logstash`: 5.0.0-alpha1
- `mongo`: 3.2.5
- `tomcat`: 7.0.69