### PR TITLE
update r-base to R 3.2.5 released last week

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,6 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.2.4: git://github.com/rocker-org/rocker@0cc8fb084f2b78a00f6741e1080d9b23f32424c8 r-base
-latest: git://github.com/rocker-org/rocker@0cc8fb084f2b78a00f6741e1080d9b23f32424c8 r-base
+3.2.5: git://github.com/rocker-org/rocker@13a345ad18c19e467a6c70cda6687128921292ff r-base
+latest: git://github.com/rocker-org/rocker@13a345ad18c19e467a6c70cda6687128921292ff r-base
 


### PR DESCRIPTION
3.2.5 is mostly a cleanup release as the version number scheme in 3.2.4-revised had side effects, and otherwise close

this is likely the last 3.2.* release as we expect 3.3.0 early next month