### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -12,23 +12,20 @@
 8.0.6: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
 8.0-apache: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
 8.0: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-8-apache: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-8: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-apache: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-latest: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
 
 8.0.6-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
 8.0-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
-8-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
 
-8.1.0-rc1-apache: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
-8.1.0-rc1: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
-8.1.0-apache: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
-8.1.0: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
-8.1-apache: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
-8.1: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/apache
+8.1.0-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8.1.0: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8.1-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8.1: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+latest: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
 
-8.1.0-rc1-fpm: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/fpm
-8.1.0-fpm: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/fpm
-8.1-fpm: git://github.com/docker-library/drupal@7f85fe228664142ed30f1e6244e2ff9022ab02eb 8.1/fpm
+8.1.0-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
+8.1-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
+8-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
+fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.13: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
-10.1: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
-10: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
-latest: git://github.com/docker-library/mariadb@6bd1bf6e03aab298bf842800059f8620a3414a81 10.1
+10.1.13: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
+10.1: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
+10: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
+latest: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
 
-10.0.24: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0
-10.0: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 10.0
+10.0.24: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.0
+10.0: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.0
 
-5.5.48: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5
-5.5: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5
-5: git://github.com/docker-library/mariadb@027cff3bc7e39065a98ca001175ba7dbdb32be32 5.5
+5.5.48: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5
+5.5: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5
+5: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-5.0.1: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
-2-5.0: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
-2-5: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
-2: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2
+2-5.1.0: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
+2-5.1: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
+2-5: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
+2: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
 
-2-5.0.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-5.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.1.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-5.0.1-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
-2-5.0-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
-2-5-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
-2-slim: git://github.com/docker-library/pypy@95f69aef340eeb9ded9730f8b10bf8bb03da770c 2/slim
+2-5.1.0-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
+2-5.1-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
+2-5-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
+2-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
 3-2.4: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7
-2.7: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7
-2: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7
+2.7.11: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
+2.7: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
+2: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/slim
-2.7-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/slim
-2-slim: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
+2.7-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
+2-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/alpine
-2-alpine: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
+2-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@7919b85ec9f5dcc282d4559c4b7511fd77771c1e 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3
-3.3: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3
+3.3.6: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3
+3.3: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/slim
-3.3-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/slim
+3.3-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4
-3.4: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4
+3.4.4: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4
+3.4: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/slim
-3.4-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/slim
+3.4-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
-3.5: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
-3: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
-latest: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5
+3.5.1: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
+3.5: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
+3: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
+latest: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
-3.5-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
-3-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
-slim: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
+3.5-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
+3-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
+slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
-3-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
-alpine: git://github.com/docker-library/python@764d302a21bd2442c2808bc802c95193b2cb8eea 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
+3-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
+alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine

--- a/library/redis
+++ b/library/redis
@@ -1,24 +1,24 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.8.23: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
-2.8: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
-2: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8
+2.8.23: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8
+2.8: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8
+2: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8
 
-2.8.23-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 2.8/32bit
+2.8.23-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8/32bit
+2.8-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8/32bit
+2-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 2.8/32bit
 
-3.0.7: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
-3.0: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
-3: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
-latest: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0
+3.0.7: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
+3.0: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
+3: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
+latest: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
 
-3.0.7-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
-32bit: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/32bit
+3.0.7-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
+3.0-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
+3-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
+32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
 
-3.0.7-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
-3-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
-alpine: git://github.com/docker-library/redis@7dec62fe6de187165dce3f771efa57ce4e5d7a32 3.0/alpine
+3.0.7-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
+3-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
+alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.26.0: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
-0.26: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
-0: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
-latest: git://github.com/RocketChat/Docker.Official.Image@4fe06cea28936a72f5d917a935b1d29a21b96de8
+0.27.0: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
+0.27: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
+0: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
+latest: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65


### PR DESCRIPTION
- `drupal`: 8.1 GA
- `mariadb`: add xtrabackup for Galera (docker-library/mariadb#47)
- `pypy`: 5.1.0
- `python`: empty `~/.cache` (docker-library/python#103)
- `redis`: use `su-exec` in Alpine variants (docker-library/redis#54)
- `rocket.chat`: 0.27.0