### PR TITLE
rethinkdb: Remove obsolete (unsupported) releases

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,37 +1,21 @@
 # maintainer: Daniel Alan Miller <dalanmiller@rethinkdb.com> (@dalanmiller)
 
-1.15.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.15.1
-1.15.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.15.2
 1.15.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.15.3
 1.15: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.15.3
-1.16.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.0
-1.16.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.1
-1.16.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.2
+
 1.16.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.3
 1.16: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.3
 1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/1.16.3
-2.0.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.0
-2.0.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.1
-2.0.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.2
-2.0.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.3
+
 2.0.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.4
 2.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.0.4
-2.1.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.0
-2.1.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.1
-2.1.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.2
-2.1.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.3
-2.1.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.4
-2.1.5: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.5
+
 2.1.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.6
 2.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.1.6
-2.2.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.0
-2.2.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.1
-2.2.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.2
-2.2.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.3
-2.2.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.4
-2.2.5: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.5
+
 2.2.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.6
 2.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.2.6
+
 2.3.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.3.0
 2.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.3.0
 2: git://github.com/rethinkdb/rethinkdb-dockerfiles@0b7134d0d80d92ca461119056b1c534d61a2e3a8 jessie/2.3.0


### PR DESCRIPTION
Per https://github.com/docker-library/official-images#library-definition-files, following the style used by Redis

Following discussion from https://github.com/rethinkdb/rethinkdb-dockerfiles/pull/27#issuecomment-212650916

cc @dalanmiller @danielmewes (please don't merge without review from at least one of these)