### PR TITLE
Update for Node.js v5.11.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,32 +1,32 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.44: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10
-0.10: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10
+0.10.44: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10
+0.10: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10
 
 0.10.44-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
 
-0.10.44-slim: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@b39ddbb7be87b9a2d1619f74757a5cec055c04ec 0.10/slim
+0.10.44-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/slim
 
-0.10.44-wheezy: git://github.com/nodejs/docker-node@9d0a1897a95b6a50660e993119608b41e3060969 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@9d0a1897a95b6a50660e993119608b41e3060969 0.10/wheezy
+0.10.44-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/wheezy
 
-0.12.13: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
-0.12: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
-0: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12
+0.12.13: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
+0.12: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
+0: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
 
 0.12.13-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 
-0.12.13-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/slim
+0.12.13-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
 
-0.12.13-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/wheezy
+0.12.13-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
 
 4.4.3: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
 4.4: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
@@ -48,22 +48,14 @@ argon-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8
 4-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
 
-5.10.1: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10
-5.10: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10
-5: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10
-latest: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10
+5.11.0: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11
+5.11: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11
 
-5.10.1-onbuild: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/onbuild
-5.10-onbuild: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/onbuild
-onbuild: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/onbuild
+5.11.0-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
+5.11-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
 
-5.10.1-slim: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/slim
-5.10-slim: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/slim
-5-slim: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/slim
-slim: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/slim
+5.11.0-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/slim
+5.11-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/slim
 
-5.10.1-wheezy: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/wheezy
-5.10-wheezy: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/wheezy
-wheezy: git://github.com/nodejs/docker-node@baad247b9df8087d4c13a3a9bfb3c65833f424bb 5.10/wheezy
+5.11.0-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/wheezy
+5.11-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/wheezy


### PR DESCRIPTION
This also includes some minor formatting updates for the 0.10 and 0.12 image Dockerfiles to make them consistent with the others.

Test build:

- https://travis-ci.org/nodejs/docker-node/builds/124889477

Reference:

- https://nodejs.org/en/blog/release/v5.11.0/
- https://github.com/nodejs/docker-node/issues/158 


Closes nodejs/docker-node#158