### PR TITLE
Publish Neo4j 3.0.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -1,7 +1,15 @@
 # maintainer: Ben Butler-Cole <ben@neotechnology.com> (@benbc)
 
 2.3.3: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3
-latest: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3
+2.3: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3
 
 2.3.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
+2.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
+
+3.0.0: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0
+3.0: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0
+latest: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0
+
+3.0.0-enterprise: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0-enterprise
+3.0-enterprise: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0-enterprise
+enterprise: git://github.com/neo4j/docker-neo4j@c1318b7a0d6312158944ec6ca3db50562e552893 3.0.0-enterprise


### PR DESCRIPTION
Hello. We have released a new major version of Neo4j. This PR introduces new tags for that version and updates the "latest" tags to point to it. There are some changes to the entrypoint script to accommodate Neo4j surface changes in this release. The Dockerfile exposes one new port but is otherwise unchanged.