### PR TITLE
Update for Node.js v6.0.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,61 +1,81 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.44: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10
-0.10: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10
+0.10.44: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10
+0.10: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10
 
 0.10.44-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@f8deeccd5355c2c275b856ab1d3eb9b85caa7d4c 0.10/onbuild
 
-0.10.44-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/slim
+0.10.44-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10/slim
 
-0.10.44-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.10/wheezy
+0.10.44-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.10/wheezy
 
-0.12.13: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
-0.12: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
-0: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12
+0.12.13: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12
+0.12: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12
+0: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12
 
 0.12.13-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@c02fde07144b8dffb00b4897a1923cf1b685b7a7 0.12/onbuild
 
-0.12.13-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/slim
+0.12.13-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/slim
 
-0.12.13-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 0.12/wheezy
+0.12.13-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 0.12/wheezy
 
-4.4.3: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
-4.4: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
-4: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
-argon: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4
+4.4.3: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4
+4.4: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4
+4: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4
+argon: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4
 
 4.4.3-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
 4.4-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
 4-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
 argon-onbuild: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/onbuild
 
-4.4.3-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/slim
+4.4.3-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/slim
 
-4.4.3-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@41b505ae714328f28a3457df9098d1e8db88a81a 4.4/wheezy
+4.4.3-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 4.4/wheezy
 
-5.11.0: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11
-5.11: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11
+5.11.0: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11
+5.11: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11
 
 5.11.0-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
 5.11-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
 
-5.11.0-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/slim
-5.11-slim: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/slim
+5.11.0-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/slim
+5.11-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/slim
 
-5.11.0-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/wheezy
-5.11-wheezy: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/wheezy
+5.11.0-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/wheezy
+5.11-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/wheezy
+
+6.0.0: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0
+6.0: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0
+6: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0
+latest: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0
+
+6.0.0-onbuild: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/onbuild
+6.0-onbuild: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/onbuild
+onbuild: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/onbuild
+
+6.0.0-slim: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/slim
+6.0-slim: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/slim
+6-slim: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/slim
+slim: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/slim
+
+6.0.0-wheezy: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/wheezy
+6.0-wheezy: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/wheezy
+6-wheezy: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/wheezy
+wheezy: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0/wheezy


### PR DESCRIPTION
Update to add Node.js v6.0.0. Also sets 6.0.0 as 'latest'.

Reference:

- https://nodejs.org/en/blog/release/v6.0.0/
- https://github.com/nodejs/docker-node/issues/166

