### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.13: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
-2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
+2.1.14: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.1
+2.1: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.1
 
-2.2.5: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
-2.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
-2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2.2.6: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
+2.2: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
+2: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
 
 3.0.5: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0
 3.0: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0

--- a/library/cassandra
+++ b/library/cassandra
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.14: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.1
-2.1: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.1
+2.1.13: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
+2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
 
-2.2.6: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
-2.2: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
-2: git://github.com/docker-library/cassandra@5c83501c904b0c514ae1e071d84107907e64df95 2.2
+2.2.5: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
 
 3.0.5: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0
 3.0: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -22,10 +22,10 @@
 2.2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 
-2.3.1: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
-2.3: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
-2: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
-latest: git://github.com/docker-library/elasticsearch@8267f6c29f06373373b4379473291d3082728cc0 2.3
+2.3.2: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
+2.3: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
+2: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
+latest: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
 
 5.0.0-alpha1: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
 5.0.0: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,3 +1,3 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-latest: git://github.com/docker-library/hello-world@22ecfe456f254d5babe6e413bed2de77cfaba047
+latest: git://github.com/docker-library/hello-world@fb12b77c31f97ef7cee73c280432d771823d9ec8

--- a/library/java
+++ b/library/java
@@ -14,14 +14,14 @@ openjdk-6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102
 6b38-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
 6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
 
-openjdk-7u95-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-openjdk-7u95: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-openjdk-7-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-openjdk-7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-7u95-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-7u95: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-7-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
-7: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jdk
+openjdk-7u101-jdk: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+openjdk-7u101: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+openjdk-7-jdk: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+openjdk-7: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+7u101-jdk: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+7u101: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+7-jdk: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
+7: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jdk
 
 openjdk-7u91-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 openjdk-7u91-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
@@ -32,10 +32,10 @@ openjdk-7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc17853
 7-jdk-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 7-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jdk/alpine
 
-openjdk-7u95-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
-openjdk-7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
-7u95-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
-7-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 7-jre
+openjdk-7u101-jre: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jre
+openjdk-7-jre: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jre
+7u101-jre: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jre
+7-jre: git://github.com/docker-library/openjdk@45dce52df7deb6a4b6ae7ad9c4b9f3cb7dc8db91 7-jre
 
 openjdk-7u91-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 openjdk-7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
@@ -76,16 +76,16 @@ openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604
 8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 
-openjdk-9-b113-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-openjdk-9-b113: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-9-b113-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-9-b113: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
-9: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jdk
+openjdk-9-b115-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+openjdk-9-b115: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+9-b115-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+9-b115: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+9: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
 
-openjdk-9-b113-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
-9-b113-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
-9-jre: git://github.com/docker-library/openjdk@11f3ec7d9cb5def04b7936cdf1eaa41da56341ab 9-jre
+openjdk-9-b115-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
+9-b115-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
+9-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre

--- a/library/logstash
+++ b/library/logstash
@@ -22,11 +22,11 @@
 2.2.4: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
 2.2: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
 
-2.3.1-1: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
-2.3.1: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
-2.3: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
-2: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
-latest: git://github.com/docker-library/logstash@bfe9885a1f498aa529385da0eb13f21d8c15eeb3 2.3
+2.3.2-1: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
+2.3.2: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
+2.3: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
+2: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
+latest: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
 
 5.0.0-alpha1-1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
 5.0.0-alpha1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.13: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
-10.1: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
-10: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
-latest: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.1
+10.1.13: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
+10.1: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
+10: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
+latest: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
 
-10.0.24: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.0
-10.0: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 10.0
+10.0.24: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.0
+10.0: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.0
 
-5.5.48: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5
-5.5: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5
-5: git://github.com/docker-library/mariadb@ab2b6d41a9a1e138cbd3fc8c8897e2431df7efc5 5.5
+5.5.49: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
+5.5: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
+5: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
-2.7: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
-2: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7
+2.7.11: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
+2.7: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
+2: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
-2.7-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
-2-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
+2.7-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
+2-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
-2-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
+2-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3
-3.3: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3
+3.3.6: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3
+3.3: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/slim
-3.3-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/slim
+3.3-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4
-3.4: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4
+3.4.4: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4
+3.4: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/slim
-3.4-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/slim
+3.4-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
-3.5: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
-3: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
-latest: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5
+3.5.1: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
+3.5: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
+3: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
+latest: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
-3.5-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
-3-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
-slim: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
+3.5-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
+3-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
+slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
-3-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
-alpine: git://github.com/docker-library/python@195213c43e66d7c97be10f277c1053620e78749d 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
+3-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
+alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.27.0: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
-0.27: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
-0: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
-latest: git://github.com/RocketChat/Docker.Official.Image@41e29d23e2c5c599b497132cac4ff063c0bc3e65
+0.28.0: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
+0.28: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
+0: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
+latest: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6

--- a/library/ruby
+++ b/library/ruby
@@ -12,34 +12,34 @@
 2.1.9-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
 2.1-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
 
-2.2.4: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2
-2.2: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2
+2.2.5: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2
+2.2: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2
 
-2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
+2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.4-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/slim
 
-2.2.4-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/alpine
 
-2.3.0: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
-2.3: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
-2: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
-latest: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3
+2.3.1: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
+2.3: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
+2: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
+latest: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
 
-2.3.0-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.0-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
-2-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
+2-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
+slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
 
-2.3.0-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
+alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,49 +1,49 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-6.0.45-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
-6.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
-6-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
-6.0.45: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
-6.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
-6: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre7
+6.0.45-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+6.0-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+6-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+6.0.45: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+6.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+6: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
 
-6.0.45-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
-6.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
-6-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 6/jre8
+6.0.45-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
+6.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
+6-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
 
-7.0.69-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
-7.0-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
-7-jre7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
-7.0.69: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
-7.0: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
-7: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre7
+7.0.69-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+7.0-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+7-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+7.0.69: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+7.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
 
-7.0.69-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
-7.0-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
-7-jre8: git://github.com/docker-library/tomcat@984d958106aebab3f124f616277a2512da4d4a9f 7/jre8
+7.0.69-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
+7.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
+7-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
 
-8.0.33-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-8.0-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-8-jre7: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-8.0.33: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-8.0: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
-latest: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre7
+8.0.33-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+8.0-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+8-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+8.0.33: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+8.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
+latest: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre7
 
-8.0.33-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
-8.0-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
-8-jre8: git://github.com/docker-library/tomcat@74b0911f36d776672bc943f9efb05868d1d5d79a 8.0/jre8
+8.0.33-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre8
+8.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre8
+8-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.0/jre8
 
-8.5.0-jre8: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
-8.5-jre8: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
-8.5.0: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
-8.5: git://github.com/docker-library/tomcat@82551c9d60c48d35a68b8eb2cc069913be9078ae 8.5/jre8
+8.5.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.5/jre8
+8.5-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.5/jre8
+8.5.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.5/jre8
+8.5: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 8.5/jre8
 
-9.0.0.M4-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9.0.0-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9.0-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9-jre8: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9.0.0.M4: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9.0.0: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9.0: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
-9: git://github.com/docker-library/tomcat@92b97a945a2241f868a91d2919e0e7e3f5c84216 9.0/jre8
+9.0.0.M4-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9.0.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9.0.0.M4: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9.0.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8
+9: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 9.0/jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.5.0-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-4.5.0: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-4.5-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-4.5: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-4-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-apache: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-4: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
-latest: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 apache
+4.5.1-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4.5.1: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4.5-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4.5: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+latest: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
 
-4.5.0-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
-4.5-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
-4-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
-fpm: git://github.com/docker-library/wordpress@6e26fd19eb1f04bc3f939098c986e44c7acb9a61 fpm
+4.5.1-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
+4.5-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
+4-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
+fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm


### PR DESCRIPTION
- ~~`cassandra`: 2.2.6 and 2.1.14~~
- `elasticsearch`: 2.3.2 (docker-library/elasticsearch#101)
- `hello-world`: update userguide link to avoid redirect (docker-library/hello-world#12)
- `java`: 7u101-2.6.6-1~deb8u1 (https://lists.debian.org/debian-security-announce/2016/msg00134.html)
- `logstash`: 2.3.2 (docker-library/logstash#46)
- `mariadb`: fix double install of `mysql-common` (docker-library/mariadb#56)
- `python`: fix removal of test folders (docker-library/python#102)
- `rocket.chat`: 0.28.0
- `ruby`: 2.3.1 and 2.2.5
- `tomcat`: add Tomcat Native Libraries (docker-library/tomcat#28)
- `wordpress`: 4.5.1