### PR TITLE
[ROS] Moving EVN and Updating MAINTAINER

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,17 +1,17 @@
 # maintainer: Dirk Thomas <dthomas+buildfarm@osrfoundation.org> (@dirk-thomas)
 
-indigo-ros-core:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
-latest:             git://github.com/osrf/docker_images@8a11109079636bcd3bdf341993d39e2b7d503c6c ros/indigo/indigo-ros-base
+indigo-ros-core:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-core
+indigo-ros-base:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-base
+indigo-robot:       git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-robot
+indigo-perception:  git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-perception
+indigo:             git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-base
+latest:             git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-base
 # Docker EOL: 2019-04
 # LTS
 
-jade-ros-core:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@d579b9325fd8546a29dfc064661b005cfbc9cf8b ros/jade/jade-ros-base
+jade-ros-core:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-base
 # Docker EOL: 2017-04


### PR DESCRIPTION
* Moving ros distro ENV to preserve more cache (https://github.com/osrf/docker_images/pull/31)
 * Looking back at our ros-core Dockerfiles and the [imagelayers.io page](https://imagelayers.io/?images=ros:indigo-ros-core,ros:indigo-ros-base,ros:indigo-robot,ros:indigo-perception,ros:jade-ros-core,ros:jade-ros-base,ros:jade-robot,ros:jade-perception) for the ros dockerhub repo, I noticed we could save about 90MB of common image layers by mantingin a common cache right up to the point where the builds realy differ with distro specific run commands.
* Also updating MAINTAINER field to Tully Foote (https://github.com/osrf/docker_templates/issues/6#)