### PR TITLE
for erlang otp release 18.3.2

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,16 +1,17 @@
 # maintainer: denc716@gmail.com (@c0b)
 
-18.3:   git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18
-18:     git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18
-latest: git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18
+18.3.2: git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18
+18.3:   git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18
+18:     git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18
+latest: git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18
 
-18.3-slim: git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/slim
-18-slim:   git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/slim
-slim:      git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/slim
+18.3-slim: git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/slim
+18-slim:   git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/slim
+slim:      git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/slim
 
-18.3-onbuild:   git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/onbuild
-18-onbuild:     git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/onbuild
-onbuild:        git://github.com/c0b/docker-erlang-otp@51abbae231cf3f666d0c4d2a41568a57153443cc 18/onbuild
+18.3-onbuild:   git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/onbuild
+18-onbuild:     git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/onbuild
+onbuild:        git://github.com/c0b/docker-erlang-otp@a9f5121f34deb30cc61e21f0370aa8f16723aa14 18/onbuild
 
 17.5.6.8: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
 17.5:     git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17


### PR DESCRIPTION
https://github.com/erlang/otp/releases/tag/OTP-18.3.2
https://travis-ci.org/c0b/docker-erlang-otp/builds/126076843