### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,47 +6,47 @@ curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db6936
 jessie-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f jessie/scm
 scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f jessie/scm
 
-jessie: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 jessie
-latest: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 jessie
+jessie: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d jessie
+latest: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d jessie
 
 precise-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 precise/curl
 
 precise-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f precise/scm
 
-precise: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 precise
+precise: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d precise
 
 sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
 
 sid-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f sid/scm
 
-sid: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 sid
+sid: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d sid
 
 stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
 
 stretch-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f stretch/scm
 
-stretch: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 stretch
+stretch: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d stretch
 
 trusty-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 trusty/curl
 
 trusty-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f trusty/scm
 
-trusty: git://github.com/docker-library/buildpack-deps@e88116df8558bd129851862e1bf56250ea52ec90 trusty
+trusty: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d trusty
 
 wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
 
 wheezy-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wheezy/scm
 
-wheezy: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 wheezy
+wheezy: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d wheezy
 
 wily-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 wily/curl
 
 wily-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wily/scm
 
-wily: git://github.com/docker-library/buildpack-deps@ca0f463579583f030cb5c8eb2c8dac207709feb5 wily
+wily: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d wily
 
 xenial-curl: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/curl
 
 xenial-scm: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/scm
 
-xenial: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial
+xenial: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d xenial

--- a/library/docker
+++ b/library/docker
@@ -1,17 +1,17 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.11.0: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11
-1.11: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11
-1: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11
-latest: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11
+1.11.1: git://github.com/docker-library/docker@f7ee50684c7ec92ce885c8b93a4ed22ddbb660f8 1.11
+1.11: git://github.com/docker-library/docker@f7ee50684c7ec92ce885c8b93a4ed22ddbb660f8 1.11
+1: git://github.com/docker-library/docker@f7ee50684c7ec92ce885c8b93a4ed22ddbb660f8 1.11
+latest: git://github.com/docker-library/docker@f7ee50684c7ec92ce885c8b93a4ed22ddbb660f8 1.11
 
-1.11.0-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
+1.11.1-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
 1.11-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
 1-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
 dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
 
-1.11.0-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
+1.11.1-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
 1.11-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
 1-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
 git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git

--- a/library/gcc
+++ b/library/gcc
@@ -11,11 +11,6 @@
 4: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
 # Docker EOL: 2016-06-26
 
-# Last Modified: 2015-04-22
-5.1.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.1
-5.1: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.1
-# Docker EOL: 2016-04-22
-
 # Last Modified: 2015-07-16
 5.2.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
 5.2: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
@@ -25,5 +20,11 @@
 5.3.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
 5.3: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
 5: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
-latest: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
 # Docker EOL: 2016-12-04
+
+# Last Modified: 2016-04-27
+6.1.0: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
+6.1: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
+6: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
+latest: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
+# Docker EOL: 2017-04-27

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1
-2.1: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1
+2.1.9: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
+2.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@1f19e5d966aadfaac7ce4a9d4db8f982db2fe690 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2
-2.2: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2
+2.2.5: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
+2.2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
-2.3: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
-2: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
-latest: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3
+2.3.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+2.3: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+latest: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
-2-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
-slim: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
-alpine: git://github.com/docker-library/ruby@1b0c4ac5996b50b3d235465b18877d7145312ba7 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine


### PR DESCRIPTION
- `buildpack-deps`: add `libdb-dev` (docker-library/buildpack-deps#45)
- `docker`: 1.11.1
- `gcc`: add 6.1.0, remove 5.1
- `ruby`: rubygems 2.6.4