### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,21 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.13: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
-2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.1
+2.1.14: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.1
+2.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.1
 
-2.2.5: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
-2.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
-2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 2.2
+2.2.6: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
+2.2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
+2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
 
-3.0.5: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0
-3.0: git://github.com/docker-library/cassandra@a7fb4a13b7ed26cd7f2e704f07e4fad994d0bf39 3.0
+3.0.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.0
+3.0: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.0
 
-3.1.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1
-3.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.1
+3.1.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.1
+3.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.1
 
-3.2.1: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.2
-3.2: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.2
+3.2.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.2
+3.2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.2
 
-3.3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3
-3: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3
-latest: git://github.com/docker-library/cassandra@90ba62c6d8859abc5f38a6d47c9da0661be04171 3.3
+3.3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.3
+
+3.4: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.4
+
+3.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
+3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
+latest: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5

--- a/library/mongo
+++ b/library/mongo
@@ -16,7 +16,7 @@
 3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
 
-3.2.5: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
-3.2: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
-3: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
-latest: git://github.com/docker-library/mongo@c3b5b55d1920845726e35c8dda67e50247eff3de 3.2
+3.2.6: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
+3.2: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
+3: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
+latest: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2

--- a/library/redmine
+++ b/library/redmine
@@ -4,28 +4,28 @@
 2.6: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
 2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
 
-2.6.10-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 2.6/passenger
+2.6.10-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
+2.6-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
+2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
 
 3.0.7: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
 3.0: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
 
-3.0.7-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.0/passenger
+3.0.7-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
+3.0-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
 
 3.1.4: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
 3.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
 
-3.1.4-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.1/passenger
-3.1-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.1/passenger
+3.1.4-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
+3.1-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
 
 3.2.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
 3.2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
 3: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
 latest: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
 
-3.2.1-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.2/passenger
-3.2-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.2/passenger
-3-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.2/passenger
-passenger: git://github.com/docker-library/redmine@27fab420389b6a04fc5d561468df4ffbad6a8e09 3.2/passenger
+3.2.1-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
+3.2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
+3-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
+passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger


### PR DESCRIPTION
- `cassandra`: 2.2.6, 2.1.14, 3.4, 3.5 (docker-library/cassandra#62), workaround for [CASSANDRA-11661](https://issues.apache.org/jira/browse/CASSANDRA-11661) (docker-library/cassandra#63)
- `mongo`: 3.2.6
- `redmine`: passenger 5.0.28