### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -10,16 +10,6 @@
 3.0.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.0
 3.0: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.0
 
-3.1.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.1
-3.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.1
-
-3.2.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.2
-3.2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.2
-
-3.3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.3
-
-3.4: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.4
-
 3.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
 3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
 latest: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5

--- a/library/php
+++ b/library/php
@@ -1,94 +1,94 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.34-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
-5.5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
-5.5.34: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
-5.5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5
+5.5.35-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
+5.5-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
+5.5.35: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
+5.5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
 
-5.5.34-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/alpine
+5.5.35-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/alpine
+5.5-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/alpine
 
-5.5.34-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/apache
-5.5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/apache
+5.5.35-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
+5.5-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
 
-5.5.34-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm
+5.5.35-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
 
-5.5.34-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/fpm/alpine
+5.5.35-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm/alpine
+5.5-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm/alpine
 
-5.5.34-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts
-5.5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts
+5.5.35-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
+5.5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
 
-5.5.34-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.5/zts/alpine
+5.5.35-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts/alpine
+5.5-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts/alpine
 
-5.6.20-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
-5.6-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
-5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
-5.6.20: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
-5.6: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
-5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6
+5.6.21-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5.6.21: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5.6: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
 
-5.6.20-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
-5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/alpine
+5.6.21-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
+5.6-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
+5-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
 
-5.6.20-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
-5.6-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
-5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/apache
+5.6.21-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
+5.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
+5-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
 
-5.6.20-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
-5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm
+5.6.21-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
+5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
 
-5.6.20-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/fpm/alpine
+5.6.21-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
+5.6-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
+5-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
 
-5.6.20-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
-5.6-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
-5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts
+5.6.21-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
+5.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
+5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
 
-5.6.20-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 5.6/zts/alpine
+5.6.21-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
+5.6-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
+5-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
 
-7.0.5-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-7.0-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-7-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-cli: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-7.0.5: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-7.0: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-7: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
-latest: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0
+7.0.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7.0-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7.0.6: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7.0: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+latest: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
 
-7.0.5-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
-7-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/alpine
+7.0.6-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
+7.0-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
+7-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
+alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
 
-7.0.5-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
-7.0-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
-7-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
-apache: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/apache
+7.0.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
+7.0-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
+7-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
+apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
 
-7.0.5-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
-7-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
-fpm: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm
+7.0.6-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
+7-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
+fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
 
-7.0.5-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/fpm/alpine
+7.0.6-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
+7.0-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
+7-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
+fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
 
-7.0.5-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
-7.0-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
-7-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
-zts: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts
+7.0.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
+7.0-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
+7-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
+zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
 
-7.0.5-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@4677ca134fe48d20c820a19becb99198824d78e3 7.0/zts/alpine
+7.0.6-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
+7.0-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
+7-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
+zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
-2.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
+2.1.9: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1
+2.1: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
-2.2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
+2.2.5: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2
+2.2: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
-2.3: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
-2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
-latest: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+2.3.1: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
+2.3: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
+2: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
+latest: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
-2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
+2-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
+slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
+alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1
-2.1: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1
+2.1.9: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
+2.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2
-2.2: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2
+2.2.5: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
+2.2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
-2.3: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
-2: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
-latest: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3
+2.3.1: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+2.3: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+2: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
+latest: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
-2-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
-slim: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+2-slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
+slim: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
-alpine: git://github.com/docker-library/ruby@339c3257380212ef0cfdc5060f3c74bef41ab52b 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine
+alpine: git://github.com/docker-library/ruby@8df91f63357f0e9256d0afe193bc8f057ff91456 2.3/alpine


### PR DESCRIPTION
- `cassandra`: remove 3.1, 3.2, 3.3, 3.4 (docker-library/cassandra#64)
- `php`: 5.5.35, 5.6.21, 7.0.6 (docker-library/php#224)
- `ruby`: bundler 1.12.0