### PR TITLE
Update docker-library images

### DIFF
--- a/library/java
+++ b/library/java
@@ -76,16 +76,16 @@ openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604
 8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
 
-openjdk-9-b115-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-openjdk-9-b115: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-9-b115-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-9-b115: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
-9: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jdk
+openjdk-9-b116-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+openjdk-9-b116: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+openjdk-9-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+openjdk-9: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+9-b116-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+9-b116: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+9-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+9: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
 
-openjdk-9-b115-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
-9-b115-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
-9-jre: git://github.com/docker-library/openjdk@68fbc1eb8a389ffc5224b32074cca52b431eb097 9-jre
+openjdk-9-b116-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
+openjdk-9-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
+9-b116-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
+9-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,8 +5,8 @@
 10: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
 latest: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
 
-10.0.24: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.0
-10.0: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.0
+10.0.25: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0
+10.0: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0
 
 5.5.49: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
 5.5: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -1,11 +1,5 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.7: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.2
-2.2: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.2
-
-2.4.14: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
-2.4: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 2.4
-
 2.6.12: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
 2.6: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
 2: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
@@ -13,10 +7,10 @@
 3.0.11: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
 3.0: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
 
-3.1.9: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
-3.1: git://github.com/docker-library/mongo@4507e9767e0810ebfba7c19438613f37d7843278 3.1
-
 3.2.6: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
 3.2: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
 3: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
 latest: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
+
+3.3.5: git://github.com/docker-library/mongo@8bb661bb5d8815929380bd577c86b3860b9aeb03 3.3
+3.3: git://github.com/docker-library/mongo@8bb661bb5d8815929380bd577c86b3860b9aeb03 3.3

--- a/library/pypy
+++ b/library/pypy
@@ -1,19 +1,19 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-5.1.0: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
-2-5.1: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
-2-5: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
-2: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2
+2-5.1.1: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
+2-5.1: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
+2-5: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
+2: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
 
-2-5.1.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+2-5.1.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-5.1.0-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
-2-5.1-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
-2-5-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
-2-slim: git://github.com/docker-library/pypy@4512a588e5e770e020e7953279c1a724b26459b7 2/slim
+2-5.1.1-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
+2-5.1-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
+2-5-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
+2-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
 
 3-2.4.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
 3-2.4: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3


### PR DESCRIPTION
- `java`: 9~b116-1
- `mariadb`: 10.0.25+maria-1~jessie
- `mongo`: remove 2.2 (EOL Feb 2014), 2.4 (EOL Mar 2016), 3.1 (old development release); add 3.3.5 (new development release)
- `pypy`: 5.1.1