### PR TITLE
Sentry 8.4

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-8.2.5: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.2
-8.2: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.2
-
-8.2.5-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
-8.2-onbuild: git://github.com/getsentry/docker-sentry@1ef759405e541ac9552fb92f2f293c8496e10d07 8.2/onbuild
-
 8.3.3: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
 8.3: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
-8: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
-latest: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
 
 8.3.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
 8.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
-8-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
+
+8.4.0: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4
+8.4: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4
+8: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4
+latest: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4
+
+8.4.0-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
+8.4-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
+8-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
+onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.4.0