### PR TITLE
Jenkins latest should point to LTS, not 2.0

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -2,10 +2,10 @@
 # maintainer: Michael Neale <mneale@cloudbees.com> (@michaelneale)
 # maintainer: Carlos Sanchez <csanchez@cloudbees.com> (@carlossg)
 
-latest: git://github.com/jenkinsci/jenkins-ci.org-docker@5a51d0a519cb6605280adb8719f0e050ea69bac6
+latest: git://github.com/jenkinsci/jenkins-ci.org-docker@b8ad2f606001fb3fa57fa5051d655e894c15c149
 2.0: git://github.com/jenkinsci/jenkins-ci.org-docker@5a51d0a519cb6605280adb8719f0e050ea69bac6
 1.651.1: git://github.com/jenkinsci/jenkins-ci.org-docker@b8ad2f606001fb3fa57fa5051d655e894c15c149
 
-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@62229b12c22e6eff4e5960cde4bb86cc61ba14db
+alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@bf76339b2a65acb309bcdc472cfcc9306eeb45f3
 2.0-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@62229b12c22e6eff4e5960cde4bb86cc61ba14db
 1.651.1-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@bf76339b2a65acb309bcdc472cfcc9306eeb45f3


### PR DESCRIPTION
I jumped the gun making latest pointing to 2.0 when LTS is still in 1.651.1