### PR TITLE
Add correct tag mapping for node:5

### DIFF
--- a/library/node
+++ b/library/node
@@ -50,15 +50,19 @@ argon-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf
 
 5.11.0: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11
 5.11: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11
+5: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11
 
 5.11.0-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
 5.11-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@5e6d1e950a50f59c74ba7e53357d97e2ff5449d5 5.11/onbuild
 
 5.11.0-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/slim
 5.11-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/slim
+5-slim: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/slim
 
 5.11.0-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/wheezy
 5.11-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@b3367b8845a0a059af00d75d401ecf83d8e57d57 5.11/wheezy
 
 6.0.0: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0
 6.0: git://github.com/nodejs/docker-node@5367524ce658e9a9d4ba6191801e86d6e942a16a 6.0


### PR DESCRIPTION
`git pull node:5` should default to node:5.11.0.

This fixes nodejs/docker-node#174 where `git pull node:5` would grab the Node.js v5.10.1 image instead of the latest v5.11.0 image.

We fixed our generate-stackbrew-library.sh script in nodejs/docker-node#175 to default to the correct version.