### PR TITLE
[security] Update ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 0aeadd4 Update tarballs
-#    - `ubuntu:precise`: 20160425
-#    - `ubuntu:trusty`: 20160424
-#    - `ubuntu:wily`: 20160424
-#    - `ubuntu:xenial`: 20160422
+#  - 045b1c5 Update tarballs
+#    - `ubuntu:precise`: 20160503
+#    - `ubuntu:trusty`: 20160503.1
+#    - `ubuntu:wily`: 20160503
+#    - `ubuntu:xenial`: 20160503
 
-# 20160425
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce precise
-precise-20160425: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce precise
+# 20160503
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
+precise-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
 
-# 20160424
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce trusty
-trusty-20160424: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce trusty
+# 20160503.1
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
+trusty-20160503.1: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
 
-# 20160424
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce wily
-wily-20160424: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce wily
+# 20160503
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
+wily-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
 
-# 20160422
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce xenial
-xenial-20160422: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce xenial
-latest: git://github.com/tianon/docker-brew-ubuntu-core@0aeadd4fc54b3624e147e8e11896bf66ddba79ce xenial
+# 20160503
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
+xenial-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
+latest: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial


### PR DESCRIPTION
- `ubuntu:precise`: 20160503
- `ubuntu:trusty`: 20160503.1
- `ubuntu:wily`: 20160503
- `ubuntu:xenial`: 20160503

https://github.com/docker-library/official-images/issues/1691