### PR TITLE
Bump Rakudo Star commit

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,5 +1,5 @@
 # maintainer: Rob Hoelz <rob AT hoelz.ro> (@hoelzro)
 
-2016.04:  git://github.com/perl6/docker@6a58fb273b193a2d497db8e4108e7e95603dde68
+2016.04:  git://github.com/perl6/docker@f9c2b6026b8c875ad97cddacfc0158bfdc25d21c
 
-latest:  git://github.com/perl6/docker@6a58fb273b193a2d497db8e4108e7e95603dde68
+latest:  git://github.com/perl6/docker@f9c2b6026b8c875ad97cddacfc0158bfdc25d21c


### PR DESCRIPTION
The latest commit fixes a problem that some people are having with
rlwrap (https://github.com/perl6/docker/issues/3), and is no longer
needed because Rakudo Star includes line editor functionality