### PR TITLE
Retire TP2 and add new URL for photon image

### DIFF
--- a/library/photon
+++ b/library/photon
@@ -1,11 +1,8 @@
 # maintainer: Fabio Rapposelli <fabio@vmware.com> (@frapposelli)
 #
 # commits: (master..dist)
-#  - a90d370 Update tarballs
+#  - 312dda8 Update tarballs
 #
 # release-dockerfiles/1.0RC
-1.0RC: git://github.com/frapposelli/photon-docker-image@a90d370fc94c08d096f0b9ee07c1c04405f5d6dd 1.0RC
-latest: git://github.com/frapposelli/photon-docker-image@a90d370fc94c08d096f0b9ee07c1c04405f5d6dd 1.0RC
-#
-# release-dockerfiles/1.0TP2
-1.0TP2: git://github.com/frapposelli/photon-docker-image@a90d370fc94c08d096f0b9ee07c1c04405f5d6dd 1.0TP2
+1.0RC: git://github.com/vmware/photon-docker-image@312dda8b87d8a7083cf1e9fcab184a7612032859 1.0RC
+latest: git://github.com/vmware/photon-docker-image@312dda8b87d8a7083cf1e9fcab184a7612032859 1.0RC


### PR DESCRIPTION
Sorry for the Nth PR in less than a week, having spoke with the PM we decided to retire TP2 as RC is now out and GA is coming very soon.

We also moved the repo from my personal account into VMware's so other people from the team can contribute.

@tianon:

![please please please](http://gif.co/pCsd.gif)