### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -1,20 +1,20 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.9.5-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
-1.9-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
-1-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
-python2: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 2.7
+1.9.6-python2: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 2.7
+1.9-python2: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 2.7
+1-python2: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 2.7
+python2: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 2.7
 
 python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
 
-1.9.5-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-1.9.5: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-1.9-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-1.9: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-1-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-1: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-python3: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
-latest: git://github.com/docker-library/django@3f371374a15ae919258c6b708298622484cae6dd 3.4
+1.9.6-python3: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+1.9.6: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+1.9-python3: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+1.9: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+1-python3: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+1: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+python3: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
+latest: git://github.com/docker-library/django@6077558dd63f65a520043eb25249f4057c73d081 3.4
 
 python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
 onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -16,16 +16,16 @@
 8.0.6-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
 8.0-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
 
-8.1.0-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-8.1.0: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-8.1-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-8.1: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-8-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-8: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-apache: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
-latest: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/apache
+8.1.1-apache: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+8.1.1: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+8.1-apache: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+8.1: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+8-apache: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+8: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+apache: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
+latest: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/apache
 
-8.1.0-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
-8.1-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
-8-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
-fpm: git://github.com/docker-library/drupal@a1a4c0913741dbe3c1e87fa860c36b0987999f9f 8.1/fpm
+8.1.1-fpm: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/fpm
+8.1-fpm: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/fpm
+8-fpm: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/fpm
+fpm: git://github.com/docker-library/drupal@ad579f7702b32722dd11af054e2f8e11ef269fd9 8.1/fpm

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -27,7 +27,7 @@
 2: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
 latest: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
 
-5.0.0-alpha1: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
-5.0.0: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
-5.0: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
-5: git://github.com/docker-library/elasticsearch@c8cd0af42d85b2025d1474366c78768aa6aa899b 5.0
+5.0.0-alpha2: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0
+5.0.0: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0
+5.0: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0
+5: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -20,7 +20,7 @@
 4: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
 latest: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
 
-5.0.0-alpha1: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
-5.0.0: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
-5.0: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
-5: git://github.com/docker-library/kibana@cc92280939a05c80282bc33e85e8a24e14f08def 5.0
+5.0.0-alpha2: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
+5.0.0: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
+5.0: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
+5: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -28,8 +28,8 @@
 2: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
 latest: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
 
-5.0.0-alpha1-1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
-5.0.0-alpha1: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
-5.0.0: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
-5.0: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
-5: git://github.com/docker-library/logstash@e3cf0d5a9ab7d5b4ee1d707b54e409d1653f1085 5.0
+5.0.0-alpha2-1: git://github.com/docker-library/logstash@d29d207d388e139ca569296d1ae9e65456d792de 5.0
+5.0.0-alpha2: git://github.com/docker-library/logstash@d29d207d388e139ca569296d1ae9e65456d792de 5.0
+5.0.0: git://github.com/docker-library/logstash@d29d207d388e139ca569296d1ae9e65456d792de 5.0
+5.0: git://github.com/docker-library/logstash@d29d207d388e139ca569296d1ae9e65456d792de 5.0
+5: git://github.com/docker-library/logstash@d29d207d388e139ca569296d1ae9e65456d792de 5.0

--- a/library/redmine
+++ b/library/redmine
@@ -14,18 +14,18 @@
 3.0.7-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
 3.0-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
 
-3.1.4: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
-3.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.1
+3.1.5: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.1
+3.1: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.1
 
-3.1.4-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
+3.1.5-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
 3.1-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
 
-3.2.1: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
-3.2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
-3: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
-latest: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 3.2
+3.2.2: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.2
+3.2: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.2
+3: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.2
+latest: git://github.com/docker-library/redmine@a96891cab13e6e0fac72fc94761a65a5e953c811 3.2
 
-3.2.1-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
+3.2.2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
 3.2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
 3-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
 passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.28.0: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
-0.28: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
-0: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
-latest: git://github.com/RocketChat/Docker.Official.Image@d4ae9b55c9a525d194779c3a44e8b7eb3cc888e6
+0.29.0: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
+0.29: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
+0: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
+latest: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1
-2.1: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1
+2.1.9: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1
+2.1: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2
-2.2: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2
+2.2.5: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2
+2.2: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3
-2.3: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3
-2: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3
-latest: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3
+2.3.1: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
+2.3: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
+2: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
+latest: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/slim
-2-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/slim
-slim: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
+2-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
+slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/alpine
-alpine: git://github.com/docker-library/ruby@ef03134f6908840c95d40c4f7594f84973c399af 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
+alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine


### PR DESCRIPTION
- `django`: 1.9.6
- `drupal`: 8.1.1
- `elasticsearch`: 5.0.0-alpha2
- `kibana`: 5.0.0-alpha2
- `logstash`: 5.0.0-alpha2
- `redmine`: 3.1.5, 3.2.2
- `rocket.chat`: 0.29.0
- `ruby`: bundler 1.12.2