### PR TITLE
Add spiped official image

### DIFF
--- a/library/spiped
+++ b/library/spiped
@@ -1,0 +1,11 @@
+# maintainer: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
+
+1.5.0: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5
+1.5: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5
+1: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5
+latest: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5
+
+1.5.0-alpine: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5/alpine
+1.5-alpine: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5/alpine
+1-alpine: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5/alpine
+alpine: git://github.com/TimWolla/docker-spiped@04b9fa8c5b8ea5ca75f656ce1104e93096f09d02 1.5/alpine


### PR DESCRIPTION
This image already resides as a popular (10k+ pulls) [automated build inside Docker hub](https://hub.docker.com/r/timwolla/spiped/) and is running in production for several months to securely connect Docker containers across multiple hosts. Therefore I think it's time to propose timwolla/spiped as an official image, as there currently is nothing similar (e.g. stunnel) if I did not miss an image.

This is the source repository: https://github.com/TimWolla/docker-spiped
This is the corresponding docs PR: docker-library/docs#564

Thanks!

# Checklist for Review

- [x] associated with or contacted upstream?
  - https://github.com/docker-library/official-images/pull/1714#issuecomment-219556607
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
  - Spiped (pronounced "ess-pipe-dee") is a utility for creating symmetrically encrypted and authenticated pipes between socket addresses, so that one may connect to one address (e.g., a UNIX socket on localhost) and transparently have a connection established to another address (e.g., a UNIX socket on a different system). This is similar to 'ssh -L' functionality, but does not use SSH and requires a pre-shared symmetric key.
  - https://www.tarsnap.com/spiped.html
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/564
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)