### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -4,8 +4,8 @@
 2.6: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
 2: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
 
-3.0.11: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
-3.0: git://github.com/docker-library/mongo@07cae8da9490ec2933464cd8d58a0fe0a0525e81 3.0
+3.0.12: git://github.com/docker-library/mongo@4b1d085ccab5728a9b9e4b65c5ed19820420809e 3.0
+3.0: git://github.com/docker-library/mongo@4b1d085ccab5728a9b9e4b65c5ed19820420809e 3.0
 
 3.2.6: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
 3.2: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2

--- a/library/owncloud
+++ b/library/owncloud
@@ -2,54 +2,54 @@
 
 # https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
 
-7.0.13-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
-7.0.13: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
-7.0: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
-7: git://github.com/docker-library/owncloud@51ac31c7508da311b2cbc7b78d0d778d2e04f59d 7.0/apache
+7.0.14-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
+7.0.14: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
+7.0-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
+7.0: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
+7-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
+7: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/apache
 
-7.0.13-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@c4860084f5175595c7243b2712ca95e79c62caa8 7.0/fpm
+7.0.14-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/fpm
+7.0-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/fpm
+7-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 7.0/fpm
 
-8.0.11-apache: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
-8.0.11: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
-8.0: git://github.com/docker-library/owncloud@cfaf356a29c8d14e3a31d19bf778a7beaf4fd2e4 8.0/apache
+8.0.12-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/apache
+8.0.12: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/apache
+8.0-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/apache
+8.0: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/apache
 
-8.0.11-fpm: git://github.com/docker-library/owncloud@0aacd0ef10b4bd0d7a9e29433ab38376324d2667 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@0aacd0ef10b4bd0d7a9e29433ab38376324d2667 8.0/fpm
+8.0.12-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/fpm
+8.0-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.0/fpm
 
-8.1.6-apache: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
-8.1.6: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
-8.1: git://github.com/docker-library/owncloud@7cd59e114e57af0c0d08144ec79cbfbcdf8d0fff 8.1/apache
+8.1.7-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/apache
+8.1.7: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/apache
+8.1-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/apache
+8.1: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/apache
 
-8.1.6-fpm: git://github.com/docker-library/owncloud@49f10ce1af40883e9499b8e7613375bbfb11476f 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@49f10ce1af40883e9499b8e7613375bbfb11476f 8.1/fpm
+8.1.7-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/fpm
+8.1-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.1/fpm
 
-8.2.3-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
-8.2.3: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
-8.2: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
-8: git://github.com/docker-library/owncloud@0b21422e305b503f59732f70b6f85e4234151a35 8.2/apache
+8.2.4-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
+8.2.4: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
+8.2-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
+8.2: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
+8-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
+8: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/apache
 
-8.2.3-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@998e99fcfb0eb917c01504ddf0f544e771856ffc 8.2/fpm
+8.2.4-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/fpm
+8.2-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/fpm
+8-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 8.2/fpm
 
-9.0.1-apache: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-9.0.1: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-9.0-apache: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-9.0: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-9-apache: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-9: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-apache: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
-latest: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/apache
+9.0.2-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+9.0.2: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+9.0-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+9.0: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+9-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+9: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+latest: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
 
-9.0.1-fpm: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/fpm
-9.0-fpm: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/fpm
-9-fpm: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/fpm
-fpm: git://github.com/docker-library/owncloud@bfaaed8dc729f4e704b651594d9873e33ef834bd 9.0/fpm
+9.0.2-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
+9.0-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
+9-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
+fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm

--- a/library/redis
+++ b/library/redis
@@ -10,15 +10,24 @@
 
 3.0.7: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
 3.0: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
-3: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
-latest: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0
 
 3.0.7-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
 3.0-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
-3-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
-32bit: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/32bit
 
 3.0.7-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
 3.0-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
-3-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
-alpine: git://github.com/docker-library/redis@bc3ca850f4a2a2e9e5d4b3b8272e5536b4d21d24 3.0/alpine
+
+3.2.0: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2
+3.2: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2
+3: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2
+latest: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2
+
+3.2.0-32bit: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/32bit
+3.2-32bit: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/32bit
+3-32bit: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/32bit
+32bit: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/32bit
+
+3.2.0-alpine: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/alpine
+3.2-alpine: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/alpine
+3-alpine: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/alpine
+alpine: git://github.com/docker-library/redis@23b10607ef1810379d16664bcdb43723aa007266 3.2/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1
-2.1: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1
+2.1.9: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1
+2.1: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2
-2.2: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2
+2.2.5: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2
+2.2: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
-2.3: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
-2: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
-latest: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3
+2.3.1: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
+2.3: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
+2: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
+latest: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
-2-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
-slim: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
+2-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
+slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
-alpine: git://github.com/docker-library/ruby@e5e6ebd5d320c52b582c146235df801e6714887c 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
+alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.5.1-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-4.5.1: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-4.5-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-4.5: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-4-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-apache: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-4: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
-latest: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c apache
+4.5.2-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4.5.2: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4.5-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4.5: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+latest: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
 
-4.5.1-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
-4.5-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
-4-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
-fpm: git://github.com/docker-library/wordpress@c68bb143801741fb9c970de0fac257bdfd4de47c fpm
+4.5.2-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
+4.5-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
+4-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
+fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm


### PR DESCRIPTION
- `mongo`: 3.0.12
- `owncloud`: 9.0.2, 8.2.4, 8.1.7, 8.0.12, 7.0.14
- `redis`: 3.2 (docker-library/redis#57)
- `ruby`: bundler 1.12.3
- `wordpress`: 4.5.2