### PR TITLE
Add Clear Linux Project base image (v8010)

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,0 +1,4 @@
+# maintainer: William Douglas <william.douglas@intel.com>
+
+latest: git://github.com/clearlinux/docker-brew-clearlinux@0ceb073491db6b8e15c370e35c42e93c5ba2951e
+base: git://github.com/clearlinux/docker-brew-clearlinux@0ceb073491db6b8e15c370e35c42e93c5ba2951e


### PR DESCRIPTION
Initial pull request for the Clear Linux Project base image. This image provides the latest released version of Clear Linux's os-core and os-core-update bundles upon which additional image types should be built. See https://clearlinux.org/ for more details on Clear Linux Project.

# Checklist for Review

- [x] associated with or contacted upstream?
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/issues/621
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] ~~existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)~~
- [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)