### PR TITLE
Updated Oracle Linux 7.2 base image to address OpenSSL CVEs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,17 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/6.7
+6.7: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@a6ad30edbf914f8b14714b005a1afb2083e6a345 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@8fd54bc7b77cbfec58a56411206dd2fc3c4c91b4 OracleLinux/5.11


### PR DESCRIPTION
This addresses issue #1691 