### PR TITLE
update r-base to R 3.3.0 released last week

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,6 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.2.5: git://github.com/rocker-org/rocker@13a345ad18c19e467a6c70cda6687128921292ff r-base
-latest: git://github.com/rocker-org/rocker@13a345ad18c19e467a6c70cda6687128921292ff r-base
-
+3.3.0: git://github.com/rocker-org/rocker@6306669deb6673fa7c53b94586f8f8e624f3c8f8 r-base
+latest: git://github.com/rocker-org/rocker@6306669deb6673fa7c53b94586f8f8e624f3c8f8 r-base


### PR DESCRIPTION
R 3.3.0 has been out a few days, has no issues, and is used in our 'rocker/r-base' container