### PR TITLE
updating notary to 0.3.0

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,6 +1,8 @@
 # maintainer: David Lawrence <david.lawrence@docker.com> (@endophage)
 
-server: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-server
+server: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-server
+server-0.3.0: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-server
+signer: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-signer
+signer-0.3.0: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-signer
 server-0.2.0: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-server
-signer: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-signer
 signer-0.2.0: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-signer


### PR DESCRIPTION
Server and Signer updated to 0.3.0.

Changelog to be published on notary repo with release of client shortly.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)