### PR TITLE
Update docker-library images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,18 +6,18 @@
 1.4.27-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
 1.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
 
-1.5.17: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5
-1.5: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5
+1.5.18: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
+1.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
 
-1.5.17-alpine: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5/alpine
-1.5-alpine: git://github.com/docker-library/haproxy@174f054dbde26993cf1bd90b1e4ba4e9165a43b6 1.5/alpine
+1.5.18-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5/alpine
+1.5-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5/alpine
 
-1.6.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
-1.6: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
-1: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
-latest: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6
+1.6.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
+1.6: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
+1: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
+latest: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
 
-1.6.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
-1.6-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
-1-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.6/alpine
+1.6.5-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
+1.6-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
+1-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
+alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine

--- a/library/java
+++ b/library/java
@@ -53,16 +53,16 @@ openjdk-8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379
 jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
 latest: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
 
-openjdk-8u77-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-openjdk-8u77-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-openjdk-8-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-8u77-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-8u77-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-8-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-8-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-jdk-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jdk/alpine
+openjdk-8u92-jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+openjdk-8u92-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+openjdk-8-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+8u92-jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+8u92-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+8-jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+8-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
+alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
 
 openjdk-8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
@@ -70,11 +70,11 @@ openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102
 8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
 
-openjdk-8u77-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
-openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
-8u77-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
-8-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
-jre-alpine: git://github.com/docker-library/openjdk@b734af2a8ee4697604035d14064fb7f3b1d5f050 8-jre/alpine
+openjdk-8u92-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
+openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
+8u92-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
+8-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
+jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
 
 openjdk-9-b116-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
 openjdk-9-b116: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk

--- a/library/kibana
+++ b/library/kibana
@@ -1,26 +1,26 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.0.3: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.0
-4.0: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.0
+4.0.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
+4.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
 
-4.1.6: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.1
-4.1: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.1
+4.1.6: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.1
+4.1: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.1
 
-4.2.2: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.2
-4.2: git://github.com/docker-library/kibana@b606ae998472df66e0c8e769ed070129edad12be 4.2
+4.2.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
+4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
 
-4.3.3: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.3
-4.3: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.3
+4.3.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.3
+4.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.3
 
-4.4.2: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
-4.4: git://github.com/docker-library/kibana@541a035374494d9386c23d58ddcf5a52a0f6078e 4.4
+4.4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
+4.4: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
 
-4.5.0: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
-4.5: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
-4: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
-latest: git://github.com/docker-library/kibana@013505006cf267437f19ebf7ab5f022aebdb5da8 4.5
+4.5.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
+4.5: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
+4: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
+latest: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
 
-5.0.0-alpha2: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
-5.0.0: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
-5.0: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
-5: git://github.com/docker-library/kibana@7be8ebdf58a2a392cc81978f41ec82459df1ed94 5.0
+5.0.0-alpha2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0
+5.0.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0
+5.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0
+5: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.13: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
-10.1: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
-10: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
-latest: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 10.1
+10.1.14: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
+10.1: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
+10: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
+latest: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
 
 10.0.25: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0
 10.0: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2-5.1.1: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
-2-5.1: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
-2-5: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
-2: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2
+2-5.1.1: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
+2-5.1: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
+2-5: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
+2: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
 
 2-5.1.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
 
-2-5.1.1-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
-2-5.1-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
-2-5-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
-2-slim: git://github.com/docker-library/pypy@6c23c3c1775bdffd8ca9c3c64f78d99042ac15ab 2/slim
+2-5.1.1-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
+2-5.1-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
+2-5-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
+2-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
-3-2.4: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
-3-2: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
-3: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
-latest: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3
+3-2.4.0: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
+3-2.4: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
+3-2: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
+3: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
+latest: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
 
 3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
@@ -27,8 +27,8 @@ latest: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037b
 3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3/slim
-3-2-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3/slim
-3-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3/slim
-slim: git://github.com/docker-library/pypy@88f8504681b844c441225a65d851c17037bcac37 3/slim
+3-2.4.0-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
+3-2.4-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
+3-2-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
+3-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
+slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim

--- a/library/python
+++ b/library/python
@@ -1,71 +1,71 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.7.11: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
-2.7: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
-2: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7
+2.7.11: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
+2.7: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
+2: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
 
 2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
 
-2.7.11-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
-2.7-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
-2-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/slim
+2.7.11-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
+2.7-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
+2-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
-2-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
+2-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 2.7/wheezy
+2.7.11-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
+2.7-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
+2-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3
-3.3: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3
+3.3.6: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3
+3.3: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3
 
 3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
 
-3.3.6-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/slim
-3.3-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/slim
+3.3.6-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
+3.3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.3/wheezy
+3.3.6-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
+3.3-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4
-3.4: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4
+3.4.4: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4
+3.4: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4
 
 3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
 
-3.4.4-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/slim
-3.4-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/slim
+3.4.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
+3.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.4/wheezy
+3.4.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
+3.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
-3.5: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
-3: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
-latest: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5
+3.5.1: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
+3.5: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
+3: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
+latest: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
 
 3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
 
-3.5.1-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
-3.5-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
-3-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
-slim: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/slim
+3.5.1-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
+3.5-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
+3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
+slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
-3-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
-alpine: git://github.com/docker-library/python@3232863ad5aba683fb084cb00097723c8c9efb47 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
+3-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
+alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.29.0: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
-0.29: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
-0: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
-latest: git://github.com/RocketChat/Docker.Official.Image@4ffa31e370d86d5725bf8140e1a2895605dbc380
+0.30.0: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
+0.30: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
+0: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
+latest: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,15 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-4.5.2-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-4.5.2: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-4.5-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-4.5: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-4-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-apache: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-4: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
-latest: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e apache
+4.5.2-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+4.5.2: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+4.5-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+4.5: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+4-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+4: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+latest: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
 
-4.5.2-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
-4.5-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
-4-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
-fpm: git://github.com/docker-library/wordpress@d67618bf348d7c1bb31bb8b501fab8b329fd5a5e fpm
+4.5.2-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
+4.5-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
+4-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
+fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm


### PR DESCRIPTION
- `haproxy`: 1.6.5, 1.5.18
- `java`: alpine to 8u92
- `kibana`: simplify linking (docker-library/kibana#44)
- `mariadb`: 10.1.14+maria-1~jessie, 10.0.25+maria-1~jessie
- `pypy`: pip 8.1.2
- `python`: pip 8.1.2
- `rocket.chat`: 0.30.0
- `wordpress`: simplify linking (docker-library/wordpress#144)