### PR TITLE
Add silverpeas as a new Docker official image

### DIFF
--- a/library/silverpeas
+++ b/library/silverpeas
@@ -1,4 +1,7 @@
-# maintainer: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
+Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 
-latest: git://github.com/Silverpeas/docker-silverpeas-prod@b87b3bb7e28e61cd9d76262e897451e2b466d265
-6.0-alpha1: git://github.com/Silverpeas/docker-silverpeas-prod@b87b3bb7e28e61cd9d76262e897451e2b466d265
+GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
+
+Tags: 6.0-alpha1
+GitCommit: b87b3bb7e28e61cd9d76262e897451e2b466d265
+

--- a/library/silverpeas
+++ b/library/silverpeas
@@ -1,0 +1,4 @@
+# maintainer: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
+
+latest: git://github.com/Silverpeas/docker-silverpeas-prod@b87b3bb7e28e61cd9d76262e897451e2b466d265
+6.0-alpha1: git://github.com/Silverpeas/docker-silverpeas-prod@b87b3bb7e28e61cd9d76262e897451e2b466d265

--- a/library/silverpeas
+++ b/library/silverpeas
@@ -1,6 +1,8 @@
 Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
-
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
+
+Tags: 6.0-alpha2, latest
+GitCommit: 35af9d88f66d84e4e26ebde6f59cabedfc66f387
 
 Tags: 6.0-alpha1
 GitCommit: b87b3bb7e28e61cd9d76262e897451e2b466d265

--- a/library/silverpeas
+++ b/library/silverpeas
@@ -2,8 +2,5 @@ Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
 
 Tags: 6.0-alpha2, latest
-GitCommit: 35af9d88f66d84e4e26ebde6f59cabedfc66f387
-
-Tags: 6.0-alpha1
-GitCommit: b87b3bb7e28e61cd9d76262e897451e2b466d265
+GitCommit: 77c7c86d82aeee270cf23ef1272cfd95767df3c4
 

--- a/test/tests/silverpeas-basics/run.sh
+++ b/test/tests/silverpeas-basics/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+cname="silverpeas-container-$RANDOM-$RANDOM"
+
+# when running the first time, a silverpeas process is spawn before starting Silverpeas
+# (this configuration process can take some time)
+cid="$(docker run -d -e DB_SERVERTYPE="H2" -e DB_SERVER=":file:" -e DB_PASSWORD="sa" --name "$cname" "$image")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+# the maximum time for Silverpeas to be configured and to be started (if no errors)
+sleep 120s
+
+silverpeas_status="$(docker exec "$cname" /opt/silverpeas/bin/silverpeas status)"
+
+[ "`echo $silverpeas_status`" = "Configured: [OK] Running: [OK] Active: [OK] INFO: JBoss is running" ]

--- a/test/tests/silverpeas-basics/run.sh
+++ b/test/tests/silverpeas-basics/run.sh
@@ -13,8 +13,12 @@ cname="silverpeas-container-$RANDOM-$RANDOM"
 cid="$(docker run -d -e DB_SERVERTYPE="H2" -e DB_SERVER=":file:" -e DB_PASSWORD="sa" --name "$cname" "$image")"
 trap "docker rm -vf $cid > /dev/null" EXIT
 
-# the maximum time for Silverpeas to be configured and to be started (if no errors)
-sleep 120s
+check_running() {
+  docker run --rm --link "$cid":silverpeas "$image" wget silverpeas:8000/silverpeas &>/dev/null
+  return $?
+}
+
+. "$dir/../../retry.sh" --tries 20 --sleep 5 'check_running'
 
 silverpeas_status="$(docker exec "$cname" /opt/silverpeas/bin/silverpeas status)"
 


### PR DESCRIPTION
Silverpeas is an open-source collaborative and social-networking portal.
The repository on the hub is for providing Docker images of a production-ready Silverpeas instance.

Doc about this image is provided by the PR https://github.com/docker-library/docs/pull/576
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
-   [x] associated with or contacted upstream?
  - https://github.com/Silverpeas
-   [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-   [ ] is it reasonably popular, or does it solve a particular use case well?
-   [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/576
-   [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-   [x] 2+ dockerization review?
-   [ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-   [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-   [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
