### PR TITLE
Update docker-library images

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,18 +1,21 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-9.1.21: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.1
-9.1: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.1
+9.1.22: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.1
+9.1: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.1
 
-9.2.16: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.2
-9.2: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.2
+9.2.17: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.2
+9.2: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.2
 
-9.3.12: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.3
-9.3: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.3
+9.3.13: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.3
+9.3: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.3
 
-9.4.7: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.4
-9.4: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.4
+9.4.8: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.4
+9.4: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.4
 
-9.5.2: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
-9.5: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
-9: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
-latest: git://github.com/docker-library/postgres@8e867c8ba0fc8fd347e43ae53ddeba8e67242a53 9.5
+9.5.3: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
+9.5: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
+9: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
+latest: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
+
+9.6-beta1: git://github.com/docker-library/postgres@b1831ce069d10b14be05b9ddf6823e3d18c62cee 9.6
+9.6: git://github.com/docker-library/postgres@b1831ce069d10b14be05b9ddf6823e3d18c62cee 9.6

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.1: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
-3.6: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
-3: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
-latest: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40
+3.6.1: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
+3.6: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
+3: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
+latest: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
 
-3.6.1-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
-3.6-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
-3-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
-management: git://github.com/docker-library/rabbitmq@e9e416f99643363b9a9195929568909eadf8ce40 management
+3.6.1-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
+3.6-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
+3-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
+management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management


### PR DESCRIPTION
- `postgres`: 9.5.3, 9.4.8, 9.3.13, 9.2.17, 9.1.22, add 9.6~beta1
- `rabbitmq`: remove X11 deps, trimming image size (docker-library/rabbitmq#78)