### PR TITLE
Mitigate ImageTragick vulnerability

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,15 +1,15 @@
 # maintainer: Damien Metzler <dmetzler@nuxeo.com> @dmetzler
 
-latest: git://github.com/nuxeo/docker-nuxeo@c8f5d5bd4fedda1ee72eb29eac5fbb0b0a490155 8.2
-FT: git://github.com/nuxeo/docker-nuxeo@c8f5d5bd4fedda1ee72eb29eac5fbb0b0a490155 8.2
-8: git://github.com/nuxeo/docker-nuxeo@c8f5d5bd4fedda1ee72eb29eac5fbb0b0a490155 8.2
-8.2: git://github.com/nuxeo/docker-nuxeo@c8f5d5bd4fedda1ee72eb29eac5fbb0b0a490155 8.2
+latest: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 8.2
+FT: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 8.2
+8: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 8.2
+8.2: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 8.2
 
-LTS-2015: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 7.10
-LTS: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 7.10
-7.10: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 7.10
-7: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 7.10
+LTS-2015: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 7.10
+LTS: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 7.10
+7.10: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 7.10
+7: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 7.10
 
-LTS-2014: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 6.0
-6: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 6.0
-6.0: git://github.com/nuxeo/docker-nuxeo@09c50e490336f28caf1278c6bffaa02e79c0f4b4 6.0
+LTS-2014: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 6.0
+6: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 6.0
+6.0: git://github.com/nuxeo/docker-nuxeo@b37540c919e58c027f7a2f5211ad12f667f1bb76 6.0


### PR DESCRIPTION
As stated in title, this should mitigate https://imagetragick.com/ vulnerability waiting for new ImageMagick version to be published. 