### PR TITLE
Including alpine version of the influxdb images

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,8 +1,12 @@
 # maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/influxdb-docker@d59001dbf8ea00655efcdea7c848d36a7c469454 0.12
-0.12.2: git://github.com/influxdata/influxdb-docker@d59001dbf8ea00655efcdea7c848d36a7c469454 0.12
+0.12: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
+0.12.2: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
 
-0.13: git://github.com/influxdata/influxdb-docker@d59001dbf8ea00655efcdea7c848d36a7c469454 0.13
-0.13.0: git://github.com/influxdata/influxdb-docker@d59001dbf8ea00655efcdea7c848d36a7c469454 0.13
-latest: git://github.com/influxdata/influxdb-docker@d59001dbf8ea00655efcdea7c848d36a7c469454 0.13
+0.13: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
+0.13.0: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
+latest: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
+
+0.13-alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine
+0.13.0-alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine
+alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,8 +1,12 @@
 # maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/kapacitor-docker@49774a46dbba47b678d4bf0ff894f7dccd530486 0.12
-0.12.0: git://github.com/influxdata/kapacitor-docker@49774a46dbba47b678d4bf0ff894f7dccd530486 0.12
+0.12: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
+0.12.0: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
 
-0.13: git://github.com/influxdata/kapacitor-docker@49774a46dbba47b678d4bf0ff894f7dccd530486 0.13
-0.13.1: git://github.com/influxdata/kapacitor-docker@49774a46dbba47b678d4bf0ff894f7dccd530486 0.13
-latest: git://github.com/influxdata/kapacitor-docker@49774a46dbba47b678d4bf0ff894f7dccd530486 0.13
+0.13: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
+0.13.1: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
+latest: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
+
+0.13-alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine
+0.13.0-alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine
+alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine

--- a/library/telegraf
+++ b/library/telegraf
@@ -1,8 +1,12 @@
 # maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/telegraf-docker@df2a09c56e7102d502be52af947c06083cca8034 0.12
-0.12.0: git://github.com/influxdata/telegraf-docker@df2a09c56e7102d502be52af947c06083cca8034 0.12
+0.12: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
+0.12.0: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
 
-0.13: git://github.com/influxdata/telegraf-docker@df2a09c56e7102d502be52af947c06083cca8034 0.13
-0.13.0: git://github.com/influxdata/telegraf-docker@df2a09c56e7102d502be52af947c06083cca8034 0.13
-latest: git://github.com/influxdata/telegraf-docker@df2a09c56e7102d502be52af947c06083cca8034 0.13
+0.13: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
+0.13.0: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
+latest: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
+
+0.13-alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine
+0.13.0-alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine
+alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine


### PR DESCRIPTION
Includes smaller alpine versions of the influxdb, kapacitor, and
telegraf images. Chronograf does not have an alpine version and isn't
included.

Enabling the admin console for influxdb by default to match the
documentation.