### PR TITLE
Update for Node.js v6.2.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -64,22 +64,22 @@ argon-wheezy: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d451379161
 5.11-wheezy: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/wheezy
 5-wheezy: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/wheezy
 
-6.1.0: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1
-6.1: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1
-6: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1
-latest: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1
+6.2.0: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2
+6.2: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2
+6: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2
+latest: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2
 
-6.1.0-onbuild: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/onbuild
-6.1-onbuild: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/onbuild
-onbuild: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/onbuild
+6.2.0-onbuild: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/onbuild
+6.2-onbuild: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/onbuild
+onbuild: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/onbuild
 
-6.1.0-slim: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/slim
-6.1-slim: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/slim
-6-slim: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/slim
-slim: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/slim
+6.2.0-slim: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/slim
+6.2-slim: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/slim
+6-slim: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/slim
+slim: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/slim
 
-6.1.0-wheezy: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/wheezy
-6.1-wheezy: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/wheezy
-6-wheezy: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/wheezy
-wheezy: git://github.com/nodejs/docker-node@10940306b6ae14f9d2fb0d9a7327e768eadc039a 6.1/wheezy
+6.2.0-wheezy: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/wheezy
+6.2-wheezy: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/wheezy
+6-wheezy: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/wheezy
+wheezy: git://github.com/nodejs/docker-node@9a4e5a31df1e7d1df8b3a2d74f23f340d5210ada 6.2/wheezy


### PR DESCRIPTION
Update for Node.js v6.2.0. 

Reference: 

- https://nodejs.org/en/blog/release/v6.2.0/
- https://github.com/nodejs/docker-node/issues/183