### PR TITLE
Add Couchbase Server 3.1.3 Community. Reduce number of tagged versions.

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,37 +1,15 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.1
-enterprise: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.1
+latest: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/4.1.1
+enterprise: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/4.1.1
+4.1.1: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/4.1.1
+enterprise-4.1.1: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/4.1.1
 
-4.1.1: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.1
-enterprise-4.1.1: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.1
+community: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd community/couchbase-server/4.0.0
+community-4.0.0: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd community/couchbase-server/4.0.0
 
-4.1.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.0
-enterprise-4.1.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.1.0
+3.1.5: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/3.1.5
+enterprise-3.1.5: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd enterprise/couchbase-server/3.1.5
 
-4.0.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.0.0
-enterprise-4.0.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/4.0.0
-community-4.0.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc community/couchbase-server/4.0.0
-community: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc community/couchbase-server/4.0.0
+community-3.1.3: git://github.com/couchbase/docker@7e380468176f83a06edf98bdf8af635d55d939dd community/couchbase-server/3.1.3
 
-3.1.5: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.5
-enterprise-3.1.5: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.5
-
-3.1.3: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.3
-enterprise-3.1.3: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.3
-
-3.1.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.0
-enterprise-3.1.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.1.0
-
-3.0.3: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.0.3
-enterprise-3.0.3: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.0.3
-
-3.0.2: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.0.2
-enterprise-3.0.2: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/3.0.2
-
-community-3.0.1: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc community/couchbase-server/3.0.1
-
-2.5.2: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/2.5.2
-enterprise-2.5.2: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc enterprise/couchbase-server/2.5.2
-
-community-2.2.0: git://github.com/couchbase/docker@0a0f0de1dbeb557f696784cc368e3cd89229b7bc community/couchbase-server/2.2.0


### PR DESCRIPTION
As requested in #1689, I've stripped out a number of older release versions to include only the most recent released versions of our 3.x and 4.x lines.