### PR TITLE
Add ibmjava (IBM® SDK, Java™ Technology Edition) docker image.

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -1,15 +1,14 @@
 # maintainer: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-8-jre: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
-jre: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
-8: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
-latest: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
-8-jre-alpine: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/alpine
-jre-alpine: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/alpine
-8-sfj: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/ubuntu
-sfj: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/ubuntu
-8-sfj-alpine: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/alpine
-sfj-alpine: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/alpine
-8-sdk: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-sdk/x86_64/ubuntu
-sdk: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-sdk/x86_64/ubuntu
-
+8-jre: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-jre/x86_64/ubuntu
+jre: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-jre/x86_64/ubuntu
+8: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-jre/x86_64/ubuntu
+latest: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-jre/x86_64/ubuntu
+8-jre-alpine: git://github.com/ibmruntimes/ci.docker@0c67d341472c6aae479701a649f6433a7c03f486 ibmjava/8-jre/x86_64/alpine
+jre-alpine: git://github.com/ibmruntimes/ci.docker@0c67d341472c6aae479701a649f6433a7c03f486 ibmjava/8-jre/x86_64/alpine
+8-sfj: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-sfj/x86_64/ubuntu
+sfj: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-sfj/x86_64/ubuntu
+8-sfj-alpine: git://github.com/ibmruntimes/ci.docker@0c67d341472c6aae479701a649f6433a7c03f486 ibmjava/8-sfj/x86_64/alpine
+sfj-alpine: git://github.com/ibmruntimes/ci.docker@0c67d341472c6aae479701a649f6433a7c03f486 ibmjava/8-sfj/x86_64/alpine
+8-sdk: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-sdk/x86_64/ubuntu
+sdk: git://github.com/ibmruntimes/ci.docker@b9765ee26706884459e96ed701415add510e6944 ibmjava/8-sdk/x86_64/ubuntu

--- a/library/ibmjava
+++ b/library/ibmjava
@@ -1,0 +1,15 @@
+# maintainer: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+
+8-jre: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
+jre: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
+8: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
+latest: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/ubuntu
+8-jre-alpine: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/alpine
+jre-alpine: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-jre/x86_64/alpine
+8-sfj: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/ubuntu
+sfj: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/ubuntu
+8-sfj-alpine: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/alpine
+sfj-alpine: git://github.com/ibmruntimes/ci.docker@9f6db3c7d72d96b1b9aeb5a887f7096f15aa679e ibmjava/8-sfj/x86_64/alpine
+8-sdk: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-sdk/x86_64/ubuntu
+sdk: git://github.com/ibmruntimes/ci.docker@62b37002827680fe9dac372f5d3133ff9ea47c41 ibmjava/8-sdk/x86_64/ubuntu
+


### PR DESCRIPTION
Add support for ibmjava (IBM® SDK, Java™ Technology Edition) docker images. This pull request is specifically only for x86_64 arch.

It has 3 variants, the SDK, JRE and the SFJ (small footprint JRE). It currently uses ubuntu 16.04 and the JRE and the SFJ support a alpine variant as well.

# Checklist for Review

- [x] associated with or contacted upstream?
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/577
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [ ] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)