### PR TITLE
updates OrientDB 2.2.x to 2.2.0

### DIFF
--- a/library/orientdb
+++ b/library/orientdb
@@ -4,6 +4,6 @@
 
 2.1.17: git://github.com/orientechnologies/orientdb-docker@a9b15e1a749b73bc6aaa88aa16c3ac87df5df309 2.1
 
-2.2.0-rc1: git://github.com/orientechnologies/orientdb-docker@a5ea1bbe14b976a11f474b2c4009545b43657b4b 2.2
+2.2.0: git://github.com/orientechnologies/orientdb-docker@ec625ff626ef36d7b10f14ec09b1d6984f7ce440 2.2
 
-latest: git://github.com/orientechnologies/orientdb-docker@a9b15e1a749b73bc6aaa88aa16c3ac87df5df309 2.1
+latest: git://github.com/orientechnologies/orientdb-docker@ec625ff626ef36d7b10f14ec09b1d6984f7ce440 2.2


### PR DESCRIPTION
We have just released 2.2.0 so:
- OrientDB 2.2.x to 2.2.0
- OrientDB "latest" is now 2.2.0