### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -22,10 +22,10 @@
 2.2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
 
-2.3.2: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
-2.3: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
-2: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
-latest: git://github.com/docker-library/elasticsearch@aa618bbdc2b5d8ab37ccc763b1e727c4eb7be3ee 2.3
+2.3.3: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
+2.3: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
+2: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
+latest: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
 
 5.0.0-alpha2: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0
 5.0.0: git://github.com/docker-library/elasticsearch@9d394dd3c4c9fcef8c7180f7f5207dc5e99a18e7 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -3,8 +3,8 @@
 4.0.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
 4.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
 
-4.1.6: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.1
-4.1: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.1
+4.1.7: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.1
+4.1: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.1
 
 4.2.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
 4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
@@ -15,10 +15,10 @@
 4.4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
 4.4: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
 
-4.5.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
-4.5: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
-4: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
-latest: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.5
+4.5.1: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
+4.5: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
+4: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
+latest: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
 
 5.0.0-alpha2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0
 5.0.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.14: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
-10.1: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
-10: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
-latest: git://github.com/docker-library/mariadb@b4752119918f053fcdbefae5e9dc599ac878a80e 10.1
+10.1.14: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
+10.1: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
+10: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
+latest: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
 
-10.0.25: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0
-10.0: git://github.com/docker-library/mariadb@82e82c5efcebed43421d0d6d4831329cacf18ea6 10.0
+10.0.25: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.0
+10.0: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.0
 
-5.5.49: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
-5.5: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
-5: git://github.com/docker-library/mariadb@489a5bb656d2dbc583e0b0e4094fae6c32bec1a4 5.5
+5.5.49: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5
+5.5: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5
+5: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5

--- a/library/percona
+++ b/library/percona
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.5
-5.5: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.5
+5.5.48: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.5
+5.5: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.5
 
-5.6.29: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
-5.6: git://github.com/docker-library/percona@c6fe35f7393ff0dcad2acb5be63bd36f48b21050 5.6
+5.6.29: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.6
+5.6: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.6
 
-5.7.11: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
-5.7: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
-5: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
-latest: git://github.com/docker-library/percona@3a950e1b2d4c707869df820e13c3fa61306d2f7a 5.7
+5.7.11: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
+5.7: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
+5: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
+latest: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7

--- a/library/php
+++ b/library/php
@@ -5,8 +5,8 @@
 5.5.35: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
 5.5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
 
-5.5.35-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/alpine
+5.5.35-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.5/alpine
+5.5-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.5/alpine
 
 5.5.35-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
 5.5-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
@@ -14,14 +14,14 @@
 5.5.35-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
 5.5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
 
-5.5.35-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm/alpine
+5.5.35-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/fpm/alpine
+5.5-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/fpm/alpine
 
 5.5.35-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
 5.5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
 
-5.5.35-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts/alpine
+5.5.35-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/zts/alpine
+5.5-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/zts/alpine
 
 5.6.21-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
 5.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
@@ -30,9 +30,9 @@
 5.6: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
 5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
 
-5.6.21-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
-5-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/alpine
+5.6.21-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
+5.6-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
+5-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
 
 5.6.21-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
 5.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
@@ -42,17 +42,17 @@
 5.6-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
 5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
 
-5.6.21-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm/alpine
+5.6.21-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
+5.6-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
+5-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
 
 5.6.21-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
 5.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
 5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
 
-5.6.21-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts/alpine
+5.6.21-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
+5.6-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
+5-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
 
 7.0.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
 7.0-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
@@ -63,10 +63,10 @@ cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b838
 7: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
 latest: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
 
-7.0.6-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
-7-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/alpine
+7.0.6-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
+7.0-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
+7-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
+alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
 
 7.0.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
 7.0-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
@@ -78,17 +78,17 @@ apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b
 7-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
 fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
 
-7.0.6-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm/alpine
+7.0.6-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
+7.0-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
+7-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
+fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
 
 7.0.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
 7.0-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
 7-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
 zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
 
-7.0.6-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts/alpine
+7.0.6-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
+7.0-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
+7-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
+zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.30.0: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
-0.30: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
-0: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
-latest: git://github.com/RocketChat/Docker.Official.Image@a9a40ab6aa0bbab6f3abe52b31dd810b1714dada
+0.31.0: git://github.com/RocketChat/Docker.Official.Image@a4efe18c874edca161553c0879d451f71b713bd0
+0.31: git://github.com/RocketChat/Docker.Official.Image@a4efe18c874edca161553c0879d451f71b713bd0
+0: git://github.com/RocketChat/Docker.Official.Image@a4efe18c874edca161553c0879d451f71b713bd0
+latest: git://github.com/RocketChat/Docker.Official.Image@a4efe18c874edca161553c0879d451f71b713bd0

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.9: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1
-2.1: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1
+2.1.9: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1
+2.1: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1
 
 2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
 
-2.1.9-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/slim
+2.1.9-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1/slim
+2.1-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.1/alpine
+2.1.9-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1/alpine
+2.1-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2
-2.2: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2
+2.2.5: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2
+2.2: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2
 
 2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
-2.2.5-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/slim
+2.2.5-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2/slim
+2.2-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.2/alpine
+2.2.5-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2/alpine
+2.2-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
-2.3: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
-2: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
-latest: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3
+2.3.1: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3
+2.3: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3
+2: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3
+latest: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3
 
 2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
 
-2.3.1-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
-2-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
-slim: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/slim
+2.3.1-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/slim
+2-slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/slim
+slim: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
-alpine: git://github.com/docker-library/ruby@72ff2d4380a136197e3f9e0c719933d7cf3161d0 2.3/alpine
+2.3.1-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/alpine
+2.3-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/alpine
+2-alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/alpine
+alpine: git://github.com/docker-library/ruby@0b94677b368947b64dcdcb312cd81ba946df3676 2.3/alpine


### PR DESCRIPTION
- `elasticsearch`: 2.3.3 (docker-library/elasticsearch#103)
- `kibana`: 4.5.1 and 4.1.7 (docker-library/kibana#46)
- `mariadb`: allow arbitrary `--user` (docker-library/mariadb#59)
- `percona`: allow arbitrary `--user` (docker-library/percona#21)
- `php`: fix Alpine cache sticking around (docker-library/php#228)
- `rocket.chat`: 0.31.0
- `ruby`: bundler 1.12.4