### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,6 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-0.7.9: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
-0.7: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
-0: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
-latest: git://github.com/docker-library/ghost@dce058cc4528fee2efa3cdd0d4d12feed8d91a5d
+0.8.0: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
+0.8: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
+0: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
+latest: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,9 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.2.31: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.2
-2.2: git://github.com/docker-library/httpd@bc72e42914f671e725d85a01ff037ce87c827f46 2.2
+2.2.31: git://github.com/docker-library/httpd@fe74fda1ef0263751b3f12dbac3b9043ba1c1651 2.2
+2.2: git://github.com/docker-library/httpd@fe74fda1ef0263751b3f12dbac3b9043ba1c1651 2.2
 
-2.4.20: git://github.com/docker-library/httpd@8291f6b393960f46b02d8faacb6cdf83a32595d9 2.4
-2.4: git://github.com/docker-library/httpd@8291f6b393960f46b02d8faacb6cdf83a32595d9 2.4
-2: git://github.com/docker-library/httpd@8291f6b393960f46b02d8faacb6cdf83a32595d9 2.4
-latest: git://github.com/docker-library/httpd@8291f6b393960f46b02d8faacb6cdf83a32595d9 2.4
+2.4.20: git://github.com/docker-library/httpd@c5a5ddd1e6a0a7cdb8b5edfcb6e034e753cdbcca 2.4
+2.4: git://github.com/docker-library/httpd@c5a5ddd1e6a0a7cdb8b5edfcb6e034e753cdbcca 2.4
+2: git://github.com/docker-library/httpd@c5a5ddd1e6a0a7cdb8b5edfcb6e034e753cdbcca 2.4
+latest: git://github.com/docker-library/httpd@c5a5ddd1e6a0a7cdb8b5edfcb6e034e753cdbcca 2.4

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,13 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-10.1.14: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
-10.1: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
-10: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
-latest: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.1
+10.1.14: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
+10.1: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
+10: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
+latest: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
 
-10.0.25: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.0
-10.0: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 10.0
+10.0.25: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.0
+10.0: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.0
 
-5.5.49: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5
-5.5: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5
-5: git://github.com/docker-library/mariadb@cc686f56875aa84d135bb89de6ca50385211bdab 5.5
+5.5.49: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5
+5.5: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5
+5: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5

--- a/library/percona
+++ b/library/percona
@@ -1,12 +1,12 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.48: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.5
-5.5: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.5
+5.5.49: git://github.com/docker-library/percona@4501310f267a20434f10b28a8e1be660a3a09439 5.5
+5.5: git://github.com/docker-library/percona@4501310f267a20434f10b28a8e1be660a3a09439 5.5
 
-5.6.29: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.6
-5.6: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.6
+5.6.29: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.6
+5.6: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.6
 
-5.7.11: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
-5.7: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
-5: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
-latest: git://github.com/docker-library/percona@19b948571963c66ea6341d77b4e308aa23e5538b 5.7
+5.7.11: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.7
+5.7: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.7
+5: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.7
+latest: git://github.com/docker-library/percona@87fc047e457d640667f876b1e180d71aacb9bb64 5.7

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.1: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
-3.6: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
-3: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
-latest: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e
+3.6.2: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
+3.6: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
+3: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
+latest: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
 
-3.6.1-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
-3.6-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
-3-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
-management: git://github.com/docker-library/rabbitmq@3b38b0b2bc8c40f7bffc485fc13d6c9c9716b01e management
+3.6.2-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
+3.6-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
+3-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
+management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management


### PR DESCRIPTION
- `ghost`: 0.8.0
- `httpd`: add `libaprutil1-ldap` (docker-library/httpd#19)
- `mariadb`: fix backwards-compat symlink
- `percona`: fix backwards-compat symlink
- `rabbitmq`: 3.6.2