### PR TITLE
Updated Oracle Linux official images to include OL6U8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,17 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/6.7
-6.7: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@1904d5ffe361cb166559c5d8cf7b0d463fdb716b OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@80e7e4936c22ca02cbb03b016d1ef9b9f9cea6d5 OracleLinux/5.11


### PR DESCRIPTION
This also updates `oraclelinux:6` to point to 6.8.