### PR TITLE
Add an official image for Apache Zookeeper

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,5 +1,5 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-3.3.6: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.3.6
-3.4.8: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.4.8
-latest: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.4.8
+3.3.6: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.3.6
+3.4.8: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.4.8
+latest: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.4.8

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,5 +1,5 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-3.3.6: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.3.6
-3.4.8: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.4.8
-latest: git://github.com/31z4/zookeeper-docker@eaa006516ac94448f99b1cb329252b4687d022cc 3.4.8
+3.3.6: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.3.6
+3.4.8: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.4.8
+latest: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.4.8

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,5 +1,5 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-3.3.6: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.3.6
-3.4.8: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.4.8
-latest: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.4.8
+3.3.6: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.3.6
+3.4.8: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.4.8
+latest: git://github.com/31z4/zookeeper-docker@deb2b6451b0bf25950de80fc1597991850788bf5 3.4.8

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,7 +1,7 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-3.3.6: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.3.6
-3.3: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.3.6
-3.4.9: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9
-3.4: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9
-latest: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9
+3.3.6: git://github.com/31z4/zookeeper-docker@c11fc48ea8096bbc725619f3e4e0d2382b8171bd 3.3.6
+3.3: git://github.com/31z4/zookeeper-docker@c11fc48ea8096bbc725619f3e4e0d2382b8171bd 3.3.6
+3.4.9: git://github.com/31z4/zookeeper-docker@c11fc48ea8096bbc725619f3e4e0d2382b8171bd 3.4.9
+3.4: git://github.com/31z4/zookeeper-docker@c11fc48ea8096bbc725619f3e4e0d2382b8171bd 3.4.9
+latest: git://github.com/31z4/zookeeper-docker@c11fc48ea8096bbc725619f3e4e0d2382b8171bd 3.4.9

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,5 +1,7 @@
 # maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 
-3.3.6: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.3.6
-3.4.8: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.4.8
-latest: git://github.com/31z4/zookeeper-docker@2a6783441424e28c8c0fdb44146aa3ecdce0d1b3 3.4.8
+3.3.6: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.3.6
+3.3: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.3.6
+3.4.9: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9
+3.4: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9
+latest: git://github.com/31z4/zookeeper-docker@51629f3414c1c461844550c839ccc5175a75a758 3.4.9

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,0 +1,5 @@
+# maintainer: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
+
+3.3.6: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.3.6
+3.4.8: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.4.8
+latest: git://github.com/31z4/zookeeper-docker@0aabd3d7864940207bb5b7aa1a904086d525b30e 3.4.8


### PR DESCRIPTION
[Apache Zookeeper](http://zookeeper.apache.org/) is required for many distributed applications and services. In particular it's needed for #1641. [docs](https://github.com/docker-library/docs) PR is about to come.

# Checklist for Review

- [x] associated with or contacted upstream?
  - [ZOOKEEPER-1940](https://issues.apache.org/jira/browse/ZOOKEEPER-1940?focusedCommentId=15295665&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15295665) :confused:
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/590
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [ ] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)