### PR TITLE
Update docker-library images

### DIFF
--- a/library/java
+++ b/library/java
@@ -42,16 +42,16 @@ openjdk-7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc1
 7u91-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 7-jre-alpine: git://github.com/docker-library/openjdk@b118fdc1e9b1aebdc178537551101dffe1f612a3 7-jre/alpine
 
-openjdk-8u72-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-openjdk-8u72: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-openjdk-8-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-openjdk-8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-8u72-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-8u72: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-8-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-8: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
-latest: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jdk
+openjdk-8u91-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+openjdk-8u91: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+openjdk-8-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+openjdk-8: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+8u91-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+8u91: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+8-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+8: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+latest: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
 
 openjdk-8u92-jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
 openjdk-8u92-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
@@ -64,11 +64,11 @@ openjdk-8-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfca
 jdk-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
 alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jdk/alpine
 
-openjdk-8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
-openjdk-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
-8u72-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
-8-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 8-jre
+openjdk-8u91-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
+openjdk-8-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
+8u91-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
+8-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
+jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
 
 openjdk-8u92-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine
 openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@8f8d04a5f77116be8ebfcaf84e4fcbd1190b95e8 8-jre/alpine

--- a/library/php
+++ b/library/php
@@ -1,94 +1,94 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-5.5.35-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
-5.5-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
-5.5.35: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
-5.5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5
+5.5.35-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5
+5.5-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5
+5.5.35: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5
+5.5: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5
 
-5.5.35-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.5/alpine
+5.5.35-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/alpine
+5.5-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/alpine
 
-5.5.35-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
-5.5-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/apache
+5.5.35-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/apache
+5.5-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/apache
 
-5.5.35-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/fpm
+5.5.35-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/fpm
+5.5-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/fpm
 
-5.5.35-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/fpm/alpine
+5.5.35-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/fpm/alpine
+5.5-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/fpm/alpine
 
-5.5.35-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
-5.5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.5/zts
+5.5.35-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/zts
+5.5-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/zts
 
-5.5.35-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.5/zts/alpine
+5.5.35-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/zts/alpine
+5.5-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.5/zts/alpine
 
-5.6.21-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
-5.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
-5-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
-5.6.21: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
-5.6: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
-5: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6
+5.6.21-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
+5.6-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
+5-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
+5.6.21: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
+5.6: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
+5: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6
 
-5.6.21-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
-5-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 5.6/alpine
+5.6.21-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/alpine
+5.6-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/alpine
+5-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/alpine
 
-5.6.21-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
-5.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
-5-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/apache
+5.6.21-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/apache
+5.6-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/apache
+5-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/apache
 
-5.6.21-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
-5-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/fpm
+5.6.21-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm
+5.6-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm
+5-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm
 
-5.6.21-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/fpm/alpine
+5.6.21-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm/alpine
+5.6-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm/alpine
+5-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/fpm/alpine
 
-5.6.21-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
-5.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
-5-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 5.6/zts
+5.6.21-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts
+5.6-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts
+5-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts
 
-5.6.21-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 5.6/zts/alpine
+5.6.21-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts/alpine
+5.6-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts/alpine
+5-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 5.6/zts/alpine
 
-7.0.6-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-7.0-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-7-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-cli: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-7.0.6: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-7.0: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-7: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
-latest: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0
+7.0.6-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+7.0-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+7-cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+cli: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+7.0.6: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+7.0: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+7: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
+latest: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0
 
-7.0.6-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
-7-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
-alpine: git://github.com/docker-library/php@85d48c88b3e3dae303118275202327f14a8106f4 7.0/alpine
+7.0.6-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/alpine
+7.0-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/alpine
+7-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/alpine
+alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/alpine
 
-7.0.6-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
-7.0-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
-7-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
-apache: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/apache
+7.0.6-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/apache
+7.0-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/apache
+7-apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/apache
+apache: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/apache
 
-7.0.6-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
-7-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
-fpm: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/fpm
+7.0.6-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm
+7.0-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm
+7-fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm
+fpm: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm
 
-7.0.6-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/fpm/alpine
+7.0.6-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm/alpine
+7.0-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm/alpine
+7-fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm/alpine
+fpm-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/fpm/alpine
 
-7.0.6-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
-7.0-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
-7-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
-zts: git://github.com/docker-library/php@0783dc544c4db755d177fc7eb16dfce7a53b8383 7.0/zts
+7.0.6-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts
+7.0-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts
+7-zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts
+zts: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts
 
-7.0.6-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@49ceb8ddbbf82965f9e9d4a65bd788e94a9264e8 7.0/zts/alpine
+7.0.6-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts/alpine
+7.0-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts/alpine
+7-zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts/alpine
+zts-alpine: git://github.com/docker-library/php@47abb34bbfc92ccd26d07351bc18542ded37ef17 7.0/zts/alpine


### PR DESCRIPTION
- `java`: 8u91 (Debian)
- `php`: adjust `phpize` deps handling for slightly smaller Alpine images (docker-library/php#206, https://github.com/docker-library/php/commit/d1c122243375cc48ee7911379ebe5edaac53845c)