### PR TITLE
Update for Node.js v4.4.5

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/wheezy
 
-4.4.4: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4
-4.4: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4
-4: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4
-argon: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4
+4.4.5: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
+4.4: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
+4: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
+argon: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
 
-4.4.4-onbuild: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/onbuild
+4.4.5-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
 
-4.4.4-slim: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/slim
+4.4.5-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
 
-4.4.4-wheezy: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@06cd6a984ed5d2c4edb7d4513791614ce7cd0c30 4.4/wheezy
+4.4.5-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
 
 5.11.1: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11
 5.11: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11


### PR DESCRIPTION
This is an update for Node.js v4.4.5 that was released today.

Reference:

- https://github.com/nodejs/docker-node/issues/186
- https://nodejs.org/en/blog/release/v4.4.5/