### PR TITLE
sentry: fix for 8.4.x

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -6,10 +6,10 @@
 8.3.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
 8.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
 
-8.4.1: git://github.com/getsentry/docker-sentry@d91f2df780d980798c64ad450f35cb4a14cd1cba 8.4
-8.4: git://github.com/getsentry/docker-sentry@d91f2df780d980798c64ad450f35cb4a14cd1cba 8.4
-8: git://github.com/getsentry/docker-sentry@d91f2df780d980798c64ad450f35cb4a14cd1cba 8.4
-latest: git://github.com/getsentry/docker-sentry@d91f2df780d980798c64ad450f35cb4a14cd1cba 8.4
+8.4.1: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
+8.4: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
+8: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
+latest: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
 
 8.4.1-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
 8.4-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild


### PR DESCRIPTION
refs: https://github.com/getsentry/docker-sentry/pull/70

/cc @omarkhan