### PR TITLE
[security] Update ubuntu (USN-2985-1)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -5,31 +5,31 @@
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 045b1c5 Update tarballs
-#    - `ubuntu:precise`: 20160503
-#    - `ubuntu:trusty`: 20160503.1
-#    - `ubuntu:wily`: 20160503
-#    - `ubuntu:xenial`: 20160503
+#  - 52c8214 Update tarballs
+#    - `ubuntu:precise`: 20160526
+#    - `ubuntu:trusty`: 20160526
+#    - `ubuntu:wily`: 20160526
+#    - `ubuntu:xenial`: 20160525
 
-# 20160503
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
-precise-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 precise
+# 20160526
+12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
+12.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
+precise-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
+precise: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
 
-# 20160503.1
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
-trusty-20160503.1: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 trusty
+# 20160526
+14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
+14.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
+trusty-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
+trusty: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
 
-# 20160503
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
-wily-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 wily
+# 20160526
+15.10: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
+wily-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
+wily: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
 
-# 20160503
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
-xenial-20160503: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
-latest: git://github.com/tianon/docker-brew-ubuntu-core@045b1c500151a8239fce3cedd1fd656e7c113041 xenial
+# 20160525
+16.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
+xenial-20160525: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
+xenial: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
+latest: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial


### PR DESCRIPTION
- `ubuntu:precise`: 20160525.1
- `ubuntu:trusty`: 20160525
- `ubuntu:wily`: 20160525.1
- `ubuntu:xenial`: 20160525

http://www.ubuntu.com/usn/usn-2985-1/