### PR TITLE
Use a client image with curl for testing.

### DIFF
--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -8,8 +8,8 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
-# Use the image being tested as our client image since it should already have curl
-clientImage="$image"
+# Use a client image with curl for testing
+clientImage="buildpack-deps:curl"
 
 # Create an instance of the container-under-test
 serverImage="$("$dir/../image-name.sh" librarytest/jetty-hello-web "$image")"


### PR DESCRIPTION
The jetty image may not have curl since there is an alpine variant.