### PR TITLE
Aerospike 3.8.2.3

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.8.1: git://github.com/aerospike/aerospike-server.docker@7d027db20c7347c23e7944b842fcc77ca9e0a34e
-latest: git://github.com/aerospike/aerospike-server.docker@7d027db20c7347c23e7944b842fcc77ca9e0a34e
+3.8.2.3: git://github.com/aerospike/aerospike-server.docker@b9d7e2f5299b79243214359d9675332f12daca46
+latest: git://github.com/aerospike/aerospike-server.docker@b9d7e2f5299b79243214359d9675332f12daca46

--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.8.2.3: git://github.com/aerospike/aerospike-server.docker@b9d7e2f5299b79243214359d9675332f12daca46
-latest: git://github.com/aerospike/aerospike-server.docker@b9d7e2f5299b79243214359d9675332f12daca46
+3.8.2.3: git://github.com/aerospike/aerospike-server.docker@171ee7f251287b4df7b9ec96a4d4f5552b418065
+latest: git://github.com/aerospike/aerospike-server.docker@171ee7f251287b4df7b9ec96a4d4f5552b418065


### PR DESCRIPTION
-Release notes:
http://www.aerospike.com/download/server/notes.html#3.8.2.3
-Server vulnerability fix of base image.
GLIBC has the following critical CVE
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-9761