### PR TITLE
Update Solr to 6.0.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,30 +1,30 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3
-5.3: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3
+5.3: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4
-5.4: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4
+5.4: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4/alpine
 
-5.5.1: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5
-5.5: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5
+5.5.1: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5
+5.5: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5
 
-5.5.1-alpine: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@ec304043980dc94eed93dfad39ab1761523dd3f5 5.5/alpine
+5.5.1-alpine: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5/alpine
 
-6.0.0: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
-6.0: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
-6: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
-latest: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
+6.0: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
+6: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
+latest: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
 
-6.0.0-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@904d84fcaa83082d8a1b7a93a980928700387ea5 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine


### PR DESCRIPTION
See the announcement on http://mail-archives.apache.org/mod_mbox/www-announce/201605.mbox/%3cCB8F8090-4541-4BC8-8F58-CF17C9E0363E@apache.org%3e.

The changes are described on https://lucene.apache.org/solr/6_0_1/changes/Changes.html.
Note in particular "If you use historical dates, specifically on or before the year 1582, you should re-index".