### PR TITLE
Update Go to 1.7beta1

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -32,3 +32,15 @@ wheezy: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae
 1.6-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
 1-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
 alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
+
+1.7beta1: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7
+1.7: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7
+
+1.7beta1-onbuild: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/onbuild
+1.7-onbuild: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/onbuild
+
+1.7beta1-wheezy: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/wheezy
+1.7-wheezy: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/wheezy
+
+1.7beta1-alpine: git://github.com/docker-library/golang@ca728c5e13b90088d0b48aaf4108bbe31838d8d1 1.7/alpine
+1.7-alpine: git://github.com/docker-library/golang@ca728c5e13b90088d0b48aaf4108bbe31838d8d1 1.7/alpine


### PR DESCRIPTION
As @tianon suggested in [this thread](https://github.com/docker-library/golang/issues/94#issuecomment-223192136).