### PR TITLE
Sentry 8.5

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,17 @@
 # maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 
-8.3.3: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
-8.3: git://github.com/getsentry/docker-sentry@2dc5abbda0e68da3519637941f796f56e886ca88 8.3
-
-8.3.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
-8.3-onbuild: git://github.com/getsentry/docker-sentry@c05ef824c01a4f2b010c2acd24031b4d22f88944 8.3/onbuild
-
 8.4.1: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
 8.4: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
-8: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
-latest: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
 
 8.4.1-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
 8.4-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
-8-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
+
+8.5.0: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
+8.5: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
+8: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
+latest: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
+
+8.5.0-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
+8.5-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
+8-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
+onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.5.0 :tada: