### PR TITLE
Publish Neo4j 3.0.2

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -6,10 +6,10 @@
 2.3.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
 2.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
 
-3.0.1: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1
-3.0: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1
-latest: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1
+3.0.2: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
+3.0: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
+latest: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
 
-3.0.1-enterprise: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1-enterprise
-3.0-enterprise: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1-enterprise
-enterprise: git://github.com/neo4j/docker-neo4j@46c7fe4deccdd09832778794dc8f52f41a9a220f 3.0.1-enterprise
+3.0.2-enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise
+3.0-enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise
+enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise


### PR DESCRIPTION
A new patch release of Neo4j a couple of minor improvements to the image (neo4j/docker-neo4j@78cb77fe5be9041434d7f5ba4d3b12209904dbfa and neo4j/docker-neo4j@84b7c912255250557889e08a4a3d252e4c8ae8f9).