### PR TITLE
Explicitly note that Docker 1.10+ is required for the new Bashbrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM docker:1.9-git
+FROM docker:1.10-git
 
 # add "edge" since Alpine 3.3 only has Go 1.5 and we need 1.6+
 RUN sed -ri -e 'p; s!^!@edge !; s!v[0-9.]+!edge!' /etc/apk/repositories
 
-RUN apk add --update \
+RUN apk add --no-cache \
+# bash for running scripts
 		bash \
-		go@edge \
-	&& rm -rf /var/cache/apk/*
+# go for compiling bashbrew
+		go@edge
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH

--- a/bashbrew/README.md
+++ b/bashbrew/README.md
@@ -34,11 +34,15 @@ GLOBAL OPTIONS:
 
 ## Building
 
+Go version 1.6 or above is required for compilation of Bashbrew.
+
 Bashbrew itself is built using `gb` ([github.com/constabulary/gb](https://github.com/constabulary/gb)).
 
 Once in the `go` subdirectory, `gb build` should produce `go/bin/bashbrew`, ready for use.
 
 ## Usage
+
+Docker version 1.10 or above is required for use of Bashbrew.
 
 In general, `bashbrew build some-repo` or `bashbrew build ./some-file` should be sufficient for using the tool at a surface level, especially for testing. For more complex usage, please see the built-in help (`bashbrew --help`, `bashbrew build --help`, etc).
 

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -141,7 +141,7 @@ func dockerBuild(tag string, context io.Reader) error {
 		cmd.Stderr = buf
 		err := cmd.Run()
 		if err != nil {
-			err = cli.NewMultiError(err, fmt.Errorf(`docker build %q output:%s`, args, "\n"+buf.String()))
+			err = cli.NewMultiError(err, fmt.Errorf(`docker %q output:%s`, args, "\n"+buf.String()))
 		}
 		return err
 	}

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -151,10 +151,10 @@ func dockerTag(tag1 string, tag2 string) error {
 	if debugFlag {
 		fmt.Printf("$ docker tag %q %q\n", tag1, tag2)
 	}
-	_, err := exec.Command("docker", "tag", "-f", tag1, tag2).Output()
+	_, err := exec.Command("docker", "tag", tag1, tag2).Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("%v\ncommand: docker tag -f %q %q\n%s", ee, tag1, tag2, string(ee.Stderr))
+			return fmt.Errorf("%v\ncommand: docker tag %q %q\n%s", ee, tag1, tag2, string(ee.Stderr))
 		}
 	}
 	return err

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -11,6 +11,9 @@ import (
 	"pault.ag/go/topsort"
 )
 
+// TODO somewhere, ensure that the Docker engine we're talking to is API version 1.22+ (Docker 1.10+)
+//   docker version --format '{{.Server.APIVersion}}'
+
 var (
 	configPath  string
 	flagsConfig *FlagsConfig

--- a/test/tests/docker-build.sh
+++ b/test/tests/docker-build.sh
@@ -34,6 +34,6 @@ if [ "$onbuilds" -gt 0 ]; then
 	mv "$tmp/Dockerfile.new" "$tmp/Dockerfile"
 fi
 
-cp -aL "$dir" "$tmp/dir"
+cp -RL "$dir" "$tmp/dir"
 
 docker build -t "$imageTag" "$tmp" > /dev/null


### PR DESCRIPTION
This is especially thanks to https://github.com/docker/docker/issues/15785 and thus https://github.com/docker/docker/commit/c8cc4fb8d9a8d0cd155b8d26a3108e7762b623e3.

cc @yosifkit