### PR TITLE
RethinkDB 2.3.4

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,15 +1,15 @@
 # maintainer: Daniel Alan Miller <dalanmiller@rethinkdb.com> (@dalanmiller)
 
-2.0.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.0.4
-2.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.0.4
+2.0.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.0.4
+2.0: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.0.4
 
-2.1.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.1.6
-2.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.1.6
+2.1.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.1.6
+2.1: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.1.6
 
-2.2.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.2.6
-2.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.2.6
+2.2.6: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.2.6
+2.2: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.2.6
 
-2.3.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.3.3
-2.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.3.3
-2: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.3.3
-latest: git://github.com/rethinkdb/rethinkdb-dockerfiles@a001c7ab3cbc2bad891f95e8dc426484edd35587 jessie/2.3.3
+2.3.4: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.3.4
+2.3: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.3.4
+2: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.3.4
+latest: git://github.com/rethinkdb/rethinkdb-dockerfiles@d129775a6b33cb9e9a3ced40edda31ba9016a647 jessie/2.3.4


### PR DESCRIPTION
This updates the RethinkDB specification to the latest bug fix release 2.3.4 which we released on Friday (just a few days after 2.3.3).

Thank you!