### PR TITLE
Sentry 8.5.1

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -6,12 +6,12 @@
 8.4.1-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
 8.4-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
 
-8.5.0: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
-8.5: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
-8: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
-latest: git://github.com/getsentry/docker-sentry@93b8783dc5ad0c452bf657b29e8d96a2800f9746 8.5
+8.5.1: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
+8.5: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
+8: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
+latest: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
 
-8.5.0-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
+8.5.1-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
 8.5-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
 8-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
 onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.5.1