### PR TITLE
Update the julia test to also invoke "download()"

### DIFF
--- a/test/tests/julia-hello-world/container.jl
+++ b/test/tests/julia-hello-world/container.jl
@@ -1,1 +1,4 @@
 println("Hello World!");
+
+# https://github.com/docker-library/julia/pull/6
+download("https://google.com");


### PR DESCRIPTION
This helps us prevent an accidental repeat of the issue described in https://github.com/docker-library/julia/pull/6.