### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,10 +1,10 @@
 # maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-1.11.2: git://github.com/docker-library/docker@6518c3c51a58bdd5b6977037d88af63993998e5a 1.11
-1.11: git://github.com/docker-library/docker@6518c3c51a58bdd5b6977037d88af63993998e5a 1.11
-1: git://github.com/docker-library/docker@6518c3c51a58bdd5b6977037d88af63993998e5a 1.11
-latest: git://github.com/docker-library/docker@6518c3c51a58bdd5b6977037d88af63993998e5a 1.11
+1.11.2: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
+1.11: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
+1: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
+latest: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
 
 1.11.2-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
 1.11-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
@@ -16,8 +16,8 @@ dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad
 1-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
 git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
 
-1.10.3: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
-1.10: git://github.com/docker-library/docker@744110cf7268354ae30928e76f392c7864d1afea 1.10
+1.10.3: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.10
+1.10: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.10
 
 1.10.3-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
 1.10-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind

--- a/library/golang
+++ b/library/golang
@@ -1,46 +1,55 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
-# maintainer: Johan Euphrosine <proppy@google.com> (@proppy)
+# this file is generated via https://github.com/docker-library/golang/blob/47dccaff3d745cddb490c291253bd3889e39c4bd/generate-stackbrew-library.sh
 
-1.5.4: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5
-1.5: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
+             Johan Euphrosine <proppy@google.com> (@proppy)
+GitRepo: https://github.com/docker-library/golang.git
 
-1.5.4-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
-1.5-onbuild: git://github.com/docker-library/golang@f1f65c0ab0097a5e3d079d5a74e2468e8d47563d 1.5/onbuild
 
-1.5.4-wheezy: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5/wheezy
-1.5-wheezy: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5/wheezy
+Tags: 1.5.4, 1.5
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5
 
-1.5.4-alpine: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5/alpine
-1.5-alpine: git://github.com/docker-library/golang@d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19 1.5/alpine
+Tags: 1.5.4-onbuild, 1.5-onbuild
+GitCommit: f1f65c0ab0097a5e3d079d5a74e2468e8d47563d
+Directory: 1.5/onbuild
 
-1.6.2: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6
-1.6: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6
-1: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6
-latest: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6
+Tags: 1.5.4-wheezy, 1.5-wheezy
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5/wheezy
 
-1.6.2-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
-1.6-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
-1-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
-onbuild: git://github.com/docker-library/golang@ce284e14cdee73fbaa8fb680011a812f272eae2e 1.6/onbuild
+Tags: 1.5.4-alpine, 1.5-alpine
+GitCommit: f3768925fd0ebeb966c30bc64206b0e6020de66e
+Directory: 1.5/alpine
 
-1.6.2-wheezy: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/wheezy
-1.6-wheezy: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/wheezy
-1-wheezy: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/wheezy
-wheezy: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/wheezy
+Tags: 1.6.2, 1.6, 1, latest
+GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+Directory: 1.6
 
-1.6.2-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
-1.6-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
-1-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
-alpine: git://github.com/docker-library/golang@0ce80411b9f41e9c3a21fc0a1bffba6ae761825a 1.6/alpine
+Tags: 1.6.2-onbuild, 1.6-onbuild, 1-onbuild, onbuild
+GitCommit: ce284e14cdee73fbaa8fb680011a812f272eae2e
+Directory: 1.6/onbuild
 
-1.7beta1: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7
-1.7: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7
+Tags: 1.6.2-wheezy, 1.6-wheezy, 1-wheezy, wheezy
+GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+Directory: 1.6/wheezy
 
-1.7beta1-onbuild: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/onbuild
-1.7-onbuild: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/onbuild
+Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: f3768925fd0ebeb966c30bc64206b0e6020de66e
+Directory: 1.6/alpine
 
-1.7beta1-wheezy: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/wheezy
-1.7-wheezy: git://github.com/docker-library/golang@2372c8cafe9cc958bade33ad0b8b54de8869c21f 1.7/wheezy
+Tags: 1.7beta1, 1.7
+GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
+Directory: 1.7
 
-1.7beta1-alpine: git://github.com/docker-library/golang@ca728c5e13b90088d0b48aaf4108bbe31838d8d1 1.7/alpine
-1.7-alpine: git://github.com/docker-library/golang@ca728c5e13b90088d0b48aaf4108bbe31838d8d1 1.7/alpine
+Tags: 1.7beta1-onbuild, 1.7-onbuild
+GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
+Directory: 1.7/onbuild
+
+Tags: 1.7beta1-wheezy, 1.7-wheezy
+GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
+Directory: 1.7/wheezy
+
+Tags: 1.7beta1-alpine, 1.7-alpine
+GitCommit: f3768925fd0ebeb966c30bc64206b0e6020de66e
+Directory: 1.7/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -3,21 +3,21 @@
 1.4.27: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
 1.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
 
-1.4.27-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
-1.4-alpine: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4/alpine
+1.4.27-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.4/alpine
+1.4-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.4/alpine
 
 1.5.18: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
 1.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
 
-1.5.18-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5/alpine
-1.5-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5/alpine
+1.5.18-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.5/alpine
+1.5-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.5/alpine
 
 1.6.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
 1.6: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
 1: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
 latest: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
 
-1.6.5-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
-1.6-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
-1-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
-alpine: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6/alpine
+1.6.5-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
+1.6-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
+1-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
+alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine

--- a/library/php
+++ b/library/php
@@ -5,8 +5,8 @@
 5.5.36: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
 5.5: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
 
-5.5.36-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/alpine
+5.5.36-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/alpine
+5.5-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/alpine
 
 5.5.36-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/apache
 5.5-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/apache
@@ -14,14 +14,14 @@
 5.5.36-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm
 5.5-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm
 
-5.5.36-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm/alpine
+5.5.36-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/fpm/alpine
+5.5-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/fpm/alpine
 
 5.5.36-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts
 5.5-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts
 
-5.5.36-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts/alpine
+5.5.36-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/zts/alpine
+5.5-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/zts/alpine
 
 5.6.22-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
 5.6-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
@@ -30,9 +30,9 @@
 5.6: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
 5: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
 
-5.6.22-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/alpine
-5-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/alpine
+5.6.22-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
+5.6-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
+5-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
 
 5.6.22-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/apache
 5.6-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/apache
@@ -42,17 +42,17 @@
 5.6-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm
 5-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm
 
-5.6.22-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm/alpine
+5.6.22-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
+5.6-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
+5-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
 
 5.6.22-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
 5.6-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
 5-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
 
-5.6.22-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts/alpine
+5.6.22-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
+5.6-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
+5-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
 
 7.0.7-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
 7.0-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
@@ -63,10 +63,10 @@ cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea77
 7: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
 latest: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
 
-7.0.7-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/alpine
-7-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/alpine
-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/alpine
+7.0.7-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
+7.0-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
+7-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
+alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
 
 7.0.7-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
 7.0-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
@@ -78,17 +78,17 @@ apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fe
 7-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
 fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
 
-7.0.7-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm/alpine
+7.0.7-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
+7.0-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
+7-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
+fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
 
 7.0.7-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
 7.0-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
 7-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
 zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
 
-7.0.7-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts/alpine
+7.0.7-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
+7.0-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
+7-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
+zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine

--- a/library/python
+++ b/library/python
@@ -12,9 +12,9 @@
 2.7-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
 2-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
-2-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/alpine
+2.7.11-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
+2.7-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
+2-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
 
 2.7.11-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
 2.7-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
@@ -29,8 +29,8 @@
 3.3.6-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
 3.3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/alpine
+3.3.6-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.3/alpine
+3.3-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.3/alpine
 
 3.3.6-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
 3.3-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
@@ -44,8 +44,8 @@
 3.4.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
 3.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/alpine
+3.4.4-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.4/alpine
+3.4-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.4/alpine
 
 3.4.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
 3.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
@@ -65,7 +65,7 @@ onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a375
 3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
 slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
-3-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
-alpine: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/alpine
+3.5.1-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
+3.5-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
+3-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
+alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine

--- a/library/redis
+++ b/library/redis
@@ -14,8 +14,8 @@
 3.0.7-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/32bit
 3.0-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/32bit
 
-3.0.7-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/alpine
+3.0.7-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.0/alpine
+3.0-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.0/alpine
 
 3.2.0: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
 3.2: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
@@ -27,7 +27,7 @@ latest: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e
 3-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
 32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
 
-3.2.0-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/alpine
-3.2-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/alpine
-3-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/alpine
-alpine: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/alpine
+3.2.0-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
+3.2-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
+3-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
+alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine


### PR DESCRIPTION
- `docker`: update to Alpine 3.4
- `golang`: update to Alpine 3.4, use Alpine's `go` package for `GOROOT_BOOTSTRAP`, convert to 2822-based format (docker-library/golang#95)
- `haproxy`: update to Alpine 3.4
- `php`: update to Alpine 3.4
- `python`: update to Alpine 3.4
- `redis`: update to Alpine 3.4