### PR TITLE
Apply constraints during "tag" and "push" (since they're only useful after "build", at least currently)

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -26,6 +26,10 @@ func cmdPush(c *cli.Context) error {
 		}
 
 		for _, entry := range r.Entries() {
+			if r.SkipConstraints(entry) {
+				continue
+			}
+
 			for _, tag := range r.Tags(namespace, uniq, entry) {
 				fmt.Printf("Pushing %s\n", tag)
 				err = dockerPush(tag)

--- a/bashbrew/go/src/bashbrew/cmd-tag.go
+++ b/bashbrew/go/src/bashbrew/cmd-tag.go
@@ -27,6 +27,10 @@ func cmdTag(c *cli.Context) error {
 		}
 
 		for _, entry := range r.Entries() {
+			if r.SkipConstraints(entry) {
+				continue
+			}
+
 			for _, tag := range r.Tags("", uniq, entry) {
 				namespacedTag := path.Join(namespace, tag)
 				fmt.Printf("Tagging %s\n", namespacedTag)


### PR DESCRIPTION
cc @yosifkit