### PR TITLE
Bump traefik to v1.0.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,8 +1,5 @@
 # maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
 # maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 
-v1.0.0-rc1: git://github.com/containous/traefik-library-image@7eaf03d205ba9bbd6dbcad2675516c33043f79ff
-v1.0.0-beta.704: git://github.com/containous/traefik-library-image@0b0c26da8cb7abc1190d95acbfc5c5e1f986f685
-v1.0.0-beta.404: git://github.com/containous/traefik-library-image@04d09c3cf006f360611fcb178d8537c318100d85
-v1.0.0-beta.392: git://github.com/containous/traefik-library-image@7f7b1e2c7d8ca00ae07e37e64a0e305f7422f6aa
-latest: git://github.com/containous/traefik-library-image@7eaf03d205ba9bbd6dbcad2675516c33043f79ff
+v1.0.0-rc2: git://github.com/containous/traefik-library-image@fc152d52349420052497e163b07134d4b2437ac9
+latest: git://github.com/containous/traefik-library-image@fc152d52349420052497e163b07134d4b2437ac9


### PR DESCRIPTION
Hello,
This PR updates traefik to v1.0.0-rc2
/cc @vdemeester @samber
Cheers :)
Emile

Signed-off-by: Emile Vauge <emile@vauge.com>