### PR TITLE
Switch influxdata stack to use a single repository

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -3,6 +3,6 @@
 0.12: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.12
 0.12.0: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.12
 
-0.13: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.13
-0.13.0: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.13
-latest: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.13
+0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13
+0.13.0: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13
+latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13

--- a/library/influxdb
+++ b/library/influxdb
@@ -3,10 +3,13 @@
 0.12: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
 0.12.2: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
 
-0.13: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
-0.13.0: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
-latest: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13
+0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
+0.13.0: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
+latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
 
-0.13-alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine
-0.13.0-alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine
-alpine: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.13/alpine
+0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
+0.13.0-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
+alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
+
+1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/1.0
+1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/1.0/alpine

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -3,10 +3,13 @@
 0.12: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
 0.12.0: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
 
-0.13: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
-0.13.1: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
-latest: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13
+0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
+0.13.1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
+latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
 
-0.13-alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine
-0.13.0-alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine
-alpine: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.13/alpine
+0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
+0.13.1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
+alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
+
+1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/1.0
+1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/1.0/alpine

--- a/library/telegraf
+++ b/library/telegraf
@@ -3,10 +3,13 @@
 0.12: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
 0.12.0: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
 
-0.13: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
-0.13.0: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
-latest: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13
+0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
+0.13.1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
+latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
 
-0.13-alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine
-0.13.0-alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine
-alpine: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.13/alpine
+0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
+0.13.1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
+alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
+
+1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/1.0
+1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/1.0/alpine


### PR DESCRIPTION
The 0.12 version is still supported, but will use the old repositories
instead of being moved to the new repository.