### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,14 +1,14 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-2.1.14: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.1
-2.1: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.1
+2.1.14: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.1
+2.1: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.1
 
-2.2.6: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
-2.2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
-2: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 2.2
+2.2.6: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
+2.2: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
+2: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
 
-3.0.6: git://github.com/docker-library/cassandra@782f9e33512363dfcb39b32841669210badf32fb 3.0
-3.0: git://github.com/docker-library/cassandra@782f9e33512363dfcb39b32841669210badf32fb 3.0
+3.0.6: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 3.0
+3.0: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 3.0
 
 3.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
 3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5

--- a/library/golang
+++ b/library/golang
@@ -1,10 +1,9 @@
-# this file is generated via https://github.com/docker-library/golang/blob/47dccaff3d745cddb490c291253bd3889e39c4bd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/292b03a23ec486861b89cbe5478b90aea4cf5a20/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
-
 
 Tags: 1.5.4, 1.5
 GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,11 @@
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
 
-3.6.2: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
-3.6: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
-3: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
-latest: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d
+3.6.2: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+3.6: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+3: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+latest: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
 
-3.6.2-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
-3.6-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
-3-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
-management: git://github.com/docker-library/rabbitmq@70a23d102e34073a324522bafb99908b1ef7023d management
+3.6.2-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
+3.6-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
+3-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
+management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management


### PR DESCRIPTION
- `cassandra`: more aggressive `SEEDS` (docker-library/cassandra#27)
- `rabbitmq`: update APT repo GPG key (https://www.rabbitmq.com/news.html; https://groups.google.com/d/topic/rabbitmq-users/BO5cmEsdEhc/discussion)