### PR TITLE
Update docker-library images (convert to RFC 2822-based format)

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,52 +1,101 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/974c358f7d1b545fbfe388dec9d149aea1b8116f/generate-stackbrew-library.sh
 
-jessie-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 jessie/curl
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/buildpack-deps.git
 
-jessie-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f jessie/scm
-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f jessie/scm
+Tags: jessie-curl, curl
+GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+Directory: jessie/curl
 
-jessie: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d jessie
-latest: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d jessie
+Tags: jessie-scm, scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: jessie/scm
 
-precise-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 precise/curl
+Tags: jessie, latest
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: jessie
 
-precise-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f precise/scm
+Tags: precise-curl
+GitCommit: af914a5bde2a749884177393c8140384048dc5f9
+Directory: precise/curl
 
-precise: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d precise
+Tags: precise-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: precise/scm
 
-sid-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 sid/curl
+Tags: precise
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: precise
 
-sid-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f sid/scm
+Tags: sid-curl
+GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+Directory: sid/curl
 
-sid: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d sid
+Tags: sid-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: sid/scm
 
-stretch-curl: git://github.com/docker-library/buildpack-deps@c7478e564dd5dc063cdb0231764379a6916fe525 stretch/curl
+Tags: sid
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: sid
 
-stretch-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f stretch/scm
+Tags: stretch-curl
+GitCommit: c7478e564dd5dc063cdb0231764379a6916fe525
+Directory: stretch/curl
 
-stretch: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d stretch
+Tags: stretch-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: stretch/scm
 
-trusty-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 trusty/curl
+Tags: stretch
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: stretch
 
-trusty-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f trusty/scm
+Tags: trusty-curl
+GitCommit: af914a5bde2a749884177393c8140384048dc5f9
+Directory: trusty/curl
 
-trusty: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d trusty
+Tags: trusty-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: trusty/scm
 
-wheezy-curl: git://github.com/docker-library/buildpack-deps@a0a59c61102e8b079d568db69368fb89421f75f2 wheezy/curl
+Tags: trusty
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: trusty
 
-wheezy-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wheezy/scm
+Tags: wheezy-curl
+GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+Directory: wheezy/curl
 
-wheezy: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d wheezy
+Tags: wheezy-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: wheezy/scm
 
-wily-curl: git://github.com/docker-library/buildpack-deps@af914a5bde2a749884177393c8140384048dc5f9 wily/curl
+Tags: wheezy
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: wheezy
 
-wily-scm: git://github.com/docker-library/buildpack-deps@1845b3f918f69b4c97912b0d4d68a5658458e84f wily/scm
+Tags: wily-curl
+GitCommit: af914a5bde2a749884177393c8140384048dc5f9
+Directory: wily/curl
 
-wily: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d wily
+Tags: wily-scm
+GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
+Directory: wily/scm
 
-xenial-curl: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/curl
+Tags: wily
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: wily
 
-xenial-scm: git://github.com/docker-library/buildpack-deps@2da658b9a1b91fa61d63ffad2ea52685cac6c702 xenial/scm
+Tags: xenial-curl
+GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
+Directory: xenial/curl
 
-xenial: git://github.com/docker-library/buildpack-deps@e7534be05255522954f50542ebf9c5f06485838d xenial
+Tags: xenial-scm
+GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
+Directory: xenial/scm
+
+Tags: xenial
+GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+Directory: xenial

--- a/library/cassandra
+++ b/library/cassandra
@@ -1,15 +1,21 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/cassandra/blob/b50c3e856f4ca719546dce2de1b4f64a923fb766/generate-stackbrew-library.sh
 
-2.1.14: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.1
-2.1: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.1
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/cassandra.git
 
-2.2.6: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
-2.2: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
-2: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 2.2
+Tags: 2.1.14, 2.1
+GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Directory: 2.1
 
-3.0.6: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 3.0
-3.0: git://github.com/docker-library/cassandra@5e291bb8fad37f2f29b8aadcc718f9a155152e92 3.0
+Tags: 2.2.6, 2.2, 2
+GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Directory: 2.2
 
-3.5: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
-3: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
-latest: git://github.com/docker-library/cassandra@b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b 3.5
+Tags: 3.0.6, 3.0
+GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Directory: 3.0
+
+Tags: 3.5, 3, latest
+GitCommit: b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b
+Directory: 3.5

--- a/library/celery
+++ b/library/celery
@@ -1,6 +1,8 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/celery/blob/d93a98b8c40c8276a0a2fd1b2f68515b63eeaf0d/generate-stackbrew-library.sh
 
-3.1.23: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
-3.1: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
-3: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
-latest: git://github.com/docker-library/celery@0652407560f353e749cbe001e8bdbb5db86c2291
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/celery.git
+
+Tags: 3.1.23, 3.1, 3, latest
+GitCommit: 0652407560f353e749cbe001e8bdbb5db86c2291

--- a/library/django
+++ b/library/django
@@ -1,20 +1,21 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/django/blob/e73a3bd34657b3fb6c87c78e16036efc474ec468/generate-stackbrew-library.sh
 
-1.9.7-python2: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 2.7
-1.9-python2: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 2.7
-1-python2: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 2.7
-python2: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 2.7
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/django.git
 
-python2-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 2.7/onbuild
+Tags: 1.9.7-python3, 1.9-python3, 1-python3, python3, 1.9.7, 1.9, 1, latest
+GitCommit: 819c332058c3638ab8f4fa5b9f70518e9aaf6325
+Directory: 3.4
 
-1.9.7-python3: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-1.9.7: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-1.9-python3: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-1.9: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-1-python3: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-1: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-python3: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
-latest: git://github.com/docker-library/django@819c332058c3638ab8f4fa5b9f70518e9aaf6325 3.4
+Tags: python3-onbuild, onbuild
+GitCommit: cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447
+Directory: 3.4/onbuild
 
-python3-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
-onbuild: git://github.com/docker-library/django@cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447 3.4/onbuild
+Tags: 1.9.7-python2, 1.9-python2, 1-python2, python2
+GitCommit: 819c332058c3638ab8f4fa5b9f70518e9aaf6325
+Directory: 2.7
+
+Tags: python2-onbuild
+GitCommit: cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447
+Directory: 2.7/onbuild

--- a/library/docker
+++ b/library/docker
@@ -1,26 +1,29 @@
-# maintainer: Tianon Gravi <tianon@dockerproject.org> (@tianon)
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/docker/blob/fddc10378d1f75aae908f4dcc6ac51c3722d12bb/generate-stackbrew-library.sh
 
-1.11.2: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
-1.11: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
-1: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
-latest: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.11
+Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/docker.git
 
-1.11.2-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
-1.11-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
-1-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
-dind: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/dind
+Tags: 1.11.2, 1.11, 1, latest
+GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
+Directory: 1.11
 
-1.11.2-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
-1.11-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
-1-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
-git: git://github.com/docker-library/docker@866c3fbd87e8eeed524fdf19ba2d63288ad49cd2 1.11/git
+Tags: 1.11.2-dind, 1.11-dind, 1-dind, dind
+GitCommit: 866c3fbd87e8eeed524fdf19ba2d63288ad49cd2
+Directory: 1.11/dind
 
-1.10.3: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.10
-1.10: git://github.com/docker-library/docker@7ef1746a46a29d89bac9aca8d0788bd629eb00e6 1.10
+Tags: 1.11.2-git, 1.11-git, 1-git, git
+GitCommit: 866c3fbd87e8eeed524fdf19ba2d63288ad49cd2
+Directory: 1.11/git
 
-1.10.3-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
-1.10-dind: git://github.com/docker-library/docker@83b2eab8bdb5d35bf343313154ab55938fca3807 1.10/dind
+Tags: 1.10.3, 1.10
+GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
+Directory: 1.10
 
-1.10.3-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
-1.10-git: git://github.com/docker-library/docker@8d7aa4652e4f677765947f19232eb17b1601f81c 1.10/git
+Tags: 1.10.3-dind, 1.10-dind
+GitCommit: 83b2eab8bdb5d35bf343313154ab55938fca3807
+Directory: 1.10/dind
+
+Tags: 1.10.3-git, 1.10-git
+GitCommit: 8d7aa4652e4f677765947f19232eb17b1601f81c
+Directory: 1.10/git

--- a/library/drupal
+++ b/library/drupal
@@ -1,31 +1,29 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/drupal/blob/e14ec7e839cc59f62302ea83277a13c3d2b10bf1/generate-stackbrew-library.sh
 
-7.43-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
-7.43: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
-7-apache: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
-7: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/apache
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/drupal.git
 
-7.43-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
-7-fpm: git://github.com/docker-library/drupal@865f61938fe7f37359d8feeb13bb03bff8f11387 7/fpm
+Tags: 7.43-apache, 7-apache, 7.43, 7
+GitCommit: 865f61938fe7f37359d8feeb13bb03bff8f11387
+Directory: 7/apache
 
-8.0.6-apache: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-8.0.6: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-8.0-apache: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
-8.0: git://github.com/docker-library/drupal@54f9aa4a327fd221cacf2f59b71682ca4004d231 8.0/apache
+Tags: 7.43-fpm, 7-fpm
+GitCommit: 865f61938fe7f37359d8feeb13bb03bff8f11387
+Directory: 7/fpm
 
-8.0.6-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
-8.0-fpm: git://github.com/docker-library/drupal@280071cdbb819aae47263463a32bf217741f2a0f 8.0/fpm
+Tags: 8.0.6-apache, 8.0-apache, 8.0.6, 8.0
+GitCommit: 54f9aa4a327fd221cacf2f59b71682ca4004d231
+Directory: 8.0/apache
 
-8.1.2-apache: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-8.1.2: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-8.1-apache: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-8.1: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-8-apache: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-8: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-apache: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
-latest: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/apache
+Tags: 8.0.6-fpm, 8.0-fpm
+GitCommit: 280071cdbb819aae47263463a32bf217741f2a0f
+Directory: 8.0/fpm
 
-8.1.2-fpm: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/fpm
-8.1-fpm: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/fpm
-8-fpm: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/fpm
-fpm: git://github.com/docker-library/drupal@2186f092b0f2547063cfee95e7e0f54565a2cd76 8.1/fpm
+Tags: 8.1.2-apache, 8.1-apache, 8-apache, apache, 8.1.2, 8.1, 8, latest
+GitCommit: 2186f092b0f2547063cfee95e7e0f54565a2cd76
+Directory: 8.1/apache
+
+Tags: 8.1.2-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 2186f092b0f2547063cfee95e7e0f54565a2cd76
+Directory: 8.1/fpm

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,33 +1,41 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/c7e74194b12c1f37355b5a609ac30c485956bfa1/generate-stackbrew-library.sh
 
-1.4.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
-1.4: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.4
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/elasticsearch.git
 
-1.5.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.5
-1.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.5
+Tags: 1.4.5, 1.4
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 1.4
 
-1.6.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.6
-1.6: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.6
+Tags: 1.5.2, 1.5
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 1.5
 
-1.7.5: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
-1.7: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
-1: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 1.7
+Tags: 1.6.2, 1.6
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 1.6
 
-2.0.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.0
-2.0: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.0
+Tags: 1.7.5, 1.7, 1
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 1.7
 
-2.1.2: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
-2.1: git://github.com/docker-library/elasticsearch@2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b 2.1
+Tags: 2.0.2, 2.0
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 2.0
 
-2.2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
-2.2: git://github.com/docker-library/elasticsearch@97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7 2.2
+Tags: 2.1.2, 2.1
+GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+Directory: 2.1
 
-2.3.3: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
-2.3: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
-2: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
-latest: git://github.com/docker-library/elasticsearch@30af4a027561ede1295621039ebc4ae6c656ea2a 2.3
+Tags: 2.2.2, 2.2
+GitCommit: 97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7
+Directory: 2.2
 
-5.0.0-alpha3: git://github.com/docker-library/elasticsearch@82ace8b3760e3a8ddbadf90a645c99c7940ce250 5.0
-5.0.0: git://github.com/docker-library/elasticsearch@82ace8b3760e3a8ddbadf90a645c99c7940ce250 5.0
-5.0: git://github.com/docker-library/elasticsearch@82ace8b3760e3a8ddbadf90a645c99c7940ce250 5.0
-5: git://github.com/docker-library/elasticsearch@82ace8b3760e3a8ddbadf90a645c99c7940ce250 5.0
+Tags: 2.3.3, 2.3, 2, latest
+GitCommit: 30af4a027561ede1295621039ebc4ae6c656ea2a
+Directory: 2.3
+
+Tags: 5.0.0-alpha3, 5.0.0, 5.0, 5
+GitCommit: 82ace8b3760e3a8ddbadf90a645c99c7940ce250
+Directory: 5.0

--- a/library/gcc
+++ b/library/gcc
@@ -1,30 +1,35 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/gcc/blob/86ac4c6b757064f427e474027285dafd50d76525/generate-stackbrew-library.sh
+
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2015-06-23
-4.8.5: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.8
-4.8: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.8
+Tags: 4.8.5, 4.8
+GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+Directory: 4.8
 # Docker EOL: 2016-06-23
 
 # Last Modified: 2015-06-26
-4.9.3: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
-4.9: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
-4: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 4.9
+Tags: 4.9.3, 4.9, 4
+GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+Directory: 4.9
 # Docker EOL: 2016-06-26
 
 # Last Modified: 2015-07-16
-5.2.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
-5.2: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.2
+Tags: 5.2.0, 5.2
+GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+Directory: 5.2
 # Docker EOL: 2016-07-16
 
 # Last Modified: 2015-12-04
-5.3.0: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
-5.3: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
-5: git://github.com/docker-library/gcc@5e3781575c04f31812375822f4f28fbb39da5dc3 5.3
+Tags: 5.3.0, 5.3, 5
+GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+Directory: 5.3
 # Docker EOL: 2016-12-04
 
 # Last Modified: 2016-04-27
-6.1.0: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
-6.1: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
-6: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
-latest: git://github.com/docker-library/gcc@2f180f02a73a9a68a6a6e62d96c11acd65a01b7d 6.1
+Tags: 6.1.0, 6.1, 6, latest
+GitCommit: 2f180f02a73a9a68a6a6e62d96c11acd65a01b7d
+Directory: 6.1
 # Docker EOL: 2017-04-27

--- a/library/ghost
+++ b/library/ghost
@@ -1,6 +1,8 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/ghost/blob/8652c806a1af1beef0f9c4ec146262e50f6a4875/generate-stackbrew-library.sh
 
-0.8.0: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
-0.8: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
-0: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
-latest: git://github.com/docker-library/ghost@dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/ghost.git
+
+Tags: 0.8.0, 0.8, 0, latest
+GitCommit: dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/292b03a23ec486861b89cbe5478b90aea4cf5a20/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/842f6e59d263db5fc85fb177c173c61a6306fe78/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,23 +1,29 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/haproxy/blob/d5ab9779df0320470577033f158a2d3fa03be8b2/generate-stackbrew-library.sh
 
-1.4.27: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
-1.4: git://github.com/docker-library/haproxy@a11db1597f9be5365028673df4d05b2ea854b3ed 1.4
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/haproxy.git
 
-1.4.27-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.4/alpine
-1.4-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.4/alpine
+Tags: 1.4.27, 1.4
+GitCommit: a11db1597f9be5365028673df4d05b2ea854b3ed
+Directory: 1.4
 
-1.5.18: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
-1.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.5
+Tags: 1.4.27-alpine, 1.4-alpine
+GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+Directory: 1.4/alpine
 
-1.5.18-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.5/alpine
-1.5-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.5/alpine
+Tags: 1.5.18, 1.5
+GitCommit: e128fc85947f0de7213185c9f948150e39cbc766
+Directory: 1.5
 
-1.6.5: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
-1.6: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
-1: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
-latest: git://github.com/docker-library/haproxy@e128fc85947f0de7213185c9f948150e39cbc766 1.6
+Tags: 1.5.18-alpine, 1.5-alpine
+GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+Directory: 1.5/alpine
 
-1.6.5-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
-1.6-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
-1-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
-alpine: git://github.com/docker-library/haproxy@667427cf0ac38b7ff7d9fcbd29493b54adf9d53d 1.6/alpine
+Tags: 1.6.5, 1.6, 1, latest
+GitCommit: e128fc85947f0de7213185c9f948150e39cbc766
+Directory: 1.6
+
+Tags: 1.6.5-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+Directory: 1.6/alpine

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,3 +1,8 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/hello-world/blob/b0306018512706518a33d24583e6c67a730de71e/generate-stackbrew-library.sh
 
-latest: git://github.com/docker-library/hello-world@fb12b77c31f97ef7cee73c280432d771823d9ec8
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/hello-world.git
+
+Tags: latest
+GitCommit: fb12b77c31f97ef7cee73c280432d771823d9ec8

--- a/library/httpd
+++ b/library/httpd
@@ -1,9 +1,13 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/httpd/blob/90fcd5ffe50e9e035133d1d175fdf772b2d60991/generate-stackbrew-library.sh
 
-2.2.31: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.2
-2.2: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.2
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/httpd.git
 
-2.4.20: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.4
-2.4: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.4
-2: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.4
-latest: git://github.com/docker-library/httpd@07de32639616a6d307c3f4bb56a01d408d1765d6 2.4
+Tags: 2.2.31, 2.2
+GitCommit: 07de32639616a6d307c3f4bb56a01d408d1765d6
+Directory: 2.2
+
+Tags: 2.4.20, 2.4, 2, latest
+GitCommit: 07de32639616a6d307c3f4bb56a01d408d1765d6
+Directory: 2.4

--- a/library/java
+++ b/library/java
@@ -1,91 +1,53 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/openjdk/blob/290aeeea3effd363031e81475bb66e90cb99c05f/generate-stackbrew-library.sh
 
-6b38-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-6b38: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-6-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-6: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-openjdk-6b38-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-openjdk-6b38: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-openjdk-6-jdk: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
-openjdk-6: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jdk
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/openjdk.git
 
-6b38-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
-6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
-openjdk-6b38-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
-openjdk-6-jre: git://github.com/docker-library/openjdk@89851f0abc3a83cfad5248102f379d6a0bd3951a 6-jre
+Tags: 6b38-jdk, 6b38, 6-jdk, 6, openjdk-6b38-jdk, openjdk-6b38, openjdk-6-jdk, openjdk-6
+GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
+Directory: 6-jdk
 
-7u101-jdk: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-7u101: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-7-jdk: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-7: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-openjdk-7u101-jdk: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-openjdk-7u101: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-openjdk-7-jdk: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
-openjdk-7: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jdk
+Tags: 6b38-jre, 6-jre, openjdk-6b38-jre, openjdk-6-jre
+GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
+Directory: 6-jre
 
-7u91-jdk-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-7u91-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-7-jdk-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-7-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-openjdk-7u91-jdk-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-openjdk-7u91-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-openjdk-7-jdk-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
-openjdk-7-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jdk/alpine
+Tags: 7u101-jdk, 7u101, 7-jdk, 7, openjdk-7u101-jdk, openjdk-7u101, openjdk-7-jdk, openjdk-7
+GitCommit: a3f06bcbc86d16912a309cf4538a00caf9a6100c
+Directory: 7-jdk
 
-7u101-jre: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jre
-7-jre: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jre
-openjdk-7u101-jre: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jre
-openjdk-7-jre: git://github.com/docker-library/openjdk@a3f06bcbc86d16912a309cf4538a00caf9a6100c 7-jre
+Tags: 7u91-jdk-alpine, 7u91-alpine, 7-jdk-alpine, 7-alpine, openjdk-7u91-jdk-alpine, openjdk-7u91-alpine, openjdk-7-jdk-alpine, openjdk-7-alpine
+GitCommit: f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9
+Directory: 7-jdk/alpine
 
-7u91-jre-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jre/alpine
-7-jre-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jre/alpine
-openjdk-7u91-jre-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jre/alpine
-openjdk-7-jre-alpine: git://github.com/docker-library/openjdk@f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9 7-jre/alpine
+Tags: 7u101-jre, 7-jre, openjdk-7u101-jre, openjdk-7-jre
+GitCommit: a3f06bcbc86d16912a309cf4538a00caf9a6100c
+Directory: 7-jre
 
-8u91-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-8u91: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-8-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-8: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-latest: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-openjdk-8u91-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-openjdk-8u91: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-openjdk-8-jdk: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
-openjdk-8: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jdk
+Tags: 7u91-jre-alpine, 7-jre-alpine, openjdk-7u91-jre-alpine, openjdk-7-jre-alpine
+GitCommit: f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9
+Directory: 7-jre/alpine
 
-8u92-jdk-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-8u92-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-8-jdk-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-8-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-jdk-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-openjdk-8u92-jdk-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-openjdk-8u92-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-openjdk-8-jdk-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
-openjdk-8-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jdk/alpine
+Tags: 8u91-jdk, 8u91, 8-jdk, 8, jdk, latest, openjdk-8u91-jdk, openjdk-8u91, openjdk-8-jdk, openjdk-8
+GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
+Directory: 8-jdk
 
-8u91-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
-8-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
-openjdk-8u91-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
-openjdk-8-jre: git://github.com/docker-library/openjdk@a0a4970a343a3c021dad760f2281d20f61931e3c 8-jre
+Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
+GitCommit: c6c90f5e09a5dc1a1ccd662de8210342f94c673e
+Directory: 8-jdk/alpine
 
-8u92-jre-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jre/alpine
-8-jre-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jre/alpine
-jre-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jre/alpine
-openjdk-8u92-jre-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jre/alpine
-openjdk-8-jre-alpine: git://github.com/docker-library/openjdk@c6c90f5e09a5dc1a1ccd662de8210342f94c673e 8-jre/alpine
+Tags: 8u91-jre, 8-jre, jre, openjdk-8u91-jre, openjdk-8-jre
+GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
+Directory: 8-jre
 
-9-b116-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-9-b116: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-9-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-9: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-openjdk-9-b116-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-openjdk-9-b116: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-openjdk-9-jdk: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
-openjdk-9: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jdk
+Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine
+GitCommit: c6c90f5e09a5dc1a1ccd662de8210342f94c673e
+Directory: 8-jre/alpine
 
-9-b116-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
-9-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
-openjdk-9-b116-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
-openjdk-9-jre: git://github.com/docker-library/openjdk@4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 9-jre
+Tags: 9-b116-jdk, 9-b116, 9-jdk, 9, openjdk-9-b116-jdk, openjdk-9-b116, openjdk-9-jdk, openjdk-9
+GitCommit: 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177
+Directory: 9-jdk
+
+Tags: 9-b116-jre, 9-jre, openjdk-9-b116-jre, openjdk-9-jre
+GitCommit: 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177
+Directory: 9-jre

--- a/library/julia
+++ b/library/julia
@@ -1,5 +1,8 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/julia/blob/7cdd4477e389248fd42f9bf6a5d34324be1fbdc4/generate-stackbrew-library.sh
 
-0.4.5: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57
-0.4: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57
-latest: git://github.com/docker-library/julia@2bb511d3378dec17ebbf417d5865ede353ba8e57
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/julia.git
+
+Tags: 0.4.5, 0.4, 0, latest
+GitCommit: 2bb511d3378dec17ebbf417d5865ede353ba8e57

--- a/library/kibana
+++ b/library/kibana
@@ -1,26 +1,33 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/kibana/blob/e620aaea18f9836246293608d3894a28aee0abb3/generate-stackbrew-library.sh
 
-4.0.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
-4.0: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.0
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/kibana.git
 
-4.1.8: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 4.1
-4.1: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 4.1
+Tags: 4.0.3, 4.0
+GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
+Directory: 4.0
 
-4.2.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
-4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.2
+Tags: 4.1.8, 4.1
+GitCommit: 0beddcb3e86d1b623ada81d423aaa98e8500657f
+Directory: 4.1
 
-4.3.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.3
-4.3: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.3
+Tags: 4.2.2, 4.2
+GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
+Directory: 4.2
 
-4.4.2: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
-4.4: git://github.com/docker-library/kibana@9fc787378f38bc25616d7118741a74b42402d344 4.4
+Tags: 4.3.3, 4.3
+GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
+Directory: 4.3
 
-4.5.1: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
-4.5: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
-4: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
-latest: git://github.com/docker-library/kibana@2015c601bab8b77f0d13475f901c9b85e6014bdb 4.5
+Tags: 4.4.2, 4.4
+GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
+Directory: 4.4
 
-5.0.0-alpha3: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 5.0
-5.0.0: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 5.0
-5.0: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 5.0
-5: git://github.com/docker-library/kibana@0beddcb3e86d1b623ada81d423aaa98e8500657f 5.0
+Tags: 4.5.1, 4.5, 4, latest
+GitCommit: 2015c601bab8b77f0d13475f901c9b85e6014bdb
+Directory: 4.5
+
+Tags: 5.0.0-alpha3, 5.0.0, 5.0, 5
+GitCommit: 0beddcb3e86d1b623ada81d423aaa98e8500657f
+Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -1,35 +1,33 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/logstash/blob/167719ff104d13f698b72a47e0f54038dcbe170a/generate-stackbrew-library.sh
 
-1.4.5-1-a2bacae: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
-1.4.5-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
-1.4.5: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
-1.4: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.4
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/logstash.git
 
-1.5.6-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
-1.5.6: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
-1.5: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 1.5
+Tags: 1.4.5-1-a2bacae, 1.4.5-1, 1.4.5, 1.4
+GitCommit: fde2012d6c14d14fa52c359eaca8b2429e9ec98a
+Directory: 1.4
 
-2.0.0-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
-2.0.0: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
-2.0: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.0
+Tags: 1.5.6-1, 1.5.6, 1.5, 1
+GitCommit: fde2012d6c14d14fa52c359eaca8b2429e9ec98a
+Directory: 1.5
 
-2.1.3-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
-2.1.3: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
-2.1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.1
+Tags: 2.0.0-1, 2.0.0, 2.0
+GitCommit: fde2012d6c14d14fa52c359eaca8b2429e9ec98a
+Directory: 2.0
 
-2.2.4-1: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
-2.2.4: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
-2.2: git://github.com/docker-library/logstash@fde2012d6c14d14fa52c359eaca8b2429e9ec98a 2.2
+Tags: 2.1.3-1, 2.1.3, 2.1
+GitCommit: fde2012d6c14d14fa52c359eaca8b2429e9ec98a
+Directory: 2.1
 
-2.3.2-1: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
-2.3.2: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
-2.3: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
-2: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
-latest: git://github.com/docker-library/logstash@e01663a9974a17b7c97e1109f1ddcaa1f6089b47 2.3
+Tags: 2.2.4-1, 2.2.4, 2.2
+GitCommit: fde2012d6c14d14fa52c359eaca8b2429e9ec98a
+Directory: 2.2
 
-5.0.0-alpha3-1: git://github.com/docker-library/logstash@326b1c1be6ec24d75f8ea942ec2326af74b50257 5.0
-5.0.0-alpha3: git://github.com/docker-library/logstash@326b1c1be6ec24d75f8ea942ec2326af74b50257 5.0
-5.0.0: git://github.com/docker-library/logstash@326b1c1be6ec24d75f8ea942ec2326af74b50257 5.0
-5.0: git://github.com/docker-library/logstash@326b1c1be6ec24d75f8ea942ec2326af74b50257 5.0
-5: git://github.com/docker-library/logstash@326b1c1be6ec24d75f8ea942ec2326af74b50257 5.0
+Tags: 2.3.2-1, 2.3.2, 2.3, 2, latest
+GitCommit: e01663a9974a17b7c97e1109f1ddcaa1f6089b47
+Directory: 2.3
+
+Tags: 5.0.0-alpha3-1, 5.0.0-alpha3, 5.0.0, 5.0, 5
+GitCommit: 326b1c1be6ec24d75f8ea942ec2326af74b50257
+Directory: 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,13 +1,17 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/mariadb/blob/a09ad0056e1b95de7d448187770f6264d9e25fe2/generate-stackbrew-library.sh
 
-10.1.14: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
-10.1: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
-10: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
-latest: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.1
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/mariadb.git
 
-10.0.25: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.0
-10.0: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 10.0
+Tags: 10.1.14, 10.1, 10, latest
+GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
+Directory: 10.1
 
-5.5.49: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5
-5.5: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5
-5: git://github.com/docker-library/mariadb@053f101cfae5f000466464717afc5f2dc8c56284 5.5
+Tags: 10.0.25, 10.0
+GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
+Directory: 10.0
+
+Tags: 5.5.49, 5.5, 5
+GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
+Directory: 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -1,6 +1,8 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/memcached/blob/f193b9d71552198b4a96585e3612fadbaef19441/generate-stackbrew-library.sh
 
-1.4.25: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
-1.4: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
-1: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
-latest: git://github.com/docker-library/memcached@a8c4206768821aa47579c6413be85be914875caa
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/memcached.git
+
+Tags: 1.4.25, 1.4, 1, latest
+GitCommit: a8c4206768821aa47579c6413be85be914875caa

--- a/library/mongo
+++ b/library/mongo
@@ -1,16 +1,21 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/mongo/blob/bb1ed9efe67502a267fb94d677dd42874989e3b9/generate-stackbrew-library.sh
 
-2.6.12: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
-2.6: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
-2: git://github.com/docker-library/mongo@fc91d681fa5808c30c3118ce7fe3f993beccc82d 2.6
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/mongo.git
 
-3.0.12: git://github.com/docker-library/mongo@4b1d085ccab5728a9b9e4b65c5ed19820420809e 3.0
-3.0: git://github.com/docker-library/mongo@4b1d085ccab5728a9b9e4b65c5ed19820420809e 3.0
+Tags: 2.6.12, 2.6, 2
+GitCommit: fc91d681fa5808c30c3118ce7fe3f993beccc82d
+Directory: 2.6
 
-3.2.6: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
-3.2: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
-3: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
-latest: git://github.com/docker-library/mongo@4bb17b336a05ad85c9bf83b103d21529e27e62f9 3.2
+Tags: 3.0.12, 3.0
+GitCommit: 4b1d085ccab5728a9b9e4b65c5ed19820420809e
+Directory: 3.0
 
-3.3.8: git://github.com/docker-library/mongo@61925116dacc2767367a09c749d905110e17a0c8 3.3
-3.3: git://github.com/docker-library/mongo@61925116dacc2767367a09c749d905110e17a0c8 3.3
+Tags: 3.2.6, 3.2, 3, latest
+GitCommit: 4bb17b336a05ad85c9bf83b103d21529e27e62f9
+Directory: 3.2
+
+Tags: 3.3.8, 3.3
+GitCommit: 61925116dacc2767367a09c749d905110e17a0c8
+Directory: 3.3

--- a/library/mysql
+++ b/library/mysql
@@ -1,12 +1,17 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/mysql/blob/c7c1d85475749066b229691ade668bc49139d52f/generate-stackbrew-library.sh
 
-5.5.50: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.5
-5.5: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.5
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/mysql.git
 
-5.6.31: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.6
-5.6: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.6
+Tags: 5.7.13, 5.7, 5, latest
+GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Directory: 5.7
 
-5.7.13: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.7
-5.7: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.7
-5: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.7
-latest: git://github.com/docker-library/mysql@f7a67d7634a68d319988ad6f99729bfeaa84ceb2 5.7
+Tags: 5.6.31, 5.6
+GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Directory: 5.6
+
+Tags: 5.5.50, 5.5
+GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Directory: 5.5

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,55 +1,45 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/owncloud/blob/0afe04142674ef5f058bf7d1166fe37ea5aa0ea4/generate-stackbrew-library.sh
 
-# https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/owncloud.git
 
-7.0.15-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
-7.0.15: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
-7.0-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
-7.0: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
-7-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
-7: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/apache
+Tags: 7.0.15-apache, 7.0-apache, 7-apache, 7.0.15, 7.0, 7
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 7.0/apache
 
-7.0.15-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/fpm
-7.0-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/fpm
-7-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 7.0/fpm
+Tags: 7.0.15-fpm, 7.0-fpm, 7-fpm
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 7.0/fpm
 
-8.0.13-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/apache
-8.0.13: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/apache
-8.0-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/apache
-8.0: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/apache
+Tags: 8.0.13-apache, 8.0-apache, 8.0.13, 8.0
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.0/apache
 
-8.0.13-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/fpm
-8.0-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.0/fpm
+Tags: 8.0.13-fpm, 8.0-fpm
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.0/fpm
 
-8.1.8-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/apache
-8.1.8: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/apache
-8.1-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/apache
-8.1: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/apache
+Tags: 8.1.8-apache, 8.1-apache, 8.1.8, 8.1
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.1/apache
 
-8.1.8-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/fpm
-8.1-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.1/fpm
+Tags: 8.1.8-fpm, 8.1-fpm
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.1/fpm
 
-8.2.5-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
-8.2.5: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
-8.2-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
-8.2: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
-8-apache: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
-8: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/apache
+Tags: 8.2.5-apache, 8.2-apache, 8-apache, 8.2.5, 8.2, 8
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.2/apache
 
-8.2.5-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/fpm
-8.2-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/fpm
-8-fpm: git://github.com/docker-library/owncloud@e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff 8.2/fpm
+Tags: 8.2.5-fpm, 8.2-fpm, 8-fpm
+GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+Directory: 8.2/fpm
 
-9.0.2-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-9.0.2: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-9.0-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-9.0: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-9-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-9: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-apache: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
-latest: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/apache
+Tags: 9.0.2-apache, 9.0-apache, 9-apache, apache, 9.0.2, 9.0, 9, latest
+GitCommit: 903a0f09109ef1d94a9cd4895a859c880ab8d702
+Directory: 9.0/apache
 
-9.0.2-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
-9.0-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
-9-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
-fpm: git://github.com/docker-library/owncloud@903a0f09109ef1d94a9cd4895a859c880ab8d702 9.0/fpm
+Tags: 9.0.2-fpm, 9.0-fpm, 9-fpm, fpm
+GitCommit: 903a0f09109ef1d94a9cd4895a859c880ab8d702
+Directory: 9.0/fpm

--- a/library/percona
+++ b/library/percona
@@ -1,12 +1,17 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/percona/blob/11b6067c39e69db2c71f6c43edb902690dc5a132/generate-stackbrew-library.sh
 
-5.5.49: git://github.com/docker-library/percona@4501310f267a20434f10b28a8e1be660a3a09439 5.5
-5.5: git://github.com/docker-library/percona@4501310f267a20434f10b28a8e1be660a3a09439 5.5
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/percona.git
 
-5.6.30: git://github.com/docker-library/percona@5981db386679e99039de1104a28920939acf59fc 5.6
-5.6: git://github.com/docker-library/percona@5981db386679e99039de1104a28920939acf59fc 5.6
+Tags: 5.7.12, 5.7, 5, latest
+GitCommit: 340269718642a7acc4580e398121ba5462308730
+Directory: 5.7
 
-5.7.12: git://github.com/docker-library/percona@340269718642a7acc4580e398121ba5462308730 5.7
-5.7: git://github.com/docker-library/percona@340269718642a7acc4580e398121ba5462308730 5.7
-5: git://github.com/docker-library/percona@340269718642a7acc4580e398121ba5462308730 5.7
-latest: git://github.com/docker-library/percona@340269718642a7acc4580e398121ba5462308730 5.7
+Tags: 5.6.30, 5.6
+GitCommit: 5981db386679e99039de1104a28920939acf59fc
+Directory: 5.6
+
+Tags: 5.5.49, 5.5
+GitCommit: 4501310f267a20434f10b28a8e1be660a3a09439
+Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -1,94 +1,89 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/php/blob/6f3edbc07daf333581eb43d1c7a9149351a1f63b/generate-stackbrew-library.sh
 
-5.5.36-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
-5.5-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
-5.5.36: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
-5.5: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/php.git
 
-5.5.36-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/alpine
-5.5-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/alpine
+Tags: 7.0.7-cli, 7.0-cli, 7-cli, cli, 7.0.7, 7.0, 7, latest
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 7.0
 
-5.5.36-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/apache
-5.5-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/apache
+Tags: 7.0.7-alpine, 7.0-alpine, 7-alpine, alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 7.0/alpine
 
-5.5.36-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm
-5.5-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/fpm
+Tags: 7.0.7-apache, 7.0-apache, 7-apache, apache
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 7.0/apache
 
-5.5.36-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/fpm/alpine
-5.5-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/fpm/alpine
+Tags: 7.0.7-fpm, 7.0-fpm, 7-fpm, fpm
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 7.0/fpm
 
-5.5.36-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts
-5.5-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.5/zts
+Tags: 7.0.7-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 7.0/fpm/alpine
 
-5.5.36-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/zts/alpine
-5.5-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.5/zts/alpine
+Tags: 7.0.7-zts, 7.0-zts, 7-zts, zts
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 7.0/zts
 
-5.6.22-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
-5.6-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
-5-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
-5.6.22: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
-5.6: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
-5: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6
+Tags: 7.0.7-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 7.0/zts/alpine
 
-5.6.22-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
-5.6-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
-5-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/alpine
+Tags: 5.6.22-cli, 5.6-cli, 5-cli, 5.6.22, 5.6, 5
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.6
 
-5.6.22-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/apache
-5.6-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/apache
-5-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/apache
+Tags: 5.6.22-alpine, 5.6-alpine, 5-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.6/alpine
 
-5.6.22-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm
-5.6-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm
-5-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/fpm
+Tags: 5.6.22-apache, 5.6-apache, 5-apache
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.6/apache
 
-5.6.22-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
-5.6-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
-5-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/fpm/alpine
+Tags: 5.6.22-fpm, 5.6-fpm, 5-fpm
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.6/fpm
 
-5.6.22-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
-5.6-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
-5-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 5.6/zts
+Tags: 5.6.22-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.6/fpm/alpine
 
-5.6.22-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
-5.6-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
-5-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 5.6/zts/alpine
+Tags: 5.6.22-zts, 5.6-zts, 5-zts
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.6/zts
 
-7.0.7-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-7.0-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-7-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-cli: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-7.0.7: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-7.0: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-7: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
-latest: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0
+Tags: 5.6.22-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.6/zts/alpine
 
-7.0.7-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
-7.0-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
-7-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/alpine
+Tags: 5.5.36-cli, 5.5-cli, 5.5.36, 5.5
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.5
 
-7.0.7-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
-7.0-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
-7-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
-apache: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/apache
+Tags: 5.5.36-alpine, 5.5-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.5/alpine
 
-7.0.7-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
-7.0-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
-7-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
-fpm: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/fpm
+Tags: 5.5.36-apache, 5.5-apache
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.5/apache
 
-7.0.7-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
-7.0-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
-7-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
-fpm-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/fpm/alpine
+Tags: 5.5.36-fpm, 5.5-fpm
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.5/fpm
 
-7.0.7-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
-7.0-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
-7-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
-zts: git://github.com/docker-library/php@81ceba13187f9488f1ab25683575ac1b62fea772 7.0/zts
+Tags: 5.5.36-fpm-alpine, 5.5-fpm-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.5/fpm/alpine
 
-7.0.7-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
-7.0-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
-7-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
-zts-alpine: git://github.com/docker-library/php@3099068733b51ad67ce19b49fc32d949cb432181 7.0/zts/alpine
+Tags: 5.5.36-zts, 5.5-zts
+GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+Directory: 5.5/zts
+
+Tags: 5.5.36-zts-alpine, 5.5-zts-alpine
+GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+Directory: 5.5/zts/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -1,21 +1,29 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/postgres/blob/4e48e3228a30763913ece952c611e5e9b95c8759/generate-stackbrew-library.sh
 
-9.1.22: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.1
-9.1: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.1
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/postgres.git
 
-9.2.17: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.2
-9.2: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.2
+Tags: 9.6-beta1, 9.6
+GitCommit: b1831ce069d10b14be05b9ddf6823e3d18c62cee
+Directory: 9.6
 
-9.3.13: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.3
-9.3: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.3
+Tags: 9.5.3, 9.5, 9, latest
+GitCommit: 04b1d366d51a942b88fff6c62943f92c7c38d9b6
+Directory: 9.5
 
-9.4.8: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.4
-9.4: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.4
+Tags: 9.4.8, 9.4
+GitCommit: 04b1d366d51a942b88fff6c62943f92c7c38d9b6
+Directory: 9.4
 
-9.5.3: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
-9.5: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
-9: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
-latest: git://github.com/docker-library/postgres@04b1d366d51a942b88fff6c62943f92c7c38d9b6 9.5
+Tags: 9.3.13, 9.3
+GitCommit: 04b1d366d51a942b88fff6c62943f92c7c38d9b6
+Directory: 9.3
 
-9.6-beta1: git://github.com/docker-library/postgres@b1831ce069d10b14be05b9ddf6823e3d18c62cee 9.6
-9.6: git://github.com/docker-library/postgres@b1831ce069d10b14be05b9ddf6823e3d18c62cee 9.6
+Tags: 9.2.17, 9.2
+GitCommit: 04b1d366d51a942b88fff6c62943f92c7c38d9b6
+Directory: 9.2
+
+Tags: 9.1.22, 9.1
+GitCommit: 04b1d366d51a942b88fff6c62943f92c7c38d9b6
+Directory: 9.1

--- a/library/pypy
+++ b/library/pypy
@@ -1,34 +1,29 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/pypy/blob/089d2c270aeab809000d301b409d200914eb5aa9/generate-stackbrew-library.sh
 
-2-5.1.1: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
-2-5.1: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
-2-5: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
-2: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/pypy.git
 
-2-5.1.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-5.1-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-5-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 2/onbuild
+Tags: 2-5.1.1, 2-5.1, 2-5, 2
+GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Directory: 2
 
-2-5.1.1-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
-2-5.1-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
-2-5-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
-2-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 2/slim
+Tags: 2-5.1.1-slim, 2-5.1-slim, 2-5-slim, 2-slim
+GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Directory: 2/slim
 
-3-2.4.0: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
-3-2.4: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
-3-2: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
-3: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
-latest: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3
+Tags: 2-5.1.1-onbuild, 2-5.1-onbuild, 2-5-onbuild, 2-onbuild
+GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
+Directory: 2/onbuild
 
-3-2.4.0-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
-3-2.4-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
-3-2-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
-3-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
-onbuild: git://github.com/docker-library/pypy@b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48 3/onbuild
+Tags: 3-2.4.0, 3-2.4, 3-2, 3, latest
+GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Directory: 3
 
-3-2.4.0-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
-3-2.4-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
-3-2-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
-3-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
-slim: git://github.com/docker-library/pypy@d0f1f8cf3dd4a4feefa0f6d101e40583429f647f 3/slim
+Tags: 3-2.4.0-slim, 3-2.4-slim, 3-2-slim, 3-slim, slim
+GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Directory: 3/slim
+
+Tags: 3-2.4.0-onbuild, 3-2.4-onbuild, 3-2-onbuild, 3-onbuild, onbuild
+GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
+Directory: 3/onbuild

--- a/library/python
+++ b/library/python
@@ -1,71 +1,81 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/python/blob/795e8bf88a2a6431f3a876a858396adc4432dcf3/generate-stackbrew-library.sh
 
-2.7.11: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
-2.7: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
-2: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/python.git
 
-2.7.11-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
-2.7-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
-2-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 2.7/onbuild
+Tags: 2.7.11, 2.7, 2
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 2.7
 
-2.7.11-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
-2.7-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
-2-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/slim
+Tags: 2.7.11-slim, 2.7-slim, 2-slim
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 2.7/slim
 
-2.7.11-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
-2.7-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
-2-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 2.7/alpine
+Tags: 2.7.11-alpine, 2.7-alpine, 2-alpine
+GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Directory: 2.7/alpine
 
-2.7.11-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
-2.7-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
-2-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 2.7/wheezy
+Tags: 2.7.11-wheezy, 2.7-wheezy, 2-wheezy
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 2.7/wheezy
 
-3.3.6: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3
-3.3: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3
+Tags: 2.7.11-onbuild, 2.7-onbuild, 2-onbuild
+GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
+Directory: 2.7/onbuild
 
-3.3.6-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
-3.3-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.3/onbuild
+Tags: 3.3.6, 3.3
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.3
 
-3.3.6-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
-3.3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/slim
+Tags: 3.3.6-slim, 3.3-slim
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.3/slim
 
-3.3.6-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.3/alpine
-3.3-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.3/alpine
+Tags: 3.3.6-alpine, 3.3-alpine
+GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Directory: 3.3/alpine
 
-3.3.6-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
-3.3-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.3/wheezy
+Tags: 3.3.6-wheezy, 3.3-wheezy
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.3/wheezy
 
-3.4.4: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4
-3.4: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4
+Tags: 3.3.6-onbuild, 3.3-onbuild
+GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
+Directory: 3.3/onbuild
 
-3.4.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
-3.4-onbuild: git://github.com/docker-library/python@7663560df7547e69d13b1b548675502f4e0917d1 3.4/onbuild
+Tags: 3.4.4, 3.4
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.4
 
-3.4.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
-3.4-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/slim
+Tags: 3.4.4-slim, 3.4-slim
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.4/slim
 
-3.4.4-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.4/alpine
-3.4-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.4/alpine
+Tags: 3.4.4-alpine, 3.4-alpine
+GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Directory: 3.4/alpine
 
-3.4.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
-3.4-wheezy: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.4/wheezy
+Tags: 3.4.4-wheezy, 3.4-wheezy
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.4/wheezy
 
-3.5.1: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
-3.5: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
-3: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
-latest: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5
+Tags: 3.4.4-onbuild, 3.4-onbuild
+GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
+Directory: 3.4/onbuild
 
-3.5.1-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
-3.5-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
-3-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
-onbuild: git://github.com/docker-library/python@0fa3202789648132971160f686f5a37595108f44 3.5/onbuild
+Tags: 3.5.1, 3.5, 3, latest
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.5
 
-3.5.1-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
-3.5-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
-3-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
-slim: git://github.com/docker-library/python@9383f7d4d2f96068e8957651aa3588fee8b48f71 3.5/slim
+Tags: 3.5.1-slim, 3.5-slim, 3-slim, slim
+GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Directory: 3.5/slim
 
-3.5.1-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
-3.5-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
-3-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
-alpine: git://github.com/docker-library/python@0610d9ccc2dc8ad4ab6038f775e7a28cadf12114 3.5/alpine
+Tags: 3.5.1-alpine, 3.5-alpine, 3-alpine, alpine
+GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Directory: 3.5/alpine
+
+Tags: 3.5.1-onbuild, 3.5-onbuild, 3-onbuild, onbuild
+GitCommit: 0fa3202789648132971160f686f5a37595108f44
+Directory: 3.5/onbuild

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,11 +1,12 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/6d3777cae4ac310b4801b954413692ee4d853927/generate-stackbrew-library.sh
 
-3.6.2: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
-3.6: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
-3: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
-latest: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/rabbitmq.git
 
-3.6.2-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
-3.6-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
-3-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
-management: git://github.com/docker-library/rabbitmq@6b496ac32e18fbff4b2b45e0577a79b10edd4df0 management
+Tags: 3.6.2, 3.6, 3, latest
+GitCommit: 6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+
+Tags: 3.6.2-management, 3.6-management, 3-management, management
+GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d
+Directory: management

--- a/library/rails
+++ b/library/rails
@@ -1,8 +1,12 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/rails/blob/bd6822c973c76fbf84f891a42a5d3a68bf66fa08/generate-stackbrew-library.sh
 
-4.2.6: git://github.com/docker-library/rails@04006011344175c10b6864193eee74d626b84b11
-4.2: git://github.com/docker-library/rails@04006011344175c10b6864193eee74d626b84b11
-4: git://github.com/docker-library/rails@04006011344175c10b6864193eee74d626b84b11
-latest: git://github.com/docker-library/rails@04006011344175c10b6864193eee74d626b84b11
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/rails.git
 
-onbuild: git://github.com/docker-library/rails@9df9b5e6b1519faf22e1565c2caaebf7cc1c665b onbuild
+Tags: 4.2.6, 4.2, 4, latest
+GitCommit: 04006011344175c10b6864193eee74d626b84b11
+
+Tags: onbuild
+GitCommit: 9df9b5e6b1519faf22e1565c2caaebf7cc1c665b
+Directory: onbuild

--- a/library/redis
+++ b/library/redis
@@ -1,33 +1,37 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/redis/blob/5169c4beff205f6523b16aaa17d8297f5ebcf9f9/generate-stackbrew-library.sh
 
-2.8.23: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8
-2.8: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8
-2: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/redis.git
 
-2.8.23-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8/32bit
-2.8-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8/32bit
-2-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 2.8/32bit
+Tags: 2.8.23, 2.8, 2
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 2.8
 
-3.0.7: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0
-3.0: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0
+Tags: 2.8.23-32bit, 2.8-32bit, 2-32bit
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 2.8/32bit
 
-3.0.7-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/32bit
-3.0-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.0/32bit
+Tags: 3.0.7, 3.0
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 3.0
 
-3.0.7-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.0/alpine
-3.0-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.0/alpine
+Tags: 3.0.7-32bit, 3.0-32bit
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 3.0/32bit
 
-3.2.0: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
-3.2: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
-3: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
-latest: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2
+Tags: 3.0.7-alpine, 3.0-alpine
+GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
+Directory: 3.0/alpine
 
-3.2.0-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
-3.2-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
-3-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
-32bit: git://github.com/docker-library/redis@6cb8a8015f126e2a7251c5d011b86b657e9febd6 3.2/32bit
+Tags: 3.2.0, 3.2, 3, latest
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 3.2
 
-3.2.0-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
-3.2-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
-3-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
-alpine: git://github.com/docker-library/redis@c49a42f6efcd2b971e43e93116a976b058035544 3.2/alpine
+Tags: 3.2.0-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Directory: 3.2/32bit
+
+Tags: 3.2.0-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
+Directory: 3.2/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -1,31 +1,37 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/redmine/blob/34dd432399eb6b082989bb90b0f7938537066590/generate-stackbrew-library.sh
 
-2.6.10: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
-2.6: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
-2: git://github.com/docker-library/redmine@59319e8ad8ddd777d88b76de6bb10cc7e54d01b3 2.6
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/redmine.git
 
-2.6.10-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
-2.6-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
-2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 2.6/passenger
+Tags: 2.6.10, 2.6, 2
+GitCommit: 59319e8ad8ddd777d88b76de6bb10cc7e54d01b3
+Directory: 2.6
 
-3.0.7: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
-3.0: git://github.com/docker-library/redmine@99752f3d9bc5ccd9f69d16e2105d287df17f5ac2 3.0
+Tags: 2.6.10-passenger, 2.6-passenger, 2-passenger
+GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+Directory: 2.6/passenger
 
-3.0.7-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
-3.0-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.0/passenger
+Tags: 3.0.7, 3.0
+GitCommit: 99752f3d9bc5ccd9f69d16e2105d287df17f5ac2
+Directory: 3.0
 
-3.1.6: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.1
-3.1: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.1
+Tags: 3.0.7-passenger, 3.0-passenger
+GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+Directory: 3.0/passenger
 
-3.1.6-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
-3.1-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.1/passenger
+Tags: 3.1.6, 3.1
+GitCommit: 7e94beb1e1979251c7b64e465738405a85e316e8
+Directory: 3.1
 
-3.2.3: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.2
-3.2: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.2
-3: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.2
-latest: git://github.com/docker-library/redmine@7e94beb1e1979251c7b64e465738405a85e316e8 3.2
+Tags: 3.1.6-passenger, 3.1-passenger
+GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+Directory: 3.1/passenger
 
-3.2.3-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
-3.2-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
-3-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
-passenger: git://github.com/docker-library/redmine@9fdf8a16772d46ce8b9596c1edf887b96700f71c 3.2/passenger
+Tags: 3.2.3, 3.2, 3, latest
+GitCommit: 7e94beb1e1979251c7b64e465738405a85e316e8
+Directory: 3.2
+
+Tags: 3.2.3-passenger, 3.2-passenger, 3-passenger, passenger
+GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,53 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/ruby/blob/2dabbe3334950b9df116a7816aca915d606a45cd/generate-stackbrew-library.sh
 
-2.1.9: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.1
-2.1: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.1
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/ruby.git
 
-2.1.9-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
-2.1-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.1/onbuild
+Tags: 2.1.9, 2.1
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.1
 
-2.1.9-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.1/slim
-2.1-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.1/slim
+Tags: 2.1.9-slim, 2.1-slim
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.1/slim
 
-2.1.9-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.1/alpine
-2.1-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.1/alpine
+Tags: 2.1.9-alpine, 2.1-alpine
+GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+Directory: 2.1/alpine
 
-2.2.5: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.2
-2.2: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.2
+Tags: 2.1.9-onbuild, 2.1-onbuild
+GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
+Directory: 2.1/onbuild
 
-2.2.5-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
-2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
+Tags: 2.2.5, 2.2
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.2
 
-2.2.5-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.2/slim
-2.2-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.2/slim
+Tags: 2.2.5-slim, 2.2-slim
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.2/slim
 
-2.2.5-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.2/alpine
-2.2-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.2/alpine
+Tags: 2.2.5-alpine, 2.2-alpine
+GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+Directory: 2.2/alpine
 
-2.3.1: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3
-2.3: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3
-2: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3
-latest: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3
+Tags: 2.2.5-onbuild, 2.2-onbuild
+GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
+Directory: 2.2/onbuild
 
-2.3.1-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
-2.3-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
-2-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
-onbuild: git://github.com/docker-library/ruby@1b08f346713a1293c2a9238e470e086126e2e28f 2.3/onbuild
+Tags: 2.3.1, 2.3, 2, latest
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.3
 
-2.3.1-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3/slim
-2.3-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3/slim
-2-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3/slim
-slim: git://github.com/docker-library/ruby@a6202f065bc6d5562703eed454e3479359234750 2.3/slim
+Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
+GitCommit: a6202f065bc6d5562703eed454e3479359234750
+Directory: 2.3/slim
 
-2.3.1-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.3/alpine
-2.3-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.3/alpine
-2-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.3/alpine
-alpine: git://github.com/docker-library/ruby@972ed547de34b8644de4819001906cfc79907be2 2.3/alpine
+Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
+GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+Directory: 2.3/alpine
+
+Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild
+GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
+Directory: 2.3/onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,49 +1,37 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/tomcat/blob/004edbd80fbc5da064b48b7de61d018a88206839/generate-stackbrew-library.sh
 
-6.0.45-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
-6.0-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
-6-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
-6.0.45: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
-6.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
-6: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre7
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/tomcat.git
 
-6.0.45-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
-6.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
-6-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 6/jre8
+Tags: 6.0.45-jre7, 6.0-jre7, 6-jre7, 6.0.45, 6.0, 6
+GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Directory: 6/jre7
 
-7.0.69-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
-7.0-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
-7-jre7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
-7.0.69: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
-7.0: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
-7: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre7
+Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
+GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Directory: 6/jre8
 
-7.0.69-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
-7.0-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
-7-jre8: git://github.com/docker-library/tomcat@ec75141e3cb6276b07d66c16042152e2d4de119c 7/jre8
+Tags: 7.0.69-jre7, 7.0-jre7, 7-jre7, 7.0.69, 7.0, 7
+GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Directory: 7/jre7
 
-8.0.35-jre7: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-8.0-jre7: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-8-jre7: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-8.0.35: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-8.0: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
-latest: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre7
+Tags: 7.0.69-jre8, 7.0-jre8, 7-jre8
+GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Directory: 7/jre8
 
-8.0.35-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre8
-8.0-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre8
-8-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.0/jre8
+Tags: 8.0.35-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.35, 8.0, 8, latest
+GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Directory: 8.0/jre7
 
-8.5.2-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.5/jre8
-8.5-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.5/jre8
-8.5.2: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.5/jre8
-8.5: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 8.5/jre8
+Tags: 8.0.35-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Directory: 8.0/jre8
 
-9.0.0.M6-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9.0.0-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9.0-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9-jre8: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9.0.0.M6: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9.0.0: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9.0: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
-9: git://github.com/docker-library/tomcat@d08341e2ed934abd7ff1baa0c26d6eac4f45f73a 9.0/jre8
+Tags: 8.5.2-jre8, 8.5-jre8, 8.5.2, 8.5
+GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Directory: 8.5/jre8
+
+Tags: 9.0.0.M6-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M6, 9.0.0, 9.0, 9
+GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Directory: 9.0/jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,15 +1,13 @@
-# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# this file is generated via https://github.com/docker-library/wordpress/blob/60e216811a18dcff77c78ad45cc55a21ac7b0b46/generate-stackbrew-library.sh
 
-4.5.2-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-4.5.2: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-4.5-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-4.5: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-4-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-apache: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-4: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
-latest: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c apache
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+GitRepo: https://github.com/docker-library/wordpress.git
 
-4.5.2-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
-4.5-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
-4-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
-fpm: git://github.com/docker-library/wordpress@61dd78ce4fa9ccd592ead1edb379f209533b850c fpm
+Tags: 4.5.2-apache, 4.5-apache, 4-apache, apache, 4.5.2, 4.5, 4, latest
+GitCommit: 61dd78ce4fa9ccd592ead1edb379f209533b850c
+Directory: apache
+
+Tags: 4.5.2-fpm, 4.5-fpm, 4-fpm, fpm
+GitCommit: 61dd78ce4fa9ccd592ead1edb379f209533b850c
+Directory: fpm


### PR DESCRIPTION
```
{{- range $i, $e := $.Entries -}}
	{{- range $i, $t := $.Tags "" false $e -}}
		{{- join " - " $t ($e.GitRepo | replace "git://" "" "https://" "" ".git" "") $e.GitCommit $e.Directory -}}
		{{- "\n" -}}
	{{- end -}}
{{- end -}}
```

```diff
@@ -270,6 +270,7 @@ java:openjdk-9-b116-jdk - github.com/docker-library/openjdk - 4427d56d00bbd05b6c
 java:openjdk-9-b116-jre - github.com/docker-library/openjdk - 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 - 9-jre
 java:openjdk-9-jdk - github.com/docker-library/openjdk - 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 - 9-jdk
 java:openjdk-9-jre - github.com/docker-library/openjdk - 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177 - 9-jre
+julia:0 - github.com/docker-library/julia - 2bb511d3378dec17ebbf417d5865ede353ba8e57 - .
 julia:0.4 - github.com/docker-library/julia - 2bb511d3378dec17ebbf417d5865ede353ba8e57 - .
 julia:0.4.5 - github.com/docker-library/julia - 2bb511d3378dec17ebbf417d5865ede353ba8e57 - .
 julia:latest - github.com/docker-library/julia - 2bb511d3378dec17ebbf417d5865ede353ba8e57 - .
@@ -565,13 +566,13 @@ python:latest - github.com/docker-library/python - 9383f7d4d2f96068e8957651aa358
 python:onbuild - github.com/docker-library/python - 0fa3202789648132971160f686f5a37595108f44 - 3.5/onbuild
 python:slim - github.com/docker-library/python - 9383f7d4d2f96068e8957651aa3588fee8b48f71 - 3.5/slim
 rabbitmq:3 - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - .
-rabbitmq:3-management - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - management
+rabbitmq:3-management - github.com/docker-library/rabbitmq - dc712681dcaeadb0371be66be5e96563be364e5d - management
 rabbitmq:3.6 - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - .
-rabbitmq:3.6-management - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - management
+rabbitmq:3.6-management - github.com/docker-library/rabbitmq - dc712681dcaeadb0371be66be5e96563be364e5d - management
 rabbitmq:3.6.2 - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - .
-rabbitmq:3.6.2-management - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - management
+rabbitmq:3.6.2-management - github.com/docker-library/rabbitmq - dc712681dcaeadb0371be66be5e96563be364e5d - management
 rabbitmq:latest - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - .
-rabbitmq:management - github.com/docker-library/rabbitmq - 6b496ac32e18fbff4b2b45e0577a79b10edd4df0 - management
+rabbitmq:management - github.com/docker-library/rabbitmq - dc712681dcaeadb0371be66be5e96563be364e5d - management
 rails:4 - github.com/docker-library/rails - 04006011344175c10b6864193eee74d626b84b11 - .
 rails:4.2 - github.com/docker-library/rails - 04006011344175c10b6864193eee74d626b84b11 - .
 rails:4.2.6 - github.com/docker-library/rails - 04006011344175c10b6864193eee74d626b84b11 - .
@@ -694,6 +695,8 @@ tomcat:9.0.0 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6e
 tomcat:9.0.0-jre8 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 9.0/jre8
 tomcat:9.0.0.M6 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 9.0/jre8
 tomcat:9.0.0.M6-jre8 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 9.0/jre8
+tomcat:jre7 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 8.0/jre7
+tomcat:jre8 - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 8.0/jre8
 tomcat:latest - github.com/docker-library/tomcat - d08341e2ed934abd7ff1baa0c26d6eac4f45f73a - 8.0/jre7
 wordpress:4 - github.com/docker-library/wordpress - 61dd78ce4fa9ccd592ead1edb379f209533b850c - apache
 wordpress:4-apache - github.com/docker-library/wordpress - 61dd78ce4fa9ccd592ead1edb379f209533b850c - apache
```