### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -17,5 +17,5 @@ GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
 Directory: 3.0
 
 Tags: 3.5, 3, latest
-GitCommit: b1edfd288bc54c5eccbc19f8fd492b0bf518ed1b
+GitCommit: 0144b0ca0e2899f2628bfd0cb66f9dc68fb13ad5
 Directory: 3.5

--- a/library/ghost
+++ b/library/ghost
@@ -5,4 +5,4 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 0.8.0, 0.8, 0, latest
-GitCommit: dd8e79cfb3bd3ad7be1ce7a79708b6d21b736c67
+GitCommit: e625fca128f8f6b41533e78a9c262701ce9027f5


### PR DESCRIPTION
- `cassandra`: apply earlier `SEEDS` change to 3.5 as well
- `ghost`: update from Node 4.2 to Node 4 (following Node LTS; see http://support.ghost.org/supported-node-versions/ and https://github.com/nodejs/LTS)