### PR TITLE
fix openSUSE-13.2 build

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -9,8 +9,8 @@ GitFetch: refs/heads/openSUSE-42.1
 GitCommit: d529ec4ff604e41997fd98b6ade9715ab20cf75c
 
 Tags: 13.2, harlequin
-GitFetch: refs/heads/openSUSE-13.1
-GitCommit: 0d21bc58cd26da2a0a59588affc506b977d6a846
+GitFetch: refs/heads/openSUSE-13.2
+GitCommit: 6bcc5f50a8eac7b37d9d55d905e72d986b727436
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed


### PR DESCRIPTION
openSUSE-13.2 was falsely set to openSUSE-13.1 before.
ping @flavio

Signed-off-by: Christian Brauner <cbrauner@suse.com>