### PR TITLE
openSUSE-13.2: update image

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -10,7 +10,7 @@ GitCommit: d529ec4ff604e41997fd98b6ade9715ab20cf75c
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 6bcc5f50a8eac7b37d9d55d905e72d986b727436
+GitCommit: 278482aef59e6637702f74b07390e8543bb918f3
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed


### PR DESCRIPTION
The image version has been updated.
/cc @jordimassaguerpla @flavio 

Signed-off-by: Christian Brauner <cbrauner@suse.com>