### PR TITLE
update swarm v1.2.4-rc1, remove older versions

### DIFF
--- a/library/swarm
+++ b/library/swarm
@@ -5,8 +5,6 @@
 # maintainer: Victor Vieux <vieux@docker.com> (@vieux)
 
 
-1.0.0: git://github.com/docker/swarm-library-image@84c0d7d2d98d5f4f4178e517523925c1d5ebe7cc
-1.0.1: git://github.com/docker/swarm-library-image@8fc43f5ab8f0a25872bb7ed6237f68dd673c1e79
 1.1.0: git://github.com/docker/swarm-library-image@d33db37e1b31d202ac7c05104bf7b5e3faa70fc9
 1.1.1: git://github.com/docker/swarm-library-image@9346bd71c2a9b1433a663b8c2fe20b2636585f54
 1.1.2: git://github.com/docker/swarm-library-image@5f284e33ef90b7bc30684ad09a5261c037fc9d5e
@@ -15,4 +13,5 @@
 1.2.1: git://github.com/docker/swarm-library-image@9d4e009b40520720ceb270408b8078284df9513e
 1.2.2: git://github.com/docker/swarm-library-image@1f9089c40ac560e7b4c878ad6bd7803f4f061e82
 1.2.3: git://github.com/docker/swarm-library-image@a1b25fc6cd2a6175d17a8ae5241c31996e8faaa8
+1.2.4-rc1: git://github.com/docker/swarm-library-image@2600149d6ab1647736d0e70e7e4bac1fcecf5c99
 latest: git://github.com/docker/swarm-library-image@a1b25fc6cd2a6175d17a8ae5241c31996e8faaa8


### PR DESCRIPTION
Added latest RC, removing 1.0.*

cc @vieux 

Ping @tianon 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>