### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -12,8 +12,8 @@ Tags: 2.2.6, 2.2, 2
 GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
 Directory: 2.2
 
-Tags: 3.0.6, 3.0
-GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Tags: 3.0.7, 3.0
+GitCommit: f387127a9bbf07439a09a95135936be42fc35277
 Directory: 3.0
 
 Tags: 3.5, 3, latest

--- a/library/logstash
+++ b/library/logstash
@@ -29,5 +29,5 @@ GitCommit: e01663a9974a17b7c97e1109f1ddcaa1f6089b47
 Directory: 2.3
 
 Tags: 5.0.0-alpha3-1, 5.0.0-alpha3, 5.0.0, 5.0, 5
-GitCommit: 326b1c1be6ec24d75f8ea942ec2326af74b50257
+GitCommit: 110f40d8444f4b5b5eaa012e8bfa9a25a41cfa12
 Directory: 5.0

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,14 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 7.0.15-apache, 7.0-apache, 7-apache, 7.0.15, 7.0, 7
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
-Directory: 7.0/apache
-
-Tags: 7.0.15-fpm, 7.0-fpm, 7-fpm
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
-Directory: 7.0/fpm
-
 Tags: 8.0.13-apache, 8.0-apache, 8.0.13, 8.0
 GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
 Directory: 8.0/apache
@@ -21,25 +13,25 @@ GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
 Directory: 8.0/fpm
 
 Tags: 8.1.8-apache, 8.1-apache, 8.1.8, 8.1
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 8.1/apache
 
 Tags: 8.1.8-fpm, 8.1-fpm
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 8.1/fpm
 
 Tags: 8.2.5-apache, 8.2-apache, 8-apache, 8.2.5, 8.2, 8
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 8.2/apache
 
 Tags: 8.2.5-fpm, 8.2-fpm, 8-fpm
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 8.2/fpm
 
 Tags: 9.0.2-apache, 9.0-apache, 9-apache, apache, 9.0.2, 9.0, 9, latest
-GitCommit: 903a0f09109ef1d94a9cd4895a859c880ab8d702
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 9.0/apache
 
 Tags: 9.0.2-fpm, 9.0-fpm, 9-fpm, fpm
-GitCommit: 903a0f09109ef1d94a9cd4895a859c880ab8d702
+GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 9.0/fpm

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.0.7-cli, 7.0-cli, 7-cli, cli, 7.0.7, 7.0, 7, latest
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 7.0
 
 Tags: 7.0.7-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 7.0/alpine
 
 Tags: 7.0.7-apache, 7.0-apache, 7-apache, apache
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 7.0/apache
 
 Tags: 7.0.7-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 7.0/fpm
 
 Tags: 7.0.7-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.7-zts, 7.0-zts, 7-zts, zts
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 7.0/zts
 
 Tags: 7.0.7-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.22-cli, 5.6-cli, 5-cli, 5.6.22, 5.6, 5
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.6
 
 Tags: 5.6.22-alpine, 5.6-alpine, 5-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.6/alpine
 
 Tags: 5.6.22-apache, 5.6-apache, 5-apache
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.6/apache
 
 Tags: 5.6.22-fpm, 5.6-fpm, 5-fpm
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.6/fpm
 
 Tags: 5.6.22-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.22-zts, 5.6-zts, 5-zts
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.6/zts
 
 Tags: 5.6.22-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.6/zts/alpine
 
 Tags: 5.5.36-cli, 5.5-cli, 5.5.36, 5.5
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.5
 
 Tags: 5.5.36-alpine, 5.5-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.5/alpine
 
 Tags: 5.5.36-apache, 5.5-apache
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.5/apache
 
 Tags: 5.5.36-fpm, 5.5-fpm
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.5/fpm
 
 Tags: 5.5.36-fpm-alpine, 5.5-fpm-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.5/fpm/alpine
 
 Tags: 5.5.36-zts, 5.5-zts
-GitCommit: 81ceba13187f9488f1ab25683575ac1b62fea772
+GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
 Directory: 5.5/zts
 
 Tags: 5.5.36-zts-alpine, 5.5-zts-alpine
-GitCommit: 3099068733b51ad67ce19b49fc32d949cb432181
+GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
 Directory: 5.5/zts/alpine

--- a/library/pypy
+++ b/library/pypy
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.1.1, 2-5.1, 2-5, 2
-GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Tags: 2-5.3.0, 2-5.3, 2-5, 2
+GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
 Directory: 2
 
-Tags: 2-5.1.1-slim, 2-5.1-slim, 2-5-slim, 2-slim
-GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Tags: 2-5.3.0-slim, 2-5.3-slim, 2-5-slim, 2-slim
+GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
 Directory: 2/slim
 
-Tags: 2-5.1.1-onbuild, 2-5.1-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.3.0-onbuild, 2-5.3-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-2.4.0, 3-2.4, 3-2, 3, latest
-GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Tags: 3-5.2.0-alpha1, 3-5.2.0, 3-5.2, 3-5, 3, latest
+GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
 Directory: 3
 
-Tags: 3-2.4.0-slim, 3-2.4-slim, 3-2-slim, 3-slim, slim
-GitCommit: d0f1f8cf3dd4a4feefa0f6d101e40583429f647f
+Tags: 3-5.2.0-alpha1-slim, 3-5.2.0-slim, 3-5.2-slim, 3-5-slim, 3-slim, slim
+GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
 Directory: 3/slim
 
-Tags: 3-2.4.0-onbuild, 3-2.4-onbuild, 3-2-onbuild, 3-onbuild, onbuild
+Tags: 3-5.2.0-alpha1-onbuild, 3-5.2.0-onbuild, 3-5.2-onbuild, 3-5-onbuild, 3-onbuild, onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.33.0: git://github.com/RocketChat/Docker.Official.Image@13acd7125ec208e41aa58bbafd3c09aa5b1e6906
-0.33: git://github.com/RocketChat/Docker.Official.Image@13acd7125ec208e41aa58bbafd3c09aa5b1e6906
-0: git://github.com/RocketChat/Docker.Official.Image@13acd7125ec208e41aa58bbafd3c09aa5b1e6906
-latest: git://github.com/RocketChat/Docker.Official.Image@13acd7125ec208e41aa58bbafd3c09aa5b1e6906
+0.34.0: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
+0.34: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
+0: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
+latest: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6

--- a/library/tomcat
+++ b/library/tomcat
@@ -20,18 +20,18 @@ Tags: 7.0.69-jre8, 7.0-jre8, 7-jre8
 GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
 Directory: 7/jre8
 
-Tags: 8.0.35-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.35, 8.0, 8, latest
-GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Tags: 8.0.36-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.36, 8.0, 8, latest
+GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
 Directory: 8.0/jre7
 
-Tags: 8.0.35-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Tags: 8.0.36-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
 Directory: 8.0/jre8
 
-Tags: 8.5.2-jre8, 8.5-jre8, 8.5.2, 8.5
-GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Tags: 8.5.3-jre8, 8.5-jre8, 8.5.3, 8.5
+GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
 Directory: 8.5/jre8
 
-Tags: 9.0.0.M6-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M6, 9.0.0, 9.0, 9
-GitCommit: d08341e2ed934abd7ff1baa0c26d6eac4f45f73a
+Tags: 9.0.0.M8-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M8, 9.0.0, 9.0, 9
+GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
 Directory: 9.0/jre8


### PR DESCRIPTION
- `cassandra`: 3.0.7
- `logstash`: fix `PATH` in 5.0.0-alpha3 (docker-library/logstash#50)
- `owncloud`: fix failing `pecl install` invocations, remove EOL 7.0
- `php`: fix `docker-php-ext-configure` to install deps if necessary in Alpine (docker-library/php#239)
- `pypy`: 3.3-5.2.0-alpha1 and 2-5.3.0
- `rocket.chat`: 0.34.0
- `tomcat`: 8.0.36, 8.5.3, 9.0.0.M8