### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -12,6 +12,6 @@ Tags: 10.0.25, 10.0
 GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
 Directory: 10.0
 
-Tags: 5.5.49, 5.5, 5
-GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
+Tags: 5.5.50, 5.5, 5
+GitCommit: 35bec16e10203a30ed66f4e0a1571ce816c6b4d2
 Directory: 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -1,8 +1,13 @@
-# this file is generated via https://github.com/docker-library/memcached/blob/f193b9d71552198b4a96585e3612fadbaef19441/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/memcached/blob/f824f7200908afa68fe4b93a2455ab8872d4402c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.25, 1.4, 1, latest
-GitCommit: a8c4206768821aa47579c6413be85be914875caa
+Tags: 1.4.26, 1.4, 1, latest
+GitCommit: 836434afd61d509daed2217c07c976ccbd9ae37a
+Directory: debian
+
+Tags: 1.4.26-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 412d4e396a3fb396abadacaad1d5394f3d6c6df8
+Directory: alpine

--- a/library/pypy
+++ b/library/pypy
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.3.0, 2-5.3, 2-5, 2
-GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
+Tags: 2-5.3.1, 2-5.3, 2-5, 2
+GitCommit: 5241fb013dcd9d11b51a9bc4946a19358c73a50f
 Directory: 2
 
-Tags: 2-5.3.0-slim, 2-5.3-slim, 2-5-slim, 2-slim
-GitCommit: cdf5a7cd566bc418aff8eb383b431abb3ea88e50
+Tags: 2-5.3.1-slim, 2-5.3-slim, 2-5-slim, 2-slim
+GitCommit: 5241fb013dcd9d11b51a9bc4946a19358c73a50f
 Directory: 2/slim
 
-Tags: 2-5.3.0-onbuild, 2-5.3-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.3.1-onbuild, 2-5.3-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 

--- a/library/redis
+++ b/library/redis
@@ -24,14 +24,14 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
 Directory: 3.0/alpine
 
-Tags: 3.2.0, 3.2, 3, latest
-GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Tags: 3.2.1, 3.2, 3, latest
+GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
 Directory: 3.2
 
-Tags: 3.2.0-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+Tags: 3.2.1-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
 Directory: 3.2/32bit
 
-Tags: 3.2.0-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
+Tags: 3.2.1-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
 Directory: 3.2/alpine


### PR DESCRIPTION
- `mariadb`: 5.5.50
- `memcached`: 1.4.26, Alpine variant! (docker-library/memcached#4, docker-library/memcached#8)
- `pypy`: 2-5.3.1
- `redis`: 3.2.1