### PR TITLE
Update Solr to 6.1.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,30 +1,36 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3
-5.3: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3
+5.3: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4
-5.4: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4
+5.4: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@2a7b200543bb63eff081ff0eb03c85a89a2f6331 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4/alpine
 
-5.5.1: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5
-5.5: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5
+5.5.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5
+5.5: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5
 
-5.5.1-alpine: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@b8c4d759249af569e169d249fb667f79a230a0c0 5.5/alpine
+5.5.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5/alpine
 
-6.0.1: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
-6.0: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
-6: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
-latest: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
+6.0: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
+6: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
+latest: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
 
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@1eb1b13400076b631ca0190e9ba0e7c49982f630 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
+
+6.1.0: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1
+6.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1
+
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1/alpine

--- a/library/solr
+++ b/library/solr
@@ -1,36 +1,36 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3
-5.3: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3
+5.3: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4
-5.4: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4
+5.4: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
 
-5.5.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5
-5.5: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5
+5.5.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5
+5.5: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5
 
-5.5.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 5.5/alpine
+5.5.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5/alpine
 
-6.0.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
-6.0: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
-6: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
-latest: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
+6.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
+6: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
+latest: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
 
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
+alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
 
-6.1.0: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1
-6.1: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1
+6.1.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
+6.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@43af88ba395a263785177ad04d75a5e8f0ec6401 6.1/alpine
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine


### PR DESCRIPTION
Add Solr 6.1.

Announcement: http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3cCAPsWd+P6f=XXxVP5b6E_ZyO1Q0h0hCLAi6vsMydCArrLY09O2A@mail.gmail.com%3e 
Changelog: https://lucene.apache.org/solr/6_1_0/changes/Changes.html.

Docker-solr issues fixed:

https://github.com/docker-solr/docker-solr/issues/43 "Add Solr 6.1"
https://github.com/docker-solr/docker-solr/issues/42 "pgpkeys error when building"
https://github.com/docker-solr/docker-solr/issues/41 "ssl_helper error when building"
https://github.com/docker-solr/docker-solr/issues/33 "mkdir mycores"
https://github.com/docker-solr/docker-solr/pull/37 "fix typo in arguments, this should be volume"

Travis build passed https://travis-ci.org/docker-solr/docker-solr/builds/138456211