### PR TITLE
update openSUSE: security fixes for Leap and 13.2

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -1,16 +1,17 @@
 Maintainers: Flavio Castelli <fcastelli@suse.com> (@flavio),
-             Aleksa Sarai <asarai@suse.de> (@cyphar)
+             Aleksa Sarai <asarai@suse.de> (@cyphar),
+             Christian Brauner <cbrauner@suse.de> (@brauner)
 GitRepo: https://github.com/openSUSE/docker-containers-build.git
 Directory: docker
 Constraints: !aufs
 
 Tags: 42.1, leap, latest
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: aa4ae805515800ca78ae472bb028be72aa7bb86f
+GitCommit: fdb195e64507f464cb5be61c9835e79663df9178
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 278482aef59e6637702f74b07390e8543bb918f3
+GitCommit: 2479d8d0f90bce3c2e33dd2fc311d6599c336fdf
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed


### PR DESCRIPTION
NOTE: Starting with this commit we now also include the sha256 hash for the underlying tar file. You can use this to verify the integrity of our tar.xz files! Please note that this commit only adds the sha256 checksums for `openSUSE-13.2` and `openSUSE-Leap`. The sha256 checksum for `openSUSE-Tumbleweed` will be added when another security update will be necessary. Thanks. :)

Signed-off-by: Christian Brauner <cbrauner@suse.com>