### PR TITLE
Update influxdb 1.0 to 1.0.0-beta2

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -1,8 +1,11 @@
-# maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
+Maintainers: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.12
-0.12.0: git://github.com/influxdata/chronograf-docker@82b30f8a10b7dde9b13953400288768f109bf749 0.12
+Tags: 0.12, 0.12.0
+GitRepo: git://github.com/influxdata/chronograf-docker
+GitCommit: 82b30f8a10b7dde9b13953400288768f109bf749
+Directory: 0.12
 
-0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13
-0.13.0: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13
-latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 chronograf/0.13
+Tags: 0.13, 0.13.0, latest
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: chronograf/0.13

--- a/library/influxdb
+++ b/library/influxdb
@@ -1,15 +1,26 @@
-# maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
+Maintainers: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
-0.12.2: git://github.com/influxdata/influxdb-docker@6d869aa598baf9d23019682ecff42d022a00ce17 0.12
+Tags: 0.12, 0.12.2
+GitRepo: git://github.com/influxdata/influxdb-docker
+GitCommit: 6d869aa598baf9d23019682ecff42d022a00ce17
+Directory: 0.12
 
-0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
-0.13.0: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
-latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13
+Tags: 0.13, 0.13.0, latest
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: a2e36a415b71cd2b0bff87d0eaaf6d5329451c7c
+Directory: influxdb/0.13
 
-0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
-0.13.0-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/0.13/alpine
+Tags: 0.13-alpine, 0.13.0-alpine, alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: a2e36a415b71cd2b0bff87d0eaaf6d5329451c7c
+Directory: influxdb/0.13/alpine
 
-1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/1.0
-1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 influxdb/1.0/alpine
+Tags: 1.0.0-beta2
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: a2e36a415b71cd2b0bff87d0eaaf6d5329451c7c
+Directory: influxdb/1.0
+
+Tags: 1.0.0-beta2-alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: a2e36a415b71cd2b0bff87d0eaaf6d5329451c7c
+Directory: influxdb/1.0/alpine

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,15 +1,26 @@
-# maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
+Maintainers: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
-0.12.0: git://github.com/influxdata/kapacitor-docker@bbfea78a0a43bd4c6d67e139afb518bac3aa424b 0.12
+Tags: 0.12, 0.12.0
+GitRepo: git://github.com/influxdata/kapacitor-docker
+GitCommit: bbfea78a0a43bd4c6d67e139afb518bac3aa424b
+Directory: 0.12
 
-0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
-0.13.1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
-latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13
+Tags: 0.13, 0.13.1, latest
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: kapacitor/0.13
 
-0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
-0.13.1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/0.13/alpine
+Tags: 0.13-alpine, 0.13.1-alpine, alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: kapacitor/0.13/alpine
 
-1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/1.0
-1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 kapacitor/1.0/alpine
+Tags: 1.0.0-beta1
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: kapacitor/1.0
+
+Tags: 1.0.0-beta1-alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: kapacitor/1.0/alpine

--- a/library/telegraf
+++ b/library/telegraf
@@ -1,15 +1,26 @@
-# maintainer: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
+Maintainers: Shubhra Kar <shubhra@influxdb.com> (@ShubhraKar)
 
-0.12: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
-0.12.0: git://github.com/influxdata/telegraf-docker@9f5442edabacd2a72627246e7ee8c7d276bd0f28 0.12
+Tags: 0.12, 0.12.0
+GitRepo: git://github.com/influxdata/telegraf-docker
+GitCommit: 9f5442edabacd2a72627246e7ee8c7d276bd0f28
+Directory: 0.12
 
-0.13: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
-0.13.1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
-latest: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13
+Tags: 0.13, 0.13.1, latest
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: telegraf/0.13
 
-0.13-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
-0.13.1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/0.13/alpine
+Tags: 0.13-alpine, 0.13.1-alpine, alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: telegraf/0.13/alpine
 
-1.0.0-beta1: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/1.0
-1.0.0-beta1-alpine: git://github.com/influxdata/influxdata-docker@215cf009c143dc739b5b10084ae330ca7f3665d6 telegraf/1.0/alpine
+Tags: 1.0.0-beta1
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: telegraf/1.0
+
+Tags: 1.0.0-beta1-alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 215cf009c143dc739b5b10084ae330ca7f3665d6
+Directory: telegraf/1.0/alpine


### PR DESCRIPTION
Update influxdata libraries to the new bashbrew library format