### PR TITLE
Update Mono 3.8 and 3.10 with workaround for mozroots

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -1,7 +1,7 @@
 # maintainer: Jo Shields <jo.shields@xamarin.com> (@directhex)
 
-3.10.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
-3.10: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.10.0
+3.10.0: git://github.com/mono/docker@915b71717dae5448dd2cceeeca084a0690aed8d0 3.10.0
+3.10: git://github.com/mono/docker@915b71717dae5448dd2cceeeca084a0690aed8d0 3.10.0
 
 3.10.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
 3.10-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.10.0/onbuild
@@ -16,8 +16,8 @@
 3.12-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
 3-onbuild: git://github.com/mono/docker@39c80bc024a4797c119c895fda70024fbc14d5b9 3.12.1/onbuild
 
-3.8.0: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
-3.8: git://github.com/mono/docker@adc7a3ec47f7d590f75a4dec0203a2103daf8db0 3.8.0
+3.8.0: git://github.com/mono/docker@915b71717dae5448dd2cceeeca084a0690aed8d0 3.8.0
+3.8: git://github.com/mono/docker@915b71717dae5448dd2cceeeca084a0690aed8d0 3.8.0
 
 3.8.0-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild
 3.8-onbuild: git://github.com/mono/docker@66226b17125b72685c2022e4fecaee2716b0fb3a 3.8.0/onbuild


### PR DESCRIPTION
Fixed version of #1858 