### PR TITLE
Correct typo in bashbrew push --namespace message

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -16,7 +16,7 @@ func cmdPush(c *cli.Context) error {
 	namespace := c.String("namespace")
 
 	if namespace == "" {
-		return fmt.Errorf(`"--namespace" is a required flag for "tag"`)
+		return fmt.Errorf(`"--namespace" is a required flag for "push"`)
 	}
 
 	for _, repo := range repos {


### PR DESCRIPTION
Correct a typo in the help text for the bashbrew --namespace option for the push command