### PR TITLE
bump version: Erlang 19.0, 18.3.4 & 17.5.6.9

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,21 +1,36 @@
-# maintainer: denc716@gmail.com (@c0b)
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/ea32d5f6f1735f9f55bee04b112166da96eb9c73/generate-stackbrew-library.sh
 
-18.3.3: git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18
-18.3:   git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18
-18:     git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18
-latest: git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18
+Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
+GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-18.3-slim: git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/slim
-18-slim:   git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/slim
-slim:      git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/slim
+Tags: 19.0, 19, latest
+GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Directory: 19
 
-18.3-onbuild:   git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/onbuild
-18-onbuild:     git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/onbuild
-onbuild:        git://github.com/c0b/docker-erlang-otp@2daeab9ef204095169b3cc96def31ce08a5f7358 18/onbuild
+Tags: 19.0-slim, 19-slim, slim
+GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Directory: 19/slim
 
-17.5.6.8: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
-17.5:     git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
-17:       git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17
+Tags: 19.0-onbuild, 19-onbuild, onbuild
+GitCommit: 847b82cdb8896d8d865bf32f2833787b5c62587c
+Directory: 19/onbuild
 
-17.5-slim: git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17/slim
-17-slim:   git://github.com/c0b/docker-erlang-otp@7b450cd7f43203d34c10ae0d35e9f8ea67257415 17/slim
+Tags: 18.3.4, 18.3, 18
+GitCommit: aeae7ea95d8f42cb3c810fb962720235e304cb60
+Directory: 18
+
+Tags: 18.3.4-slim, 18.3-slim, 18-slim
+GitCommit: aeae7ea95d8f42cb3c810fb962720235e304cb60
+Directory: 18/slim
+
+Tags: 18.3.4-onbuild, 18.3-onbuild, 18-onbuild
+GitCommit: 20e41464075dc0fc76709be77701530eddb6fe33
+Directory: 18/onbuild
+
+Tags: 17.5.6.9, 17.5.6, 17.5, 17
+GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Directory: 17
+
+Tags: 17.5.6.9-slim, 17.5.6-slim, 17.5-slim, 17-slim
+GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Directory: 17/slim


### PR DESCRIPTION
as well as the new 2822-based manifest file format :v: