### PR TITLE
Updated Oracle Linux images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,18 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@d45f1439a3c281d01265bc9a04e778282d7fde4b OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/5.11


### PR DESCRIPTION
This PR updates all three OL images. We address some OpenSSL CVEs (`CVE-2016-0799, CVE-2016-2105, CVE-2016-2106, CVE-2016-2109`) in the new OL5 image and have added the `yum-utils` package to the base filesystem install for OL6 and OL7.

Signed-off-by: Avi Miller <avi.miller@oracle.com>