### PR TITLE
Update clojure alpine commits to latest

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,8 +3,8 @@
 
 latest: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59
 onbuild: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59 onbuild
-alpine: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59 alpine
+alpine: git://github.com/Quantisan/docker-clojure@534102a7ee7e6f4825e86a648a52c44cc25eb39d alpine
 
 lein-2.6.1: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59
 lein-2.6.1-onbuild: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59 onbuild
-lein-2.6.1-alpine: git://github.com/Quantisan/docker-clojure@0d4a0abe13497a6081ebd080e83d1be0abab3f59 alpine
+lein-2.6.1-alpine: git://github.com/Quantisan/docker-clojure@534102a7ee7e6f4825e86a648a52c44cc25eb39d alpine


### PR DESCRIPTION
I updated this image to get a newer JVM release and Alpine 3.4 from the latest official Java 8 image.