### PR TITLE
Publish Neo4j 3.0.3

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -6,10 +6,10 @@
 2.3.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
 2.3-enterprise: git://github.com/neo4j/docker-neo4j@89955a10604656aa8def4e3d658cc870818d7535 2.3.3-enterprise
 
-3.0.2: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
-3.0: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
-latest: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2
+3.0.3: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-community
+3.0: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-community
+latest: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-community
 
-3.0.2-enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise
-3.0-enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise
-enterprise: git://github.com/neo4j/docker-neo4j@34173c9954c660a67042fbf617aeedae397e0445 3.0.2-enterprise
+3.0.3-enterprise: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-enterprise
+3.0-enterprise: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-enterprise
+enterprise: git://github.com/neo4j/docker-neo4j-publish@860588baa6a9e97c7d10bdbc0084e4c59f3886a6 3.0.3-enterprise


### PR DESCRIPTION
We've moved our "built" image contexts into a separate repo to simplify our build process.