### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -6,14 +6,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
-Tags: 1.24.2-glibc, 1.24-glibc, 1-glibc, glibc
-GitCommit: 729aa3010c3ee9088e74647d9f04a4c338fa86c4
+Tags: 1.25.0-glibc, 1.25-glibc, 1-glibc, glibc
+GitCommit: a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f
 Directory: glibc
 
-Tags: 1.24.2-musl, 1.24-musl, 1-musl, musl
-GitCommit: 729aa3010c3ee9088e74647d9f04a4c338fa86c4
+Tags: 1.25.0-musl, 1.25-musl, 1-musl, musl
+GitCommit: a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f
 Directory: musl
 
-Tags: 1.24.2-uclibc, 1.24-uclibc, 1-uclibc, uclibc, 1.24.2, 1.24, 1, latest
-GitCommit: 729aa3010c3ee9088e74647d9f04a4c338fa86c4
+Tags: 1.25.0-uclibc, 1.25-uclibc, 1-uclibc, uclibc, 1.25.0, 1.25, 1, latest
+GitCommit: a0558a9006ce0dd6f6ec5d56cfd3f32ebeeb815f
 Directory: uclibc

--- a/library/julia
+++ b/library/julia
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.4.5, 0.4, 0, latest
-GitCommit: 2bb511d3378dec17ebbf417d5865ede353ba8e57
+Tags: 0.4.6, 0.4, 0, latest
+GitCommit: 59a01cf8cdb0b0f9cc229aca415755a64226e4ed

--- a/library/php
+++ b/library/php
@@ -4,60 +4,60 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.0.7-cli, 7.0-cli, 7-cli, cli, 7.0.7, 7.0, 7, latest
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 7.0.8-cli, 7.0-cli, 7-cli, cli, 7.0.8, 7.0, 7, latest
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0
 
-Tags: 7.0.7-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 7.0.8-alpine, 7.0-alpine, 7-alpine, alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/alpine
 
-Tags: 7.0.7-apache, 7.0-apache, 7-apache, apache
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 7.0.8-apache, 7.0-apache, 7-apache, apache
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/apache
 
-Tags: 7.0.7-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 7.0.8-fpm, 7.0-fpm, 7-fpm, fpm
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/fpm
 
-Tags: 7.0.7-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 7.0.8-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.7-zts, 7.0-zts, 7-zts, zts
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 7.0.8-zts, 7.0-zts, 7-zts, zts
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/zts
 
-Tags: 7.0.7-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 7.0.8-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.22-cli, 5.6-cli, 5-cli, 5.6.22, 5.6, 5
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 5.6.23-cli, 5.6-cli, 5-cli, 5.6.23, 5.6, 5
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6
 
-Tags: 5.6.22-alpine, 5.6-alpine, 5-alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 5.6.23-alpine, 5.6-alpine, 5-alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/alpine
 
-Tags: 5.6.22-apache, 5.6-apache, 5-apache
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 5.6.23-apache, 5.6-apache, 5-apache
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/apache
 
-Tags: 5.6.22-fpm, 5.6-fpm, 5-fpm
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 5.6.23-fpm, 5.6-fpm, 5-fpm
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/fpm
 
-Tags: 5.6.22-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 5.6.23-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.22-zts, 5.6-zts, 5-zts
-GitCommit: 8344a7fdb4ddba205781d1dda1ec62981733e9ba
+Tags: 5.6.23-zts, 5.6-zts, 5-zts
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/zts
 
-Tags: 5.6.22-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 145f0de1bc4cfe9c1d599a221ac83239805e1e81
+Tags: 5.6.23-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/zts/alpine
 
 Tags: 5.5.36-cli, 5.5-cli, 5.5.36, 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 9.6-beta1, 9.6
-GitCommit: b1831ce069d10b14be05b9ddf6823e3d18c62cee
+Tags: 9.6-beta2, 9.6
+GitCommit: 3cff98db82f2dd6c3647296335bbc37233e0b9bc
 Directory: 9.6
 
 Tags: 9.5.3, 9.5, 9, latest

--- a/library/redmine
+++ b/library/redmine
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 2.6.10, 2.6, 2
-GitCommit: 59319e8ad8ddd777d88b76de6bb10cc7e54d01b3
+GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
 Directory: 2.6
 
 Tags: 2.6.10-passenger, 2.6-passenger, 2-passenger
-GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 2.6/passenger
 
 Tags: 3.0.7, 3.0
-GitCommit: 99752f3d9bc5ccd9f69d16e2105d287df17f5ac2
+GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
 Directory: 3.0
 
 Tags: 3.0.7-passenger, 3.0-passenger
-GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.0/passenger
 
 Tags: 3.1.6, 3.1
-GitCommit: 7e94beb1e1979251c7b64e465738405a85e316e8
+GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
 Directory: 3.1
 
 Tags: 3.1.6-passenger, 3.1-passenger
-GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.1/passenger
 
 Tags: 3.2.3, 3.2, 3, latest
-GitCommit: 7e94beb1e1979251c7b64e465738405a85e316e8
+GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
 Directory: 3.2
 
 Tags: 3.2.3-passenger, 3.2-passenger, 3-passenger, passenger
-GitCommit: 9fdf8a16772d46ce8b9596c1edf887b96700f71c
+GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.9, 2.1
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.1
 
 Tags: 2.1.9-slim, 2.1-slim
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.1/slim
 
 Tags: 2.1.9-alpine, 2.1-alpine
-GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.1/alpine
 
 Tags: 2.1.9-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: a6202f065bc6d5562703eed454e3479359234750
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: 972ed547de34b8644de4819001906cfc79907be2
+GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -12,12 +12,12 @@ Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
 GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
 Directory: 6/jre8
 
-Tags: 7.0.69-jre7, 7.0-jre7, 7-jre7, 7.0.69, 7.0, 7
-GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Tags: 7.0.70-jre7, 7.0-jre7, 7-jre7, 7.0.70, 7.0, 7
+GitCommit: 7c4365e43f352c981a97eae5090bb055a68ff6a9
 Directory: 7/jre7
 
-Tags: 7.0.69-jre8, 7.0-jre8, 7-jre8
-GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+Tags: 7.0.70-jre8, 7.0-jre8, 7-jre8
+GitCommit: 7c4365e43f352c981a97eae5090bb055a68ff6a9
 Directory: 7/jre8
 
 Tags: 8.0.36-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.36, 8.0, 8, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.5.2-apache, 4.5-apache, 4-apache, apache, 4.5.2, 4.5, 4, latest
-GitCommit: 61dd78ce4fa9ccd592ead1edb379f209533b850c
+Tags: 4.5.3-apache, 4.5-apache, 4-apache, apache, 4.5.3, 4.5, 4, latest
+GitCommit: 4cfa30302dbf66d002ed15b01c881acee605e2dc
 Directory: apache
 
-Tags: 4.5.2-fpm, 4.5-fpm, 4-fpm, fpm
-GitCommit: 61dd78ce4fa9ccd592ead1edb379f209533b850c
+Tags: 4.5.3-fpm, 4.5-fpm, 4-fpm, fpm
+GitCommit: c674e9ceedf582705e0ad8487c16b42b37a5e9da
 Directory: fpm


### PR DESCRIPTION
- `busybox`: 1.25.0
- `julia`: 0.4.6
- `php`: 7.0.8, 5.6.23
- `postgres`: 9.6-beta2
- `redmine`: refactor environment variable usage, esp for non-linking (docker-library/redmine#24)
- `ruby`: rubygems 2.6.6
- `tomcat`: 7.0.70
- `wordpress`: 4.5.3