### PR TITLE
Update Ubuntu (precise, trusty, and wily)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,35 +1,35 @@
-# maintainer: Tianon Gravi <tianon@debian.org> (@tianon)
-# proxy for upstream's official builds
-# see https://partner-images.canonical.com/core/
+# Maintained by Tianon as proxy for upstream's offical builds.
 
+Maintainers: Tianon Gravi <tianon@debian.org> (@tianon)
+GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
+GitFetch: refs/heads/dist
+
+# see https://partner-images.canonical.com/core/
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 52c8214 Update tarballs
-#    - `ubuntu:precise`: 20160526
-#    - `ubuntu:trusty`: 20160526
-#    - `ubuntu:wily`: 20160526
+#  - f2682b5 Update tarballs
+#    - `ubuntu:precise`: 20160624
+#    - `ubuntu:trusty`: 20160624
+#    - `ubuntu:wily`: 20160602
 #    - `ubuntu:xenial`: 20160525
 
-# 20160526
-12.04.5: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
-12.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
-precise-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
-precise: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 precise
+# 20160624
+Tags: 12.04.5, 12.04, precise-20160624, precise
+GitCommit: f2682b59c32241b97e904af6691e997fa9c79c91
+Directory: precise
 
-# 20160526
-14.04.4: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
-14.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
-trusty-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
-trusty: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 trusty
+# 20160624
+Tags: 14.04.4, 14.04, trusty-20160624, trusty
+GitCommit: f2682b59c32241b97e904af6691e997fa9c79c91
+Directory: trusty
 
-# 20160526
-15.10: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
-wily-20160526: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
-wily: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 wily
+# 20160602
+Tags: 15.10, wily-20160602, wily
+GitCommit: f2682b59c32241b97e904af6691e997fa9c79c91
+Directory: wily
 
 # 20160525
-16.04: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
-xenial-20160525: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
-xenial: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
-latest: git://github.com/tianon/docker-brew-ubuntu-core@52c8214ecac89d45592d16ce7c14ef82ac7b0822 xenial
+Tags: 16.04, xenial-20160525, xenial, latest
+GitCommit: f2682b59c32241b97e904af6691e997fa9c79c91
+Directory: xenial


### PR DESCRIPTION
- `ubuntu:precise`: 20160624
- `ubuntu:trusty`: 20160624
- `ubuntu:wily`: 20160602

(also, convert to the 2822-based format)