### PR TITLE
[security] Update for Node.js v0.10.46, v0.12.15, v4.4.6 and v5.12.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,68 +1,68 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.45: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10
-0.10: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10
+0.10.46: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10
+0.10: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10
 
-0.10.45-onbuild: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/onbuild
+0.10.46-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
 
-0.10.45-slim: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/slim
+0.10.46-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/slim
 
-0.10.45-wheezy: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@5e058d36cc69303d1f62d424615fa03e050f20ef 0.10/wheezy
+0.10.46-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/wheezy
 
-0.12.14: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12
-0.12: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12
-0: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12
+0.12.15: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
+0.12: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
+0: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
 
-0.12.14-onbuild: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/onbuild
+0.12.15-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
 
-0.12.14-slim: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/slim
+0.12.15-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
 
-0.12.14-wheezy: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@6778e14c0c1ae53cc413f77a94c21c7cf05f651f 0.12/wheezy
+0.12.15-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
 
-4.4.5: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
-4.4: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
-4: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
-argon: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4
+4.4.6: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
+4.4: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
+4: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
+argon: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
 
-4.4.5-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/onbuild
+4.4.6-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
 
-4.4.5-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/slim
+4.4.6-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
 
-4.4.5-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@fdcbbd6445c70290c50396cba2b2b67357a00629 4.4/wheezy
+4.4.6-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
 
-5.11.1: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11
-5.11: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11
-5: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11
+5.12.0: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
+5.12: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
+5: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
 
-5.11.1-onbuild: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/onbuild
-5.11-onbuild: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/onbuild
+5.12.0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
+5.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
+5-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
 
-5.11.1-slim: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/slim
-5.11-slim: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/slim
-5-slim: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/slim
+5.12.0-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
+5.12-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
+5-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
 
-5.11.1-wheezy: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/wheezy
-5.11-wheezy: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@cbdacad677bafa044140610f851bed00254de1ca 5.11/wheezy
+5.12.0-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
+5.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
 
 6.2.2: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2
 6.2: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2


### PR DESCRIPTION
Reference:

- https://github.com/nodejs/LTS/issues/114
- https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/
- https://nodejs.org/en/blog/release/v0.10.46/
- https://nodejs.org/en/blog/release/v0.12.15/
- https://nodejs.org/en/blog/release/v4.4.6/
- https://nodejs.org/en/blog/release/v5.12.0/
- https://github.com/nodejs/docker-node/issues/201