### PR TITLE
bump version: Elixir 1.3.0 on top of Erlang 19.0

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,14 +1,24 @@
-# maintainer: denc716@gmail.com (@c0b)
+# this file is generated via https://github.com/c0b/docker-elixir/blob/77b9a3da43ce035327ae29083e567191d60a6ac8/generate-stackbrew-library.sh
 
-1.2.5:  git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
-1.2:    git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
-latest: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
+Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
+GitRepo: https://github.com/c0b/docker-elixir.git
 
-1.2-slim: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/slim
-slim:     git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/slim
+Tags: 1.3.0, 1.3, latest
+GitCommit: 033f8f8015a012cbb84cf4df4c3bcdbdd1c017af
+Directory: 1.3
 
-1.2-onbuild: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/onbuild
-onbuild:     git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/onbuild
+Tags: 1.3.0-onbuild, 1.3-onbuild, onbuild
+GitCommit: b17f0a82e1007f00d8c8c93a277c01e39951c439
+Directory: 1.3/onbuild
 
-1.2.4:  git://github.com/c0b/docker-elixir@8a1bf2bebcf4488408fc5e9f51c6ef09e0abbee6 1.2
-1.2.3:  git://github.com/c0b/docker-elixir@08b645312bcbf020214e36679eec248234485b3a 1.2
+Tags: 1.2.6, 1.2
+GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
+Directory: 1.2
+
+Tags: 1.2.6-slim, 1.2-slim
+GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
+Directory: 1.2/slim
+
+Tags: 1.2.6-onbuild, 1.2-onbuild
+GitCommit: b17f0a82e1007f00d8c8c93a277c01e39951c439
+Directory: 1.2/onbuild


### PR DESCRIPTION
as well as the new 2822-based manifest file format.