### PR TITLE
Move websphere-liberty to 16.0.0.2 release

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,17 +1,10 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 # maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
-kernel: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/kernel
-8.5.5.9-kernel: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/kernel
-common: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/common
-8.5.5.9-common: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/webProfile6
-8.5.5.9-webProfile6: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/webProfile7
-8.5.5.9-webProfile7: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.9-javaee7: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/javaee7
-8.5.5.9: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/javaee7
-8.5.5: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@074289767a4d5d51d8d5c0cdb4d140489b605282 websphere-liberty/8.5.5/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@a929e657995d92c6cbf407acd8c2ac2b2a8215c2 websphere-liberty/beta
+kernel: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/kernel
+common: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/common
+webProfile6: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 beta


### PR DESCRIPTION
Apologies for the restructuring of the source project but we've changed our release numbering convention. As a consequence, this also means that it is no longer appropriate to have images tagged with version numbers.