### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2015-06-23
-Tags: 4.8.5, 4.8
-GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
-Directory: 4.8
-# Docker EOL: 2016-06-23
-
 # Last Modified: 2015-06-26
 Tags: 4.9.3, 4.9, 4
 GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: c6c90f5e09a5dc1a1ccd662de8210342f94c673e
 Directory: 8-jre/alpine
 
-Tags: 9-b116-jdk, 9-b116, 9-jdk, 9, openjdk-9-b116-jdk, openjdk-9-b116, openjdk-9-jdk, openjdk-9
-GitCommit: 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177
+Tags: 9-b124-jdk, 9-b124, 9-jdk, 9, openjdk-9-b124-jdk, openjdk-9-b124, openjdk-9-jdk, openjdk-9
+GitCommit: d1890fa5206eee489ab6285afa2a52f409dcfdc4
 Directory: 9-jdk
 
-Tags: 9-b116-jre, 9-jre, openjdk-9-b116-jre, openjdk-9-jre
-GitCommit: 4427d56d00bbd05b6c7e0f5ce7a3a7a01b6d4177
+Tags: 9-b124-jre, 9-jre, openjdk-9-b124-jre, openjdk-9-jre
+GitCommit: d1890fa5206eee489ab6285afa2a52f409dcfdc4
 Directory: 9-jre


### PR DESCRIPTION
- `gcc`: remove 4.8 (Docker EOL)
- `java`: Debian 9~b124