### PR TITLE
Add Solr 5.5.2 and fix aliases

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -30,9 +30,9 @@
 6.1.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 6.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 6: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
-latest,: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
+latest: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 
 6.1.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
 6.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
 6-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
-latest,-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine

--- a/library/solr
+++ b/library/solr
@@ -13,24 +13,26 @@
 5.4.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
 5.4-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
 
-5.5.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5
-5.5: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5
+5.5.2: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
+5.5: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
+5: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
 
-5.5.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.5/alpine
+5.5.2-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
 
 6.0.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
 6.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
-6: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
-latest: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
 
 6.0.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
 6.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
 
 6.1.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 6.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
+6: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
+latest,: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 
 6.1.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
 6.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+latest,-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/www-announce/201606.mbox/%3c93C75552-DF74-4E0D-B02C-9B33B5E36587@apache.org%3e

Release Notes: https://lucene.apache.org/solr/5_5_2/changes/Changes.html