### PR TITLE
Add bashbrew as the entrypoint to make using the image easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,6 @@ COPY . $DIR
 RUN cd bashbrew/go && gb build
 
 VOLUME $BASHBREW_CACHE
+
+RUN ln -s "$PWD/bashbrew/bashbrew-entrypoint.sh" /usr/local/bin/bashbrew-entrypoint.sh
+ENTRYPOINT ["bashbrew-entrypoint.sh"]

--- a/bashbrew/bashbrew-entrypoint.sh
+++ b/bashbrew/bashbrew-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- bashbrew "$@"
+fi
+
+# if our command is a valid bashbrew subcommand, let's invoke it through bashbrew instead
+# (this allows for "docker run bashbrew build", etc)
+if bashbrew "$1" --help > /dev/null 2>&1; then
+	set -- bashbrew "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Makes it simpler to use bashbrew. Currently no specific entrypoint is being set, so it uses the Docker entrypoint from the FROM line.