### PR TITLE
Add ability to set build args

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -19,6 +19,7 @@ func cmdBuild(c *cli.Context) error {
 
 	uniq := c.Bool("uniq")
 	namespace := c.String("namespace")
+	build_args := c.StringSlice("build-args")
 	pull := c.String("pull")
 	switch pull {
 	case "always", "missing", "never":
@@ -88,7 +89,7 @@ func cmdBuild(c *cli.Context) error {
 				}
 				defer archive.Close()
 
-				err = dockerBuild(cacheTag, archive)
+				err = dockerBuild(cacheTag, build_args, archive)
 				if err != nil {
 					return cli.NewMultiError(fmt.Errorf(`failed building %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 				}

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -125,8 +125,11 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 	}, nil
 }
 
-func dockerBuild(tag string, context io.Reader) error {
+func dockerBuild(tag string, build_args []string, context io.Reader) error {
 	args := []string{"build", "-t", tag, "--rm", "--force-rm"}
+	for _, arg := range build_args {
+		args = append(args, "--build-arg", arg)
+	}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = context

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -237,6 +237,10 @@ func main() {
 			Name:  "namespace",
 			Usage: "a repo namespace to act upon/in",
 		},
+		"build-arg": cli.StringSliceFlag{
+			Name:  "build-arg",
+			Usage: "set build-time variables",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -270,6 +274,7 @@ func main() {
 				commonFlags["all"],
 				commonFlags["uniq"],
 				commonFlags["namespace"],
+				commonFlags["build-arg"],
 				cli.StringFlag{
 					Name:  "pull",
 					Value: "missing",


### PR DESCRIPTION
While probably not at all useful for the official images, this is handy for other users of bashbrew - enabling them to pass in build args to the process for anything potentially sensitive (e.g. passwords)