### PR TITLE
bump version: Elixir 1.3.0 on top of Erlang 19.0

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,14 +1,20 @@
-# maintainer: denc716@gmail.com (@c0b)
+# this file is generated via https://github.com/c0b/docker-elixir/blob/50bb23cfce41cafeb4f6bd0a1eeeb412ddc780ca/generate-stackbrew-library.sh
 
-1.2.5:  git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
-1.2:    git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
-latest: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2
+Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
+GitRepo: https://github.com/c0b/docker-elixir.git
 
-1.2-slim: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/slim
-slim:     git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/slim
+Tags: 1.3.0, 1.3, latest
+GitCommit: 50bb23cfce41cafeb4f6bd0a1eeeb412ddc780ca
+Directory: 1.3
 
-1.2-onbuild: git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/onbuild
-onbuild:     git://github.com/c0b/docker-elixir@22ee98417200ef8d9a049b2b4504e7cf279e911f 1.2/onbuild
+Tags: 1.3.0-slim, 1.3-slim, slim
+GitCommit: 50bb23cfce41cafeb4f6bd0a1eeeb412ddc780ca
+Directory: 1.3/slim
 
-1.2.4:  git://github.com/c0b/docker-elixir@8a1bf2bebcf4488408fc5e9f51c6ef09e0abbee6 1.2
-1.2.3:  git://github.com/c0b/docker-elixir@08b645312bcbf020214e36679eec248234485b3a 1.2
+Tags: 1.2.6, 1.2
+GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
+Directory: 1.2
+
+Tags: 1.2.6-slim, 1.2-slim
+GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
+Directory: 1.2/slim


### PR DESCRIPTION
as well as the new 2822-based manifest file format.

This will close #1882 which is the original approach of installing from source code, use a different PR to differentiate. the onbuild is an empty structure for travis-ci code not necessary to create its own image.