### PR TITLE
Update photon to GA version, remove previous RC

### DIFF
--- a/library/photon
+++ b/library/photon
@@ -1,8 +1,8 @@
 # maintainer: Fabio Rapposelli <fabio@vmware.com> (@frapposelli)
-#
+
 # commits: (master..dist)
-#  - 312dda8 Update tarballs
-#
-# release-dockerfiles/1.0RC
-1.0RC: git://github.com/vmware/photon-docker-image@312dda8b87d8a7083cf1e9fcab184a7612032859 1.0RC
-latest: git://github.com/vmware/photon-docker-image@312dda8b87d8a7083cf1e9fcab184a7612032859 1.0RC
+#  - 39c3c62 Update tarballs
+
+# release-dockerfiles/1.0
+1.0: git://github.com/vmware/photon-docker-image@39c3c62cd649b1d64178b24cd23d9196461dc818 1.0
+latest: git://github.com/vmware/photon-docker-image@39c3c62cd649b1d64178b24cd23d9196461dc818 1.0


### PR DESCRIPTION
Photon OS hit GA :tada:

![gif-keyboard-3043077059440207965](https://cloud.githubusercontent.com/assets/541832/16374244/f3045c32-3c55-11e6-967a-350d23f6adc8.gif)
