### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,7 +6,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 
 Tags: 1.5.4, 1.5
-GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.5
 
 Tags: 1.5.4-onbuild, 1.5-onbuild
@@ -14,15 +14,15 @@ GitCommit: f1f65c0ab0097a5e3d079d5a74e2468e8d47563d
 Directory: 1.5/onbuild
 
 Tags: 1.5.4-wheezy, 1.5-wheezy
-GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.5/wheezy
 
 Tags: 1.5.4-alpine, 1.5-alpine
-GitCommit: f3768925fd0ebeb966c30bc64206b0e6020de66e
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.5/alpine
 
 Tags: 1.6.2, 1.6, 1, latest
-GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.6
 
 Tags: 1.6.2-onbuild, 1.6-onbuild, 1-onbuild, onbuild
@@ -30,15 +30,15 @@ GitCommit: ce284e14cdee73fbaa8fb680011a812f272eae2e
 Directory: 1.6/onbuild
 
 Tags: 1.6.2-wheezy, 1.6-wheezy, 1-wheezy, wheezy
-GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.6/wheezy
 
 Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: f3768925fd0ebeb966c30bc64206b0e6020de66e
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.6/alpine
 
 Tags: 1.7beta2, 1.7
-GitCommit: 13b4447729b4367396148cc18745c9901e5fe4a8
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.7
 
 Tags: 1.7beta2-onbuild, 1.7-onbuild
@@ -46,9 +46,9 @@ GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
 Tags: 1.7beta2-wheezy, 1.7-wheezy
-GitCommit: 13b4447729b4367396148cc18745c9901e5fe4a8
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.7/wheezy
 
 Tags: 1.7beta2-alpine, 1.7-alpine
-GitCommit: 13b4447729b4367396148cc18745c9901e5fe4a8
+GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.7/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -20,10 +20,10 @@ Tags: 1.5.18-alpine, 1.5-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.5/alpine
 
-Tags: 1.6.5, 1.6, 1, latest
-GitCommit: e128fc85947f0de7213185c9f948150e39cbc766
+Tags: 1.6.6, 1.6, 1, latest
+GitCommit: 6298ef75a7eddeae3b8fbf5137e6eba69a41ff81
 Directory: 1.6
 
-Tags: 1.6.5-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+Tags: 1.6.6-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 6298ef75a7eddeae3b8fbf5137e6eba69a41ff81
 Directory: 1.6/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -16,6 +16,6 @@ Tags: 3.2.7, 3.2, 3, latest
 GitCommit: d805e40bdb590ac09a88a4fdfd2b29023da37ef0
 Directory: 3.2
 
-Tags: 3.3.8, 3.3
-GitCommit: 61925116dacc2767367a09c749d905110e17a0c8
+Tags: 3.3.9, 3.3
+GitCommit: ee77db94092c03d9e8555a54ec8d22b4b1cf647d
 Directory: 3.3

--- a/library/python
+++ b/library/python
@@ -4,23 +4,23 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 2.7.11, 2.7, 2
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 2.7.12, 2.7, 2
+GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
 Directory: 2.7
 
-Tags: 2.7.11-slim, 2.7-slim, 2-slim
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 2.7.12-slim, 2.7-slim, 2-slim
+GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
 Directory: 2.7/slim
 
-Tags: 2.7.11-alpine, 2.7-alpine, 2-alpine
-GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
+GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
 Directory: 2.7/alpine
 
-Tags: 2.7.11-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
+GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
 Directory: 2.7/wheezy
 
-Tags: 2.7.11-onbuild, 2.7-onbuild, 2-onbuild
+Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
@@ -44,38 +44,38 @@ Tags: 3.3.6-onbuild, 3.3-onbuild
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.3/onbuild
 
-Tags: 3.4.4, 3.4
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 3.4.5, 3.4
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.4
 
-Tags: 3.4.4-slim, 3.4-slim
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 3.4.5-slim, 3.4-slim
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.4/slim
 
-Tags: 3.4.4-alpine, 3.4-alpine
-GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Tags: 3.4.5-alpine, 3.4-alpine
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.4/alpine
 
-Tags: 3.4.4-wheezy, 3.4-wheezy
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 3.4.5-wheezy, 3.4-wheezy
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.4/wheezy
 
-Tags: 3.4.4-onbuild, 3.4-onbuild
+Tags: 3.4.5-onbuild, 3.4-onbuild
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.4/onbuild
 
-Tags: 3.5.1, 3.5, 3, latest
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 3.5.2, 3.5, 3, latest
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.5
 
-Tags: 3.5.1-slim, 3.5-slim, 3-slim, slim
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.5/slim
 
-Tags: 3.5.1-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
+GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
 Directory: 3.5/alpine
 
-Tags: 3.5.1-onbuild, 3.5-onbuild, 3-onbuild, onbuild
+Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
 GitCommit: 0fa3202789648132971160f686f5a37595108f44
 Directory: 3.5/onbuild

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 2.6.10, 2.6, 2
-GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
+GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
 Directory: 2.6
 
 Tags: 2.6.10-passenger, 2.6-passenger, 2-passenger
@@ -13,7 +13,7 @@ GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 2.6/passenger
 
 Tags: 3.0.7, 3.0
-GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
+GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
 Directory: 3.0
 
 Tags: 3.0.7-passenger, 3.0-passenger
@@ -21,7 +21,7 @@ GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.0/passenger
 
 Tags: 3.1.6, 3.1
-GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
+GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
 Directory: 3.1
 
 Tags: 3.1.6-passenger, 3.1-passenger
@@ -29,7 +29,7 @@ GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.1/passenger
 
 Tags: 3.2.3, 3.2, 3, latest
-GitCommit: 48c6faf95059d0b1f4e5938fd88bc2d0404ad8a2
+GitCommit: 794d8a58ac855ea5ad2541c1058a8910f9514710
 Directory: 3.2
 
 Tags: 3.2.3-passenger, 3.2-passenger, 3-passenger, passenger


### PR DESCRIPTION
- `golang`: add `go-wrapper` to Alpine variants (docker-library/golang#98)
- `haproxy`: 1.6.6
- `mongo`: 3.3.9
- `python`: 3.5.2, 3.4.5, 2.7.12
- `redmine`: refactor environment variables for non-linked usage (docker-library/redmine#24, docker-library/redmine#28)