### PR TITLE
Update for Node.js v4.4.7

### DIFF
--- a/library/node
+++ b/library/node
@@ -28,25 +28,25 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
 
-4.4.6: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
-4.4: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
-4: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
-argon: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4
+4.4.7: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4
+4.4: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4
+4: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4
+argon: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4
 
-4.4.6-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
-4.4-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/onbuild
+4.4.7-onbuild: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/onbuild
+4.4-onbuild: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/onbuild
 
-4.4.6-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
-4.4-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
-4-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
-argon-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/slim
+4.4.7-slim: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/slim
+4.4-slim: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/slim
+4-slim: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/slim
+argon-slim: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/slim
 
-4.4.6-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
-4.4-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 4.4/wheezy
+4.4.7-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/wheezy
+4.4-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c7d3ad0e1aa 4.4/wheezy
 
 5.12.0: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
 5.12: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v4.4.7/
- https://github.com/nodejs/docker-node/issues/202