### PR TITLE
Update websphere-liberty:beta to 2016.7.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,5 +1,4 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
-# maintainer: Kavitha Suresh Kumar <kavisurya@in.ibm.com> (@kavisuresh)
 
 kernel: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/kernel
 common: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/common
@@ -7,4 +6,4 @@ webProfile6: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8
 webProfile7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/webProfile7
 javaee7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
 latest: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 beta
+beta: git://github.com/WASdev/ci.docker@c2ccb0fe4d282a8bfb51395d12d541da84f3041a beta


### PR DESCRIPTION
Hopefully less contentious this time...

Removing Kavitha as she is about to move on to another project. I will switch the maintainer in the images in the next round of updates.