### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -9,7 +9,7 @@ GitCommit: 99287145029122cf49321fa2a055d14240001d1d
 Directory: 1.12-rc
 
 Tags: 1.12.0-rc2-dind, 1.12-rc-dind, rc-dind
-GitCommit: 4d1f83ee6e25a5c2bb1c8a04de0643b1a964ba5e
+GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.12-rc/dind
 
 Tags: 1.12.0-rc2-git, 1.12-rc-git, rc-git
@@ -21,7 +21,7 @@ GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
 Directory: 1.11
 
 Tags: 1.11.2-dind, 1.11-dind, 1-dind, dind
-GitCommit: 866c3fbd87e8eeed524fdf19ba2d63288ad49cd2
+GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.11/dind
 
 Tags: 1.11.2-git, 1.11-git, 1-git, git
@@ -33,7 +33,7 @@ GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
 Directory: 1.10
 
 Tags: 1.10.3-dind, 1.10-dind
-GitCommit: 83b2eab8bdb5d35bf343313154ab55938fca3807
+GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.10/dind
 
 Tags: 1.10.3-git, 1.10-git

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -32,6 +32,6 @@ Tags: 2.3.3, 2.3, 2, latest
 GitCommit: 30af4a027561ede1295621039ebc4ae6c656ea2a
 Directory: 2.3
 
-Tags: 5.0.0-alpha3, 5.0.0, 5.0, 5
-GitCommit: 82ace8b3760e3a8ddbadf90a645c99c7940ce250
+Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5
+GitCommit: 4093013f00696225cd9e316d5f892ae8f98b7888
 Directory: 5.0

--- a/library/golang
+++ b/library/golang
@@ -18,7 +18,7 @@ GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.5/wheezy
 
 Tags: 1.5.4-alpine, 1.5-alpine
-GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
+GitCommit: 5a84ebfbf3c55674dd6f36c66828c2e7461f2f0b
 Directory: 1.5/alpine
 
 Tags: 1.6.2, 1.6, 1, latest
@@ -34,7 +34,7 @@ GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.6/wheezy
 
 Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
+GitCommit: 5a84ebfbf3c55674dd6f36c66828c2e7461f2f0b
 Directory: 1.6/alpine
 
 Tags: 1.7beta2, 1.7
@@ -50,5 +50,5 @@ GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
 Directory: 1.7/wheezy
 
 Tags: 1.7beta2-alpine, 1.7-alpine
-GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
+GitCommit: 5a84ebfbf3c55674dd6f36c66828c2e7461f2f0b
 Directory: 1.7/alpine

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -6,4 +6,4 @@ GitRepo: https://github.com/docker-library/hello-world.git
 Directory: hello-seattle
 
 Tags: latest
-GitCommit: a2654a926677e91e30a233758e23b9acb2ef1ea8
+GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d

--- a/library/hello-world
+++ b/library/hello-world
@@ -6,4 +6,4 @@ GitRepo: https://github.com/docker-library/hello-world.git
 Directory: hello-world
 
 Tags: latest
-GitCommit: a2654a926677e91e30a233758e23b9acb2ef1ea8
+GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -6,4 +6,4 @@ GitRepo: https://github.com/docker-library/hello-world.git
 Directory: hola-mundo
 
 Tags: latest
-GitCommit: a2654a926677e91e30a233758e23b9acb2ef1ea8
+GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d

--- a/library/kibana
+++ b/library/kibana
@@ -28,6 +28,6 @@ Tags: 4.5.1, 4.5, 4, latest
 GitCommit: 2015c601bab8b77f0d13475f901c9b85e6014bdb
 Directory: 4.5
 
-Tags: 5.0.0-alpha3, 5.0.0, 5.0, 5
-GitCommit: 0beddcb3e86d1b623ada81d423aaa98e8500657f
+Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5
+GitCommit: 90abf46493103a3c6a7061b400d76f109c4104e7
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -24,6 +24,6 @@ Tags: 2.3.3-1, 2.3.3, 2.3, 2, latest
 GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
 Directory: 2.3
 
-Tags: 5.0.0-alpha3-1, 5.0.0-alpha3, 5.0.0, 5.0, 5
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+Tags: 5.0.0-alpha4-1, 5.0.0-alpha4, 5.0.0, 5.0, 5
+GitCommit: 963e75bbedf450b7a1733f2571410adc152aac12
 Directory: 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.14, 10.1, 10, latest
-GitCommit: 053f101cfae5f000466464717afc5f2dc8c56284
+Tags: 10.1.15, 10.1, 10, latest
+GitCommit: 14fa9fab60856471be80afdbb4044f31d78e9a08
 Directory: 10.1
 
 Tags: 10.0.26, 10.0

--- a/library/owncloud
+++ b/library/owncloud
@@ -20,18 +20,18 @@ Tags: 8.1.8-fpm, 8.1-fpm
 GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
 Directory: 8.1/fpm
 
-Tags: 8.2.5-apache, 8.2-apache, 8-apache, 8.2.5, 8.2, 8
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+Tags: 8.2.6-apache, 8.2-apache, 8-apache, 8.2.6, 8.2, 8
+GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
 Directory: 8.2/apache
 
-Tags: 8.2.5-fpm, 8.2-fpm, 8-fpm
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm
+GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
 Directory: 8.2/fpm
 
-Tags: 9.0.2-apache, 9.0-apache, 9-apache, apache, 9.0.2, 9.0, 9, latest
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+Tags: 9.0.3-apache, 9.0-apache, 9-apache, apache, 9.0.3, 9.0, 9, latest
+GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
 Directory: 9.0/apache
 
-Tags: 9.0.2-fpm, 9.0-fpm, 9-fpm, fpm
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+Tags: 9.0.3-fpm, 9.0-fpm, 9-fpm, fpm
+GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
 Directory: 9.0/fpm

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: cc63f456f57b0537d03ff3362252d40091654c85
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,19 +25,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 3.3.6, 3.3
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 0610d9ccc2dc8ad4ab6038f775e7a28cadf12114
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 9383f7d4d2f96068e8957651aa3588fee8b48f71
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -45,19 +45,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -65,15 +65,15 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 80e4493d12382a86662a518a5730b8eb99b20d27
+GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.34.0: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
-0.34: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
-0: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
-latest: git://github.com/RocketChat/Docker.Official.Image@e98402bdc34e70d0465d1c35bb38611d4d7d1de6
+0.35.0: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
+0.35: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
+0: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
+latest: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd


### PR DESCRIPTION
- `docker`: ootb support for `--userns-remap=default` (docker-library/docker#13)
- `elasticsearch`: 5.0.0-alpha4
- `golang`: Alpine `ca-certificates` (esp. for `net/http` usage; docker-library/golang#99)
- `hello-seattle`: use C for multi-architecture compatibility (docker-library/hello-world#17)
- `hello-world`: use C for multi-architecture compatibility (docker-library/hello-world#17)
- `hola-mundo`: use C for multi-architecture compatibility (docker-library/hello-world#17)
- `kibana`: 5.0.0-alpha4
- `logstash`: 5.0.0-alpha4
- `mariadb`: 10.1.15
- `owncloud`: 9.0.3, 8.2.6
- `python`: remove double-`pip` (docker-library/python#121)
- `rocket.chat`: 0.35.0