### PR TITLE
Sentry 8.6

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,17 +1,20 @@
-# maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/09d2b56ded2f669f40d5295bfe36529bbafb914d/generate-stackbrew-library.sh
 
-8.4.1: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
-8.4: git://github.com/getsentry/docker-sentry@04470f5f81423762ffe376e2ee3657cb1c5b6b1a 8.4
+Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
+GitRepo: https://github.com/getsentry/docker-sentry.git
 
-8.4.1-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
-8.4-onbuild: git://github.com/getsentry/docker-sentry@80218c227b188fad17575040421d600303c5f7bf 8.4/onbuild
+Tags: 8.5.1, 8.5
+GitCommit: d69a0096ee2f885047f95bdd2e2edfc761674580
+Directory: 8.5
 
-8.5.1: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
-8.5: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
-8: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
-latest: git://github.com/getsentry/docker-sentry@902ac5c7e65aa0bfe891b6273b8693af704ccfde 8.5
+Tags: 8.5.1-onbuild, 8.5-onbuild
+GitCommit: ce5121a71f55c2fb0659f552e361b1174c85bccf
+Directory: 8.5/onbuild
 
-8.5.1-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
-8.5-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
-8-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
-onbuild: git://github.com/getsentry/docker-sentry@ce5121a71f55c2fb0659f552e361b1174c85bccf 8.5/onbuild
+Tags: 8.6.0, 8.6, 8, latest
+GitCommit: 09d2b56ded2f669f40d5295bfe36529bbafb914d
+Directory: 8.6
+
+Tags: 8.6.0-onbuild, 8.6-onbuild, 8-onbuild, onbuild
+GitCommit: 09d2b56ded2f669f40d5295bfe36529bbafb914d
+Directory: 8.6/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.6.0 :tada: