### PR TITLE
Convert centos over to new 2822-based format for Constraints

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -1,45 +1,44 @@
-# maintainer: The CentOS Project <cloud-ops@centos.org> (@CentOS)
-# Build date 20160701
+Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
+GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
+Directory: docker
+Constraints: !aufs
 
-# CentOS 7 rolling builds
-latest: git://github.com/CentOS/sig-cloud-instance-images@9df44a818e1ffeca33aedf75342d84bb7d6010a2 docker
-centos7: git://github.com/CentOS/sig-cloud-instance-images@9df44a818e1ffeca33aedf75342d84bb7d6010a2 docker
-7: git://github.com/CentOS/sig-cloud-instance-images@9df44a818e1ffeca33aedf75342d84bb7d6010a2 docker
+Tags: latest, centos7, 7
+GitFetch: refs/heads/CentOS-7
+GitCommit: 9df44a818e1ffeca33aedf75342d84bb7d6010a2
 
-# CentOS 6 rolling builds
-centos6: git://github.com/CentOS/sig-cloud-instance-images@f1ef5434caf93a1c5fcc80572855e8629f2d1f6e docker
-6: git://github.com/CentOS/sig-cloud-instance-images@f1ef5434caf93a1c5fcc80572855e8629f2d1f6e docker
+Tags: centos6, 6
+GitFetch: refs/heads/CentOS-6
+GitCommit: f1ef5434caf93a1c5fcc80572855e8629f2d1f6e
 
-# CentOS 5 rolling builds
-centos5: git://github.com/CentOS/sig-cloud-instance-images@4bf8330498e1c10cf365aff31d2a8a5c3254c2cf docker
-5: git://github.com/CentOS/sig-cloud-instance-images@4bf8330498e1c10cf365aff31d2a8a5c3254c2cf docker
+Tags: centos5, 5
+GitFetch: refs/heads/CentOS-5
+GitCommit: 4bf8330498e1c10cf365aff31d2a8a5c3254c2cf
 
-## Minor tagged builds
-#
-#7.2.1511
-centos7.2.1511: git://github.com/CentOS/sig-cloud-instance-images@a3c59bd4e98a7f9c063d993955c8ec19c5b1ceff docker
-7.2.1511: git://github.com/CentOS/sig-cloud-instance-images@a3c59bd4e98a7f9c063d993955c8ec19c5b1ceff docker
+Tags: centos7.2.1511, 7.2.1511
+GitFetch: refs/heads/CentOS-7.2.1511
+GitCommit: a3c59bd4e98a7f9c063d993955c8ec19c5b1ceff
 
-#7.1.1503
-centos7.1.1503: git://github.com/CentOS/sig-cloud-instance-images@bc561dfdd671d612dbb9f92e7e17dd8009befc44 docker
-7.1.1503: git://github.com/CentOS/sig-cloud-instance-images@bc561dfdd671d612dbb9f92e7e17dd8009befc44 docker
+Tags: centos7.1.1503, 7.1.1503
+GitFetch: refs/heads/CentOS-7.1.1503
+GitCommit: bc561dfdd671d612dbb9f92e7e17dd8009befc44
 
-#7.0.1406
-centos7.0.1406: git://github.com/CentOS/sig-cloud-instance-images@f1d1e0bd83baef08e257da50e6fb446e4dd1b90c docker
-7.0.1406: git://github.com/CentOS/sig-cloud-instance-images@f1d1e0bd83baef08e257da50e6fb446e4dd1b90c docker
+Tags: centos7.0.1406, 7.0.1406
+GitFetch: refs/heads/CentOS-7.0.1406
+GitCommit: f1d1e0bd83baef08e257da50e6fb446e4dd1b90c
 
-# 6.8
-centos6.8: git://github.com/CentOS/sig-cloud-instance-images@f32666d2af356ed6835942ed753a4970e18bca94 docker
-6.8: git://github.com/CentOS/sig-cloud-instance-images@f32666d2af356ed6835942ed753a4970e18bca94 docker
+Tags: centos6.8, 6.8
+GitFetch: refs/heads/CentOS-6.8
+GitCommit: f32666d2af356ed6835942ed753a4970e18bca94
 
-# 6.7
-centos6.7: git://github.com/CentOS/sig-cloud-instance-images@d0b72df83f49da844f88aabebe3826372f675370 docker
-6.7: git://github.com/CentOS/sig-cloud-instance-images@d0b72df83f49da844f88aabebe3826372f675370 docker
+Tags: centos6.7, 6.7
+GitFetch: refs/heads/CentOS-6.7
+GitCommit: d0b72df83f49da844f88aabebe3826372f675370
 
-# 6.6
-centos6.6: git://github.com/CentOS/sig-cloud-instance-images@8911843d9a6cc71aadd81e491f94618aded94f30 docker
-6.6: git://github.com/CentOS/sig-cloud-instance-images@8911843d9a6cc71aadd81e491f94618aded94f30 docker
+Tags: centos6.6, 6.6
+GitFetch: refs/heads/CentOS-6.6
+GitCommit: 8911843d9a6cc71aadd81e491f94618aded94f30
 
-# 5.11
-centos5.11: git://github.com/CentOS/sig-cloud-instance-images@2d0554464ae19f4fd70d1b540c8968dbe872797b docker
-5.11: git://github.com/CentOS/sig-cloud-instance-images@2d0554464ae19f4fd70d1b540c8968dbe872797b docker
+Tags: centos5.11, 5.11
+GitFetch: refs/heads/CentOS-5.11
+GitCommit: 2d0554464ae19f4fd70d1b540c8968dbe872797b


### PR DESCRIPTION
The official build server was runs into "Untar re-exec error: exit status 1: output: operation not supported" with the latest tarballs, so I've converted to the new format so we can add "Constraints" and build "centos" officially on non-aufs.

cc @jperrin

(If you have a script that was building the previous output for you, I'd be happy to help convert it to output this newer format, but I couldn't find one. :smile:)