### PR TITLE
Add ability to set build args

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -86,7 +86,7 @@ func cmdBuild(c *cli.Context) error {
 				}
 				defer archive.Close()
 
-				err = dockerBuild(cacheTag, archive)
+				err = dockerBuild(cacheTag, entry.BuildArgs, archive)
 				if err != nil {
 					return cli.NewMultiError(fmt.Errorf(`failed building %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 				}

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -137,8 +137,11 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 	}, nil
 }
 
-func dockerBuild(tag string, context io.Reader) error {
+func dockerBuild(tag string, build_args []string, context io.Reader) error {
 	args := []string{"build", "-t", tag, "--rm", "--force-rm"}
+	for _, arg := range build_args {
+		args = append(args, "--build-arg", os.ExpandEnv(arg))
+	}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = context

--- a/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/rfc2822.go
+++ b/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/rfc2822.go
@@ -32,6 +32,7 @@ type Manifest2822Entry struct {
 	GitCommit   string
 	Directory   string
 	Constraints []string `delim:"," strip:"\n\r\t "`
+	BuildArgs   []string `delim:"," strip:"\n\r\t "`
 }
 
 var DefaultManifestEntry = Manifest2822Entry{
@@ -44,6 +45,7 @@ func (entry Manifest2822Entry) Clone() Manifest2822Entry {
 	entry.Maintainers = append([]string{}, entry.Maintainers...)
 	entry.Tags = append([]string{}, entry.Tags...)
 	entry.Constraints = append([]string{}, entry.Constraints...)
+	entry.BuildArgs = append([]string{}, entry.BuildArgs...)
 	return entry
 }
 
@@ -61,9 +63,13 @@ func (entry Manifest2822Entry) ConstraintsString() string {
 	return strings.Join(entry.Constraints, StringSeparator2822)
 }
 
+func (entry Manifest2822Entry) BuildArgsString() string {
+	return strings.Join(entry.BuildArgs, StringSeparator2822)
+}
+
 // if this method returns "true", then a.Tags and b.Tags can safely be combined (for the purposes of building)
 func (a Manifest2822Entry) SameBuildArtifacts(b Manifest2822Entry) bool {
-	return a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.ConstraintsString() == b.ConstraintsString()
+	return a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.ConstraintsString() == b.ConstraintsString() && a.BuildArgsString() == b.BuildArgsString()
 }
 
 // returns a new Entry with any of the values that are equal to the values in "defaults" cleared
@@ -88,6 +94,9 @@ func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifes
 	}
 	if entry.ConstraintsString() == defaults.ConstraintsString() {
 		entry.Constraints = nil
+	}
+	if entry.BuildArgsString() == defaults.BuildArgsString() {
+		entry.BuildArgs = nil
 	}
 	return entry
 }
@@ -114,6 +123,9 @@ func (entry Manifest2822Entry) String() string {
 	}
 	if str := entry.ConstraintsString(); str != "" {
 		ret = append(ret, "Constraints: "+str)
+	}
+	if str := entry.BuildArgsString(); str != "" {
+		ret = append(ret, "BuildArgs: "+str)
 	}
 	return strings.Join(ret, "\n")
 }


### PR DESCRIPTION
Signed-off-by: Stuart Clark stuart.clark@Jahingo.com

Add a new option "BuildArgs" to the RFC2822 form of the image manifest which can contain comma separated lists of build arguments (in name=value format). These arguments are then passed to docker (via --build-arg in docker build) during build, with $VAR and ${VAR} environment substitutions allowed.

While not particularly useful for the official image builds it can be very handy for other users of bashbrew to pass build-time arguments from the build system (e.g. credentials which shouldn't be stored inside the image/Dockerfile)

For example:

Tags: latest
GitRepo: https://...
GitCommit: 12345
BuildArgs: arg1=value1, arg2=$HOME, arg3=the${USER}
