### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.0-rc2, 1.12-rc, rc
-GitCommit: 99287145029122cf49321fa2a055d14240001d1d
+Tags: 1.12.0-rc3, 1.12-rc, rc
+GitCommit: 3fe09e2340b6d431c0618c466d54e9f0231c2f7a
 Directory: 1.12-rc
 
-Tags: 1.12.0-rc2-dind, 1.12-rc-dind, rc-dind
+Tags: 1.12.0-rc3-dind, 1.12-rc-dind, rc-dind
 GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.12-rc/dind
 
-Tags: 1.12.0-rc2-git, 1.12-rc-git, rc-git
+Tags: 1.12.0-rc3-git, 1.12-rc-git, rc-git
 GitCommit: 4d1f83ee6e25a5c2bb1c8a04de0643b1a964ba5e
 Directory: 1.12-rc/git
 

--- a/library/httpd
+++ b/library/httpd
@@ -8,6 +8,6 @@ Tags: 2.2.31, 2.2
 GitCommit: 07de32639616a6d307c3f4bb56a01d408d1765d6
 Directory: 2.2
 
-Tags: 2.4.20, 2.4, 2, latest
-GitCommit: 07de32639616a6d307c3f4bb56a01d408d1765d6
+Tags: 2.4.23, 2.4, 2, latest
+GitCommit: 2d50ff61c9e68036a7829fed797e65ebeebb2d18
 Directory: 2.4

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.15, 10.1, 10, latest
-GitCommit: 14fa9fab60856471be80afdbb4044f31d78e9a08
+Tags: 10.1.14, 10.1, 10, latest
+GitCommit: 21b143d133b2250eb473eb5492cfa38e5d094e62
 Directory: 10.1
 
 Tags: 10.0.26, 10.0

--- a/library/python
+++ b/library/python
@@ -79,3 +79,19 @@ Directory: 3.5/alpine
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
 GitCommit: 0fa3202789648132971160f686f5a37595108f44
 Directory: 3.5/onbuild
+
+Tags: 3.6.0a2, 3.6
+GitCommit: d92b2e00353ad8f20f6d5c658802741c33ebbd7d
+Directory: 3.6
+
+Tags: 3.6.0a2-slim, 3.6-slim
+GitCommit: 8a66fdc3257c2dab06d0fbf614d5cbfa6365c9cc
+Directory: 3.6/slim
+
+Tags: 3.6.0a2-alpine, 3.6-alpine
+GitCommit: d92b2e00353ad8f20f6d5c658802741c33ebbd7d
+Directory: 3.6/alpine
+
+Tags: 3.6.0a2-onbuild, 3.6-onbuild
+GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
+Directory: 3.6/onbuild

--- a/library/rails
+++ b/library/rails
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rails.git
 
-Tags: 4.2.6, 4.2, 4, latest
-GitCommit: 04006011344175c10b6864193eee74d626b84b11
+Tags: 5.0.0, 5.0, 5, latest
+GitCommit: 15389f3f777fe16044a04709c2000f98948d16fa
 
 Tags: onbuild
 GitCommit: 9df9b5e6b1519faf22e1565c2caaebf7cc1c665b


### PR DESCRIPTION
- `docker`: 1.12.0-rc3
- `httpd`: 2.4.23
- `mariadb`: revert back to 10.1.14 (docker-library/mariadb#67)
- `python`: 3.6.0a2 (docker-library/python#123)
- `rails`: 5.0.0 (docker-library/rails#44)