### PR TITLE
Add Vault image

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -1,4 +1,4 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
-v0.6.0: git://github.com/hashicorp/docker-vault@64003edf3c1105161340bc7fe1b364d5fb3f5b57 0.6
-latest: git://github.com/hashicorp/docker-vault@64003edf3c1105161340bc7fe1b364d5fb3f5b57 0.6
+v0.6.0: git://github.com/hashicorp/docker-vault@a77fd5f7256af73c082cfef56403ecc4df58fa94 0.6
+latest: git://github.com/hashicorp/docker-vault@a77fd5f7256af73c082cfef56403ecc4df58fa94 0.6

--- a/library/vault
+++ b/library/vault
@@ -1,0 +1,4 @@
+# maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
+
+v0.6.0: git://github.com/hashicorp/docker-vault@64003edf3c1105161340bc7fe1b364d5fb3f5b57 0.6
+latest: git://github.com/hashicorp/docker-vault@64003edf3c1105161340bc7fe1b364d5fb3f5b57 0.6


### PR DESCRIPTION
This adds an official image for Vault. The Dockerfile and entrypoint script were heavily based upon the approved official Consul image.

Documentation pull request is at https://github.com/docker-library/docs/pull/634

# Checklist for Review

- [x] associated with or contacted upstream?
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)