### PR TITLE
Add eggdrop to official-images

### DIFF
--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,7 +2,7 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: c0cadfaa7fdd295d611cc87f91f4d32eea2fcd81
+GitCommit: 81b43df126aa2c6bd1256ec5c815c67670fb0012
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,4 +1,4 @@
-Maintainer: Geo Van O <geo@eggheads.org> (@vansg),
+Maintainers: Geo Van O <geo@eggheads.org> (@vanosg),
 
 Tags: 1.6.21, 1.6, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,10 +2,10 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, stable, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: 81b43df126aa2c6bd1256ec5c815c67670fb0012
+GitCommit: 036b77b792fd5e9b288a49c83bd943c6a687de25
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop
 GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: a971599ba00ac3510a0d24fc6f9e07f72908197a
+GitCommit: 036b77b792fd5e9b288a49c83bd943c6a687de25
 Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,5 +1,5 @@
 Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
-GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
+GitRepo: https://github.com/eggheads/eggdrop-docker.git
 
 Tags: 1.6.21, 1.6, stable, latest
 GitCommit: def15a99429271388c9f2958dcc1a825f729e3d3

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,4 +1,4 @@
-Maintainers: Geo Van O <geo@eggheads.org> (@vanosg),
+Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,10 +2,10 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, stable, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: a60010cda8d03f08d34b55d5f00642a873497e8b
+GitCommit: def15a99429271388c9f2958dcc1a825f729e3d3
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop
 GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: a60010cda8d03f08d34b55d5f00642a873497e8b
+GitCommit: def15a99429271388c9f2958dcc1a825f729e3d3
 Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,10 +2,10 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, stable, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: 036b77b792fd5e9b288a49c83bd943c6a687de25
+GitCommit: a60010cda8d03f08d34b55d5f00642a873497e8b
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop
 GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: 036b77b792fd5e9b288a49c83bd943c6a687de25
+GitCommit: a60010cda8d03f08d34b55d5f00642a873497e8b
 Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,11 +1,10 @@
 Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
+GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
 
 Tags: 1.6.21, 1.6, stable, latest
-GitRepo: https://github.com/eggheads/eggdrop-docker.git
 GitCommit: def15a99429271388c9f2958dcc1a825f729e3d3
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop
-GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
 GitCommit: def15a99429271388c9f2958dcc1a825f729e3d3
 Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,10 +2,10 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg),
 
 Tags: 1.6.21, 1.6, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: 6d1e38421203d1143720073922c1eb70e7cb466d
+GitCommit: a971599ba00ac3510a0d24fc6f9e07f72908197a
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop
 GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: 6d1e38421203d1143720073922c1eb70e7cb466d
+GitCommit: a971599ba00ac3510a0d24fc6f9e07f72908197a
 Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -2,7 +2,7 @@ Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
 Tags: 1.6.21, 1.6, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
-GitCommit: a971599ba00ac3510a0d24fc6f9e07f72908197a
+GitCommit: c0cadfaa7fdd295d611cc87f91f4d32eea2fcd81
 Directory: 1.6
 
 Tags: 1.8.0, 1.8, develop

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,0 +1,11 @@
+Maintainer: Geo Van O <geo@eggheads.org> (@vansg),
+
+Tags: 1.6.21, 1.6, latest
+GitRepo: https://github.com/eggheads/eggdrop-docker.git
+GitCommit: 6d1e38421203d1143720073922c1eb70e7cb466d
+Directory: 1.6
+
+Tags: 1.8.0, 1.8, develop
+GitRepo: GitRepo: https://github.com/eggheads/eggdrop-docker.git
+GitCommit: 6d1e38421203d1143720073922c1eb70e7cb466d
+Directory: 1.8

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -1,6 +1,6 @@
 Maintainers: Geo Van O <geo@eggheads.org> (@vanosg)
 
-Tags: 1.6.21, 1.6, latest
+Tags: 1.6.21, 1.6, stable, latest
 GitRepo: https://github.com/eggheads/eggdrop-docker.git
 GitCommit: 81b43df126aa2c6bd1256ec5c815c67670fb0012
 Directory: 1.6


### PR DESCRIPTION
# Checklist for Review

- [x] associated with or contacted upstream?
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/632
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)