### PR TITLE
Support JVM Options in Jetty images

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,16 +4,16 @@ GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.3.10, 9.3, 9, 9.3.10-jre8, 9.3-jre8, 9-jre8, latest, jre8
 Directory: 9.3-jre8
-GitCommit: 25ff3e0419721dd1812a49de72ee3aa37e41bbfd
+GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
 
 Tags: 9.3.10-alpine, 9.3-alpine, 9-alpine, 9.3.10-jre8-alpine, 9.3-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: 25ff3e0419721dd1812a49de72ee3aa37e41bbfd
+GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
 
 Tags: 9.2.17, 9.2, 9.2.17-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: 1ea4d8064136369ed2ec08fc5f4fbc3cae30c8d2
+GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
 
 Tags: 9.2.17-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: 1ea4d8064136369ed2ec08fc5f4fbc3cae30c8d2
+GitCommit: e399f08087f8efce4a272225e667c04a09a1996b


### PR DESCRIPTION
This PR includes the fix for [37](https://github.com/appropriate/docker-jetty/issues/37).

The `docker-entrypoint.sh` script has been updated to include the `$JAVA_OPTIONS`
environment variable in the command line arguments if the command is java.