### PR TITLE
update openSUSE: security fixes for 42.1/Leap

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -7,7 +7,7 @@ Constraints: !aufs
 
 Tags: 42.1, leap, latest
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: fdb195e64507f464cb5be61c9835e79663df9178
+GitCommit: 3ed6d2da90ab4fcef4c4afde20b7c28bcc69ce9d
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2


### PR DESCRIPTION
NOTE: We now also include the sha256 hash for the underlying tar file. You can use this to verify the integrity of our tar.xz files:
sha256 checksum for openSUSE-42.1: https://github.com/openSUSE/docker-containers-build/blob/openSUSE-42.1/docker/openSUSE-42.1.tar.xz.sha256
Thanks! :)

Signed-off-by: Christian Brauner <cbrauner@suse.de>

//cc @flavio, @jordimassaguerpla 