### PR TITLE
Add DockerCacheName to be able to use it from templates

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -65,12 +65,10 @@ func cmdBuild(c *cli.Context) error {
 				}
 			}
 
-			cacheHash, err := r.dockerCacheHash(&entry)
+			cacheTag, err := r.DockerCacheName(&entry)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed calculating "cache hash" for %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 			}
-
-			cacheTag := "bashbrew/cache:" + cacheHash
 
 			// check whether we've already built this artifact
 			_, err = dockerInspect("{{.Id}}", cacheTag)

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -82,6 +82,14 @@ func dockerfileFrom(dockerfile io.Reader) (string, error) {
 	return "", nil
 }
 
+func (r Repo) DockerCacheName(entry *manifest.Manifest2822Entry) (string, error) {
+	cacheHash, err := r.dockerCacheHash(entry)
+	if err != nil {
+		return "", err
+	}
+	return "bashbrew/cache:" + cacheHash, err
+}
+
 func (r Repo) dockerCacheHash(entry *manifest.Manifest2822Entry) (string, error) {
 	uniqueBits, err := r.dockerBuildUniqueBits(entry)
 	if err != nil {


### PR DESCRIPTION
 - like the following to get `golang:latest` and the cache name of its parent

   ```console
$ bashbrew cat --format '{{ range .Entries }}{{ $.DockerCacheName . }}{{ range .Tags }}{{"\n"}}{{ join ":" $.RepoName . }}{{end}}{{"\n"}}{{end}}' golang:latest
bashbrew/cache:93d6b24fcb40f0139a5af8e27158658e1dcd38d5040d0448c2d91a83e89ae09e
golang:1.6.2
golang:1.6
golang:1
golang:latest
   ```

It can then also be used to figure out if you have old official images on your system (if you build them): 
```console
$ comm -13 \
    <(bashbrew cat --format '{{ range .Entries }}{{ $.DockerCacheName . }}{{ range .Tags }}{{"\n"}}{{ join ":" $.RepoName . }}{{end}}{{"\n"}}{{end}}' --all | sort) \
    <(docker images | awk 'NR>1 && $1 !~ /^custom|images|<none>/ { print $1 ":" $2 }' | sort)"
```