### PR TITLE
Upgrade Node to 6.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -64,22 +64,22 @@ argon-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c
 5.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
 5-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
 
-6.2.2: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2
-6.2: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2
-6: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2
-latest: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2
+6.3.0: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3
+6.3: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3
+6: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3
+latest: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3
 
-6.2.2-onbuild: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/onbuild
-6.2-onbuild: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/onbuild
-onbuild: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/onbuild
+6.3.0-onbuild: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/onbuild
+6.3-onbuild: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/onbuild
+onbuild: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/onbuild
 
-6.2.2-slim: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/slim
-6.2-slim: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/slim
-6-slim: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/slim
-slim: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/slim
+6.3.0-slim: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/slim
+6.3-slim: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/slim
+6-slim: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/slim
+slim: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/slim
 
-6.2.2-wheezy: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/wheezy
-6.2-wheezy: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/wheezy
-6-wheezy: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/wheezy
-wheezy: git://github.com/nodejs/docker-node@dc9ceb77ad6d98258c825ee45aac219169bc3532 6.2/wheezy
+6.3.0-wheezy: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/wheezy
+6.3-wheezy: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/wheezy
+6-wheezy: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/wheezy
+wheezy: git://github.com/nodejs/docker-node@6a984d5b1f27b0344cbbab20019e77e6c0420b91 6.3/wheezy


### PR DESCRIPTION
This PR updates the latest `node` Docker Image to v5.3.0 of Node.js.

Changeset: https://github.com/nodejs/docker-node/compare/dc9ceb77ad6d98258c825ee45aac219169bc3532...6a984d5b1f27b0344cbbab20019e77e6c0420b91

Related: nodejs/node#7550
Related: nodejs/docker-node#210

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>