### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -12,10 +12,10 @@ Tags: 7.44-fpm, 7-fpm
 GitCommit: 09ecd6173dee9401924cbe350eced0ec7c477e43
 Directory: 7/fpm
 
-Tags: 8.1.3-apache, 8.1-apache, 8-apache, apache, 8.1.3, 8.1, 8, latest
-GitCommit: 09ecd6173dee9401924cbe350eced0ec7c477e43
+Tags: 8.1.4-apache, 8.1-apache, 8-apache, apache, 8.1.4, 8.1, 8, latest
+GitCommit: d79663db4cb85f58443aaa562a766e4bff89f2b1
 Directory: 8.1/apache
 
-Tags: 8.1.3-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 09ecd6173dee9401924cbe350eced0ec7c477e43
+Tags: 8.1.4-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: d79663db4cb85f58443aaa562a766e4bff89f2b1
 Directory: 8.1/fpm

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 1.5.2, 1.5
-GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 1.5
 
 Tags: 1.6.2, 1.6
-GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 1.6
 
 Tags: 1.7.5, 1.7, 1
-GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
-GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.0
 
 Tags: 2.1.2, 2.1
-GitCommit: 2ceaacde5b9dcc3e15f5daa4b1a282bf0f190d2b
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.1
 
 Tags: 2.2.2, 2.2
-GitCommit: 97739a4b07d856d2cf861e5e4e7bb2bc8cded7f7
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.2
 
 Tags: 2.3.3, 2.3, 2, latest
-GitCommit: 30af4a027561ede1295621039ebc4ae6c656ea2a
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.3
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5
-GitCommit: 4093013f00696225cd9e316d5f892ae8f98b7888
+GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 5.0

--- a/library/java
+++ b/library/java
@@ -17,7 +17,7 @@ GitCommit: a3f06bcbc86d16912a309cf4538a00caf9a6100c
 Directory: 7-jdk
 
 Tags: 7u91-jdk-alpine, 7u91-alpine, 7-jdk-alpine, 7-alpine, openjdk-7u91-jdk-alpine, openjdk-7u91-alpine, openjdk-7-jdk-alpine, openjdk-7-alpine
-GitCommit: f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9
+GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 7-jdk/alpine
 
 Tags: 7u101-jre, 7-jre, openjdk-7u101-jre, openjdk-7-jre
@@ -25,7 +25,7 @@ GitCommit: a3f06bcbc86d16912a309cf4538a00caf9a6100c
 Directory: 7-jre
 
 Tags: 7u91-jre-alpine, 7-jre-alpine, openjdk-7u91-jre-alpine, openjdk-7-jre-alpine
-GitCommit: f60edc7cfe9fa4d4473ef027c6fb2d5e1f6c17f9
+GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 7-jre/alpine
 
 Tags: 8u91-jdk, 8u91, 8-jdk, 8, jdk, latest, openjdk-8u91-jdk, openjdk-8u91, openjdk-8-jdk, openjdk-8
@@ -33,7 +33,7 @@ GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
 Directory: 8-jdk
 
 Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
-GitCommit: c6c90f5e09a5dc1a1ccd662de8210342f94c673e
+GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jdk/alpine
 
 Tags: 8u91-jre, 8-jre, jre, openjdk-8u91-jre, openjdk-8-jre
@@ -41,7 +41,7 @@ GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
 Directory: 8-jre
 
 Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine
-GitCommit: c6c90f5e09a5dc1a1ccd662de8210342f94c673e
+GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
 Tags: 9-b124-jdk, 9-b124, 9-jdk, 9, openjdk-9-b124-jdk, openjdk-9-b124, openjdk-9-jdk, openjdk-9

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.27, 1.4, 1, latest
-GitCommit: 3f5295b2be7ad0dd396c75e7b4b0f5aad2215cbd
+Tags: 1.4.28, 1.4, 1, latest
+GitCommit: 20f1e32162f9376a75b569519a375ce18e659a8d
 Directory: debian
 
-Tags: 1.4.27-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 3f5295b2be7ad0dd396c75e7b4b0f5aad2215cbd
+Tags: 1.4.28-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 20f1e32162f9376a75b569519a375ce18e659a8d
 Directory: alpine

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.12, 5.7, 5, latest
-GitCommit: 340269718642a7acc4580e398121ba5462308730
+Tags: 5.7.13, 5.7, 5, latest
+GitCommit: b1f72280a3464a12979111287255da27c6537405
 Directory: 5.7
 
 Tags: 5.6.30, 5.6

--- a/library/php
+++ b/library/php
@@ -13,7 +13,7 @@ GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 7.0/alpine
 
 Tags: 7.0.8-apache, 7.0-apache, 7-apache, apache
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: 2dc37fa5199d38a1e53493c315fd0f5c1054e2c3
 Directory: 7.0/apache
 
 Tags: 7.0.8-fpm, 7.0-fpm, 7-fpm, fpm
@@ -41,7 +41,7 @@ GitCommit: d0993972f314576849e4489cc25729d05e1391ca
 Directory: 5.6/alpine
 
 Tags: 5.6.23-apache, 5.6-apache, 5-apache
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: 2dc37fa5199d38a1e53493c315fd0f5c1054e2c3
 Directory: 5.6/apache
 
 Tags: 5.6.23-fpm, 5.6-fpm, 5-fpm
@@ -69,7 +69,7 @@ GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
 Directory: 5.5/alpine
 
 Tags: 5.5.37-apache, 5.5-apache
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: 2dc37fa5199d38a1e53493c315fd0f5c1054e2c3
 Directory: 5.5/apache
 
 Tags: 5.5.37-fpm, 5.5-fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.2, 3.6, 3, latest
-GitCommit: 6b496ac32e18fbff4b2b45e0577a79b10edd4df0
+Tags: 3.6.3, 3.6, 3, latest
+GitCommit: ab3b8b85c19b8fce28b13fe5aa4cf3c099908d88
 
-Tags: 3.6.2-management, 3.6-management, 3-management, management
+Tags: 3.6.3-management, 3.6-management, 3-management, management
 GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d
 Directory: management


### PR DESCRIPTION
- `drupal`: 8.1.4
- `elasticsearch`: remove unused `ELASTICSEARCH_MAJOR` (docker-library/elasticsearch#107)
- `java`: add more bits to `PATH` for `alpine` variants
- `memcached`: 1.4.28 (docker-library/memcached#10)
- `percona`: 5.7.13
- `php`: use `/etc/apache2/envvars` and thus the default, stock Debian Apache configuration (docker-library/php#251)
- `rabbitmq`: `hipe_compile` (docker-library/rabbitmq#91), 3.6.3 (docker-library/rabbitmq#93), `RABBITMQ_SSL_VERIFY` + `RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT` support (docker-library/rabbitmq#94)