### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 7.44-apache, 7-apache, 7.44, 7
-GitCommit: 09ecd6173dee9401924cbe350eced0ec7c477e43
+Tags: 7.50-apache, 7-apache, 7.50, 7
+GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
 Directory: 7/apache
 
-Tags: 7.44-fpm, 7-fpm
-GitCommit: 09ecd6173dee9401924cbe350eced0ec7c477e43
+Tags: 7.50-fpm, 7-fpm
+GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
 Directory: 7/fpm
 
-Tags: 8.1.4-apache, 8.1-apache, 8-apache, apache, 8.1.4, 8.1, 8, latest
-GitCommit: d79663db4cb85f58443aaa562a766e4bff89f2b1
+Tags: 8.1.5-apache, 8.1-apache, 8-apache, apache, 8.1.5, 8.1, 8, latest
+GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
 Directory: 8.1/apache
 
-Tags: 8.1.4-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: d79663db4cb85f58443aaa562a766e4bff89f2b1
+Tags: 8.1.5-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
 Directory: 8.1/fpm

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -28,8 +28,8 @@ Tags: 2.2.2, 2.2
 GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.2
 
-Tags: 2.3.3, 2.3, 2, latest
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+Tags: 2.3.4, 2.3, 2, latest
+GitCommit: 1e62c7d84cc549883e3404d79356d3fadfdf6c3d
 Directory: 2.3
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5

--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2015-06-26
-Tags: 4.9.3, 4.9, 4
-GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
-Directory: 4.9
-# Docker EOL: 2016-06-26
-
 # Last Modified: 2015-07-16
 Tags: 5.2.0, 5.2
 GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3

--- a/library/kibana
+++ b/library/kibana
@@ -8,8 +8,8 @@ Tags: 4.0.3, 4.0
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.0
 
-Tags: 4.1.8, 4.1
-GitCommit: 0beddcb3e86d1b623ada81d423aaa98e8500657f
+Tags: 4.1.9, 4.1
+GitCommit: 7d664ca170976c354d12287ffcf44384be06f286
 Directory: 4.1
 
 Tags: 4.2.2, 4.2
@@ -24,8 +24,8 @@ Tags: 4.4.2, 4.4
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.4
 
-Tags: 4.5.1, 4.5, 4, latest
-GitCommit: 2015c601bab8b77f0d13475f901c9b85e6014bdb
+Tags: 4.5.2, 4.5, 4, latest
+GitCommit: 2adb45495b617c5f966c714f55fb3eb3d7d1c853
 Directory: 4.5
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5

--- a/library/logstash
+++ b/library/logstash
@@ -20,8 +20,8 @@ Tags: 2.2.4-1, 2.2.4, 2.2
 GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
 Directory: 2.2
 
-Tags: 2.3.3-1, 2.3.3, 2.3, 2, latest
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+Tags: 2.3.4-1, 2.3.4, 2.3, 2, latest
+GitCommit: b0342c0fdfe41b89a02b4edd75303e6a143a19c1
 Directory: 2.3
 
 Tags: 5.0.0-alpha4-1, 5.0.0-alpha4, 5.0.0, 5.0, 5

--- a/library/percona
+++ b/library/percona
@@ -8,8 +8,8 @@ Tags: 5.7.13, 5.7, 5, latest
 GitCommit: b1f72280a3464a12979111287255da27c6537405
 Directory: 5.7
 
-Tags: 5.6.30, 5.6
-GitCommit: 5981db386679e99039de1104a28920939acf59fc
+Tags: 5.6.31, 5.6
+GitCommit: 97b1c658432db2deae77b6577681d45e6c8ee493
 Directory: 5.6
 
 Tags: 5.5.49, 5.5

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: ac647c4b59919136759da632acf231933e022492
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: ac647c4b59919136759da632acf231933e022492
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: ac647c4b59919136759da632acf231933e022492
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: ac647c4b59919136759da632acf231933e022492
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,19 +25,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 3.3.6, 3.3
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -45,19 +45,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -65,15 +65,15 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 682708e7866caccd3f476f1d30ca60c0851249e1
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
@@ -81,15 +81,15 @@ GitCommit: 0fa3202789648132971160f686f5a37595108f44
 Directory: 3.5/onbuild
 
 Tags: 3.6.0a2, 3.6
-GitCommit: d92b2e00353ad8f20f6d5c658802741c33ebbd7d
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.6
 
 Tags: 3.6.0a2-slim, 3.6-slim
-GitCommit: 8a66fdc3257c2dab06d0fbf614d5cbfa6365c9cc
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.6/slim
 
 Tags: 3.6.0a2-alpine, 3.6-alpine
-GitCommit: d92b2e00353ad8f20f6d5c658802741c33ebbd7d
+GitCommit: 3db904b3f5407840e591daf3aa54670a685b22b3
 Directory: 3.6/alpine
 
 Tags: 3.6.0a2-onbuild, 3.6-onbuild


### PR DESCRIPTION
- `drupal`: 8.1.5, 7.50
- `elasticsearch`: 2.3.4 (docker-library/elasticsearch#109)
- `gcc`: remove 4.9 (Docker EOL)
- `kibana`: 4.5.2, 4.1.9 (docker-library/kibana#49)
- `logstash`: 2.3.4 (docker-library/logstash#53)
- `percona`: 5.6.31
- `python`: `--enable-loadable-sqlite-extensions` (docker-library/python#125)