### PR TITLE
Support JVM Options in Jetty images

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,16 +4,16 @@ GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.3.10, 9.3, 9, 9.3.10-jre8, 9.3-jre8, 9-jre8, latest, jre8
 Directory: 9.3-jre8
-GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
+GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
 
 Tags: 9.3.10-alpine, 9.3-alpine, 9-alpine, 9.3.10-jre8-alpine, 9.3-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
+GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
 
 Tags: 9.2.17, 9.2, 9.2.17-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
+GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
 
 Tags: 9.2.17-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: e399f08087f8efce4a272225e667c04a09a1996b
+GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce


### PR DESCRIPTION
This PR completes the fix for [37](https://github.com/appropriate/docker-jetty/issues/37):
 - fix also applied to alpine image
 - removes unused ENV vars