### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.14, 2.1
-GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Tags: 2.1.15, 2.1
+GitCommit: ef66ec669d3930aea018f74dc58f5bd2ef5df880
 Directory: 2.1
 
-Tags: 2.2.6, 2.2, 2
-GitCommit: 5e291bb8fad37f2f29b8aadcc718f9a155152e92
+Tags: 2.2.7, 2.2, 2
+GitCommit: ef66ec669d3930aea018f74dc58f5bd2ef5df880
 Directory: 2.2
 
-Tags: 3.0.7, 3.0
-GitCommit: f387127a9bbf07439a09a95135936be42fc35277
+Tags: 3.0.8, 3.0
+GitCommit: ef66ec669d3930aea018f74dc58f5bd2ef5df880
 Directory: 3.0
 
 Tags: 3.7, 3, latest

--- a/library/golang
+++ b/library/golang
@@ -37,18 +37,18 @@ Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
 GitCommit: 5a84ebfbf3c55674dd6f36c66828c2e7461f2f0b
 Directory: 1.6/alpine
 
-Tags: 1.7beta2, 1.7
-GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
+Tags: 1.7rc1, 1.7
+GitCommit: ba6a0e7a5bc08ecf0f760cbbd32d1cb71f8da8b9
 Directory: 1.7
 
-Tags: 1.7beta2-onbuild, 1.7-onbuild
+Tags: 1.7rc1-onbuild, 1.7-onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7beta2-wheezy, 1.7-wheezy
-GitCommit: 7fd2b76513e537343f088da671a51f5b2ea7d4c3
+Tags: 1.7rc1-wheezy, 1.7-wheezy
+GitCommit: ba6a0e7a5bc08ecf0f760cbbd32d1cb71f8da8b9
 Directory: 1.7/wheezy
 
-Tags: 1.7beta2-alpine, 1.7-alpine
-GitCommit: 5a84ebfbf3c55674dd6f36c66828c2e7461f2f0b
+Tags: 1.7rc1-alpine, 1.7-alpine
+GitCommit: ba6a0e7a5bc08ecf0f760cbbd32d1cb71f8da8b9
 Directory: 1.7/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -1,13 +1,21 @@
-# this file is generated via https://github.com/docker-library/httpd/blob/90fcd5ffe50e9e035133d1d175fdf772b2d60991/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/httpd/blob/12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.31, 2.2
-GitCommit: 07de32639616a6d307c3f4bb56a01d408d1765d6
+GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
 Directory: 2.2
 
+Tags: 2.2.31-alpine, 2.2-alpine
+GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+Directory: 2.2/alpine
+
 Tags: 2.4.23, 2.4, 2, latest
-GitCommit: 2d50ff61c9e68036a7829fed797e65ebeebb2d18
+GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
 Directory: 2.4
+
+Tags: 2.4.23-alpine, 2.4-alpine, 2-alpine, alpine
+GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+Directory: 2.4/alpine

--- a/library/percona
+++ b/library/percona
@@ -12,6 +12,6 @@ Tags: 5.6.31, 5.6
 GitCommit: 97b1c658432db2deae77b6577681d45e6c8ee493
 Directory: 5.6
 
-Tags: 5.5.49, 5.5
-GitCommit: 4501310f267a20434f10b28a8e1be660a3a09439
+Tags: 5.5.50, 5.5
+GitCommit: 9eb3ba8a16b4a037dbfe2314d17055743795e712
 Directory: 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.3, 3.6, 3, latest
-GitCommit: 3569ec7f11b1b01bd94163707cea2c7381cb48d6
+GitCommit: 01cebb700efb951058263f3439ab83fbe81222aa
 
 Tags: 3.6.3-management, 3.6-management, 3-management, management
 GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/004edbd80fbc5da064b48b7de61d018a88206839/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/5f1abae99c0b1ebbd4f020bc4b5696619d948cfd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -13,25 +13,49 @@ GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
 Directory: 6/jre8
 
 Tags: 7.0.70-jre7, 7.0-jre7, 7-jre7, 7.0.70, 7.0, 7
-GitCommit: 7c4365e43f352c981a97eae5090bb055a68ff6a9
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 7/jre7
 
+Tags: 7.0.70-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.70-alpine, 7.0-alpine, 7-alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 7/jre7-alpine
+
 Tags: 7.0.70-jre8, 7.0-jre8, 7-jre8
-GitCommit: 7c4365e43f352c981a97eae5090bb055a68ff6a9
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 7/jre8
 
+Tags: 7.0.70-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 7/jre8-alpine
+
 Tags: 8.0.36-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.36, 8.0, 8, latest
-GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 8.0/jre7
 
+Tags: 8.0.36-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.36-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 8.0/jre7-alpine
+
 Tags: 8.0.36-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 8.0/jre8
 
+Tags: 8.0.36-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 8.0/jre8-alpine
+
 Tags: 8.5.3-jre8, 8.5-jre8, 8.5.3, 8.5
-GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 8.5/jre8
 
+Tags: 8.5.3-jre8-alpine, 8.5-jre8-alpine, 8.5.3-alpine, 8.5-alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 8.5/jre8-alpine
+
 Tags: 9.0.0.M8-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M8, 9.0.0, 9.0, 9
-GitCommit: 8323df4824d3661f094a1a6c30ed7e13c0536b9e
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 9.0/jre8
+
+Tags: 9.0.0.M8-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M8-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `cassandra`: 3.0.8, 2.2.7, 2.1.15
- `golang`: 1.7rc1 (docker-library/golang#100)
- `httpd`: add `alpine` variants (docker-library/httpd#26)
- `percona`: 5.5.50
- `rabbitmq`: fix more SSL issues (bad defaults for management; docker-library/rabbitmq#97)
- `tomcat`: add `alpine` variants (docker-library/tomcat#36)