### PR TITLE
update openSUSE: security fixes for 42.1/Leap

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -7,7 +7,7 @@ Constraints: !aufs
 
 Tags: 42.1, leap, latest
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: 3ed6d2da90ab4fcef4c4afde20b7c28bcc69ce9d
+GitCommit: 5c63b0a9d2c8b13b81855751168066666d77adb1
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2


### PR DESCRIPTION
Due to various glibc bugs we update our Docker images. The update for glibc
provides the following fixes:

- Do not copy d_name field of struct dirent. (CVE-2016-1234)
- Fix stack overflow in _nss_dns_getnetbyname_r. (CVE-2016-3075)
- Fix getaddrinfo stack overflow in hostent conversion. (CVE-2016-3706)
- Do not use alloca in clntudp_call. (CVE-2016-4429)

The repo provides the tar.xz file as well as its checksum:
	- openSUSE-42.1.tar.xz
	- openSUSE-42.1.tar.xz.sha256

Signed-off-by: Christian Brauner <cbrauner@suse.de>

Thanks! :)