### PR TITLE
Updates to drupal, haproxy, memcached, mongo, owncloud, php, and tomcat

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/drupal.git
 
 Tags: 7.50-apache, 7-apache, 7.50, 7
-GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
+GitCommit: 41970d6f598cf64fe90aa63651ba52cdc384c002
 Directory: 7/apache
 
 Tags: 7.50-fpm, 7-fpm
-GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
+GitCommit: 41970d6f598cf64fe90aa63651ba52cdc384c002
 Directory: 7/fpm
 
-Tags: 8.1.5-apache, 8.1-apache, 8-apache, apache, 8.1.5, 8.1, 8, latest
-GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
+Tags: 8.1.6-apache, 8.1-apache, 8-apache, apache, 8.1.6, 8.1, 8, latest
+GitCommit: 32eb5057dac4bb54f70e2462f2544191bd930906
 Directory: 8.1/apache
 
-Tags: 8.1.5-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 92664797bf793c8a290d46958bd91fcf56cc63d1
+Tags: 8.1.6-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 32eb5057dac4bb54f70e2462f2544191bd930906
 Directory: 8.1/fpm

--- a/library/haproxy
+++ b/library/haproxy
@@ -20,10 +20,10 @@ Tags: 1.5.18-alpine, 1.5-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.5/alpine
 
-Tags: 1.6.6, 1.6, 1, latest
-GitCommit: 6298ef75a7eddeae3b8fbf5137e6eba69a41ff81
+Tags: 1.6.7, 1.6, 1, latest
+GitCommit: fee22521901f01ccde1a1f63c6d3b619053ef196
 Directory: 1.6
 
-Tags: 1.6.6-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: 6298ef75a7eddeae3b8fbf5137e6eba69a41ff81
+Tags: 1.6.7-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: fee22521901f01ccde1a1f63c6d3b619053ef196
 Directory: 1.6/alpine

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.28, 1.4, 1, latest
-GitCommit: 20f1e32162f9376a75b569519a375ce18e659a8d
+Tags: 1.4.29, 1.4, 1, latest
+GitCommit: 7b8ed32cdbc0b14fd86bf4b6fb9136a08c9af29e
 Directory: debian
 
-Tags: 1.4.28-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 20f1e32162f9376a75b569519a375ce18e659a8d
+Tags: 1.4.29-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 7b8ed32cdbc0b14fd86bf4b6fb9136a08c9af29e
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -12,8 +12,8 @@ Tags: 3.0.12, 3.0
 GitCommit: 4b1d085ccab5728a9b9e4b65c5ed19820420809e
 Directory: 3.0
 
-Tags: 3.2.7, 3.2, 3, latest
-GitCommit: d805e40bdb590ac09a88a4fdfd2b29023da37ef0
+Tags: 3.2.8, 3.2, 3, latest
+GitCommit: 92669ba9c463593f85007faf371522201167a5ee
 Directory: 3.2
 
 Tags: 3.3.9, 3.3

--- a/library/owncloud
+++ b/library/owncloud
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 8.0.13-apache, 8.0-apache, 8.0.13, 8.0
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.0/apache
 
 Tags: 8.0.13-fpm, 8.0-fpm
-GitCommit: e58cf3d60e84e8dd113337e4a4ab7e4cdb8805ff
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.0/fpm
 
 Tags: 8.1.8-apache, 8.1-apache, 8.1.8, 8.1
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.1/apache
 
 Tags: 8.1.8-fpm, 8.1-fpm
-GitCommit: 410ebaf1fc10badfb39429091628fc3c6e894682
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.1/fpm
 
 Tags: 8.2.6-apache, 8.2-apache, 8-apache, 8.2.6, 8.2, 8
-GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.2/apache
 
 Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm
-GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 8.2/fpm
 
 Tags: 9.0.3-apache, 9.0-apache, 9-apache, apache, 9.0.3, 9.0, 9, latest
-GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 9.0/apache
 
 Tags: 9.0.3-fpm, 9.0-fpm, 9-fpm, fpm
-GitCommit: 4f41bc0906d03515a0faf79c7707fe477c2a6125
+GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
 Directory: 9.0/fpm

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.0.8-cli, 7.0-cli, 7-cli, cli, 7.0.8, 7.0, 7, latest
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0
 
 Tags: 7.0.8-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/alpine
 
 Tags: 7.0.8-apache, 7.0-apache, 7-apache, apache
-GitCommit: 11c5d11f1da7033ab3e3c0c1eb4442b57618a9cd
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/apache
 
 Tags: 7.0.8-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/fpm
 
 Tags: 7.0.8-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.8-zts, 7.0-zts, 7-zts, zts
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/zts
 
 Tags: 7.0.8-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.23-cli, 5.6-cli, 5-cli, 5.6.23, 5.6, 5
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6
 
 Tags: 5.6.23-alpine, 5.6-alpine, 5-alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/alpine
 
 Tags: 5.6.23-apache, 5.6-apache, 5-apache
-GitCommit: 11c5d11f1da7033ab3e3c0c1eb4442b57618a9cd
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/apache
 
 Tags: 5.6.23-fpm, 5.6-fpm, 5-fpm
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/fpm
 
 Tags: 5.6.23-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.23-zts, 5.6-zts, 5-zts
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/zts
 
 Tags: 5.6.23-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: d0993972f314576849e4489cc25729d05e1391ca
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.6/zts/alpine
 
 Tags: 5.5.37-cli, 5.5-cli, 5.5.37, 5.5
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5
 
 Tags: 5.5.37-alpine, 5.5-alpine
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/alpine
 
 Tags: 5.5.37-apache, 5.5-apache
-GitCommit: 11c5d11f1da7033ab3e3c0c1eb4442b57618a9cd
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/apache
 
 Tags: 5.5.37-fpm, 5.5-fpm
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/fpm
 
 Tags: 5.5.37-fpm-alpine, 5.5-fpm-alpine
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/fpm/alpine
 
 Tags: 5.5.37-zts, 5.5-zts
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/zts
 
 Tags: 5.5.37-zts-alpine, 5.5-zts-alpine
-GitCommit: e37ca400ba0e1c34357bf06732bc77064e5a4941
+GitCommit: f016f5dc420e7d360f7381eb014ac6697e247e11
 Directory: 5.5/zts/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,18 +44,18 @@ Tags: 8.0.36-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
 GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.3-jre8, 8.5-jre8, 8.5.3, 8.5
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Tags: 8.5.4-jre8, 8.5-jre8, 8.5.4, 8.5
+GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
 Directory: 8.5/jre8
 
-Tags: 8.5.3-jre8-alpine, 8.5-jre8-alpine, 8.5.3-alpine, 8.5-alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Tags: 8.5.4-jre8-alpine, 8.5-jre8-alpine, 8.5.4-alpine, 8.5-alpine
+GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M8-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M8, 9.0.0, 9.0, 9
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Tags: 9.0.0.M9-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M9, 9.0.0, 9.0, 9
+GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M8-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M8-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+Tags: 9.0.0.M9-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M9-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
 - `drupal` bump `8.1.6` and https://github.com/docker-library/drupal/pull/51
 - `haproxy` bump to `1.6.7`
 - `memcached` bump to `1.4.29`
 - `mongo` bump to `3.2.8`
 - `owncloud` https://github.com/docker-library/owncloud/pull/74 and https://github.com/docker-library/owncloud/pull/75
 - `php` https://github.com/docker-library/php/pull/256
 - `tomcat` bump to `8.5.4` and `9.0.0.M9`