### PR TITLE
Add 'shell' image to run a Unix shell

### DIFF
--- a/library/shell
+++ b/library/shell
@@ -1,0 +1,4 @@
+# maintainer: Weaveworks Inc <help@weave.works> (@weaveworks)
+
+3.4: git://github.com/weaveworks/shell-image@357be742ceb4d830b7b900e3b3fdaa804d3fad8e versions/3.4
+latest: git://github.com/weaveworks/shell-image@357be742ceb4d830b7b900e3b3fdaa804d3fad8e versions/3.4


### PR DESCRIPTION
The idea here is that running a shell to demonstrate features of Docker should be as quick and simple as possible, especially for newcomers.  If this PR is accepted, users could do:

    docker run -ti shell

and get an interactive shell.

Previously we used `docker run -ti ubuntu` for this purpose, but many tools were removed from the official Ubuntu image recently, including `ping`, `nslookup` and `sudo`.  Also, this image is based on Alpine so is less than 5MB compared to `ubuntu:latest` at 125MB.

This image only adds two things to `alpine`:
 * `CMD [ "/bin/sh" ]`.  Alpine's maintainers [have rejected this](http://github.com/gliderlabs/docker-alpine/pull/60)
 * it is called "shell", which is easier to explain to a complete beginner than "alpine".