### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.0-rc3, 1.12-rc, rc
-GitCommit: 3fe09e2340b6d431c0618c466d54e9f0231c2f7a
+Tags: 1.12.0-rc4, 1.12-rc, rc
+GitCommit: 61353e617f3fe89519de1e00f7de043087839e45
 Directory: 1.12-rc
 
-Tags: 1.12.0-rc3-dind, 1.12-rc-dind, rc-dind
+Tags: 1.12.0-rc4-dind, 1.12-rc-dind, rc-dind
 GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.12-rc/dind
 
-Tags: 1.12.0-rc3-git, 1.12-rc-git, rc-git
+Tags: 1.12.0-rc4-git, 1.12-rc-git, rc-git
 GitCommit: 4d1f83ee6e25a5c2bb1c8a04de0643b1a964ba5e
 Directory: 1.12-rc/git
 

--- a/library/kibana
+++ b/library/kibana
@@ -8,8 +8,8 @@ Tags: 4.0.3, 4.0
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.0
 
-Tags: 4.1.9, 4.1
-GitCommit: 7d664ca170976c354d12287ffcf44384be06f286
+Tags: 4.1.10, 4.1
+GitCommit: 6328ebb12009f2b8bee76c22e7ba4e11c1c9175e
 Directory: 4.1
 
 Tags: 4.2.2, 4.2
@@ -24,8 +24,8 @@ Tags: 4.4.2, 4.4
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.4
 
-Tags: 4.5.2, 4.5, 4, latest
-GitCommit: 2adb45495b617c5f966c714f55fb3eb3d7d1c853
+Tags: 4.5.3, 4.5, 4, latest
+GitCommit: 6328ebb12009f2b8bee76c22e7ba4e11c1c9175e
 Directory: 4.5
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5

--- a/library/redmine
+++ b/library/redmine
@@ -1,24 +1,8 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/34dd432399eb6b082989bb90b0f7938537066590/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/c070428e8c4c43b2d0608a1e77ae44f78220967e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
-
-Tags: 2.6.10, 2.6, 2
-GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
-Directory: 2.6
-
-Tags: 2.6.10-passenger, 2.6-passenger, 2-passenger
-GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
-Directory: 2.6/passenger
-
-Tags: 3.0.7, 3.0
-GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
-Directory: 3.0
-
-Tags: 3.0.7-passenger, 3.0-passenger
-GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
-Directory: 3.0/passenger
 
 Tags: 3.1.6, 3.1
 GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
@@ -28,10 +12,18 @@ Tags: 3.1.6-passenger, 3.1-passenger
 GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.1/passenger
 
-Tags: 3.2.3, 3.2, 3, latest
+Tags: 3.2.3, 3.2
 GitCommit: 794d8a58ac855ea5ad2541c1058a8910f9514710
 Directory: 3.2
 
-Tags: 3.2.3-passenger, 3.2-passenger, 3-passenger, passenger
+Tags: 3.2.3-passenger, 3.2-passenger
 GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
 Directory: 3.2/passenger
+
+Tags: 3.3.0, 3.3, 3, latest
+GitCommit: c070428e8c4c43b2d0608a1e77ae44f78220967e
+Directory: 3.3
+
+Tags: 3.3.0-passenger, 3.3-passenger, 3-passenger, passenger
+GitCommit: c070428e8c4c43b2d0608a1e77ae44f78220967e
+Directory: 3.3/passenger


### PR DESCRIPTION
- `docker`: 1.12.0-rc4
- `kibana`: 4.5.3, 4.1.10
- `redmine`: 3.3.0 (docker-library/redmine#30), remove 2.6 and 3.0 (docker-library/redmine#31)