### PR TITLE
Update Ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -8,34 +8,34 @@ GitFetch: refs/heads/dist
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - a638d60 Update tarballs
+#  - e68c4b0 Update tarballs
 #    - `ubuntu:precise`: 20160707
-#    - `ubuntu:trusty`: 20160624
+#    - `ubuntu:trusty`: 20160711
 #    - `ubuntu:wily`: 20160706
-#    - `ubuntu:xenial`: 20160706
-#    - `ubuntu:yakkety`: 20160708
+#    - `ubuntu:xenial`: 20160713
+#    - `ubuntu:yakkety`: 20160717
 
 # 20160707
 Tags: 12.04.5, 12.04, precise-20160707, precise
-GitCommit: a638d604a2eb4f80015d2d4d2eb7de2b1bcbb40f
+GitCommit: e68c4b0d4c860a8e0547cfea6f1b07f0adb9ff46
 Directory: precise
 
-# 20160624
-Tags: 14.04.4, 14.04, trusty-20160624, trusty
-GitCommit: a638d604a2eb4f80015d2d4d2eb7de2b1bcbb40f
+# 20160711
+Tags: 14.04.4, 14.04, trusty-20160711, trusty
+GitCommit: e68c4b0d4c860a8e0547cfea6f1b07f0adb9ff46
 Directory: trusty
 
 # 20160706
 Tags: 15.10, wily-20160706, wily
-GitCommit: a638d604a2eb4f80015d2d4d2eb7de2b1bcbb40f
+GitCommit: e68c4b0d4c860a8e0547cfea6f1b07f0adb9ff46
 Directory: wily
 
-# 20160706
-Tags: 16.04, xenial-20160706, xenial, latest
-GitCommit: a638d604a2eb4f80015d2d4d2eb7de2b1bcbb40f
+# 20160713
+Tags: 16.04, xenial-20160713, xenial, latest
+GitCommit: e68c4b0d4c860a8e0547cfea6f1b07f0adb9ff46
 Directory: xenial
 
-# 20160708
-Tags: 16.10, yakkety-20160708, yakkety
-GitCommit: a638d604a2eb4f80015d2d4d2eb7de2b1bcbb40f
+# 20160717
+Tags: 16.10, yakkety-20160717, yakkety, devel
+GitCommit: e68c4b0d4c860a8e0547cfea6f1b07f0adb9ff46
 Directory: yakkety


### PR DESCRIPTION
- `ubuntu:trusty`: 20160711
- `ubuntu:xenial`: 20160713
- `ubuntu:yakkety`: 20160717

Also notable is the addition of "ubuntu:devel" as an alias for "ubuntu:yakkety" (to roll over into the z* release when the time comes)