### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/django.git
 
-Tags: 1.9.7-python3, 1.9-python3, 1-python3, python3, 1.9.7, 1.9, 1, latest
-GitCommit: 819c332058c3638ab8f4fa5b9f70518e9aaf6325
+Tags: 1.9.8-python3, 1.9-python3, 1-python3, python3, 1.9.8, 1.9, 1, latest
+GitCommit: f610710985af4757e51695fee47f33de47b0293c
 Directory: 3.4
 
 Tags: python3-onbuild, onbuild
 GitCommit: cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447
 Directory: 3.4/onbuild
 
-Tags: 1.9.7-python2, 1.9-python2, 1-python2, python2
-GitCommit: 819c332058c3638ab8f4fa5b9f70518e9aaf6325
+Tags: 1.9.8-python2, 1.9-python2, 1-python2, python2
+GitCommit: f610710985af4757e51695fee47f33de47b0293c
 Directory: 2.7
 
 Tags: python2-onbuild

--- a/library/drupal
+++ b/library/drupal
@@ -12,10 +12,10 @@ Tags: 7.50-fpm, 7-fpm
 GitCommit: 41970d6f598cf64fe90aa63651ba52cdc384c002
 Directory: 7/fpm
 
-Tags: 8.1.6-apache, 8.1-apache, 8-apache, apache, 8.1.6, 8.1, 8, latest
-GitCommit: 32eb5057dac4bb54f70e2462f2544191bd930906
+Tags: 8.1.7-apache, 8.1-apache, 8-apache, apache, 8.1.7, 8.1, 8, latest
+GitCommit: 570d5995dfc3a98a71bea55ae957307c266ba694
 Directory: 8.1/apache
 
-Tags: 8.1.6-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 32eb5057dac4bb54f70e2462f2544191bd930906
+Tags: 8.1.7-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 570d5995dfc3a98a71bea55ae957307c266ba694
 Directory: 8.1/fpm

--- a/library/gcc
+++ b/library/gcc
@@ -6,18 +6,18 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2015-07-16
 Tags: 5.2.0, 5.2
-GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+GitCommit: df055b1ba29bd666470f4735f2a7bab9acffd0b3
 Directory: 5.2
 # Docker EOL: 2016-07-16
 
 # Last Modified: 2015-12-04
 Tags: 5.3.0, 5.3, 5
-GitCommit: 5e3781575c04f31812375822f4f28fbb39da5dc3
+GitCommit: df055b1ba29bd666470f4735f2a7bab9acffd0b3
 Directory: 5.3
 # Docker EOL: 2016-12-04
 
 # Last Modified: 2016-04-27
 Tags: 6.1.0, 6.1, 6, latest
-GitCommit: 2f180f02a73a9a68a6a6e62d96c11acd65a01b7d
+GitCommit: d9c8446748f7d69626f2e9425376a6672fff09af
 Directory: 6.1
 # Docker EOL: 2017-04-27

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.14, 10.1, 10, latest
-GitCommit: 21b143d133b2250eb473eb5492cfa38e5d094e62
+Tags: 10.1.16, 10.1, 10, latest
+GitCommit: 2c8418204a2ca6d39b9999641451200dee9212bc
 Directory: 10.1
 
 Tags: 10.0.26, 10.0


### PR DESCRIPTION
- `django`: 1.9.8
- `drupal`: 8.1.7
- `gcc`: add Fortran support (docker-library/gcc#28)
- `mariadb`: 10.1.16 (docker-library/mariadb#70)