### PR TITLE
Bump traefik to v1.0.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,6 +1,6 @@
 # maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
 # maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 
-v1.0.0: git://github.com/containous/traefik-library-image@556367439faa4266171318b433201e3fdd7f81f2
-reblochon: git://github.com/containous/traefik-library-image@556367439faa4266171318b433201e3fdd7f81f2
-latest: git://github.com/containous/traefik-library-image@556367439faa4266171318b433201e3fdd7f81f2
+v1.0.1: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587
+reblochon: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587
+latest: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.0.1.
/cc @emilevauge 

Cheers

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>