### PR TITLE
Add a note of clarification about who is expected to interact with the "new image checklist"

### DIFF
--- a/NEW-IMAGE-CHECKLIST.md
+++ b/NEW-IMAGE-CHECKLIST.md
@@ -1,5 +1,7 @@
 # Checklist for Review
 
+**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
+
 -	[ ] associated with or contacted upstream?
 -	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
 -	[ ] is it reasonably popular, or does it solve a particular use case well?


### PR DESCRIPTION
This is as was discussed in https://github.com/docker-library/official-images/pull/1765#issuecomment-228353753 (showing that there was some definite confusion about the intended purpose of the checklist). :heart: