### PR TITLE
update to fix incorrect /var/run/nologin file

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -5,7 +5,7 @@ Constraints: !aufs
 
 Tags: latest, centos7, 7
 GitFetch: refs/heads/CentOS-7
-GitCommit: 9df44a818e1ffeca33aedf75342d84bb7d6010a2
+GitCommit: 9681bb924c70a60dc4042dbc5fc3ed6c27aa3e1c
 
 Tags: centos6, 6
 GitFetch: refs/heads/CentOS-6


### PR DESCRIPTION
Resolves https://github.com/CentOS/sig-cloud-instance-images/issues/60