### PR TITLE
Updated OL images to include yum-plugin-ovl to address overlayfs issues.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,18 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@2421becd93d7e179d1f64208235e622be3b55b32 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@955835cfaa9edcfe7b941b9b224efc65c5104614 OracleLinux/5.11


### PR DESCRIPTION
Addresses https://github.com/docker/docker/issues/10180 by including `yum-plugin-ovl` in the base image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>