### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -16,6 +16,6 @@ Tags: 3.2.8, 3.2, 3, latest
 GitCommit: 92669ba9c463593f85007faf371522201167a5ee
 Directory: 3.2
 
-Tags: 3.3.9, 3.3
-GitCommit: ee77db94092c03d9e8555a54ec8d22b4b1cf647d
+Tags: 3.3.10, 3.3
+GitCommit: 7065352d915f03584da8a57cc070e612106496ef
 Directory: 3.3

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 8.0.13-apache, 8.0-apache, 8.0.13, 8.0
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.0.14-apache, 8.0-apache, 8.0.14, 8.0
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.0/apache
 
-Tags: 8.0.13-fpm, 8.0-fpm
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.0.14-fpm, 8.0-fpm
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.0/fpm
 
-Tags: 8.1.8-apache, 8.1-apache, 8.1.8, 8.1
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.1.9-apache, 8.1-apache, 8.1.9, 8.1
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.1/apache
 
-Tags: 8.1.8-fpm, 8.1-fpm
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.1.9-fpm, 8.1-fpm
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.1/fpm
 
-Tags: 8.2.6-apache, 8.2-apache, 8-apache, 8.2.6, 8.2, 8
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.2.7-apache, 8.2-apache, 8-apache, 8.2.7, 8.2, 8
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.2/apache
 
-Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 8.2.7-fpm, 8.2-fpm, 8-fpm
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 8.2/fpm
 
-Tags: 9.0.3-apache, 9.0-apache, 9-apache, apache, 9.0.3, 9.0, 9, latest
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 9.0.4-apache, 9.0-apache, 9-apache, apache, 9.0.4, 9.0, 9, latest
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 9.0/apache
 
-Tags: 9.0.3-fpm, 9.0-fpm, 9-fpm, fpm
-GitCommit: ad635b3fe661ca61cb4ba5c23f564f3201472a1b
+Tags: 9.0.4-fpm, 9.0-fpm, 9-fpm, fpm
+GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
 Directory: 9.0/fpm

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,9 +5,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.5.3-apache, 4.5-apache, 4-apache, apache, 4.5.3, 4.5, 4, latest
-GitCommit: 4cfa30302dbf66d002ed15b01c881acee605e2dc
+GitCommit: 6afa0720da89f31d6c61fd38bb0d6de6e9a14a49
 Directory: apache
 
 Tags: 4.5.3-fpm, 4.5-fpm, 4-fpm, fpm
-GitCommit: c674e9ceedf582705e0ad8487c16b42b37a5e9da
+GitCommit: 6afa0720da89f31d6c61fd38bb0d6de6e9a14a49
 Directory: fpm


### PR DESCRIPTION
- `mongo`: 3.3.10
- `owncloud`: 9.0.4, 8.2.7, 8.1.9, 8.0.14
- `wordpress`: support Unix sockets for connecting to MySQL (docker-library/wordpress#161)