### PR TITLE
Update "github.com/docker-library/go-dockerlibrary" for parsing line-based maintainers comments

### DIFF
--- a/bashbrew/go/vendor/manifest
+++ b/bashbrew/go/vendor/manifest
@@ -10,7 +10,7 @@
 		{
 			"importpath": "github.com/docker-library/go-dockerlibrary",
 			"repository": "https://github.com/docker-library/go-dockerlibrary",
-			"revision": "945a488370ddcccdd3b1bcbf8cb8e2beaf0d4825",
+			"revision": "6c6566f129042695444eb647d5cee653ca943b0d",
 			"branch": "master"
 		},
 		{

--- a/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/line-based.go
+++ b/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/line-based.go
@@ -46,22 +46,29 @@ func ParseLineBased(readerIn io.Reader) (*Manifest2822, error) {
 	manifest := &Manifest2822{
 		Global: DefaultManifestEntry.Clone(),
 	}
-	manifest.Global.Maintainers = []string{`TODO parse old-style "maintainer:" comment lines?`}
 	manifest.Global.GitFetch = DefaultLineBasedFetch
 
 	for {
 		line, err := reader.ReadString('\n')
 
 		line = strings.TrimSpace(line)
-		if len(line) > 0 && line[0] != '#' {
-			entry, parseErr := ParseLineBasedLine(line, manifest.Global)
-			if parseErr != nil {
-				return nil, parseErr
-			}
+		if len(line) > 0 {
+			if line[0] == '#' {
+				maintainerLine := strings.TrimPrefix(line, "# maintainer: ")
+				if line != maintainerLine {
+					// if the prefix was removed, it must be a maintainer line!
+					manifest.Global.Maintainers = append(manifest.Global.Maintainers, maintainerLine)
+				}
+			} else {
+				entry, parseErr := ParseLineBasedLine(line, manifest.Global)
+				if parseErr != nil {
+					return nil, parseErr
+				}
 
-			err = manifest.AddEntry(*entry)
-			if err != nil {
-				return nil, err
+				err = manifest.AddEntry(*entry)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 


### PR DESCRIPTION
This pulls in https://github.com/docker-library/go-dockerlibrary/pull/1 so we can get at least some very basic `# maintainer:` line parsing. :+1: