### PR TITLE
Remove "vivid" and "squeeze" from neurodebian

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -6,14 +6,8 @@ nd12.04: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb123
 trusty: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/trusty
 nd14.04: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/trusty
 
-vivid: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/vivid
-nd15.04: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/vivid
-
 wily: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/wily
 nd15.10: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/wily
-
-squeeze: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/squeeze
-nd60: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/squeeze
 
 wheezy: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/wheezy
 nd70: git://github.com/neurodebian/dockerfiles@dc947232d6c7bf67d1dba642fdb1234fbaa95ab7 dockerfiles/wheezy


### PR DESCRIPTION
See https://github.com/neurodebian/dockerfiles/pull/2