### PR TITLE
Update postgres to 9.6~beta3

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 9.6-beta2, 9.6
-GitCommit: 3cff98db82f2dd6c3647296335bbc37233e0b9bc
+Tags: 9.6-beta3, 9.6
+GitCommit: bcfa58b2f0c971ad55f541f3fb868607cd391089
 Directory: 9.6
 
 Tags: 9.5.3, 9.5, 9, latest


### PR DESCRIPTION
Split off from https://github.com/docker-library/official-images/pull/1971