### PR TITLE
Add a separate "EntryIdentifier" so that build output is more informative

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -60,7 +60,7 @@ func cmdBuild(c *cli.Context) error {
 					return fmt.Errorf(`unexpected value for --pull: %s`, pull)
 				}
 				if doPull {
-					fmt.Printf("Pulling %s (%s)\n", from, r.Identifier())
+					fmt.Printf("Pulling %s (%s)\n", from, r.EntryIdentifier(entry))
 					dockerPull(from)
 				}
 			}
@@ -73,7 +73,7 @@ func cmdBuild(c *cli.Context) error {
 			// check whether we've already built this artifact
 			_, err = dockerInspect("{{.Id}}", cacheTag)
 			if err != nil {
-				fmt.Printf("Building %s (%s)\n", cacheTag, r.Identifier())
+				fmt.Printf("Building %s (%s)\n", cacheTag, r.EntryIdentifier(entry))
 
 				commit, err := r.fetchGitRepo(&entry)
 				if err != nil {
@@ -92,7 +92,7 @@ func cmdBuild(c *cli.Context) error {
 				}
 				archive.Close() // be sure this happens sooner rather than later (defer might take a while, and we want to reap zombies more aggressively)
 			} else {
-				fmt.Printf("Using %s (%s)\n", cacheTag, r.Identifier())
+				fmt.Printf("Using %s (%s)\n", cacheTag, r.EntryIdentifier(entry))
 			}
 
 			for _, tag := range r.Tags(namespace, uniq, entry) {

--- a/bashbrew/go/src/bashbrew/repo.go
+++ b/bashbrew/go/src/bashbrew/repo.go
@@ -31,6 +31,10 @@ func (r Repo) Identifier() string {
 	return r.RepoName
 }
 
+func (r Repo) EntryIdentifier(entry manifest.Manifest2822Entry) string {
+	return r.RepoName + ":" + entry.Tags[0]
+}
+
 func (r Repo) SkipConstraints(entry manifest.Manifest2822Entry) bool {
 	repoTag := r.RepoName + ":" + entry.Tags[0]
 


### PR DESCRIPTION
This changes something like:

    Using bashbrew/cache:277...af2 (buildpack-deps)

into:

    Using bashbrew/cache:277...af2 (buildpack-deps:wheezy)