### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -37,18 +37,18 @@ Tags: 1.6.3-alpine, 1.6-alpine, 1-alpine, alpine
 GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
 Directory: 1.6/alpine
 
-Tags: 1.7rc2, 1.7
-GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
+Tags: 1.7rc3, 1.7
+GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
 Directory: 1.7
 
-Tags: 1.7rc2-onbuild, 1.7-onbuild
+Tags: 1.7rc3-onbuild, 1.7-onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7rc2-wheezy, 1.7-wheezy
-GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
+Tags: 1.7rc3-wheezy, 1.7-wheezy
+GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
 Directory: 1.7/wheezy
 
-Tags: 1.7rc2-alpine, 1.7-alpine
-GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
+Tags: 1.7rc3-alpine, 1.7-alpine
+GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
 Directory: 1.7/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.1.16, 10.1, 10, latest
-GitCommit: 2c8418204a2ca6d39b9999641451200dee9212bc
+GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
 Directory: 10.1
 
 Tags: 10.0.26, 10.0
-GitCommit: dfc7026e1c2588388a929151810a28e6319ddead
+GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
 Directory: 10.0
 
 Tags: 5.5.50, 5.5, 5
-GitCommit: 35bec16e10203a30ed66f4e0a1571ce816c6b4d2
+GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
 Directory: 5.5

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.13, 5.7, 5, latest
-GitCommit: b1f72280a3464a12979111287255da27c6537405
+GitCommit: 9f24653b2c4dd2e40cdced347c0ca388b8ab0cb2
 Directory: 5.7
 
 Tags: 5.6.31, 5.6
-GitCommit: 97b1c658432db2deae77b6577681d45e6c8ee493
+GitCommit: 9f24653b2c4dd2e40cdced347c0ca388b8ab0cb2
 Directory: 5.6
 
 Tags: 5.5.50, 5.5
-GitCommit: 9eb3ba8a16b4a037dbfe2314d17055743795e712
+GitCommit: 9f24653b2c4dd2e40cdced347c0ca388b8ab0cb2
 Directory: 5.5


### PR DESCRIPTION
- `golang`: 1.7rc3
- `mariadb`: add the now-forced `https` to Percona's APT repo (docker-library/mariadb#71)
- `percona`: add the now-forced `https` to Percona's APT repo