### PR TITLE
Update nuxeo

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -3,7 +3,7 @@ Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
 
 Tags: latest, FT, 8, 8.3
 GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: 7b617f4065c06c151e17cc86bbf88bd4ec404355
+GitCommit: 9738485ee1a4f96ed401053dd265e4f914c880ba
 Directory: 8.3
 
 Tags: 8.2


### PR DESCRIPTION
Bump commit id to use the new MD5. 
The zip has been updated to fix a blocker on our side.