### PR TITLE
Registry v2.5.0 release.

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,8 +3,8 @@
 # maintainer: Richard Scothern <richard.scothern@gmail.com> (@RichardScothern)
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
-2: git://github.com/docker/distribution-library-image@5cbbc8d1e6046cef5938e3380fd2a5fbd854f921
-2.4: git://github.com/docker/distribution-library-image@5cbbc8d1e6046cef5938e3380fd2a5fbd854f921
-2.4.1: git://github.com/docker/distribution-library-image@5cbbc8d1e6046cef5938e3380fd2a5fbd854f921
-2.5.0-rc.2: git://github.com/docker/distribution-library-image@ac4732789b3e30a887b9f2c5bb163473cd89d0cb
+2: git://github.com/docker/distribution-library-image@f7992f4a9f7fade2be6240ffe84270b9438fc1bf
+2.5: git://github.com/docker/distribution-library-image@f7992f4a9f7fade2be6240ffe84270b9438fc1bf
+2.5.0: git://github.com/docker/distribution-library-image@f7992f4a9f7fade2be6240ffe84270b9438fc1bf
+latest: git://github.com/docker/distribution-library-image@f7992f4a9f7fade2be6240ffe84270b9438fc1bf
 


### PR DESCRIPTION
Update 2, 2.5, 2.5.0 and latest 😍 
Remove 2.4 and rc tags.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>