### PR TITLE
Aerospike 3.9.0.2

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.9.0: git://github.com/aerospike/aerospike-server.docker@7ef9d8868b7d82a8f2c961aa40b720d831d7588e
-latest: git://github.com/aerospike/aerospike-server.docker@7ef9d8868b7d82a8f2c961aa40b720d831d7588e
+3.9.0.2: git://github.com/aerospike/aerospike-server.docker@25b73449f1b728ba7967607402b226e22c6eaf0b
+latest: git://github.com/aerospike/aerospike-server.docker@25b73449f1b728ba7967607402b226e22c6eaf0b


### PR DESCRIPTION
http://www.aerospike.com/download/server/notes.html#3.9.0.2

Bug Fix:
[AER-5159] - Hot key transactions with some timeout can cause transaction to fail, manifesting as "non-null 'from'" assert and abort server.