### PR TITLE
Ghost 0.9.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.8.0, 0.8, 0, latest
-GitCommit: e625fca128f8f6b41533e78a9c262701ce9027f5
+Tags: 0.9.0, 0.9, 0, latest
+GitCommit: 13c06085f3de1264fc8c40a0d66fd4eafbfc322e


### PR DESCRIPTION
Bumped the Ghost image version up to 0.9.0 from 0.8.0 to get the latest image version onto Docker Hub.