### PR TITLE
ZDOCK-19 - Mitigate the httpoxy security vulnerability

### DIFF
--- a/library/php-zendserver
+++ b/library/php-zendserver
@@ -1,14 +1,14 @@
 # maintainer: David Lowes <david.l@zend.com> (@davidl-zend)
 
-5.5: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 8.5/5.5
-8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 8.5/5.5
+5.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.5
+8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.5
 
-5.6: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 8.5/5.6
-8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 8.5/5.6
-8.5: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 8.5/5.6
+5.6: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
+8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
+8.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
 
-5.4: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 7.0/5.4
-7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@df88fc00133cb8578e5d571a74336f831e5ef8cd 7.0/5.4
+5.4: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 7.0/5.4
+7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 7.0/5.4
 
 9.0: git://github.com/zendtech/php-zendserver-docker@359ed95e4d49da8123eb01c4b929917c7595754c 9.0/7.0
 9.0-php7: git://github.com/zendtech/php-zendserver-docker@359ed95e4d49da8123eb01c4b929917c7595754c 9.0/7.0

--- a/library/php-zendserver
+++ b/library/php-zendserver
@@ -1,16 +1,16 @@
 # maintainer: David Lowes <david.l@zend.com> (@davidl-zend)
 
-5.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.5
-8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.5
+5.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.5
+8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.5
 
-5.6: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
-8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
-8.5: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 8.5/5.6
+5.6: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
+8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
+8.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
 
-5.4: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 7.0/5.4
-7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@ab04eeef23d3c33238a522234a54f694ce2c8875 7.0/5.4
+5.4: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 7.0/5.4
+7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 7.0/5.4
 
-9.0: git://github.com/zendtech/php-zendserver-docker@359ed95e4d49da8123eb01c4b929917c7595754c 9.0/7.0
-9.0-php7: git://github.com/zendtech/php-zendserver-docker@359ed95e4d49da8123eb01c4b929917c7595754c 9.0/7.0
+9.0: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0
+9.0-php7: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0
 
-latest: git://github.com/zendtech/php-zendserver-docker@359ed95e4d49da8123eb01c4b929917c7595754c 9.0/7.0
+latest: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0


### PR DESCRIPTION
Apache now removes the "HTTP_PROXY" header before passing it to PHP. This should mitigate:
CVE-2016-5385: PHP
CVE-2016-5386: Go
CVE-2016-5387: Apache HTTP Server
CVE-2016-5388: Apache Tomcat
CVE-2016-1000109: HHVM
CVE-2016-1000110: Python