### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,41 +1,29 @@
-# this file is generated via https://github.com/docker-library/docker/blob/fddc10378d1f75aae908f4dcc6ac51c3722d12bb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/f55342de56b4463895cfbfcd95972306e517cd57/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.0-rc5, 1.12-rc, rc
-GitCommit: c35f7c0ded8b4153d5d7711054ac17132a3e7155
-Directory: 1.12-rc
+Tags: 1.12.0, 1.12, 1, latest
+GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
+Directory: 1.12
 
-Tags: 1.12.0-rc5-dind, 1.12-rc-dind, rc-dind
-GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
-Directory: 1.12-rc/dind
+Tags: 1.12.0-dind, 1.12-dind, 1-dind, dind
+GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
+Directory: 1.12/dind
 
-Tags: 1.12.0-rc5-git, 1.12-rc-git, rc-git
-GitCommit: 4d1f83ee6e25a5c2bb1c8a04de0643b1a964ba5e
-Directory: 1.12-rc/git
+Tags: 1.12.0-git, 1.12-git, 1-git, git
+GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
+Directory: 1.12/git
 
-Tags: 1.11.2, 1.11, 1, latest
+Tags: 1.11.2, 1.11
 GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
 Directory: 1.11
 
-Tags: 1.11.2-dind, 1.11-dind, 1-dind, dind
+Tags: 1.11.2-dind, 1.11-dind
 GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
 Directory: 1.11/dind
 
-Tags: 1.11.2-git, 1.11-git, 1-git, git
+Tags: 1.11.2-git, 1.11-git
 GitCommit: 866c3fbd87e8eeed524fdf19ba2d63288ad49cd2
 Directory: 1.11/git
-
-Tags: 1.10.3, 1.10
-GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
-Directory: 1.10
-
-Tags: 1.10.3-dind, 1.10-dind
-GitCommit: 1c8b144ed9ec49ac8cc7ca75f8628fd8de6c82b5
-Directory: 1.10/dind
-
-Tags: 1.10.3-git, 1.10-git
-GitCommit: 8d7aa4652e4f677765947f19232eb17b1601f81c
-Directory: 1.10/git

--- a/library/mysql
+++ b/library/mysql
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 5.7.13, 5.7, 5, latest
-GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Tags: 5.7.14, 5.7, 5, latest
+GitCommit: 77f0a50ecd54edafe48ce3a2a328c22e9e7564a8
 Directory: 5.7
 
-Tags: 5.6.31, 5.6
-GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Tags: 5.6.32, 5.6
+GitCommit: 77f0a50ecd54edafe48ce3a2a328c22e9e7564a8
 Directory: 5.6
 
-Tags: 5.5.50, 5.5
-GitCommit: f7a67d7634a68d319988ad6f99729bfeaa84ceb2
+Tags: 5.5.51, 5.5
+GitCommit: 77f0a50ecd54edafe48ce3a2a328c22e9e7564a8
 Directory: 5.5

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,19 +25,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 3.3.6, 3.3
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -45,19 +45,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -65,15 +65,15 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
@@ -81,15 +81,15 @@ GitCommit: 0fa3202789648132971160f686f5a37595108f44
 Directory: 3.5/onbuild
 
 Tags: 3.6.0a2, 3.6
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.6
 
 Tags: 3.6.0a2-slim, 3.6-slim
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
 Directory: 3.6/slim
 
 Tags: 3.6.0a2-alpine, 3.6-alpine
-GitCommit: 8d03a5036b0170c12ae422ed8f10169e8db9b30b
+GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
 Directory: 3.6/alpine
 
 Tags: 3.6.0a2-onbuild, 3.6-onbuild

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.3, 3.6, 3, latest
-GitCommit: 01cebb700efb951058263f3439ab83fbe81222aa
+Tags: 3.6.4, 3.6, 3, latest
+GitCommit: c00d3aeef0b32add4063994c37bb339e574ee7c0
 
-Tags: 3.6.3-management, 3.6-management, 3-management, management
+Tags: 3.6.4-management, 3.6-management, 3-management, management
 GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d
 Directory: management

--- a/library/redis
+++ b/library/redis
@@ -16,14 +16,14 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
 Directory: 3.0/alpine
 
-Tags: 3.2.1, 3.2, 3, latest
-GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
+Tags: 3.2.2, 3.2, 3, latest
+GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
 Directory: 3.2
 
-Tags: 3.2.1-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
+Tags: 3.2.2-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
 Directory: 3.2/32bit
 
-Tags: 3.2.1-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 5d3e1e5ff708d038527c719d52f3e87f1970d721
+Tags: 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
 Directory: 3.2/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
 Directory: 3.1
 
 Tags: 3.1.6-passenger, 3.1-passenger
-GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
+GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.1/passenger
 
 Tags: 3.2.3, 3.2
@@ -17,7 +17,7 @@ GitCommit: 794d8a58ac855ea5ad2541c1058a8910f9514710
 Directory: 3.2
 
 Tags: 3.2.3-passenger, 3.2-passenger
-GitCommit: 6a13e140f58586a4ecd08d0eb22b119593732ef3
+GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.2/passenger
 
 Tags: 3.3.0, 3.3, 3, latest
@@ -25,5 +25,5 @@ GitCommit: c070428e8c4c43b2d0608a1e77ae44f78220967e
 Directory: 3.3
 
 Tags: 3.3.0-passenger, 3.3-passenger, 3-passenger, passenger
-GitCommit: c070428e8c4c43b2d0608a1e77ae44f78220967e
+GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.3/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.1.9, 2.1
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+Tags: 2.1.10, 2.1
+GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
 Directory: 2.1
 
-Tags: 2.1.9-slim, 2.1-slim
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+Tags: 2.1.10-slim, 2.1-slim
+GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
 Directory: 2.1/slim
 
-Tags: 2.1.9-alpine, 2.1-alpine
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+Tags: 2.1.10-alpine, 2.1-alpine
+GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
 Directory: 2.1/alpine
 
-Tags: 2.1.9-onbuild, 2.1-onbuild
+Tags: 2.1.10-onbuild, 2.1-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 


### PR DESCRIPTION
- `docker`: 1.12.0 GA; remove 1.10
- `mysql`: 5.7.14, 5.6.32, and 5.5.51
- `python`: use `dpkg-divert` instead of `purge` against Debian Python (docker-library/python#131)
- `rabbitmq`: 3.6.4
- `redis`: 3.2.2
- `redmine`: passenger 5.0.30
- `ruby`: 2.1.10