### PR TITLE
Remove "wily" variants of buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -76,18 +76,6 @@ Tags: wheezy
 GitCommit: e7534be05255522954f50542ebf9c5f06485838d
 Directory: wheezy
 
-Tags: wily-curl
-GitCommit: af914a5bde2a749884177393c8140384048dc5f9
-Directory: wily/curl
-
-Tags: wily-scm
-GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
-Directory: wily/scm
-
-Tags: wily
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
-Directory: wily
-
 Tags: xenial-curl
 GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
 Directory: xenial/curl


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/1995