### PR TITLE
Update "top 10 ruby gems" list and conditionalize "rack" and "activesupport" now that they're 2.2.2+ only

### DIFF
--- a/test/tests/ruby-gems/container.sh
+++ b/test/tests/ruby-gems/container.sh
@@ -1,18 +1,35 @@
 #!/bin/sh
 set -e
 
+# ruby 2.2.2+: rack activesupport
+# ruby 2.0+: mime-types
+# (jruby 1.7 is ruby 1.9)
+extras="$(ruby -e '
+	rubyVersion = Gem::Version.new(RUBY_VERSION)
+	puts (
+		(
+			rubyVersion >= Gem::Version.new("2.2.2") ? [
+				"rack",
+				"activesupport",
+			] : []
+		) + (
+			rubyVersion >= Gem::Version.new("2.0") ? [
+				"mime-types",
+			] : []
+		)
+	).join(" ")
+')"
+
 # list taken from https://rubygems.org/stats
 for gem in \
+	$extras \
 	rake \
-	rack \
+	multi_json \
+	bundler \
 	json \
-	activesupport \
 	thor \
-	rails \
-	activerecord \
-	actionpack \
-	actionmailer \
-	activeresource \
+	i18n \
+	builder \
 ; do
 	gem install "$gem"
 done


### PR DESCRIPTION
```console
	'ruby-gems' [7/9]...ERROR:  Error installing rack:
	rack requires Ruby version >= 2.2.2.
failed
```