### PR TITLE
ZDOCK-21 - enable mod headers by default on apache configuration

### DIFF
--- a/library/php-zendserver
+++ b/library/php-zendserver
@@ -1,16 +1,16 @@
 # maintainer: David Lowes <david.l@zend.com> (@davidl-zend)
 
-5.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.5
-8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.5
+5.5: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 8.5/5.5
+8.5-php5.5: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 8.5/5.5
 
-5.6: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
-8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
-8.5: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 8.5/5.6
+5.6: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 8.5/5.6
+8.5-php5.6: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 8.5/5.6
+8.5: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 8.5/5.6
 
-5.4: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 7.0/5.4
-7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 7.0/5.4
+5.4: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 7.0/5.4
+7.0-php5.4: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 7.0/5.4
 
-9.0: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0
-9.0-php7: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0
+9.0: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 9.0/7.0
+9.0-php7: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 9.0/7.0
 
-latest: git://github.com/zendtech/php-zendserver-docker@01d0fe3e9b64a1539d63a2183f48e492e29fe9c8 9.0/7.0
+latest: git://github.com/zendtech/php-zendserver-docker@b9f59920986c0471fee9c0cb7e83f0f894413454 9.0/7.0


### PR DESCRIPTION
Enable mod_headers by default in apache configuration to allow for header filtering.