### PR TITLE
Bump traefik to v1.0.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,6 +1,6 @@
 # maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
 # maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 
-v1.0.1: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587
-reblochon: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587
-latest: git://github.com/containous/traefik-library-image@a390a09245fe8f47fc30f826b80e4a8723cc1587
+v1.0.2: git://github.com/containous/traefik-library-image@d196677d04b5bc804dbc3c264ac5be664601d6a3
+reblochon: git://github.com/containous/traefik-library-image@d196677d04b5bc804dbc3c264ac5be664601d6a3
+latest: git://github.com/containous/traefik-library-image@d196677d04b5bc804dbc3c264ac5be664601d6a3


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.0.2.
/cc @vdemeester 

Cheers

