### PR TITLE
Update django, golang, redis

### DIFF
--- a/library/django
+++ b/library/django
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/django.git
 
-Tags: 1.9.8-python3, 1.9-python3, 1-python3, python3, 1.9.8, 1.9, 1, latest
-GitCommit: f610710985af4757e51695fee47f33de47b0293c
+Tags: 1.10-python3, 1-python3, python3, 1.10, 1, latest
+GitCommit: eb6088320ccd1449f21c4050583bd835913e56ec
 Directory: 3.4
 
 Tags: python3-onbuild, onbuild
 GitCommit: cecbb2bbbcb69d1b8358398eaf8d9638e3bdd447
 Directory: 3.4/onbuild
 
-Tags: 1.9.8-python2, 1.9-python2, 1-python2, python2
-GitCommit: f610710985af4757e51695fee47f33de47b0293c
+Tags: 1.10-python2, 1-python2, python2
+GitCommit: eb6088320ccd1449f21c4050583bd835913e56ec
 Directory: 2.7
 
 Tags: python2-onbuild

--- a/library/golang
+++ b/library/golang
@@ -37,18 +37,18 @@ Tags: 1.6.3-alpine, 1.6-alpine, 1-alpine, alpine
 GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
 Directory: 1.6/alpine
 
-Tags: 1.7rc3, 1.7
-GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
+Tags: 1.7rc4, 1.7
+GitCommit: cdf73bb71f9a0c0f9aa22beb3d9d34274aaf1b03
 Directory: 1.7
 
-Tags: 1.7rc3-onbuild, 1.7-onbuild
+Tags: 1.7rc4-onbuild, 1.7-onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7rc3-wheezy, 1.7-wheezy
-GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
+Tags: 1.7rc4-wheezy, 1.7-wheezy
+GitCommit: cdf73bb71f9a0c0f9aa22beb3d9d34274aaf1b03
 Directory: 1.7/wheezy
 
-Tags: 1.7rc3-alpine, 1.7-alpine
-GitCommit: 42e12071d6b84da9abbeb1d0b9eaef59d7ad2f30
+Tags: 1.7rc4-alpine, 1.7-alpine
+GitCommit: cdf73bb71f9a0c0f9aa22beb3d9d34274aaf1b03
 Directory: 1.7/alpine

--- a/library/redis
+++ b/library/redis
@@ -16,14 +16,14 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
 Directory: 3.0/alpine
 
-Tags: 3.2.2, 3.2, 3, latest
-GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
+Tags: 3.2.3, 3.2, 3, latest
+GitCommit: ab537600e90916e0425c938054db1bf50256853c
 Directory: 3.2
 
-Tags: 3.2.2-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
+Tags: 3.2.3-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: ab537600e90916e0425c938054db1bf50256853c
 Directory: 3.2/32bit
 
-Tags: 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 4c7dd909f428409bd8b8ada7db04e6eda919787f
+Tags: 3.2.3-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: ab537600e90916e0425c938054db1bf50256853c
 Directory: 3.2/alpine


### PR DESCRIPTION
 - `django` bump to `1.10`
 - `golang` bump to `1.7rc4`
 - `redis` bump to `3.2.3`

Fixes #2013