### PR TITLE
Update elasticsearch 2.3.5 and kibana 4.1.11, 4.5.4

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -28,8 +28,8 @@ Tags: 2.2.2, 2.2
 GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
 Directory: 2.2
 
-Tags: 2.3.4, 2.3, 2, latest
-GitCommit: 1e62c7d84cc549883e3404d79356d3fadfdf6c3d
+Tags: 2.3.5, 2.3, 2, latest
+GitCommit: 95b84a6e29f056d0f9608e5e1bb2129067852e6b
 Directory: 2.3
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5

--- a/library/kibana
+++ b/library/kibana
@@ -8,8 +8,8 @@ Tags: 4.0.3, 4.0
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.0
 
-Tags: 4.1.10, 4.1
-GitCommit: 6328ebb12009f2b8bee76c22e7ba4e11c1c9175e
+Tags: 4.1.11, 4.1
+GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.1
 
 Tags: 4.2.2, 4.2
@@ -24,8 +24,8 @@ Tags: 4.4.2, 4.4
 GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
 Directory: 4.4
 
-Tags: 4.5.3, 4.5, 4, latest
-GitCommit: 6328ebb12009f2b8bee76c22e7ba4e11c1c9175e
+Tags: 4.5.4, 4.5, 4, latest
+GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.5
 
 Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5


### PR DESCRIPTION
pr elasticsearch: docker-library/elasticsearch/pull/112
pr kibana: docker-library/kibana/pull/51