### PR TITLE
Updated Piwik to use version 2.16.2

### DIFF
--- a/library/piwik
+++ b/library/piwik
@@ -1,6 +1,6 @@
 # maintainer: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 
-2.16.1: git://github.com/piwik/docker-piwik.git@70bb9d02587964baee0e652cebc4fb85ac553f38
-2.16: git://github.com/piwik/docker-piwik.git@70bb9d02587964baee0e652cebc4fb85ac553f38
-2: git://github.com/piwik/docker-piwik.git@70bb9d02587964baee0e652cebc4fb85ac553f38
-latest: git://github.com/piwik/docker-piwik.git@70bb9d02587964baee0e652cebc4fb85ac553f38
+2.16.2: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
+2.16: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
+2: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
+latest: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1


### PR DESCRIPTION
Updated refs to the official piwik docker repository due to new version release.

A new version of Piwik ([2.16.2](https://piwik.org/changelog/piwik-2-16-2/) was released and already has been [merged](https://github.com/piwik/docker-piwik/pull/32) into the official [piwik docker](https://github.com/piwik/docker-piwik) repository