### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 1.12.0, 1.12, 1, latest
-GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
+GitCommit: 39269f78ed82ab27b8a560b43f3091b2f503052b
 Directory: 1.12
 
 Tags: 1.12.0-dind, 1.12-dind, 1-dind, dind
@@ -17,7 +17,7 @@ GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
 Tags: 1.11.2, 1.11
-GitCommit: 7ef1746a46a29d89bac9aca8d0788bd629eb00e6
+GitCommit: b83d8a3f9b77c2592f383cd58625e000af4f2dde
 Directory: 1.11
 
 Tags: 1.11.2-dind, 1.11-dind

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b124-jdk, 9-b124, 9-jdk, 9, openjdk-9-b124-jdk, openjdk-9-b124, openjdk-9-jdk, openjdk-9
-GitCommit: d1890fa5206eee489ab6285afa2a52f409dcfdc4
+Tags: 9-b130-jdk, 9-b130, 9-jdk, 9, openjdk-9-b130-jdk, openjdk-9-b130, openjdk-9-jdk, openjdk-9
+GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
 Directory: 9-jdk
 
-Tags: 9-b124-jre, 9-jre, openjdk-9-b124-jre, openjdk-9-jre
-GitCommit: d1890fa5206eee489ab6285afa2a52f409dcfdc4
+Tags: 9-b130-jre, 9-jre, openjdk-9-b130-jre, openjdk-9-jre
+GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.0.9-cli, 7.0-cli, 7-cli, cli, 7.0.9, 7.0, 7, latest
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0
 
 Tags: 7.0.9-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/alpine
 
 Tags: 7.0.9-apache, 7.0-apache, 7-apache, apache
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/apache
 
 Tags: 7.0.9-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/fpm
 
 Tags: 7.0.9-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.9-zts, 7.0-zts, 7-zts, zts
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/zts
 
 Tags: 7.0.9-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.24-cli, 5.6-cli, 5-cli, 5.6.24, 5.6, 5
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6
 
 Tags: 5.6.24-alpine, 5.6-alpine, 5-alpine
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/alpine
 
 Tags: 5.6.24-apache, 5.6-apache, 5-apache
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/apache
 
 Tags: 5.6.24-fpm, 5.6-fpm, 5-fpm
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/fpm
 
 Tags: 5.6.24-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.24-zts, 5.6-zts, 5-zts
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/zts
 
 Tags: 5.6.24-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: cd1769f395d6c3114d2b379573311b8044582ada
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.6/zts/alpine
 
 Tags: 5.5.38-cli, 5.5-cli, 5.5.38, 5.5
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5
 
 Tags: 5.5.38-alpine, 5.5-alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/alpine
 
 Tags: 5.5.38-apache, 5.5-apache
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/apache
 
 Tags: 5.5.38-fpm, 5.5-fpm
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/fpm
 
 Tags: 5.5.38-fpm-alpine, 5.5-fpm-alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/fpm/alpine
 
 Tags: 5.5.38-zts, 5.5-zts
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/zts
 
 Tags: 5.5.38-zts-alpine, 5.5-zts-alpine
-GitCommit: d8a4ccf4d620ec866d5b42335b699742df08c5f0
+GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
 Directory: 5.5/zts/alpine

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,19 +25,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 3.3.6, 3.3
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -45,19 +45,19 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -65,33 +65,33 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
 GitCommit: 0fa3202789648132971160f686f5a37595108f44
 Directory: 3.5/onbuild
 
-Tags: 3.6.0a2, 3.6
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+Tags: 3.6.0a3, 3.6
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.6
 
-Tags: 3.6.0a2-slim, 3.6-slim
-GitCommit: a819c92949e182901df10e52d41bc57c6ca73bd5
+Tags: 3.6.0a3-slim, 3.6-slim
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.6/slim
 
-Tags: 3.6.0a2-alpine, 3.6-alpine
-GitCommit: 8ab2af26df98ddbcd7ce7d39b0ee343dd8d86d41
+Tags: 3.6.0a3-alpine, 3.6-alpine
+GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
 Directory: 3.6/alpine
 
-Tags: 3.6.0a2-onbuild, 3.6-onbuild
+Tags: 3.6.0a3-onbuild, 3.6-onbuild
 GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
 Directory: 3.6/onbuild

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,6 +1,6 @@
 # maintainer: Rocket.Chat Image Team <buildmaster@rocket.chat>
 
-0.35.0: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
-0.35: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
-0: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
-latest: git://github.com/RocketChat/Docker.Official.Image@d048a0d60f75b6a7e704e097488fd167484885cd
+0.36.0: git://github.com/RocketChat/Docker.Official.Image@6a71d57ee5576455a0acfdf0ab144ef5489022ef
+0.36: git://github.com/RocketChat/Docker.Official.Image@6a71d57ee5576455a0acfdf0ab144ef5489022ef
+0: git://github.com/RocketChat/Docker.Official.Image@6a71d57ee5576455a0acfdf0ab144ef5489022ef
+latest: git://github.com/RocketChat/Docker.Official.Image@6a71d57ee5576455a0acfdf0ab144ef5489022ef


### PR DESCRIPTION
- `docker`: `${DOCKER_VERSION}` (cosmetic; docker-library/docker#16)
- `java`: Debian 9~b130
- `php`: note that `Dockerfile`s are generated (https://github.com/docker-library/php/commit/e36077f85c5302f46e9c55bf1f9164e9dae7992d)
- `python`: use `PATH` instead of `dpkg-divert` or `purge` (docker-library/python#137)
- `rocket.chat`: 0.36.0