### PR TITLE
Sentry 8.7

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/09d2b56ded2f669f40d5295bfe36529bbafb914d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/22e75e5254b5707b77a747cd4e90bc4327f2ce9b/generate-stackbrew-library.sh
 
 Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
 
-Tags: 8.5.1, 8.5
-GitCommit: d69a0096ee2f885047f95bdd2e2edfc761674580
-Directory: 8.5
-
-Tags: 8.5.1-onbuild, 8.5-onbuild
-GitCommit: ce5121a71f55c2fb0659f552e361b1174c85bccf
-Directory: 8.5/onbuild
-
-Tags: 8.6.0, 8.6, 8, latest
+Tags: 8.6.0, 8.6
 GitCommit: 09d2b56ded2f669f40d5295bfe36529bbafb914d
 Directory: 8.6
 
-Tags: 8.6.0-onbuild, 8.6-onbuild, 8-onbuild, onbuild
+Tags: 8.6.0-onbuild, 8.6-onbuild
 GitCommit: 09d2b56ded2f669f40d5295bfe36529bbafb914d
 Directory: 8.6/onbuild
+
+Tags: 8.7.0, 8.7, 8, latest
+GitCommit: 22e75e5254b5707b77a747cd4e90bc4327f2ce9b
+Directory: 8.7
+
+Tags: 8.7.0-onbuild, 8.7-onbuild, 8-onbuild, onbuild
+GitCommit: 22e75e5254b5707b77a747cd4e90bc4327f2ce9b
+Directory: 8.7/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.7.0 :tada: