### PR TITLE
[NATS] Release v0.9.2

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -1,6 +1,8 @@
-# maintainer: Derek Collison <derek@apcera.com> (@derekcollison)
-# maintainer: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
-# maintainer: Waldemar Salinas <wally@apcera.com> (@wallyqs)
+Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
+             Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
+             Waldemar Salinas <wally@apcera.com> (@wallyqs)
 
-0.8.1: git://github.com/nats-io/nats-docker@4c81602c04da12b6c3c932c4a38a45db75bf7e99
-latest: git://github.com/nats-io/nats-docker@4c81602c04da12b6c3c932c4a38a45db75bf7e99
+Tags: 0.9.2, latest
+GitRepo: https://github.com/nats-io/nats-docker.git
+GitCommit: 471bbbe6669d7e6bafe85a30dfa1f5490822bc80
+

--- a/library/nats
+++ b/library/nats
@@ -1,4 +1,5 @@
 # maintainer: Derek Collison <derek@apcera.com> (@derekcollison)
+# maintainer: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 # maintainer: Waldemar Salinas <wally@apcera.com> (@wallyqs)
 
 0.8.1: git://github.com/nats-io/nats-docker@4c81602c04da12b6c3c932c4a38a45db75bf7e99


### PR DESCRIPTION
New NATS Server release: [v0.9.2](https://github.com/nats-io/gnatsd/releases/tag/v0.9.2).

Use new file format for the library definition file.