### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -32,6 +32,6 @@ Tags: 2.3.5, 2.3, 2, latest
 GitCommit: 95b84a6e29f056d0f9608e5e1bb2129067852e6b
 Directory: 2.3
 
-Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+Tags: 5.0.0-alpha5, 5.0.0, 5.0, 5
+GitCommit: 56315cbb71d3f04e6da05989ace7a5ecd4f2bfed
 Directory: 5.0

--- a/library/piwik
+++ b/library/piwik
@@ -1,6 +1,6 @@
 # maintainer: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 
-2.16.2: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
-2.16: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
-2: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
-latest: git://github.com/piwik/docker-piwik.git@d2ac33889381c06a71a480896fd20ca535af4ea1
+2.16.2: git://github.com/piwik/docker-piwik.git@5e0bb9e49ae72291cf357c9ef1b4671c4ae25f9c
+2.16: git://github.com/piwik/docker-piwik.git@5e0bb9e49ae72291cf357c9ef1b4671c4ae25f9c
+2: git://github.com/piwik/docker-piwik.git@5e0bb9e49ae72291cf357c9ef1b4671c4ae25f9c
+latest: git://github.com/piwik/docker-piwik.git@5e0bb9e49ae72291cf357c9ef1b4671c4ae25f9c

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: f1bc9f790605ecf0dabce4c24ef9ee5ce205e496
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 2664a9b68104d35c99aa79c56eea24423e6f9807
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 2664a9b68104d35c99aa79c56eea24423e6f9807
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: f1bc9f790605ecf0dabce4c24ef9ee5ce205e496
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,71 +25,71 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 3.3.6, 3.3
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
-GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
-GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
-GitCommit: 0fa3202789648132971160f686f5a37595108f44
+GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
 Tags: 3.6.0a3, 3.6
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: f1bc9f790605ecf0dabce4c24ef9ee5ce205e496
 Directory: 3.6
 
 Tags: 3.6.0a3-slim, 3.6-slim
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: f1bc9f790605ecf0dabce4c24ef9ee5ce205e496
 Directory: 3.6/slim
 
 Tags: 3.6.0a3-alpine, 3.6-alpine
-GitCommit: 7ea58b992e65e0c95226e8acb1a4f3b2e2f72554
+GitCommit: f1bc9f790605ecf0dabce4c24ef9ee5ce205e496
 Directory: 3.6/alpine
 
 Tags: 3.6.0a3-onbuild, 3.6-onbuild


### PR DESCRIPTION
- `elasticsearch`: 5.0.0-alpha5 (docker-library/elasticsearch#113)
- `piwik`: swap from merge commit to commit with substance (direct output of `generate-stackbrew-library.sh`)
- `python`: templates (docker-library/python#139), fix `import dbm` (docker-library/python#140)
