### PR TITLE
Add library file for NATS Streaming

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,0 +1,6 @@
+Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
+
+Tags: 0.2.2, latest
+GitRepo: https://github.com/nats-io/nats-streaming-docker.git
+GitCommit: d7e21255fec8967f7dbdacdb4501c8e78d821e49
+

--- a/test/config.sh
+++ b/test/config.sh
@@ -174,16 +174,19 @@ globalExcludeTests+=(
 	# single-binary images
 	[hello-world_utc]=1
 	[nats_utc]=1
+	[nats-streaming_utc]=1
 	[swarm_utc]=1
 	[traefik_utc]=1
 
 	[hello-world_no-hard-coded-passwords]=1
 	[nats_no-hard-coded-passwords]=1
+	[nats-streaming_no-hard-coded-passwords]=1
 	[swarm_no-hard-coded-passwords]=1
 	[traefik_no-hard-coded-passwords]=1
 
 	[hello-world_override-cmd]=1
 	[nats_override-cmd]=1
+	[nats-streaming_override-cmd]=1
 	[swarm_override-cmd]=1
 	[traefik_override-cmd]=1
 


### PR DESCRIPTION
This is for [NATS Streaming Server](http://nats.io/documentation/streaming/nats-streaming-intro/), a streaming server of the [NATS](http://nats.io) family.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
  * https://github.com/nats-io/nats-streaming-server/issues/137
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty 
image page on the Hub for very long)
  * https://github.com/docker-library/docs/pull/657
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] ~~existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)~~
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)