### PR TITLE
Update docker-library images

### DIFF
--- a/library/java
+++ b/library/java
@@ -28,16 +28,16 @@ Tags: 7u91-jre-alpine, 7-jre-alpine, openjdk-7u91-jre-alpine, openjdk-7-jre-alpi
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 7-jre/alpine
 
-Tags: 8u91-jdk, 8u91, 8-jdk, 8, jdk, latest, openjdk-8u91-jdk, openjdk-8u91, openjdk-8-jdk, openjdk-8
-GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
+Tags: 8u102-jdk, 8u102, 8-jdk, 8, jdk, latest, openjdk-8u102-jdk, openjdk-8u102, openjdk-8-jdk, openjdk-8
+GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
 Directory: 8-jdk
 
 Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jdk/alpine
 
-Tags: 8u91-jre, 8-jre, jre, openjdk-8u91-jre, openjdk-8-jre
-GitCommit: a0a4970a343a3c021dad760f2281d20f61931e3c
+Tags: 8u102-jre, 8-jre, jre, openjdk-8u102-jre, openjdk-8-jre
+GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
 Directory: 8-jre
 
 Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine

--- a/library/kibana
+++ b/library/kibana
@@ -28,6 +28,6 @@ Tags: 4.5.4, 4.5, 4, latest
 GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.5
 
-Tags: 5.0.0-alpha4, 5.0.0, 5.0, 5
-GitCommit: 90abf46493103a3c6a7061b400d76f109c4104e7
+Tags: 5.0.0-alpha5, 5.0.0, 5.0, 5
+GitCommit: f1e01a0c5d64b1eea3c9d90a2cba93d9f3924bd0
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -24,6 +24,6 @@ Tags: 2.3.4-1, 2.3.4, 2.3, 2, latest
 GitCommit: b0342c0fdfe41b89a02b4edd75303e6a143a19c1
 Directory: 2.3
 
-Tags: 5.0.0-alpha4-1, 5.0.0-alpha4, 5.0.0, 5.0, 5
-GitCommit: 963e75bbedf450b7a1733f2571410adc152aac12
+Tags: 5.0.0-alpha5-1, 5.0.0-alpha5, 5.0.0, 5.0, 5
+GitCommit: 5b9e3413105f69be181d9648d146bce4180afcf5
 Directory: 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,6 +12,6 @@ Tags: 10.0.26, 10.0
 GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
 Directory: 10.0
 
-Tags: 5.5.50, 5.5, 5
-GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
+Tags: 5.5.51, 5.5, 5
+GitCommit: 0bcd1e2db0ef04f4abac85e2a759b04231ba60a0
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.0.9-cli, 7.0-cli, 7-cli, cli, 7.0.9, 7.0, 7, latest
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0
 
 Tags: 7.0.9-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/alpine
 
 Tags: 7.0.9-apache, 7.0-apache, 7-apache, apache
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/apache
 
 Tags: 7.0.9-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/fpm
 
 Tags: 7.0.9-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.9-zts, 7.0-zts, 7-zts, zts
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/zts
 
 Tags: 7.0.9-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.24-cli, 5.6-cli, 5-cli, 5.6.24, 5.6, 5
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6
 
 Tags: 5.6.24-alpine, 5.6-alpine, 5-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/alpine
 
 Tags: 5.6.24-apache, 5.6-apache, 5-apache
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/apache
 
 Tags: 5.6.24-fpm, 5.6-fpm, 5-fpm
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/fpm
 
 Tags: 5.6.24-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.24-zts, 5.6-zts, 5-zts
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/zts
 
 Tags: 5.6.24-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.6/zts/alpine
 
 Tags: 5.5.38-cli, 5.5-cli, 5.5.38, 5.5
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5
 
 Tags: 5.5.38-alpine, 5.5-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/alpine
 
 Tags: 5.5.38-apache, 5.5-apache
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/apache
 
 Tags: 5.5.38-fpm, 5.5-fpm
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/fpm
 
 Tags: 5.5.38-fpm-alpine, 5.5-fpm-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/fpm/alpine
 
 Tags: 5.5.38-zts, 5.5-zts
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/zts
 
 Tags: 5.5.38-zts-alpine, 5.5-zts-alpine
-GitCommit: 2cc40ce1de4206a9bc55e38331937b4bd7d58700
+GitCommit: d6b446a77a77c8247e2206be8f966fdb24516862
 Directory: 5.5/zts/alpine


### PR DESCRIPTION
- `java`: 8u102 (Debian)
- `kibana`: 5.0.0-alpha5
- `logstash`: 5.0.0-alpha5
- `mariadb`: 5.5.51
- `php`: `--enable-ftp` (docker-library/php#287), backwards compatibility fixes (docker-library/php#288)