### PR TITLE
Move websphere-liberty to base on ibmjava and remove :common

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,9 +1,8 @@
 # maintainer: David Currie <david_currie@uk.ibm.com> (@davidcurrie)
 
-kernel: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/kernel
-common: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/common
-webProfile6: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/webProfile6
-webProfile7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/webProfile7
-javaee7: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
-latest: git://github.com/WASdev/ci.docker@b9acc6726d03cd7f97be5e7ec246579d8258b6d6 ga/developer/javaee7
-beta: git://github.com/WASdev/ci.docker@fd3efde8f3c63ef8c40572ae31649300fec22267 beta
+kernel: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f ga/developer/kernel
+webProfile6: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f ga/developer/webProfile6
+webProfile7: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f ga/developer/webProfile7
+javaee7: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f ga/developer/javaee7
+latest: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f ga/developer/javaee7
+beta: git://github.com/WASdev/ci.docker@0c0fa33fabbbf0a9be57df2b2940c5e6c9603e6f beta


### PR DESCRIPTION
Rebasing websphere-liberty on to the new ibmjava official image (which will also upgrade to the latest IBM JRE). Also, removing the websphere-liberty:common image from the hierarchy. It was never intended for direct usage (just as the base for webProfile6 and webProfile7) but is actually leading to an inflation in the size of the webProfile7 image (as some features are pulled in again in that layer).