### PR TITLE
Add a new "openjdk" image (renamed from "java") so that "java" can be deprecated

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,50 +4,50 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 6b38-jdk, 6b38, 6-jdk, 6, openjdk-6b38-jdk, openjdk-6b38, openjdk-6-jdk, openjdk-6
+Tags: 6b38-jdk, 6b38, 6-jdk, 6
 GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
 Directory: 6-jdk
 
-Tags: 6b38-jre, 6-jre, openjdk-6b38-jre, openjdk-6-jre
+Tags: 6b38-jre, 6-jre
 GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
 Directory: 6-jre
 
-Tags: 7u111-jdk, 7u111, 7-jdk, 7, openjdk-7u111-jdk, openjdk-7u111, openjdk-7-jdk, openjdk-7
+Tags: 7u111-jdk, 7u111, 7-jdk, 7
 GitCommit: ac78a119a294925b60c8fe4e64c79abab1dd8dbf
 Directory: 7-jdk
 
-Tags: 7u91-jdk-alpine, 7u91-alpine, 7-jdk-alpine, 7-alpine, openjdk-7u91-jdk-alpine, openjdk-7u91-alpine, openjdk-7-jdk-alpine, openjdk-7-alpine
+Tags: 7u91-jdk-alpine, 7u91-alpine, 7-jdk-alpine, 7-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 7-jdk/alpine
 
-Tags: 7u111-jre, 7-jre, openjdk-7u111-jre, openjdk-7-jre
+Tags: 7u111-jre, 7-jre
 GitCommit: ac78a119a294925b60c8fe4e64c79abab1dd8dbf
 Directory: 7-jre
 
-Tags: 7u91-jre-alpine, 7-jre-alpine, openjdk-7u91-jre-alpine, openjdk-7-jre-alpine
+Tags: 7u91-jre-alpine, 7-jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 7-jre/alpine
 
-Tags: 8u102-jdk, 8u102, 8-jdk, 8, jdk, latest, openjdk-8u102-jdk, openjdk-8u102, openjdk-8-jdk, openjdk-8
+Tags: 8u102-jdk, 8u102, 8-jdk, 8, jdk, latest
 GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
 Directory: 8-jdk
 
-Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
+Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jdk/alpine
 
-Tags: 8u102-jre, 8-jre, jre, openjdk-8u102-jre, openjdk-8-jre
+Tags: 8u102-jre, 8-jre, jre
 GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
 Directory: 8-jre
 
-Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine
+Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b130-jdk, 9-b130, 9-jdk, 9, openjdk-9-b130-jdk, openjdk-9-b130, openjdk-9-jdk, openjdk-9
+Tags: 9-b130-jdk, 9-b130, 9-jdk, 9
 GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
 Directory: 9-jdk
 
-Tags: 9-b130-jre, 9-jre, openjdk-9-b130-jre, openjdk-9-jre
+Tags: 9-b130-jre, 9-jre
 GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
 Directory: 9-jre


### PR DESCRIPTION
https://github.com/docker-library/docs/pull/660