### PR TITLE
Allow globs in diff to get files beginning with `.`

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+shopt -s dotglob
 
 # make sure we can GTFO
 trap 'echo >&2 Ctrl+C captured, exiting; exit 1' SIGINT


### PR DESCRIPTION
This was needed for https://github.com/docker-library/official-images/pull/2020 since they used `COPY ./local-package/*` for a file that starts with `.`.  Which is more similar to the glob matching that docker uses anyway.