### PR TITLE
Adjust no-hard-coded-passwords test to not run on clearlinux

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -187,6 +187,10 @@ globalExcludeTests+=(
 	[swarm_override-cmd]=1
 	[traefik_override-cmd]=1
 
+	# clearlinux has no /etc/password
+	# https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477
+	[clearlinux_no-hard-coded-passwords]=1
+
 	# no "native" dependencies
 	[ruby:alpine_ruby-bundler]=1
 	[ruby:alpine_ruby-gems]=1


### PR DESCRIPTION
See discussion on PR for clearlinux: https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477