### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 1.5.2, 1.5
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 1.5
 
 Tags: 1.6.2, 1.6
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 1.6
 
 Tags: 1.7.5, 1.7, 1
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 2.0
 
 Tags: 2.1.2, 2.1
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 2.1
 
 Tags: 2.2.2, 2.2
-GitCommit: 2bfa45254a681e4f667c96c5de13438209e2f0ec
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 2.2
 
 Tags: 2.3.5, 2.3, 2, latest
-GitCommit: 95b84a6e29f056d0f9608e5e1bb2129067852e6b
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 2.3
 
 Tags: 5.0.0-alpha5, 5.0.0, 5.0, 5
-GitCommit: 56315cbb71d3f04e6da05989ace7a5ecd4f2bfed
+GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
 Directory: 5.0

--- a/library/haproxy
+++ b/library/haproxy
@@ -20,10 +20,10 @@ Tags: 1.5.18-alpine, 1.5-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.5/alpine
 
-Tags: 1.6.7, 1.6, 1, latest
-GitCommit: fee22521901f01ccde1a1f63c6d3b619053ef196
+Tags: 1.6.8, 1.6, 1, latest
+GitCommit: 94237f1aaae12342b93605b1c1ef4cdecd6e848f
 Directory: 1.6
 
-Tags: 1.6.7-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: fee22521901f01ccde1a1f63c6d3b619053ef196
+Tags: 1.6.8-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 94237f1aaae12342b93605b1c1ef4cdecd6e848f
 Directory: 1.6/alpine

--- a/library/logstash
+++ b/library/logstash
@@ -5,25 +5,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 1.5.6-1, 1.5.6, 1.5, 1
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 1.5
 
 Tags: 2.0.0-1, 2.0.0, 2.0
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 2.0
 
 Tags: 2.1.3-1, 2.1.3, 2.1
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 2.1
 
 Tags: 2.2.4-1, 2.2.4, 2.2
-GitCommit: bb4f8b0d3f3e92a04dfbfee1d2b94196f64bd78c
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 2.2
 
 Tags: 2.3.4-1, 2.3.4, 2.3, 2, latest
-GitCommit: b0342c0fdfe41b89a02b4edd75303e6a143a19c1
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 2.3
 
 Tags: 5.0.0-alpha5-1, 5.0.0-alpha5, 5.0.0, 5.0, 5
-GitCommit: 5b9e3413105f69be181d9648d146bce4180afcf5
+GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
 Directory: 5.0

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.29, 1.4, 1, latest
-GitCommit: 7b8ed32cdbc0b14fd86bf4b6fb9136a08c9af29e
+Tags: 1.4.30, 1.4, 1, latest
+GitCommit: 3653cceece53495fc99af785c3ce130197f0922d
 Directory: debian
 
-Tags: 1.4.29-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 7b8ed32cdbc0b14fd86bf4b6fb9136a08c9af29e
+Tags: 1.4.30-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 3653cceece53495fc99af785c3ce130197f0922d
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -16,6 +16,6 @@ Tags: 3.2.8, 3.2, 3, latest
 GitCommit: 92669ba9c463593f85007faf371522201167a5ee
 Directory: 3.2
 
-Tags: 3.3.10, 3.3
-GitCommit: 7065352d915f03584da8a57cc070e612106496ef
+Tags: 3.3.11, 3.3
+GitCommit: 753674533d5f413d4d63f9da74682bddec5a3c39
 Directory: 3.3

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.36.0, 0.36, 0, latest
-GitCommit: 6a71d57ee5576455a0acfdf0ab144ef5489022ef
+Tags: 0.37.0, 0.37, 0, latest
+GitCommit: 2e5736297a21955a2f1c373829f24daa691201d4

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,57 +5,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.45-jre7, 6.0-jre7, 6-jre7, 6.0.45, 6.0, 6
-GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 6/jre7
 
 Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
-GitCommit: ec75141e3cb6276b07d66c16042152e2d4de119c
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 6/jre8
 
 Tags: 7.0.70-jre7, 7.0-jre7, 7-jre7, 7.0.70, 7.0, 7
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 7/jre7
 
 Tags: 7.0.70-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.70-alpine, 7.0-alpine, 7-alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 7/jre7-alpine
 
 Tags: 7.0.70-jre8, 7.0-jre8, 7-jre8
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 7/jre8
 
 Tags: 7.0.70-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 7/jre8-alpine
 
 Tags: 8.0.36-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.36, 8.0, 8, latest
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.0/jre7
 
 Tags: 8.0.36-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.36-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.36-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.0/jre8
 
 Tags: 8.0.36-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 5f1abae99c0b1ebbd4f020bc4b5696619d948cfd
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.4-jre8, 8.5-jre8, 8.5.4, 8.5
-GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.5/jre8
 
 Tags: 8.5.4-jre8-alpine, 8.5-jre8-alpine, 8.5.4-alpine, 8.5-alpine
-GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M9-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M9, 9.0.0, 9.0, 9
-GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M9-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M9-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: b0cb4ee4d375ade382d77c450903b7c3a0c2b39f
+GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `elasticsearch`: `FROM openjdk`
- `haproxy`: 1.6.8
- `logstash`: `FROM openjdk`
- `memcached`: 1.4.30
- `mongo`: 3.3.11
- `rocket.chat`: 0.37.0
- `tomcat`: `FROM openjdk`