### PR TITLE
Update for Node.js v6.4.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -64,22 +64,22 @@ argon-wheezy: git://github.com/nodejs/docker-node@bf93fccf8e127824cd2478f491502c
 5.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
 5-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
 
-6.3.1: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3
-6.3: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3
-6: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3
-latest: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3
+6.4.0: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
+6.4: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
+6: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
+latest: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
 
-6.3.1-onbuild: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/onbuild
-6.3-onbuild: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/onbuild
-onbuild: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/onbuild
+6.4.0-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
+6.4-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
+onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
 
-6.3.1-slim: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/slim
-6.3-slim: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/slim
-6-slim: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/slim
-slim: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/slim
+6.4.0-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
+6.4-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
+6-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
+slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
 
-6.3.1-wheezy: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/wheezy
-6.3-wheezy: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/wheezy
-6-wheezy: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/wheezy
-wheezy: git://github.com/nodejs/docker-node@ae9e2d4f04a0fa82261df86fd9556a76cefc020d 6.3/wheezy
+6.4.0-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
+6.4-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
+6-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
+wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v6.4.0/
- https://github.com/nodejs/docker-node/issues/216