### PR TITLE
[NATS] Update to version v0.9.4

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,7 +2,7 @@ Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
              Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
              Waldemar Salinas <wally@apcera.com> (@wallyqs)
 
-Tags: 0.9.2, latest
+Tags: 0.9.4, latest
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 471bbbe6669d7e6bafe85a30dfa1f5490822bc80
+GitCommit: d37917c2830bfe3b54de8d92ac36b62cc1309cfc
 


### PR DESCRIPTION
New release includes a panic fix.
Details here: https://github.com/nats-io/gnatsd/releases/tag/v0.9.4