### PR TITLE
version bump: otp-19.0.5 & 18.3.4.4

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -3,27 +3,27 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-Tags: 19.0.3, 19.0, 19, latest
-GitCommit: d4b2a7c2bef381344ca28183d625e2db066be22b
+Tags: 19.0.5, 19.0, 19, latest
+GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
 Directory: 19
 
-Tags: 19.0.3-slim, 19.0-slim, 19-slim, slim
-GitCommit: d4b2a7c2bef381344ca28183d625e2db066be22b
+Tags: 19.0.5-slim, 19.0-slim, 19-slim, slim
+GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
 Directory: 19/slim
 
-Tags: 19.0.3-onbuild, 19.0-onbuild, 19-onbuild, onbuild
+Tags: 19.0.5-onbuild, 19.0-onbuild, 19-onbuild, onbuild
 GitCommit: 847b82cdb8896d8d865bf32f2833787b5c62587c
 Directory: 19/onbuild
 
-Tags: 18.3.4.3, 18.3.4, 18.3, 18
-GitCommit: d4b2a7c2bef381344ca28183d625e2db066be22b
+Tags: 18.3.4.4, 18.3.4, 18.3, 18
+GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
 Directory: 18
 
-Tags: 18.3.4.3-slim, 18.3.4-slim, 18.3-slim, 18-slim
-GitCommit: d4b2a7c2bef381344ca28183d625e2db066be22b
+Tags: 18.3.4.4-slim, 18.3.4-slim, 18.3-slim, 18-slim
+GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
 Directory: 18/slim
 
-Tags: 18.3.4.3-onbuild, 18.3.4-onbuild, 18.3-onbuild, 18-onbuild
+Tags: 18.3.4.4-onbuild, 18.3.4-onbuild, 18.3-onbuild, 18-onbuild
 GitCommit: 20e41464075dc0fc76709be77701530eddb6fe33
 Directory: 18/onbuild
 


### PR DESCRIPTION
c0b/docker-erlang-otp#23