### PR TITLE
Update mongo-express to 0.31.0

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.30.59: git://github.com/mongo-express/mongo-express-docker@d1a908ad4cce8bcf4453fd2b40022eeb8f5c3724
-0.30: git://github.com/mongo-express/mongo-express-docker@d1a908ad4cce8bcf4453fd2b40022eeb8f5c3724
-latest: git://github.com/mongo-express/mongo-express-docker@d1a908ad4cce8bcf4453fd2b40022eeb8f5c3724
+0.31.0: git://github.com/mongo-express/mongo-express-docker@8307e91473be1b6849e89acc4d347eec0116293a
+0.31: git://github.com/mongo-express/mongo-express-docker@8307e91473be1b6849e89acc4d347eec0116293a
+latest: git://github.com/mongo-express/mongo-express-docker@8307e91473be1b6849e89acc4d347eec0116293a


### PR DESCRIPTION
This mongo-express update includes the following:

- Use the latest node 5 version
- Adds a gridFSEnabled option in the config file
- Fix a DBRef field broken error
- Fix a variable name typo