### PR TITLE
Aerospike 3.9.1

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.9.0.3: git://github.com/aerospike/aerospike-server.docker@27944b4607e63498931f3c1602ccf2322bb84a0e
-latest: git://github.com/aerospike/aerospike-server.docker@27944b4607e63498931f3c1602ccf2322bb84a0e
+3.9.1: git://github.com/aerospike/aerospike-server.docker@2ac3aa54b16eb6ab836783bc9c9215a8c2f1d66b
+latest: git://github.com/aerospike/aerospike-server.docker@2ac3aa54b16eb6ab836783bc9c9215a8c2f1d66b


### PR DESCRIPTION
http://www.aerospike.com/enterprise/download/server/notes.html#3.9.1

Improvements

    [AER-4454] - (KVS) Enhanced heartbeat subsystem.
    [AER-5146] - (KVS) Socket API refactoring.
    [AER-5172] - (KVS) Add new error codes for map_add() operations - ELEMENT_NOT_FOUND & ELEMENT_EXISTS.
    [AER-5187] - (KVS) Add deleted_last_bin stat for record deleted via last bin deleted.
    [AER-5060] - (KVS) Log when set-delete reverts to false.
    [AER-4669] - (KVS) Obsolete "mesh-address" configuration.
    [AER-5128] - (Fabric) Obsolete migrate_progress_send/recv.
    [AER-4587] - (Cluster) Allow seed node to accept hostnames - via tip and via config.

Bug Fixes

    [AER-5184] - (KVS) Unexpected binless record created by Rapid Rebalance.
    [AER-5127] - (KVS) Full bin data incorrectly returned when querying for a non-existent map key - Respond_all_ops reads now consistent.
    [AER-5143] - (KVS) Return cluster config also in "config-get:" call.
    [AER-5166] - (KVS) cf_fault_event_nostack() should respect log-local-time.
    [AER-5199] - (KVS) Generation & TTL in client response incorrect (zero) for writes that duplicate resolve and replicate.
    [AER-5213] - (KVS) Crash or garbage returned on list/map read-only operations that has empty results.
    [AER-5140] - (UDF) Correctly adjust storage stats when record is deleted via no-more bins in UDF.
    [AER-5178] - (UDF) Log entries generated from Lua should display the Lua file name and line number.
    [AER-5113] - (Scan) Partial scans can cause memory/stack corruption.
    [AER-5145] - (Fabric) Race conditions and object reference fixes for fb and fne.
    [AER-4822] - (Cluster) Server crash paxos-max-cluster-size set differently on different nodes.
    [AER-5136] - (Cluster) Unstable cluster formation if the cluster size reaches paxos-max-cluster-size.
    [AER-5108] - (XDR) Bin-level shipping not handling deleted bins.
    [AER-5124] - (XDR) Failed node processing to other DCs is aborted if a link is down.
    [AER-5131] - (XDR) xdr-info-timeout dynamic config change is not reflected properly.