### PR TITLE
Fix library/vault entrypoint script

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -1,6 +1,6 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
-0.6.0: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6
-0.6: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1
-0.6.1: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1
-latest: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1
+0.6.0: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6
+0.6: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1
+0.6.1: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1
+latest: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1

--- a/library/vault
+++ b/library/vault
@@ -1,6 +1,6 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
-0.6.0: git://github.com/hashicorp/docker-vault@296309e4e40be197e89b9f063463fe02c4c5c3e2 0.6
-0.6: git://github.com/hashicorp/docker-vault@296309e4e40be197e89b9f063463fe02c4c5c3e2 0.6.1
-0.6.1: git://github.com/hashicorp/docker-vault@296309e4e40be197e89b9f063463fe02c4c5c3e2 0.6.1
-latest: git://github.com/hashicorp/docker-vault@296309e4e40be197e89b9f063463fe02c4c5c3e2 0.6.1
+0.6.0: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6
+0.6: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1
+0.6.1: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1
+latest: git://github.com/hashicorp/docker-vault@7c54a44d323e4fe01ba6a83c7d731902b5b96e5b 0.6.1


### PR DESCRIPTION
Vault < 0.6.2 errors out if the development server listen address is set when not running in dev mode; this means that the original fix for hashicorp/docker-vault#2 makes it very difficult to run not in dev mode (basically requiring your own entrypoint). This fixes that issue with a check that can be removed for 0.6.2+.