### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -13,7 +13,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
 Tags: jessie, latest
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: jessie
 
 Tags: precise-curl
@@ -25,7 +25,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: precise/scm
 
 Tags: precise
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: precise
 
 Tags: sid-curl
@@ -37,7 +37,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: sid/scm
 
 Tags: sid
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: sid
 
 Tags: stretch-curl
@@ -49,7 +49,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
 Tags: stretch
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: stretch
 
 Tags: trusty-curl
@@ -61,7 +61,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: trusty/scm
 
 Tags: trusty
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: trusty
 
 Tags: wheezy-curl
@@ -73,7 +73,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: wheezy/scm
 
 Tags: wheezy
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: wheezy
 
 Tags: xenial-curl
@@ -85,5 +85,5 @@ GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
 Directory: xenial/scm
 
 Tags: xenial
-GitCommit: e7534be05255522954f50542ebf9c5f06485838d
+GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
 Directory: xenial

--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/f55342de56b4463895cfbfcd95972306e517cd57/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/eb714a73e7e3f87705f468c3c6e9f4e316136bf5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -15,6 +15,18 @@ Directory: 1.12/dind
 Tags: 1.12.1-git, 1.12-git, 1-git, git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
+
+Tags: 1.12.1-experimental, 1.12-experimental, 1-experimental, experimental
+GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
+Directory: 1.12/experimental
+
+Tags: 1.12.1-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
+Directory: 1.12/experimental/dind
+
+Tags: 1.12.1-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
+Directory: 1.12/experimental/git
 
 Tags: 1.11.2, 1.11
 GitCommit: b83d8a3f9b77c2592f383cd58625e000af4f2dde

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.13, 5.7, 5, latest
-GitCommit: 9f24653b2c4dd2e40cdced347c0ca388b8ab0cb2
+Tags: 5.7.14, 5.7, 5, latest
+GitCommit: c44a378d50a1d58f58c202c9a0f59f434fdd72b0
 Directory: 5.7
 
 Tags: 5.6.32, 5.6

--- a/library/php
+++ b/library/php
@@ -5,57 +5,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.0.10-cli, 7.0-cli, 7-cli, cli, 7.0.10, 7.0, 7, latest
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0
 
 Tags: 7.0.10-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/alpine
 
 Tags: 7.0.10-apache, 7.0-apache, 7-apache, apache
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/apache
 
 Tags: 7.0.10-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/fpm
 
 Tags: 7.0.10-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.10-zts, 7.0-zts, 7-zts, zts
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/zts
 
 Tags: 7.0.10-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 8c97d460ceab62ba76f0344d07f9e5c5d312b295
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.25-cli, 5.6-cli, 5-cli, 5.6.25, 5.6, 5
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6
 
 Tags: 5.6.25-alpine, 5.6-alpine, 5-alpine
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/alpine
 
 Tags: 5.6.25-apache, 5.6-apache, 5-apache
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/apache
 
 Tags: 5.6.25-fpm, 5.6-fpm, 5-fpm
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/fpm
 
 Tags: 5.6.25-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.25-zts, 5.6-zts, 5-zts
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/zts
 
 Tags: 5.6.25-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 7e86d3dd84f4594a1e44f3241bbd0a8a91ace012
+GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
 Directory: 5.6/zts/alpine


### PR DESCRIPTION
- `buildpack-deps`: add `libkrb5-dev` (docker-library/buildpack-deps#48)
- `docker`: add `experimental` variant for 1.12+ (docker-library/docker#22)
- `php`: use https for communication with php.net (docker-library/php#293)