### PR TITLE
Improve redis-basics-persistent by actually checking

### DIFF
--- a/test/tests/redis-basics-persistent/real-run.sh
+++ b/test/tests/redis-basics-persistent/real-run.sh
@@ -1,1 +1,0 @@
-../redis-basics/run.sh

--- a/test/tests/redis-basics-persistent/run.sh
+++ b/test/tests/redis-basics-persistent/run.sh
@@ -5,10 +5,29 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
-newImage="$("$dir/../image-name.sh" librarytest/redis-basics-persistent "$image")"
-"$dir/../docker-build.sh" "$dir" "$newImage" <<EOD
-FROM $image
-CMD ["--appendonly", "yes"]
-EOD
+cname="redis-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" "$image")"
+trap "docker rm -vf $cid > /dev/null" EXIT
 
-exec "$dir/real-run.sh" "$newImage"
+redis-cli() {
+	docker run --rm -i \
+		--link "$cname":redis \
+		--entrypoint redis-cli \
+		"$image" \
+		-h redis \
+		"$@"
+}
+
+# http://redis.io/topics/quickstart#check-if-redis-is-working
+
+. "$dir/../../retry.sh" --tries 20 '[ "$(redis-cli ping)" = "PONG" ]'
+
+[ "$(redis-cli set mykey somevalue)" = 'OK' ]
+[ "$(redis-cli get mykey)" = 'somevalue' ]
+
+docker stop "$cname"
+docker start "$cname"
+
+. "$dir/../../retry.sh" --tries 20 '[ "$(redis-cli ping)" = "PONG" ]'
+
+[ "$(redis-cli get mykey)" = 'somevalue' ]


### PR DESCRIPTION
I'm not entirely sure what redis-basics-persistent should check, but it currently does not check whether redis persists something. So I thought I'd recycle that test.

I removed the building of the new image, as setting the `appendonly --yes` parameter no `dump.rdb` is created on exit.

If you want I can create an entirely new test for this as well.

see docker-library/redis#4, https://github.com/docker-library/redis/pull/71#issuecomment-241876353