### PR TITLE
Update Solr to 6.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -29,10 +29,16 @@
 
 6.1.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 6.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
-6: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
-latest: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
 
 6.1.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
 6.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+
+6.2.0: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
+6.2: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
+6: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
+latest: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
+
+6.2.0-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
+6.2-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
+alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine

--- a/library/solr
+++ b/library/solr
@@ -13,13 +13,13 @@
 5.4.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
 5.4-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
 
-5.5.2: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
-5.5: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
-5: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5
+5.5.2: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
+5.5: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
+5: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
 
-5.5.2-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@a0da4f3103dc01bc99ca8fca29535f2964a3a294 5.5/alpine
+5.5.2-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
 
 6.0.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
 6.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
@@ -27,18 +27,18 @@
 6.0.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
 6.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
 
-6.1.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
-6.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1
+6.1.0: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1
+6.1: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1
 
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.1/alpine
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1/alpine
 
-6.2.0: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
-6.2: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
-6: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
-latest: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2
+6.2.0: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
+6.2: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
+6: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
+latest: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
 
-6.2.0-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
-6.2-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
-alpine: git://github.com/docker-solr/docker-solr@92b9a6d8415979f5a7e6d6ad4dc7df8856604d12 6.2/alpine
+6.2.0-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
+6.2-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
+alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine


### PR DESCRIPTION
Update Solr to 6.2.

See [Announcement](https://mail-archives.apache.org/mod_mbox/www-announce/201608.mbox/%3CCAL8PwkayNPprMcX3Y8K40isFDt2M2UyJ0jfA2st-fkaADOP81w@mail.gmail.com%3E) and [Changelog](http://lucene.apache.org/solr/6_2_0/changes/Changes.html).
