### PR TITLE
Update for Node.js v6.5.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,85 +1,85 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.46: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10
-0.10: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10
+0.10.46: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10
+0.10: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10
 
 0.10.46-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
 0.10-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
 
-0.10.46-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/slim
-0.10-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/slim
+0.10.46-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
+0.10-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
 
-0.10.46-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/wheezy
-0.10-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/wheezy
+0.10.46-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
+0.10-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
 
-0.12.15: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
-0.12: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
-0: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12
+0.12.15: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
+0.12: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
+0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
 
 0.12.15-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
 0.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
 0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
 
-0.12.15-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
-0.12-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
-0-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/slim
+0.12.15-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
+0.12-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
+0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
 
-0.12.15-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
-0.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
-0-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/wheezy
+0.12.15-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
+0.12-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
+0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
 
-4.5.0: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5
-4.5: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5
-4: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5
-argon: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5
+4.5.0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
+4.5: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
+4: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
+argon: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
 
 4.5.0-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
 4.5-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
 4-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
 argon-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
 
-4.5.0-slim: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/slim
-4.5-slim: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/slim
-4-slim: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/slim
-argon-slim: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/slim
+4.5.0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
+4.5-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
+4-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
+argon-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
 
-4.5.0-wheezy: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/wheezy
-4.5-wheezy: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/wheezy
-4-wheezy: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/wheezy
-argon-wheezy: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/wheezy
+4.5.0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
+4.5-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
+4-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
+argon-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 
-5.12.0: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
-5.12: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
-5: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12
+5.12.0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
+5.12: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
+5: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
 
 5.12.0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
 5.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
 5-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
 
-5.12.0-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
-5.12-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
-5-slim: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/slim
+5.12.0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
+5.12-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
+5-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
 
-5.12.0-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
-5.12-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/wheezy
+5.12.0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
+5.12-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
+5-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
 
-6.4.0: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
-6.4: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
-6: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
-latest: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4
+6.5.0: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5
+6.5: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5
+6: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5
+latest: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5
 
-6.4.0-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
-6.4-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
-onbuild: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/onbuild
+6.5.0-onbuild: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/onbuild
+6.5-onbuild: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/onbuild
+onbuild: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/onbuild
 
-6.4.0-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
-6.4-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
-6-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
-slim: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/slim
+6.5.0-slim: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/slim
+6.5-slim: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/slim
+6-slim: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/slim
+slim: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/slim
 
-6.4.0-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
-6.4-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
-6-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
-wheezy: git://github.com/nodejs/docker-node@be9abca6b1be7657fd0f00f005b867393184d19c 6.4/wheezy
+6.5.0-wheezy: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/wheezy
+6.5-wheezy: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/wheezy
+6-wheezy: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/wheezy
+wheezy: git://github.com/nodejs/docker-node@910443c39c80291f0bf24712d8d94279cf15b7b5 6.5/wheezy


### PR DESCRIPTION
Also includes a new symlink (/usr/local/bin/nodejs ->
/usr/local/bin/node) per https://github.com/nodejs/docker-node/pull/192 to add compatibility with the
Debian/Ubuntu packages that assume a
'nodejs' binary

Reference:

- https://nodejs.org/en/blog/release/v6.5.0/
- https://github.com/nodejs/docker-node/pull/226