### PR TITLE
Update Jetty image version and base

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -2,18 +2,18 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.3.10, 9.3, 9, 9.3.10-jre8, 9.3-jre8, 9-jre8, latest, jre8
+Tags: 9.3.11, 9.3, 9, 9.3.11-jre8, 9.3-jre8, 9-jre8, latest, jre8
 Directory: 9.3-jre8
-GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
+GitCommit: 41c3c040f5868519b806cdab2336b7b8e47f9339
 
-Tags: 9.3.10-alpine, 9.3-alpine, 9-alpine, 9.3.10-jre8-alpine, 9.3-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
+Tags: 9.3.11-alpine, 9.3-alpine, 9-alpine, 9.3.11-jre8-alpine, 9.3-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
+GitCommit: 41c3c040f5868519b806cdab2336b7b8e47f9339
 
-Tags: 9.2.17, 9.2, 9.2.17-jre8, 9.2-jre8
+Tags: 9.2.18, 9.2, 9.2.18-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
+GitCommit: 41c3c040f5868519b806cdab2336b7b8e47f9339
 
-Tags: 9.2.17-jre7, 9.2-jre7, 9-jre7, jre7
+Tags: 9.2.18-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: c228052ac9459c1303601e90fd66a44d7be6b8ce
+GitCommit: 41c3c040f5868519b806cdab2336b7b8e47f9339


### PR DESCRIPTION
* Updates the base image to openjdk (https://github.com/appropriate/docker-jetty/pull/48)
* Updates to version 9.2.18 and 9.3.11 (https://github.com/appropriate/docker-jetty/pull/49)