### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -5,25 +5,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/drupal.git
 
 Tags: 7.50-apache, 7-apache, 7.50, 7
-GitCommit: 41970d6f598cf64fe90aa63651ba52cdc384c002
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 7/apache
 
 Tags: 7.50-fpm, 7-fpm
-GitCommit: 41970d6f598cf64fe90aa63651ba52cdc384c002
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 7/fpm
 
 Tags: 8.1.8-apache, 8.1-apache, 8-apache, apache, 8.1.8, 8.1, 8, latest
-GitCommit: ee9b5787b307fba785f5cf15e626ee1d9c6e4d4d
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 8.1/apache
 
 Tags: 8.1.8-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: ee9b5787b307fba785f5cf15e626ee1d9c6e4d4d
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 8.1/fpm
 
 Tags: 8.2.0-beta3-apache, 8.2.0-apache, 8.2-apache, 8.2.0-beta3, 8.2.0, 8.2
-GitCommit: 607242be7d811c380aba061ad8f995f0cc223e37
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 8.2/apache
 
 Tags: 8.2.0-beta3-fpm, 8.2.0-fpm, 8.2-fpm
-GitCommit: 607242be7d811c380aba061ad8f995f0cc223e37
+GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 8.2/fpm

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.9.0, 0.9, 0, latest
-GitCommit: 13c06085f3de1264fc8c40a0d66fd4eafbfc322e
+Tags: 0.10.0, 0.10, 0, latest
+GitCommit: b1a49c5deb435395b4720575ef2bf46f1396d82f

--- a/library/haproxy
+++ b/library/haproxy
@@ -20,10 +20,10 @@ Tags: 1.5.18-alpine, 1.5-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.5/alpine
 
-Tags: 1.6.8, 1.6, 1, latest
-GitCommit: 94237f1aaae12342b93605b1c1ef4cdecd6e848f
+Tags: 1.6.9, 1.6, 1, latest
+GitCommit: 24fd0637e58d931e99ae6717b3e13bb389985fa1
 Directory: 1.6
 
-Tags: 1.6.8-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: 94237f1aaae12342b93605b1c1ef4cdecd6e848f
+Tags: 1.6.9-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 24fd0637e58d931e99ae6717b3e13bb389985fa1
 Directory: 1.6/alpine

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b130-jdk, 9-b130, 9-jdk, 9, openjdk-9-b130-jdk, openjdk-9-b130, openjdk-9-jdk, openjdk-9
-GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
+Tags: 9-b133-jdk, 9-b133, 9-jdk, 9, openjdk-9-b133-jdk, openjdk-9-b133, openjdk-9-jdk, openjdk-9
+GitCommit: 2a8c028a7246cd03a96c7cc8f41c4087303c642d
 Directory: 9-jdk
 
-Tags: 9-b130-jre, 9-jre, openjdk-9-b130-jre, openjdk-9-jre
-GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
+Tags: 9-b133-jre, 9-jre, openjdk-9-b133-jre, openjdk-9-jre
+GitCommit: 2a8c028a7246cd03a96c7cc8f41c4087303c642d
 Directory: 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.16, 10.1, 10, latest
-GitCommit: d969a465ee48fe10f4b532276f7337ddaaf3fc36
+Tags: 10.1.17, 10.1, 10, latest
+GitCommit: 7556dd6530170f6e41126423fd292dae159c272a
 Directory: 10.1
 
 Tags: 10.0.27, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -18,7 +18,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.9, 3.2, 3, latest
-GitCommit: 1d405a9c3614bd26968b05f45e055599494a8385
+GitCommit: 4d7bd01562edefad38a240c40a4b162a1cd7b9c2
 Directory: 3.2
 
 Tags: 3.2.9-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
@@ -26,11 +26,11 @@ GitCommit: 89549b2b779421c057b04858477012b7aa17f498
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.11, 3.3
-GitCommit: 753674533d5f413d4d63f9da74682bddec5a3c39
+Tags: 3.3.12, 3.3
+GitCommit: 174bd96682dc3613df9b670658ac81c9dd17ba74
 Directory: 3.3
 
-Tags: 3.3.11-windowsservercore, 3.3-windowsservercore
-GitCommit: 89549b2b779421c057b04858477012b7aa17f498
+Tags: 3.3.12-windowsservercore, 3.3-windowsservercore
+GitCommit: 174bd96682dc3613df9b670658ac81c9dd17ba74
 Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b130-jdk, 9-b130, 9-jdk, 9
-GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
+Tags: 9-b133-jdk, 9-b133, 9-jdk, 9
+GitCommit: 2a8c028a7246cd03a96c7cc8f41c4087303c642d
 Directory: 9-jdk
 
-Tags: 9-b130-jre, 9-jre
-GitCommit: a344905a72f381b3084c4c1cd0b3a24bcc9b4e23
+Tags: 9-b133-jre, 9-jre
+GitCommit: 2a8c028a7246cd03a96c7cc8f41c4087303c642d
 Directory: 9-jre

--- a/library/pypy
+++ b/library/pypy
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.3.1, 2-5.3, 2-5, 2
-GitCommit: 5241fb013dcd9d11b51a9bc4946a19358c73a50f
+Tags: 2-5.4.0, 2-5.4, 2-5, 2
+GitCommit: 8f0599b2696145385f3183dee5b1cabb0baa268c
 Directory: 2
 
-Tags: 2-5.3.1-slim, 2-5.3-slim, 2-5-slim, 2-slim
-GitCommit: 5241fb013dcd9d11b51a9bc4946a19358c73a50f
+Tags: 2-5.4.0-slim, 2-5.4-slim, 2-5-slim, 2-slim
+GitCommit: 8f0599b2696145385f3183dee5b1cabb0baa268c
 Directory: 2/slim
 
-Tags: 2-5.3.1-onbuild, 2-5.3-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.4.0-onbuild, 2-5.4-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.1.6, 3.1
-GitCommit: b91f07d9ef3a33462db1f1a66ba0d4993f9fbecf
+GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
 Directory: 3.1
 
 Tags: 3.1.6-passenger, 3.1-passenger
@@ -13,7 +13,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.1/passenger
 
 Tags: 3.2.3, 3.2
-GitCommit: 794d8a58ac855ea5ad2541c1058a8910f9514710
+GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
 Directory: 3.2
 
 Tags: 3.2.3-passenger, 3.2-passenger
@@ -21,7 +21,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.2/passenger
 
 Tags: 3.3.0, 3.3, 3, latest
-GitCommit: c070428e8c4c43b2d0608a1e77ae44f78220967e
+GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
 Directory: 3.3
 
 Tags: 3.3.0-passenger, 3.3-passenger, 3-passenger, passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.37.1, 0.37, 0, latest
-GitCommit: f2e625711a770839c65ff4db5c8d0e726b357b04
+Tags: 0.38.0, 0.38, 0, latest
+GitCommit: f26193a41722ad47bf649d443e87b2effd8e7c44


### PR DESCRIPTION
- `drupal`: use `https` (docker-library/drupal#55)
- `ghost`: 0.10.0
- `haproxy`: 1.6.9
- `java`: 9~b133 (debian)
- `mariadb`: 10.1.17
- `mongo`: use `jessie` for 3.2 (docker-library/mongo#111), 3.3.12
- `openjdk`: 9~b133 (debian)
- `pypy`: 5.4.0
- `redmine`: use `https` (docker-library/redmine#34)
- `rocket.chat`: 0.38.0