### PR TITLE
- Added geonetwork library

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97/generate-stackbrew-library.sh
+# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/afcf6ce829d4f07e3374ce6d332a1b3db673f9be/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geocat/geonetwork-official-images
 
-Tags: 3.0.4, 3.0.4
+Tags: 3.0.4
 GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
 Directory: 3.0.4
 
-Tags: 3.0.4-postgres, 3.0.4-postgres
+Tags: 3.0.4-postgres
 GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
 Directory: 3.0.4/postgres
 
-Tags: 3.0.5, 3.0.5, 3, latest
+Tags: 3.0.5, 3, latest
 GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
 Directory: 3.0.5
 
-Tags: 3.0.5-postgres, 3.0.5-postgres, 3-postgres, postgres
+Tags: 3.0.5-postgres, 3-postgres, postgres
 GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
 Directory: 3.0.5/postgres
 
-Tags: 3.2.0, 3.2.0, 3.2, develop
+Tags: 3.2.0, 3.2, develop
 GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
 Directory: 3.2.0
 
-Tags: 3.2.0-postgres, 3.2.0-postgres, 3.2-postgres, develop-postgres
+Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
 GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
 Directory: 3.2.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/23f6fea6d92ceb0caf2b28dbe691f343bb7a2c97/generate-stackbrew-library.sh
+# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geocat/geonetwork-official-images
 
-Tags: 3.0.4-h2, old,-h2, 3.0.4, old,
-GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
-Directory: 3.0.4/h2
+Tags: 3.0.4, 3.0.4
+GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+Directory: 3.0.4
 
-Tags: 3.0.4-postgres, old,-postgres
+Tags: 3.0.4-postgres, 3.0.4-postgres
 GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
 Directory: 3.0.4/postgres
 
-Tags: 3.0.5-h2, 3-h2, 3.0-h2, latest,-h2, 3.0.5, 3, 3.0, latest,
-GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
-Directory: 3.0.5/h2
+Tags: 3.0.5, 3.0.5, 3, latest
+GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+Directory: 3.0.5
 
-Tags: 3.0.5-postgres, 3-postgres, 3.0-postgres, latest,-postgres
+Tags: 3.0.5-postgres, 3.0.5-postgres, 3-postgres, postgres
 GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
 Directory: 3.0.5/postgres
 
-Tags: 3.2.0-h2, 3.2-h2, develop-h2, 3.2.0, 3.2, develop
-GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
-Directory: 3.2.0/h2
+Tags: 3.2.0, 3.2.0, 3.2, develop
+GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+Directory: 3.2.0
 
-Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
+Tags: 3.2.0-postgres, 3.2.0-postgres, 3.2-postgres, develop-postgres
 GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
 Directory: 3.2.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,12 +1,28 @@
-# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/cdbac105e97d1c5f3ba969c6c137a24fbf936084/generate-stackbrew-library.sh
+# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/23f6fea6d92ceb0caf2b28dbe691f343bb7a2c97/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geocat/geonetwork-official-images
 
-Tags: 3.0.4-h2, 3-h2, h2, 3.0.4, 3, latest
+Tags: 3.0.4-h2, old,-h2, 3.0.4, old,
 GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
 Directory: 3.0.4/h2
 
-Tags: 3.0.4-postgres, 3-postgres, postgres
+Tags: 3.0.4-postgres, old,-postgres
 GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
 Directory: 3.0.4/postgres
+
+Tags: 3.0.5-h2, 3-h2, 3.0-h2, latest,-h2, 3.0.5, 3, 3.0, latest,
+GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+Directory: 3.0.5/h2
+
+Tags: 3.0.5-postgres, 3-postgres, 3.0-postgres, latest,-postgres
+GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+Directory: 3.0.5/postgres
+
+Tags: 3.2.0-h2, 3.2-h2, develop-h2, 3.2.0, 3.2, develop
+GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+Directory: 3.2.0/h2
+
+Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
+GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+Directory: 3.2.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,0 +1,12 @@
+# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/cdbac105e97d1c5f3ba969c6c137a24fbf936084/generate-stackbrew-library.sh
+
+Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
+GitRepo: https://github.com/geocat/geonetwork-official-images
+
+Tags: 3.0.4-h2, 3-h2, h2, 3.0.4, 3, latest
+GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
+Directory: 3.0.4/h2
+
+Tags: 3.0.4-postgres, 3-postgres, postgres
+GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
+Directory: 3.0.4/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,28 +1,20 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/c3eba2643bc57c9679ad0cfce1ab5bd7e33fea2d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/fdcf9fda5a4e1ec121288e64055818beeaee55d1/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
-Tags: 3.0.4
-GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
-Directory: 3.0.4
-
-Tags: 3.0.4-postgres
-GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
-Directory: 3.0.4/postgres
-
-Tags: 3.0.5, 3, latest
-GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
+Tags: 3.0.5, 3.0
+GitCommit: c2af30125f631f6357d3af3837ec4b80f04b5917
 Directory: 3.0.5
 
-Tags: 3.0.5-postgres, 3-postgres, postgres
-GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
+Tags: 3.0.5-postgres, 3.0-postgres
+GitCommit: e5cf5da76f557481c35b4a4d3e3cac77768a1302
 Directory: 3.0.5/postgres
 
-Tags: 3.2.0, 3.2, develop
-GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
+Tags: 3.2.0, 3.2, latest
+GitCommit: c2af30125f631f6357d3af3837ec4b80f04b5917
 Directory: 3.2.0
 
-Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
-GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
+Tags: 3.2.0-postgres, 3.2-postgres, postgres
+GitCommit: e5cf5da76f557481c35b4a4d3e3cac77768a1302
 Directory: 3.2.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -4,25 +4,25 @@ Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
 Tags: 3.0.4
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
 Directory: 3.0.4
 
 Tags: 3.0.4-postgres
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
 Directory: 3.0.4/postgres
 
 Tags: 3.0.5, 3, latest
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
 Directory: 3.0.5
 
 Tags: 3.0.5-postgres, 3-postgres, postgres
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
 Directory: 3.0.5/postgres
 
 Tags: 3.2.0, 3.2, develop
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: b65e0df997508b59559e7f5e1be06ee12a8f8567
 Directory: 3.2.0
 
 Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
-GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
+GitCommit: 35a1391f8bd9c8d607cc9ac9fc1fa753160df79c
 Directory: 3.2.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/GeoCat/geonetwork-official-images/blob/afcf6ce829d4f07e3374ce6d332a1b3db673f9be/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/c3eba2643bc57c9679ad0cfce1ab5bd7e33fea2d/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
-GitRepo: https://github.com/geocat/geonetwork-official-images
+GitRepo: https://github.com/geonetwork/docker-geonetwork
 
 Tags: 3.0.4
-GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.0.4
 
 Tags: 3.0.4-postgres
-GitCommit: 7b12888fee485e19953ba7387c9ea6d61f5c69e2
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.0.4/postgres
 
 Tags: 3.0.5, 3, latest
-GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.0.5
 
 Tags: 3.0.5-postgres, 3-postgres, postgres
-GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.0.5/postgres
 
 Tags: 3.2.0, 3.2, develop
-GitCommit: a320f026e9ac1d00d4e5c53d7ccb5f1dd008db97
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.2.0
 
 Tags: 3.2.0-postgres, 3.2-postgres, develop-postgres
-GitCommit: c180183ce9de0ad70fa89ed53a36c773e66c63ef
+GitCommit: afc3f2437f1e1d28896fa6273f6df19c5eae61fd
 Directory: 3.2.0/postgres


### PR DESCRIPTION
Adding library file for [geonetwork](http://www.geonetwork-opensource.org/), the catalog service for geospatial information.

The default image ships with an H2 database backend, and a variant is included which supports connecting to a **postgresql** instance.
This image also supports setting a **custom data directory**, which is recommended for production environments.

We will support all major and minor versions, from the latest branch.

![geonetwork](http://www.geonetwork-opensource.org/_images/gn3-search1.png)
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
-   [x] associated with or contacted upstream?
  - https://github.com/geonetwork
-   [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-   [x] is it reasonably popular, or does it solve a particular use case well?
-   [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/683
-   [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-   [x] 2+ dockerization review?
-   [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
  - `FROM tomcat`
-   [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-   [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
