### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -12,18 +12,18 @@ Tags: 7.50-fpm, 7-fpm
 GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 7/fpm
 
-Tags: 8.1.8-apache, 8.1-apache, 8-apache, apache, 8.1.8, 8.1, 8, latest
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 8.1.9-apache, 8.1-apache, 8-apache, apache, 8.1.9, 8.1, 8, latest
+GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
 Directory: 8.1/apache
 
-Tags: 8.1.8-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 8.1.9-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
 Directory: 8.1/fpm
 
-Tags: 8.2.0-beta3-apache, 8.2.0-apache, 8.2-apache, 8.2.0-beta3, 8.2.0, 8.2
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 8.2.0-rc1-apache, 8.2.0-apache, 8.2-apache, 8.2.0-rc1, 8.2.0, 8.2
+GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
 Directory: 8.2/apache
 
-Tags: 8.2.0-beta3-fpm, 8.2.0-fpm, 8.2-fpm
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 8.2.0-rc1-fpm, 8.2.0-fpm, 8.2-fpm
+GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
 Directory: 8.2/fpm

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.10.0, 0.10, 0, latest
-GitCommit: 3718f2566fce96f42df5aa132742fab493c5299a
+Tags: 0.10.1, 0.10, 0, latest
+GitCommit: 89dfe2bc79ddfa8cbd3e8cf0e1b87a66fcc4d564

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.6.0-apache, 4.6-apache, 4-apache, apache, 4.6.0, 4.6, 4, latest
-GitCommit: 40d7cd3ef5f806a9c74243141b51c590c632af40
+Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest
+GitCommit: 81d061a68456cc14fcebb88a17b61d600eac30e9
 Directory: apache
 
-Tags: 4.6.0-fpm, 4.6-fpm, 4-fpm, fpm
-GitCommit: 40d7cd3ef5f806a9c74243141b51c590c632af40
+Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm
+GitCommit: 81d061a68456cc14fcebb88a17b61d600eac30e9
 Directory: fpm


### PR DESCRIPTION
- `drupal`: 8.2.0-rc1, 8.1.9
- `ghost`: 0.10.1 (docker-library/ghost#44)
- `wordpress`: 4.6.1 (docker-library/wordpress#167)