### PR TITLE
Update Solr to 5.5.3

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,44 +1,44 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3
-5.3: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3
+5.3: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4
-5.4: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4
+5.4: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4/alpine
 
-5.5.2: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
-5.5: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
-5: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5
+5.5.3: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
+5.5: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
+5: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
 
-5.5.2-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 5.5/alpine
+5.5.3-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
 
-6.0.1: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
-6.0: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0
+6.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0
 
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@1c2f9a0791e854c05c41952d5a086d57ebadc5f2 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0/alpine
 
-6.1.0: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1
-6.1: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1
+6.1.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1
+6.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1
 
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.1/alpine
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1/alpine
 
-6.2.0: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
-6.2: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
-6: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
-latest: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2
+6.2.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
+6.2: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
+6: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
+latest: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
 
-6.2.0-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
-6.2-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
-alpine: git://github.com/docker-solr/docker-solr@47c11e69172fdb71c8c1824e6b1b5eb64ce3ec13 6.2/alpine
+6.2.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
+6.2-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
+alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine


### PR DESCRIPTION
This release includes 5 bug fixes since the 5.5.2 release.

Changelog:  https://lucene.apache.org/solr/5_5_3/changes/Changes.html
