### PR TITLE
Remove outdated note about zombie solution in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ RUN set -x \
 	&& tini -h
 ```
 
-**NOTE**: if [docker/docker#11529](https://github.com/docker/docker/issues/11529) gets solved, then `tini` would no longer be needed for reaping zombies.
-
 #### Cacheability
 
 This is one place that experience ends up trumping documentation for the path to enlightenment, but the following tips might help:


### PR DESCRIPTION
After reading the issue that this points to (https://github.com/docker/docker/issues/11529), it seems our note is not really true.  Digging deeper led me to this https://github.com/docker/docker/issues/23214#issuecomment-223627273, suggesting that this note be removed.