### PR TITLE
Update ruby images

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
+GitCommit: 82016a6f0a94260e3771835455f577d1117da527
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
+GitCommit: 82016a6f0a94260e3771835455f577d1117da527
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: b0dac732e8b7a64a32e09f1cc8fa93cea8edc785
+GitCommit: 82016a6f0a94260e3771835455f577d1117da527
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: 2d6449f03976ededa14be5cac1e9e070b74e4de4
+GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
I used the script  (https://github.com/docker-library/ruby/blob/master/generate-stackbrew-library.sh) to generate this file.

This include the new version of bundler (1.13.1) which fix the bundler inside bundler issue.  See https://github.com/bundler/bundler/issues/4602 for more infos. 