### PR TITLE
version bump: otp-19.0.7

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -3,15 +3,15 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-Tags: 19.0.5, 19.0, 19, latest
-GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
+Tags: 19.0.7, 19.0, 19, latest
+GitCommit: 6da7cea045b2603a42db5804cc15e6cffbb65e19
 Directory: 19
 
-Tags: 19.0.5-slim, 19.0-slim, 19-slim, slim
-GitCommit: 7f5e7b4768136caa5f15e0b84d6b503fa430ef7b
+Tags: 19.0.7-slim, 19.0-slim, 19-slim, slim
+GitCommit: 6da7cea045b2603a42db5804cc15e6cffbb65e19
 Directory: 19/slim
 
-Tags: 19.0.5-onbuild, 19.0-onbuild, 19-onbuild, onbuild
+Tags: 19.0.7-onbuild, 19.0-onbuild, 19-onbuild, onbuild
 GitCommit: 847b82cdb8896d8d865bf32f2833787b5c62587c
 Directory: 19/onbuild
 


### PR DESCRIPTION
together with rebar tools upgrade as well

c0b/docker-erlang-otp#25