### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/celery.git
 
-Tags: 4.0.0rc3, 4.0, 4
-GitCommit: 2b56f641be3c38c4367fa7501268b43398199922
+Tags: 4.0.0rc4, 4.0, 4
+GitCommit: 8e10b9f6008ca34cd9ef2a74f032531bd44193b4
 Directory: 4.0
 
 Tags: 3.1.23, 3.1, 3, latest

--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2015-07-16
-Tags: 5.2.0, 5.2
-GitCommit: df055b1ba29bd666470f4735f2a7bab9acffd0b3
-Directory: 5.2
-# Docker EOL: 2016-07-16
-
 # Last Modified: 2015-12-04
 Tags: 5.3.0, 5.3, 5
 GitCommit: df055b1ba29bd666470f4735f2a7bab9acffd0b3

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.10.1, 0.10, 0, latest
-GitCommit: 89dfe2bc79ddfa8cbd3e8cf0e1b87a66fcc4d564
+Tags: 0.11.0, 0.11, 0, latest
+GitCommit: e9592030a951f9fd865cfabcc05252326e7192a7

--- a/library/httpd
+++ b/library/httpd
@@ -9,7 +9,7 @@ GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
 Directory: 2.2
 
 Tags: 2.2.31-alpine, 2.2-alpine
-GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+GitCommit: 8a0e3b8535245d914e703ae12afffc699f241cb8
 Directory: 2.2/alpine
 
 Tags: 2.4.23, 2.4, 2, latest
@@ -17,5 +17,5 @@ GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
 Directory: 2.4
 
 Tags: 2.4.23-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+GitCommit: 8a0e3b8535245d914e703ae12afffc699f241cb8
 Directory: 2.4/alpine

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b134-jdk, 9-b134, 9-jdk, 9, openjdk-9-b134-jdk, openjdk-9-b134, openjdk-9-jdk, openjdk-9
-GitCommit: efa60b19f5b9c4ccd676eb03ce955f1444a10d80
+Tags: 9-b135-jdk, 9-b135, 9-jdk, 9, openjdk-9-b135-jdk, openjdk-9-b135, openjdk-9-jdk, openjdk-9
+GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
 Directory: 9-jdk
 
-Tags: 9-b134-jre, 9-jre, openjdk-9-b134-jre, openjdk-9-jre
-GitCommit: efa60b19f5b9c4ccd676eb03ce955f1444a10d80
+Tags: 9-b135-jre, 9-jre, openjdk-9-b135-jre, openjdk-9-jre
+GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
 Directory: 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,6 +12,6 @@ Tags: 10.0.27, 10.0
 GitCommit: 9d7717c9d7e98619a3b7e7d4337e64b0de7d2f5b
 Directory: 10.0
 
-Tags: 5.5.51, 5.5, 5
-GitCommit: 0bcd1e2db0ef04f4abac85e2a759b04231ba60a0
+Tags: 5.5.52, 5.5, 5
+GitCommit: a0c4133675061dde79d08e13f20e365570acd866
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b134-jdk, 9-b134, 9-jdk, 9
-GitCommit: efa60b19f5b9c4ccd676eb03ce955f1444a10d80
+Tags: 9-b135-jdk, 9-b135, 9-jdk, 9
+GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
 Directory: 9-jdk
 
-Tags: 9-b134-jre, 9-jre
-GitCommit: efa60b19f5b9c4ccd676eb03ce955f1444a10d80
+Tags: 9-b135-jre, 9-jre
+GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -4,86 +4,86 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.0RC1-cli, 7.1-cli, 7.1.0RC1, 7.1
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-cli, 7.1-cli, 7.1.0RC2, 7.1
+GitCommit: d04f88956847d801bdd37f89dee747a7445a77a0
 Directory: 7.1
 
-Tags: 7.1.0RC1-alpine, 7.1-alpine
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-alpine, 7.1-alpine
+GitCommit: d04f88956847d801bdd37f89dee747a7445a77a0
 Directory: 7.1/alpine
 
-Tags: 7.1.0RC1-apache, 7.1-apache
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-apache, 7.1-apache
+GitCommit: d04f88956847d801bdd37f89dee747a7445a77a0
 Directory: 7.1/apache
 
-Tags: 7.1.0RC1-fpm, 7.1-fpm
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-fpm, 7.1-fpm
+GitCommit: d04f88956847d801bdd37f89dee747a7445a77a0
 Directory: 7.1/fpm
 
-Tags: 7.1.0RC1-fpm-alpine, 7.1-fpm-alpine
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-fpm-alpine, 7.1-fpm-alpine
+GitCommit: 3493e29c9bd8dda055dbb9dc0d81065d3d76456d
 Directory: 7.1/fpm/alpine
 
-Tags: 7.1.0RC1-zts, 7.1-zts
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-zts, 7.1-zts
+GitCommit: d04f88956847d801bdd37f89dee747a7445a77a0
 Directory: 7.1/zts
 
-Tags: 7.1.0RC1-zts-alpine, 7.1-zts-alpine
-GitCommit: ce3d81c7eefbe69860a8eaf63c05db5dd7a98a8d
+Tags: 7.1.0RC2-zts-alpine, 7.1-zts-alpine
+GitCommit: 3493e29c9bd8dda055dbb9dc0d81065d3d76456d
 Directory: 7.1/zts/alpine
 
-Tags: 7.0.10-cli, 7.0-cli, 7-cli, cli, 7.0.10, 7.0, 7, latest
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-cli, 7.0-cli, 7-cli, cli, 7.0.11, 7.0, 7, latest
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0
 
-Tags: 7.0.10-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-alpine, 7.0-alpine, 7-alpine, alpine
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/alpine
 
-Tags: 7.0.10-apache, 7.0-apache, 7-apache, apache
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-apache, 7.0-apache, 7-apache, apache
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/apache
 
-Tags: 7.0.10-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-fpm, 7.0-fpm, 7-fpm, fpm
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/fpm
 
-Tags: 7.0.10-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.10-zts, 7.0-zts, 7-zts, zts
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-zts, 7.0-zts, 7-zts, zts
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/zts
 
-Tags: 7.0.10-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 7.0.11-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: 6924505927f75e74098cc55e53e4f66bf71e0068
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.25-cli, 5.6-cli, 5-cli, 5.6.25, 5.6, 5
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-cli, 5.6-cli, 5-cli, 5.6.26, 5.6, 5
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6
 
-Tags: 5.6.25-alpine, 5.6-alpine, 5-alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-alpine, 5.6-alpine, 5-alpine
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/alpine
 
-Tags: 5.6.25-apache, 5.6-apache, 5-apache
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-apache, 5.6-apache, 5-apache
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/apache
 
-Tags: 5.6.25-fpm, 5.6-fpm, 5-fpm
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-fpm, 5.6-fpm, 5-fpm
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/fpm
 
-Tags: 5.6.25-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.25-zts, 5.6-zts, 5-zts
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-zts, 5.6-zts, 5-zts
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/zts
 
-Tags: 5.6.25-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 2f96a00aaa90ee1c503140724936ca7005273df5
+Tags: 5.6.26-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -90,23 +90,23 @@ GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.0a4, 3.6
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+Tags: 3.6.0b1, 3.6
+GitCommit: a70c6819aa38d938d56e96408aa6e7c3a9162c64
 Directory: 3.6
 
-Tags: 3.6.0a4-slim, 3.6-slim
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+Tags: 3.6.0b1-slim, 3.6-slim
+GitCommit: a70c6819aa38d938d56e96408aa6e7c3a9162c64
 Directory: 3.6/slim
 
-Tags: 3.6.0a4-alpine, 3.6-alpine
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+Tags: 3.6.0b1-alpine, 3.6-alpine
+GitCommit: a70c6819aa38d938d56e96408aa6e7c3a9162c64
 Directory: 3.6/alpine
 
-Tags: 3.6.0a4-onbuild, 3.6-onbuild
+Tags: 3.6.0b1-onbuild, 3.6-onbuild
 GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
 Directory: 3.6/onbuild
 
-Tags: 3.6.0a4-windowsservercore, 3.6-windowsservercore
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+Tags: 3.6.0b1-windowsservercore, 3.6-windowsservercore
+GitCommit: a70c6819aa38d938d56e96408aa6e7c3a9162c64
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/python
+++ b/library/python
@@ -106,7 +106,7 @@ Tags: 3.6.0b1-onbuild, 3.6-onbuild
 GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
 Directory: 3.6/onbuild
 
-Tags: 3.6.0b1-windowsservercore, 3.6-windowsservercore
-GitCommit: a70c6819aa38d938d56e96408aa6e7c3a9162c64
+Tags: 3.6.0a4-windowsservercore, 3.6-windowsservercore
+GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
- `celery`: 4.0.0rc4
- `gcc`: remove 5.2 (Docker EOL on 2016-07-16)
- `ghost`: 0.11.0
- `httpd`: add `perl` as runtime dep (docker-library/httpd#28)
- `java`: 9~b135, debian 9~b135-1
- `mariadb`: 5.5.52+maria-1~wheezy
- `openjdk`: 9~b135, debian 9~b135-1
- `php`: 7.1.0RC2 (docker-library/php#298)
- `python`: 3.6.0b1