### PR TITLE
Drop node 5

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,10 +1,10 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.46: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10
-0.10: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10
+0.10.46: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10
+0.10: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10
 
-0.10.46-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.10/onbuild
+0.10.46-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10/onbuild
 
 0.10.46-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
 0.10-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
@@ -12,13 +12,13 @@
 0.10.46-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
 0.10-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
 
-0.12.15: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
-0.12: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
-0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12
+0.12.15: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
+0.12: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
+0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
 
-0.12.15-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 0.12/onbuild
+0.12.15-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
 
 0.12.15-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
 0.12-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
@@ -28,15 +28,15 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
 
-4.5.0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
-4.5: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
-4: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
-argon: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5
+4.5.0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
+4.5: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
+4: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
+argon: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
 
-4.5.0-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
-4.5-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c 4.5/onbuild
+4.5.0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
+4.5-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
 
 4.5.0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
 4.5-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
@@ -48,15 +48,15 @@ argon-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd
 4-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 
-6.6.0: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
-6.6: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
-6: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
-latest: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
+6.6.0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
+6.6: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
+6: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
+latest: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
 
-6.6.0-onbuild: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/onbuild
-6.6-onbuild: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/onbuild
-onbuild: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/onbuild
+6.6.0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
+6.6-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
+onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
 
 6.6.0-slim: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/slim
 6.6-slim: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/slim

--- a/library/node
+++ b/library/node
@@ -1,10 +1,10 @@
 # maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 
-0.10.46: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10
-0.10: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10
+0.10.46: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.10
+0.10: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.10
 
-0.10.46-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10/onbuild
-0.10-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.10/onbuild
+0.10.46-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.10/onbuild
+0.10-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.10/onbuild
 
 0.10.46-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
 0.10-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/slim
@@ -12,13 +12,13 @@
 0.10.46-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
 0.10-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.10/wheezy
 
-0.12.15: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
-0.12: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
-0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12
+0.12.15: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12
+0.12: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12
+0: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12
 
-0.12.15-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
-0.12-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
-0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 0.12/onbuild
+0.12.15-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12/onbuild
+0.12-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12/onbuild
+0-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 0.12/onbuild
 
 0.12.15-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
 0.12-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/slim
@@ -28,15 +28,15 @@
 0.12-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
 0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 0.12/wheezy
 
-4.5.0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
-4.5: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
-4: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
-argon: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5
+4.5.0: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5
+4.5: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5
+4: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5
+argon: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5
 
-4.5.0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
-4.5-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
-4-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
-argon-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 4.5/onbuild
+4.5.0-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5/onbuild
+4.5-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5/onbuild
+4-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5/onbuild
+argon-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 4.5/onbuild
 
 4.5.0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
 4.5-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/slim
@@ -48,15 +48,15 @@ argon-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd
 4-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 
-6.6.0: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
-6.6: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
-6: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
-latest: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6
+6.6.0: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6
+6.6: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6
+6: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6
+latest: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6
 
-6.6.0-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
-6.6-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
-6-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
-onbuild: git://github.com/nodejs/docker-node@3e3981062292823fbb83622d1fae8abe1dc50a68 6.6/onbuild
+6.6.0-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6/onbuild
+6.6-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6/onbuild
+6-onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6/onbuild
+onbuild: git://github.com/nodejs/docker-node@1c65c4ed3785432fe9e9fa71a26799d86df10de4 6.6/onbuild
 
 6.6.0-slim: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/slim
 6.6-slim: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6/slim

--- a/library/node
+++ b/library/node
@@ -48,22 +48,6 @@ argon-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd
 4-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 argon-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 4.5/wheezy
 
-5.12.0: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
-5.12: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
-5: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12
-
-5.12.0-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
-5.12-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
-5-onbuild: git://github.com/nodejs/docker-node@50b56d39a236fd519eda2231757aa2173e270807 5.12/onbuild
-
-5.12.0-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
-5.12-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
-5-slim: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/slim
-
-5.12.0-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
-5.12-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
-5-wheezy: git://github.com/nodejs/docker-node@5ad063e3ba340743e394114d3038d0fd4e0fe570 5.12/wheezy
-
 6.6.0: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
 6.6: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6
 6: git://github.com/nodejs/docker-node@62a39d8d527a8992734ba2d066c3983fe560ee44 6.6


### PR DESCRIPTION
Support for Node.js v5 was dropped at the end of June of this year and
is no longer being updated.

See: https://nodejs.org/en/blog/community/v5-to-v7/

This also adds NODE_ENV ARG to the onbuild template so you can do
things like `docker build --build-arg NODE_ENV=production`