### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,17 +1,23 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/86ac4c6b757064f427e474027285dafd50d76525/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/8c7687860cdd4ef9227c249ca4587984e2636a55/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2015-12-04
-Tags: 5.3.0, 5.3, 5
-GitCommit: df055b1ba29bd666470f4735f2a7bab9acffd0b3
-Directory: 5.3
-# Docker EOL: 2016-12-04
+# Last Modified: 2016-08-03
+Tags: 4.9.4, 4.9, 4
+GitCommit: 8c7687860cdd4ef9227c249ca4587984e2636a55
+Directory: 4.9
+# Docker EOL: 2017-08-03
 
-# Last Modified: 2016-04-27
-Tags: 6.1.0, 6.1, 6, latest
-GitCommit: d9c8446748f7d69626f2e9425376a6672fff09af
-Directory: 6.1
-# Docker EOL: 2017-04-27
+# Last Modified: 2016-06-03
+Tags: 5.4.0, 5.4, 5
+GitCommit: 8c7687860cdd4ef9227c249ca4587984e2636a55
+Directory: 5
+# Docker EOL: 2017-06-03
+
+# Last Modified: 2016-08-22
+Tags: 6.2.0, 6.2, 6, latest
+GitCommit: 8c7687860cdd4ef9227c249ca4587984e2636a55
+Directory: 6
+# Docker EOL: 2017-08-22

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 4.0.3, 4.0
-GitCommit: 9fc787378f38bc25616d7118741a74b42402d344
-Directory: 4.0
-
 Tags: 4.1.11, 4.1
 GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.1

--- a/library/tomcat
+++ b/library/tomcat
@@ -12,20 +12,20 @@ Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
 GitCommit: 989f50ed5db788921a4954109b90362e2209295e
 Directory: 6/jre8
 
-Tags: 7.0.70-jre7, 7.0-jre7, 7-jre7, 7.0.70, 7.0, 7
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
+GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
 Directory: 7/jre7
 
-Tags: 7.0.70-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.70-alpine, 7.0-alpine, 7-alpine
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
+GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
 Directory: 7/jre7-alpine
 
-Tags: 7.0.70-jre8, 7.0-jre8, 7-jre8
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
+GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
 Directory: 7/jre8
 
-Tags: 7.0.70-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
 Directory: 7/jre8-alpine
 
 Tags: 8.0.37-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.37, 8.0, 8, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,9 +5,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest
-GitCommit: 81d061a68456cc14fcebb88a17b61d600eac30e9
+GitCommit: d6294d103d2eb8d618dd09e28240ea2de2577c25
 Directory: apache
 
 Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm
-GitCommit: 81d061a68456cc14fcebb88a17b61d600eac30e9
+GitCommit: d6294d103d2eb8d618dd09e28240ea2de2577c25
 Directory: fpm


### PR DESCRIPTION
- `gcc`: explicitly support 4.9 (4.9.4), 5 (5.4.0), and 6 (6.2.0) tracks as upstream does (docker-library/gcc#29)
- `kibana`: remove 4.0 (EOL)
- `tomcat`: 7.0.72
- `wordpress`: fix escaping issues, especially for values starting with `-` (docker-library/wordpress#172)