### PR TITLE
[security] Update Irssi to 0.8.20 for CVE-2016-7044 and CVE-2016-7045

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -1,16 +1,16 @@
 # maintainer: Jessie Frazelle <jess@docker.com> (@jfrazelle)
 # maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
-0.8.19: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-0.8: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-0: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-latest: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-0.8.19-debian: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-0.8-debian: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-0-debian: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
-debian: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 debian
+0.8.20: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+0.8: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+0: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+latest: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+0.8.20-debian: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+0.8-debian: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+0-debian: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+debian: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
 
-0.8.19-alpine: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 alpine
-0.8-alpine: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 alpine
-0-alpine: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 alpine
-alpine: git://github.com/jfrazelle/irssi@1377885afb36b08ec0984e8563f945895776caa8 alpine
+0.8.20-alpine: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
+0.8-alpine: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
+0-alpine: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
+alpine: git://github.com/jfrazelle/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine


### PR DESCRIPTION
See https://irssi.org/security/irssi_sa_2016.txt for details and mitigation for existing instances.

https://security-tracker.debian.org/tracker/DSA-3672-1 is also useful.