### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -12,8 +12,8 @@ Tags: 2.2.7, 2.2, 2
 GitCommit: ef66ec669d3930aea018f74dc58f5bd2ef5df880
 Directory: 2.2
 
-Tags: 3.0.8, 3.0
-GitCommit: ef66ec669d3930aea018f74dc58f5bd2ef5df880
+Tags: 3.0.9, 3.0
+GitCommit: caf1d916f7ffaecef5685668a878495dc6222537
 Directory: 3.0
 
 Tags: 3.7, 3, latest

--- a/library/drupal
+++ b/library/drupal
@@ -12,12 +12,12 @@ Tags: 7.50-fpm, 7-fpm
 GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 7/fpm
 
-Tags: 8.1.9-apache, 8.1-apache, 8-apache, apache, 8.1.9, 8.1, 8, latest
-GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
+Tags: 8.1.10-apache, 8.1-apache, 8-apache, apache, 8.1.10, 8.1, 8, latest
+GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
 Directory: 8.1/apache
 
-Tags: 8.1.9-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
+Tags: 8.1.10-fpm, 8.1-fpm, 8-fpm, fpm
+GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
 Directory: 8.1/fpm
 
 Tags: 8.2.0-rc1-apache, 8.2.0-apache, 8.2-apache, 8.2.0-rc1, 8.2.0, 8.2

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b135-jdk, 9-b135, 9-jdk, 9, openjdk-9-b135-jdk, openjdk-9-b135, openjdk-9-jdk, openjdk-9
-GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
+Tags: 9-b136-jdk, 9-b136, 9-jdk, 9, openjdk-9-b136-jdk, openjdk-9-b136, openjdk-9-jdk, openjdk-9
+GitCommit: 2ff433f60dd918bd852442dbb4f7b24a148c2fb0
 Directory: 9-jdk
 
-Tags: 9-b135-jre, 9-jre, openjdk-9-b135-jre, openjdk-9-jre
-GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
+Tags: 9-b136-jre, 9-jre, openjdk-9-b136-jre, openjdk-9-jre
+GitCommit: 2ff433f60dd918bd852442dbb4f7b24a148c2fb0
 Directory: 9-jre

--- a/library/julia
+++ b/library/julia
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.4.6, 0.4, 0, latest
-GitCommit: 59a01cf8cdb0b0f9cc229aca415755a64226e4ed
+Tags: 0.5.0, 0.5, 0, latest
+GitCommit: 1eb5fbfa0d88c831bf70963e39a1ec14f8f64c34

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b135-jdk, 9-b135, 9-jdk, 9
-GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
+Tags: 9-b136-jdk, 9-b136, 9-jdk, 9
+GitCommit: 2ff433f60dd918bd852442dbb4f7b24a148c2fb0
 Directory: 9-jdk
 
-Tags: 9-b135-jre, 9-jre
-GitCommit: 908ea317c41a63cb4e2d000c362aa86c9bd4c876
+Tags: 9-b136-jre, 9-jre
+GitCommit: 2ff433f60dd918bd852442dbb4f7b24a148c2fb0
 Directory: 9-jre

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,42 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 8.0.14-apache, 8.0-apache, 8.0.14, 8.0
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.0.15-apache, 8.0-apache, 8.0.15, 8.0
+GitCommit: 12b61400b292cfdef89ae568f726798f197ec409
 Directory: 8.0/apache
 
-Tags: 8.0.14-fpm, 8.0-fpm
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.0.15-fpm, 8.0-fpm
+GitCommit: 12b61400b292cfdef89ae568f726798f197ec409
 Directory: 8.0/fpm
 
-Tags: 8.1.9-apache, 8.1-apache, 8.1.9, 8.1
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.1.10-apache, 8.1-apache, 8.1.10, 8.1
+GitCommit: 066a4f1d22f703605b00d70178dd7bb71b7d7140
 Directory: 8.1/apache
 
-Tags: 8.1.9-fpm, 8.1-fpm
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.1.10-fpm, 8.1-fpm
+GitCommit: 066a4f1d22f703605b00d70178dd7bb71b7d7140
 Directory: 8.1/fpm
 
-Tags: 8.2.7-apache, 8.2-apache, 8-apache, 8.2.7, 8.2, 8
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.2.8-apache, 8.2-apache, 8-apache, 8.2.8, 8.2, 8
+GitCommit: f73b5dc1306f54c0744ad3dce726cbd7fb0530a7
 Directory: 8.2/apache
 
-Tags: 8.2.7-fpm, 8.2-fpm, 8-fpm
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 8.2.8-fpm, 8.2-fpm, 8-fpm
+GitCommit: f73b5dc1306f54c0744ad3dce726cbd7fb0530a7
 Directory: 8.2/fpm
 
-Tags: 9.0.4-apache, 9.0-apache, 9.0.4, 9.0
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 9.0.5-apache, 9.0-apache, 9.0.5, 9.0
+GitCommit: 92727b0d210b489161340f740b3693eb87915e16
 Directory: 9.0/apache
 
-Tags: 9.0.4-fpm, 9.0-fpm
-GitCommit: 94143a2da24c5f5ca90fede12cd5bb1aa5dc1f1a
+Tags: 9.0.5-fpm, 9.0-fpm
+GitCommit: 92727b0d210b489161340f740b3693eb87915e16
 Directory: 9.0/fpm
 
-Tags: 9.1.0-apache, 9.1-apache, 9-apache, apache, 9.1.0, 9.1, 9, latest
-GitCommit: 6011c09fec9dea07faae2282bdeba541a5b77a53
+Tags: 9.1.1-apache, 9.1-apache, 9-apache, apache, 9.1.1, 9.1, 9, latest
+GitCommit: 51ba952ab82bdc0755275d31fc288af39ac1ba74
 Directory: 9.1/apache
 
-Tags: 9.1.0-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 6011c09fec9dea07faae2282bdeba541a5b77a53
+Tags: 9.1.1-fpm, 9.1-fpm, 9-fpm, fpm
+GitCommit: 51ba952ab82bdc0755275d31fc288af39ac1ba74
 Directory: 9.1/fpm

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.14, 5.7, 5, latest
-GitCommit: c44a378d50a1d58f58c202c9a0f59f434fdd72b0
+GitCommit: 8f69178d3e8ee9b85eeb92f2b404236ffe1f6a0c
 Directory: 5.7
 
 Tags: 5.6.32, 5.6
-GitCommit: 10541a9b50359dfe9c8ea59165adecf3a97b8760
+GitCommit: f8979af93c4ba4d9646cad026909d5f2691fceec
 Directory: 5.6
 
 Tags: 5.5.51, 5.5
-GitCommit: 10541a9b50359dfe9c8ea59165adecf3a97b8760
+GitCommit: 5bf6984507572e1c26ff9466940797c3e40973ba
 Directory: 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -2,4 +2,4 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 2.16.2, 2.16, 2, latest
-GitCommit: 5e0bb9e49ae72291cf357c9ef1b4671c4ae25f9c
+GitCommit: 2f8892a595e78b966141d70d51fdef5e6d627298

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.39.0, 0.39, 0, latest
-GitCommit: 2bebcb481dea3084342f9406f73403ced829aa34
+Tags: 0.40.0, 0.40, 0, latest
+GitCommit: 396ad607cbe221309e86a767cb6b2da527d128ab

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: 82016a6f0a94260e3771835455f577d1117da527
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: 82016a6f0a94260e3771835455f577d1117da527
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: 82016a6f0a94260e3771835455f577d1117da527
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: b0c1198e8917675c3d3b895967018418f77d1cdd
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: 39c4d80c42e0dffc14b2d6dce89daa28201b4d04
+GitCommit: 281978ef87397763e377774740d82c8d87674ae9
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `cassandra`: 3.0.9
- `drupal`: 8.1.10
- `java`: debian 9~b136-1
- `julia`: 0.5.0
- `openjdk`: debian 9~b136-1
- `owncloud`: 8.0.15, 8.1.10, 8.2.8, 9.0.5, 9.1.1
- `percona`: 5.7.14-8-1.jessie, 5.6.32-78.1-1.jessie, 5.5.51-rel38.2-1.jessie
- `piwik`: LDAP support (https://github.com/piwik/docker-piwik/pull/40)
- `rocket.chat`: 0.40.0, Node.JS 4
- `ruby`: use `wget` instead of `curl` in `slim`/`alpine`, comment reminder of why we `ENABLE_PATH_CHECK=0` (docker-library/ruby#88)