### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -20,10 +20,10 @@ Tags: 8.1.10-fpm, 8.1-fpm, 8-fpm, fpm
 GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
 Directory: 8.1/fpm
 
-Tags: 8.2.0-rc1-apache, 8.2.0-apache, 8.2-apache, 8.2.0-rc1, 8.2.0, 8.2
-GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
+Tags: 8.2.0-rc2-apache, 8.2.0-apache, 8.2-apache, 8.2.0-rc2, 8.2.0, 8.2
+GitCommit: 7996e3654f78992d322619358aa7277b99c857ca
 Directory: 8.2/apache
 
-Tags: 8.2.0-rc1-fpm, 8.2.0-fpm, 8.2-fpm
-GitCommit: 9a95a290b9b9bbe6f4669ad85e712312f0ebd84b
+Tags: 8.2.0-rc2-fpm, 8.2.0-fpm, 8.2-fpm
+GitCommit: 7996e3654f78992d322619358aa7277b99c857ca
 Directory: 8.2/fpm

--- a/library/httpd
+++ b/library/httpd
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.31, 2.2
-GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
 Directory: 2.2
 
 Tags: 2.2.31-alpine, 2.2-alpine
-GitCommit: 8a0e3b8535245d914e703ae12afffc699f241cb8
+GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
 Directory: 2.2/alpine
 
 Tags: 2.4.23, 2.4, 2, latest
-GitCommit: 12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a
+GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
 Directory: 2.4
 
 Tags: 2.4.23-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 8a0e3b8535245d914e703ae12afffc699f241cb8
+GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
 Directory: 2.4/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -26,11 +26,11 @@ GitCommit: 89549b2b779421c057b04858477012b7aa17f498
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.12, 3.3
-GitCommit: 174bd96682dc3613df9b670658ac81c9dd17ba74
+Tags: 3.3.14, 3.3
+GitCommit: abe4de7ed3e951c3c37cdab0891914aca3f99fef
 Directory: 3.3
 
-Tags: 3.3.12-windowsservercore, 3.3-windowsservercore
-GitCommit: 174bd96682dc3613df9b670658ac81c9dd17ba74
+Tags: 3.3.14-windowsservercore, 3.3-windowsservercore
+GitCommit: abe4de7ed3e951c3c37cdab0891914aca3f99fef
 Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -13,5 +13,5 @@ GitCommit: 9fc086343ebd36af0448438622188264d1dc2e1c
 Directory: 5.6
 
 Tags: 5.5.52, 5.5
-GitCommit: 9fc086343ebd36af0448438622188264d1dc2e1c
+GitCommit: 78c736cef063f6c69256aa34f87ee463949af34f
 Directory: 5.5

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.1.6, 3.1
-GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
+GitCommit: dd11f72412d392db8b8a86ed81821643f8a52835
 Directory: 3.1
 
 Tags: 3.1.6-passenger, 3.1-passenger
@@ -13,7 +13,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.1/passenger
 
 Tags: 3.2.3, 3.2
-GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
+GitCommit: dd11f72412d392db8b8a86ed81821643f8a52835
 Directory: 3.2
 
 Tags: 3.2.3-passenger, 3.2-passenger
@@ -21,7 +21,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.2/passenger
 
 Tags: 3.3.0, 3.3, 3, latest
-GitCommit: c7fbe17fb7c3f1b33cb2d6fbdeaf1ee42ac9cbb9
+GitCommit: dd11f72412d392db8b8a86ed81821643f8a52835
 Directory: 3.3
 
 Tags: 3.3.0-passenger, 3.3-passenger, 3-passenger, passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.40.0, 0.40, 0, latest
-GitCommit: 396ad607cbe221309e86a767cb6b2da527d128ab
+Tags: 0.40.1, 0.40, 0, latest
+GitCommit: 0d0ef7c834c35623e69919a37e8b86fc349fb99e

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,57 +5,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.45-jre7, 6.0-jre7, 6-jre7, 6.0.45, 6.0, 6
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 6/jre7
 
 Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
-GitCommit: 989f50ed5db788921a4954109b90362e2209295e
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
-GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: b2bcdfb78e2fdc63423dfc210066b381f6f73a14
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre8-alpine
 
 Tags: 8.0.37-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.37, 8.0, 8, latest
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.0/jre7
 
 Tags: 8.0.37-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.37-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.37-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.0/jre8
 
 Tags: 8.0.37-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.5-jre8, 8.5-jre8, 8.5.5, 8.5
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.5/jre8
 
 Tags: 8.5.5-jre8-alpine, 8.5-jre8-alpine, 8.5.5-alpine, 8.5-alpine
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M10-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M10, 9.0.0, 9.0, 9
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M10-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M10-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 6b46a2812e6a8ad528a8004fa16ea66cc48b1420
+GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `drupal`: 8.2.0-rc2
- `httpd`: use Apache's `closer.cgi?action=download` functionality for automatic mirror selection (docker-library/httpd#32)
- `mongo`: 3.3.14
- `mysql`: use https (docker-library/mysql#212)
- `redmine`: account for `ruby:slim` changes (docker-library/redmine#39)
- `rocket.chat`: 0.40.1
- `tomcat`: update `openssl` to `1.0.2i-1`; use Apache's `closer.cgi?action=download` functionality for automatic mirror selection (docker-library/tomcat#49)