### PR TITLE
Update Solr to 6.2.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,44 +1,44 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3
-5.3: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3
+5.3: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4
-5.4: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4
+5.4: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4/alpine
 
-5.5.3: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
-5.5: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
-5: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5
+5.5.3: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
+5.5: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
+5: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
 
-5.5.3-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@e45bf96dba8ad5b5003e4cf409e3cd163af25cea 5.5/alpine
+5.5.3-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
 
-6.0.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0
-6.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0
+6.0: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0
 
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0/alpine
 
-6.1.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1
-6.1: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1
+6.1.0: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1
+6.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1
 
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.1/alpine
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1/alpine
 
-6.2.0: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
-6.2: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
-6: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
-latest: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2
+6.2.1: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
+6.2: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
+6: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
+latest: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
 
-6.2.0-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
-6.2-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
-alpine: git://github.com/docker-solr/docker-solr@2d436fc7fdc54874a8f209281978bc2ed4a17937 6.2/alpine
+6.2.1-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
+6.2-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
+alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine


### PR DESCRIPTION
Adding Solr 6.2.1.

See release announcement at http://mail-archives.apache.org/mod_mbox/www-announce/201609.mbox/%3CCAOOKt51KpaD3k7PLqHY0XpgXGEoCQKFLqAwOC8a%2BEZevD9qCHQ%40mail.gmail.com%3E