### PR TITLE
[security] Updates for Node.js v6.7.0, v4.6.0, v0.12.16 and v0.10.47

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/06eb255cfaf9a256286f9b77359d40eb7592740f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/4029a8f71920e1e23efa79602167014f9c325ba0/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.6.0, 6.6, 6, latest
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
-Directory: 6.6
+Tags: 6.7.0, 6.7, 6, latest
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 6.7
 
-Tags: 6.6.0-onbuild, 6.6-onbuild, 6-onbuild, onbuild
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
-Directory: 6.6/onbuild
+Tags: 6.7.0-onbuild, 6.7-onbuild, 6-onbuild, onbuild
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 6.7/onbuild
 
-Tags: 6.6.0-slim, 6.6-slim, 6-slim, slim
-GitCommit: 62a39d8d527a8992734ba2d066c3983fe560ee44
-Directory: 6.6/slim
+Tags: 6.7.0-slim, 6.7-slim, 6-slim, slim
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 6.7/slim
 
-Tags: 6.6.0-wheezy, 6.6-wheezy, 6-wheezy, wheezy
-GitCommit: 62a39d8d527a8992734ba2d066c3983fe560ee44
-Directory: 6.6/wheezy
+Tags: 6.7.0-wheezy, 6.7-wheezy, 6-wheezy, wheezy
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 6.7/wheezy
 
-Tags: 4.5.0, 4.5, 4, argon
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
-Directory: 4.5
+Tags: 4.6.0, 4.6, 4, argon
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 4.6
 
-Tags: 4.5.0-onbuild, 4.5-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
-Directory: 4.5/onbuild
+Tags: 4.6.0-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 4.6/onbuild
 
-Tags: 4.5.0-slim, 4.5-slim, 4-slim, argon-slim
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
-Directory: 4.5/slim
+Tags: 4.6.0-slim, 4.6-slim, 4-slim, argon-slim
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 4.6/slim
 
-Tags: 4.5.0-wheezy, 4.5-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
-Directory: 4.5/wheezy
+Tags: 4.6.0-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Directory: 4.6/wheezy
 
-Tags: 0.12.15, 0.12, 0
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
+Tags: 0.12.16, 0.12, 0
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.12
 
-Tags: 0.12.15-onbuild, 0.12-onbuild, 0-onbuild
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
+Tags: 0.12.16-onbuild, 0.12-onbuild, 0-onbuild
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.12/onbuild
 
-Tags: 0.12.15-slim, 0.12-slim, 0-slim
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
+Tags: 0.12.16-slim, 0.12-slim, 0-slim
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.12/slim
 
-Tags: 0.12.15-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
+Tags: 0.12.16-wheezy, 0.12-wheezy, 0-wheezy
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.12/wheezy
 
-Tags: 0.10.46, 0.10
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
+Tags: 0.10.47, 0.10
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.10
 
-Tags: 0.10.46-onbuild, 0.10-onbuild
-GitCommit: 1c65c4ed3785432fe9e9fa71a26799d86df10de4
+Tags: 0.10.47-onbuild, 0.10-onbuild
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.10/onbuild
 
-Tags: 0.10.46-slim, 0.10-slim
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
+Tags: 0.10.47-slim, 0.10-slim
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.10/slim
 
-Tags: 0.10.46-wheezy, 0.10-wheezy
-GitCommit: 5ad063e3ba340743e394114d3038d0fd4e0fe570
+Tags: 0.10.47-wheezy, 0.10-wheezy
+GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
 Directory: 0.10/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/vulnerability/september-2016-security-releases/
- https://github.com/nodejs/docker-node/pull/237