### PR TITLE
Update telegraf 1.0 to 1.0.1

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -10,12 +10,12 @@ GitRepo: git://github.com/influxdata/influxdata-docker
 GitCommit: ec08f02c8a4a15bcea2a6c46517eceb9284633a2
 Directory: telegraf/0.13/alpine
 
-Tags: 1.0, 1.0.0, latest
+Tags: 1.0, 1.0.1, latest
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: ec08f02c8a4a15bcea2a6c46517eceb9284633a2
+GitCommit: a86d1ecbaa12a696c10ed66bf4390c42fe733582
 Directory: telegraf/1.0
 
-Tags: 1.0-alpine, 1.0.0-alpine, alpine
+Tags: 1.0-alpine, 1.0.1-alpine, alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: ec08f02c8a4a15bcea2a6c46517eceb9284633a2
+GitCommit: a86d1ecbaa12a696c10ed66bf4390c42fe733582
 Directory: telegraf/1.0/alpine


### PR DESCRIPTION
Include ca-certificates in the telegraf alpine image for 1.0 so
connecting to https endpoints works.