### PR TITLE
Updated Oracle Linux for OpenSSL CVEs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,18 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@a44844fe085a561ded44865eafb63f742e4250c1 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@a85e4256ce131ed5522f4cd56967401119efad08 OracleLinux/5.11


### PR DESCRIPTION
This addresses #2171 .

Signed-off-by: Avi Miller <avi.miller@oracle.com>