### PR TITLE
Add latest Mono 4.6.1.3

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -78,12 +78,18 @@
 
 4.6.0.245: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245
 4.6.0: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245
-4.6: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245
-4: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245
-latest: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245
 
 4.6.0.245-onbuild: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245/onbuild
 4.6.0-onbuild: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245/onbuild
-4.6-onbuild: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245/onbuild
-4-onbuild: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245/onbuild
-onbuild: git://github.com/mono/docker@9fdd0e79b4eb3e7e7e818fbd58bd324d4c5ab7e1 4.6.0.245/onbuild
+
+4.6.1.3: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3
+4.6.1: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3
+4.6: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3
+4: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3
+latest: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3
+
+4.6.1.3-onbuild: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3/onbuild
+4.6.1-onbuild: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3/onbuild
+4.6-onbuild: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3/onbuild
+4-onbuild: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3/onbuild
+onbuild: git://github.com/mono/docker@f0f1e0b9f693bd7c58d9623d402c8dc69234bbe1 4.6.1.3/onbuild


### PR DESCRIPTION
It is the service release 0 for Mono 4.6.

@tianon Out of curiosity, I saw that a bunch of other images seem to have migrated to a different format, e.g. [java](https://github.com/docker-library/official-images/blob/master/library/java) or [go](https://github.com/docker-library/official-images/blob/master/library/golang). Should we migrate too? Is there an updated version of the generate-stackbrew-library.sh script?