### PR TITLE
Add an official image for Rapidoid

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -1,0 +1,5 @@
+Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski)
+GitRepo: https://github.com/rapidoid/docker-rapidoid.git
+
+Tags: 5.2.5, 5.2, 5, latest
+GitCommit: dd2939c3329a6fb13696ff736f5a172f4e4e3c1b

--- a/library/rapidoid
+++ b/library/rapidoid
@@ -1,5 +1,5 @@
 Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski)
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
-Tags: 5.2.5, 5.2, 5, latest
-GitCommit: 2bb7c6b4c2cad4ca19db97c0926598424da2b592
+Tags: 5.2.6, 5.2, 5, latest
+GitCommit: 6a75cf0421884958268dc9619cda157aa10bc33f

--- a/library/rapidoid
+++ b/library/rapidoid
@@ -2,4 +2,4 @@ Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.2.6, 5.2, 5, latest
-GitCommit: 6a75cf0421884958268dc9619cda157aa10bc33f
+GitCommit: 4552df257bda6f2f62921e776484c5df3d10553c

--- a/library/rapidoid
+++ b/library/rapidoid
@@ -2,4 +2,4 @@ Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.2.5, 5.2, 5, latest
-GitCommit: dd2939c3329a6fb13696ff736f5a172f4e4e3c1b
+GitCommit: 2bb7c6b4c2cad4ca19db97c0926598424da2b592

--- a/test/config.sh
+++ b/test/config.sh
@@ -146,6 +146,10 @@ imageTests+=(
 	'
 	[rails]='
 	'
+	[rapidoid]='
+		rapidoid-hello-world
+		rapidoid-load-balancer
+	'
 	[redis]='
 		redis-basics
 		redis-basics-config

--- a/test/tests/rapidoid-hello-world/index.html
+++ b/test/tests/rapidoid-hello-world/index.html
@@ -1,0 +1,1 @@
+Hello world!

--- a/test/tests/rapidoid-hello-world/run.sh
+++ b/test/tests/rapidoid-hello-world/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+[ "$DEBUG" ] && set -x
+
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# Use a client image with curl for testing
+clientImage="buildpack-deps:curl"
+
+# Create an instance of the container-under-test
+serverImage="$("$dir/../image-name.sh" librarytest/rapidoid-hello-web "$image")"
+
+"$dir/../docker-build.sh" "$dir" "$serverImage" <<EOD
+FROM $image
+RUN mkdir -p /app/public
+COPY dir/index.html /app/public/
+EOD
+
+cid="$(docker run -d "$serverImage" app.services=ping)"
+
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+_request() {
+	local method="$1"
+	shift
+
+	local url="${1#/}"
+	shift
+
+	docker run --rm --link "$cid":rapidoid "$clientImage" \
+		curl -fs -X"$method" "$@" "http://rapidoid:8888/$url"
+}
+
+# Make sure that Rapidoid is listening on port 8888
+. "$dir/../../retry.sh" --tries 40 --sleep 0.25 '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
+
+# Make sure that Rapidoid serves the static page index.html
+[ "$(_request GET "/")" = "Hello world!" ]
+[ "$(_request GET "/index.html")" = "Hello world!" ]
+
+# Make sure that Rapidoid's built-in Ping service works correctly
+[ "$(_request GET "/_ping")" = "OK" ]

--- a/test/tests/rapidoid-load-balancer/run.sh
+++ b/test/tests/rapidoid-load-balancer/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+[ "$DEBUG" ] && set -x
+
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# Use a client image with curl for testing
+clientImage="buildpack-deps:curl"
+
+app1id="$(docker run -d "$image" on.port=80 id=app1 app.services=ping,status)"
+app2id="$(docker run -d "$image" on.port=80 id=app2 app.services=ping,status)"
+
+proxyid="$(docker run -d --link "$app1id":app1 --link "$app2id":app2 "$image" on.port=80 '/ -> http://app1, http://app2' app.services=ping)"
+
+trap "docker rm -vf $proxyid $app1id $app2id > /dev/null" EXIT
+
+_request() {
+    local cid="$1"
+	shift
+
+	local method="$1"
+	shift
+
+	local url="${1#/}"
+	shift
+
+	docker run --rm --link "$cid":rapidoid "$clientImage" \
+		curl -fs -X"$method" "$@" "http://rapidoid/$url"
+}
+
+# Make sure all Rapidoid servers are listening on port 80
+for cid in $app1id $app2id $proxyid; do
+    . "$dir/../../retry.sh" --tries 40 --sleep 0.25 '[ "$(_request '$cid' GET /_ping --output /dev/null || echo $?)" != 7 ]'
+done
+
+# Make sure that the round-robin load balancing works properly
+for n in `seq 1 5`; do
+    for i in 1 2; do
+        [[ "$(_request $cid GET "/_status")" == *"\"app$i\""* ]]
+    done
+done


### PR DESCRIPTION
Rapidoid is an extremely fast HTTP server and modern Java web framework / application container, with a strong focus on high productivity and high performance.

Documentation PR: docker-library/docs#705
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
-   [x] associated with or contacted upstream?
  - https://github.com/rapidoid
-   [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-   [x] is it reasonably popular, or does it solve a particular use case well?
-   [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/issues/705
-   [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-   [x] 2+ dockerization review?
-   [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
  - `FROM java`
-   [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-   [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
