### PR TITLE
Bump traefik to v1.1.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,6 +1,9 @@
 # maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
 # maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 
+v1.1.0-rc1: git://github.com/containous/traefik-library-image@ac09f6208236a539d67c076ae25354d884ad5be7
+camembert: git://github.com/containous/traefik-library-image@ac09f6208236a539d67c076ae25354d884ad5be7
+
 v1.0.3: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe
 reblochon: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe
 latest: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.1.0-rc1.
/cc @vdemeester

Cheers