### PR TITLE
Sentry 8.9

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/90e5f20bf418a42986c9716d07a4de980a4dfc07/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/06d750bddc0e6499446e73ca22fbd4c915b29cbd/generate-stackbrew-library.sh
 
 Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
 
-Tags: 8.7.0, 8.7
-GitCommit: 2bef8f6386c891f9b8ce1d6940f0aff81c25d475
-Directory: 8.7
-
-Tags: 8.7.0-onbuild, 8.7-onbuild
-GitCommit: 22e75e5254b5707b77a747cd4e90bc4327f2ce9b
-Directory: 8.7/onbuild
-
-Tags: 8.8.0, 8.8, 8, latest
+Tags: 8.8.0, 8.8
 GitCommit: 90e5f20bf418a42986c9716d07a4de980a4dfc07
 Directory: 8.8
 
-Tags: 8.8.0-onbuild, 8.8-onbuild, 8-onbuild, onbuild
+Tags: 8.8.0-onbuild, 8.8-onbuild
 GitCommit: 90e5f20bf418a42986c9716d07a4de980a4dfc07
 Directory: 8.8/onbuild
+
+Tags: 8.9.0, 8.9, 8, latest
+GitCommit: 06d750bddc0e6499446e73ca22fbd4c915b29cbd
+Directory: 8.9
+
+Tags: 8.9.0-onbuild, 8.9-onbuild, 8-onbuild, onbuild
+GitCommit: 06d750bddc0e6499446e73ca22fbd4c915b29cbd
+Directory: 8.9/onbuild


### PR DESCRIPTION
:tada: https://github.com/getsentry/sentry/releases/tag/8.9.0 :tada: