### PR TITLE
Add "bash" image

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -1,0 +1,32 @@
+# this file is generated via https://github.com/tianon/docker-bash/blob/cd1de3dfc885b3395cd354ddb988922350b092a7/generate-stackbrew-library.sh
+
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+GitRepo: https://github.com/tianon/docker-bash.git
+
+Tags: 4.4.0, 4.4, 4, latest
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 4.4
+
+Tags: 4.3.48, 4.3
+GitCommit: 2f7c9c45567b18b74c321f0ff1e460ae1117a9b5
+Directory: 4.3
+
+Tags: 4.2.53, 4.2
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 4.2
+
+Tags: 4.1.17, 4.1
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 4.1
+
+Tags: 4.0.44, 4.0
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 4.0
+
+Tags: 3.2.57, 3.2, 3
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 3.2
+
+Tags: 3.1.23, 3.1
+GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Directory: 3.1


### PR DESCRIPTION
> The primary use cases this image is targeting are testing new features of more recent Bash versions before your primary distribution updates packages and testing shell scripts against different Bash versions to ensure compatibility. There are likely other interesting use cases as well, but those are the primary two the image was initially created to solve!

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
	-	https://lists.gnu.org/archive/html/bug-bash/2016-10/msg00001.html
	-	had a chat with Chet himself in response to this query:

		> I support a move to make these official.

-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/712
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)