### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/63d112e0991f47710053e279a2030452e3313434/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/7832a56e4da025d9d87db6cab5c056564995958c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,6 +16,6 @@ Tags: 3.0.9, 3.0
 GitCommit: ef57ef961003e27469b86178f0b4d184bb64d82e
 Directory: 3.0
 
-Tags: 3.7, 3, latest
-GitCommit: ef57ef961003e27469b86178f0b4d184bb64d82e
-Directory: 3.7
+Tags: 3.9, 3, latest
+GitCommit: ce8566d1ce825d2d0e16b2b0b76befed1defe62c
+Directory: 3.9

--- a/library/celery
+++ b/library/celery
@@ -8,6 +8,6 @@ Tags: 4.0.0rc4, 4.0, 4
 GitCommit: 8e10b9f6008ca34cd9ef2a74f032531bd44193b4
 Directory: 4.0
 
-Tags: 3.1.23, 3.1, 3, latest
-GitCommit: 2b56f641be3c38c4367fa7501268b43398199922
+Tags: 3.1.24, 3.1, 3, latest
+GitCommit: f2a36a7fef472332e7e214e98f45407bd68bf451
 Directory: 3.1

--- a/library/django
+++ b/library/django
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/django.git
 
-Tags: 1.10.1-python3, 1.10-python3, 1-python3, python3, 1.10.1, 1.10, 1, latest
-GitCommit: 16723cfa3765534e4e9eebe4f70c5404eb2b4532
+Tags: 1.10.2-python3, 1.10-python3, 1-python3, python3, 1.10.2, 1.10, 1, latest
+GitCommit: 55ed1a6140b7152aa96a230ddb4d5a1f45fa6e52
 Directory: 3.4
 
 Tags: python3-onbuild, onbuild
 GitCommit: 4fe080675e4a85ef6ee25c811e9d3d3ef0905794
 Directory: 3.4/onbuild
 
-Tags: 1.10.1-python2, 1.10-python2, 1-python2, python2
-GitCommit: 16723cfa3765534e4e9eebe4f70c5404eb2b4532
+Tags: 1.10.2-python2, 1.10-python2, 1-python2, python2
+GitCommit: 55ed1a6140b7152aa96a230ddb4d5a1f45fa6e52
 Directory: 2.7
 
 Tags: python2-onbuild

--- a/library/docker
+++ b/library/docker
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.2-rc1, 1.12-rc, rc
-GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
+Tags: 1.12.2-rc2, 1.12-rc, rc
+GitCommit: b1560edfa1e5bb0fbbada15600612da6104d2e04
 Directory: 1.12-rc
 
-Tags: 1.12.2-rc1-dind, 1.12-rc-dind, rc-dind
+Tags: 1.12.2-rc2-dind, 1.12-rc-dind, rc-dind
 GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
 Directory: 1.12-rc/dind
 
-Tags: 1.12.2-rc1-git, 1.12-rc-git, rc-git
+Tags: 1.12.2-rc2-git, 1.12-rc-git, rc-git
 GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
 Directory: 1.12-rc/git
 
-Tags: 1.12.2-rc1-experimental, 1.12-rc-experimental, rc-experimental
-GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
+Tags: 1.12.2-rc2-experimental, 1.12-rc-experimental, rc-experimental
+GitCommit: b1560edfa1e5bb0fbbada15600612da6104d2e04
 Directory: 1.12-rc/experimental
 
-Tags: 1.12.2-rc1-experimental-dind, 1.12-rc-experimental-dind, rc-experimental-dind
+Tags: 1.12.2-rc2-experimental-dind, 1.12-rc-experimental-dind, rc-experimental-dind
 GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
 Directory: 1.12-rc/experimental/dind
 
-Tags: 1.12.2-rc1-experimental-git, 1.12-rc-experimental-git, rc-experimental-git
+Tags: 1.12.2-rc2-experimental-git, 1.12-rc-experimental-git, rc-experimental-git
 GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
 Directory: 1.12-rc/experimental/git
 

--- a/library/drupal
+++ b/library/drupal
@@ -1,8 +1,24 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/e14ec7e839cc59f62302ea83277a13c3d2b10bf1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/7f849190fd64db8d6b55c05bd52773e50c5f8326/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
+
+Tags: 8.2.0-apache, 8.2-apache, 8-apache, apache, 8.2.0, 8.2, 8, latest
+GitCommit: 1b3df9afb3a949b1c8ee29b52018abc8ccc3600e
+Directory: 8.2/apache
+
+Tags: 8.2.0-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: 1b3df9afb3a949b1c8ee29b52018abc8ccc3600e
+Directory: 8.2/fpm
+
+Tags: 8.1.10-apache, 8.1-apache, 8.1.10, 8.1
+GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
+Directory: 8.1/apache
+
+Tags: 8.1.10-fpm, 8.1-fpm
+GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
+Directory: 8.1/fpm
 
 Tags: 7.50-apache, 7-apache, 7.50, 7
 GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
@@ -11,19 +27,3 @@ Directory: 7/apache
 Tags: 7.50-fpm, 7-fpm
 GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
 Directory: 7/fpm
-
-Tags: 8.1.10-apache, 8.1-apache, 8-apache, apache, 8.1.10, 8.1, 8, latest
-GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
-Directory: 8.1/apache
-
-Tags: 8.1.10-fpm, 8.1-fpm, 8-fpm, fpm
-GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
-Directory: 8.1/fpm
-
-Tags: 8.2.0-rc2-apache, 8.2.0-apache, 8.2-apache, 8.2.0-rc2, 8.2.0, 8.2
-GitCommit: 7996e3654f78992d322619358aa7277b99c857ca
-Directory: 8.2/apache
-
-Tags: 8.2.0-rc2-fpm, 8.2.0-fpm, 8.2-fpm
-GitCommit: 7996e3654f78992d322619358aa7277b99c857ca
-Directory: 8.2/fpm

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.0, 0.11, 0, latest
-GitCommit: e9592030a951f9fd865cfabcc05252326e7192a7
+Tags: 0.11.1, 0.11, 0, latest
+GitCommit: 8d638ab5035f7ac2d559a760f0bb4d6b4ea07264

--- a/library/percona
+++ b/library/percona
@@ -12,6 +12,6 @@ Tags: 5.6.32, 5.6
 GitCommit: f8979af93c4ba4d9646cad026909d5f2691fceec
 Directory: 5.6
 
-Tags: 5.5.51, 5.5
-GitCommit: 5bf6984507572e1c26ff9466940797c3e40973ba
+Tags: 5.5.52, 5.5
+GitCommit: d59697ff8fdc0d83950d8a72ebabab11cbde84a3
 Directory: 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -1,5 +1,5 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 2.16.2, 2.16, 2, latest
-GitCommit: 2f8892a595e78b966141d70d51fdef5e6d627298
+Tags: 2.16.5, 2.16, 2, latest
+GitCommit: 93ad1ed911e037431200e361f9735ea8a2a44c26

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.41.0, 0.41, 0, latest
-GitCommit: 7a26ad31bfcebb1980d76056a15b0828e86f5e4e
+Tags: 0.42.0, 0.42, 0, latest
+GitCommit: 4b9fbede1e0262c40ab1979a8c669d2ca325e000


### PR DESCRIPTION
- `cassandra`: 3.9
- `celery`: 3.1.24
- `django`: 1.10.2
- `docker`: 1.12.2-rc2
- `drupal`: 8.2.0 (GA)
- `ghost`: 0.11.1
- `percona`: 5.5.52-rel38.3-1.jessie
- `piwik`: 2.16.5
- `rocket.chat`: 0.42.0