### PR TITLE
Update drupal to 7.51 and remove the now-EOL 8.1 series

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -12,18 +12,10 @@ Tags: 8.2.0-fpm, 8.2-fpm, 8-fpm, fpm
 GitCommit: 1b3df9afb3a949b1c8ee29b52018abc8ccc3600e
 Directory: 8.2/fpm
 
-Tags: 8.1.10-apache, 8.1-apache, 8.1.10, 8.1
-GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
-Directory: 8.1/apache
-
-Tags: 8.1.10-fpm, 8.1-fpm
-GitCommit: 35aada37a9179e8e9e70d29bbbb894ade2cad36a
-Directory: 8.1/fpm
-
-Tags: 7.50-apache, 7-apache, 7.50, 7
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 7.51-apache, 7-apache, 7.51, 7
+GitCommit: 814261d4b2d82854c50746c3e480dd514d5aa1d0
 Directory: 7/apache
 
-Tags: 7.50-fpm, 7-fpm
-GitCommit: 61f25e58353d7ca9b2e07a46ff152892b2f7d9cf
+Tags: 7.51-fpm, 7-fpm
+GitCommit: 814261d4b2d82854c50746c3e480dd514d5aa1d0
 Directory: 7/fpm


### PR DESCRIPTION
See also https://www.drupal.org/blog/drupal-8110-released, especially:

> This is the final security release of the 8.1.x series.