### PR TITLE
Update Wordpress (lower opcache.revalidate_freq, PHP 7.0 variants)

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,13 +1,21 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/60e216811a18dcff77c78ad45cc55a21ac7b0b46/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/9c8f5d09839868b8e1a4adb4534429628c2e9b59/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest
-GitCommit: d6294d103d2eb8d618dd09e28240ea2de2577c25
-Directory: apache
+Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest, 4.6.1-php5.6-apache, 4.6-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.6.1-php5.6, 4.6-php5.6, 4-php5.6, php5.6
+GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+Directory: php5.6/apache
 
-Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm
-GitCommit: d6294d103d2eb8d618dd09e28240ea2de2577c25
-Directory: fpm
+Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm, 4.6.1-php5.6-fpm, 4.6-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+Directory: php5.6/fpm
+
+Tags: 4.6.1-php7.0-apache, 4.6-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.6.1-php7.0, 4.6-php7.0, 4-php7.0, php7.0
+GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+Directory: php7.0/apache
+
+Tags: 4.6.1-php7.0-fpm, 4.6-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+Directory: php7.0/fpm


### PR DESCRIPTION
See also docker-library/wordpress#177 and docker-library/wordpress#178.