### PR TITLE
Jenkins fix 2.19.1 and 2.7.4 tags

### DIFF
--- a/library/jenkins
+++ b/library/jenkins
@@ -3,7 +3,9 @@
 # maintainer: Carlos Sanchez <csanchez@cloudbees.com> (@carlossg)
 
 latest: git://github.com/jenkinsci/jenkins-ci.org-docker@2fb0684fe6eb11a3c1145d71e0cb50bf2dda8d11
-2.7.4: git://github.com/jenkinsci/jenkins-ci.org-docker@2fb0684fe6eb11a3c1145d71e0cb50bf2dda8d11
+2.7.4: git://github.com/jenkinsci/jenkins-ci.org-docker@6eaa9b15926232310317490a3b9975ef61be763c
+2.19.1: git://github.com/jenkinsci/jenkins-ci.org-docker@2fb0684fe6eb11a3c1145d71e0cb50bf2dda8d11
 
 alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@3fc5d6038dc717055b15001cd7e039e965f24542
-2.7.4-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@3fc5d6038dc717055b15001cd7e039e965f24542
+2.7.4-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@d2eeb20813164526f0443599fd82fd79fadee77e
+2.19.1-alpine: git://github.com/jenkinsci/jenkins-ci.org-docker@3fc5d6038dc717055b15001cd7e039e965f24542


### PR DESCRIPTION
I screwed the last PR #2226 overwriting the 2.7.4 tag