### PR TITLE
Adds a Consul tag w/o a "v" prefix.

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,5 +1,6 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
 latest: git://github.com/hashicorp/docker-consul@470868df3885ad93f45a2c63c648bf119a544fa4 0.X
+0.7.0: git://github.com/hashicorp/docker-consul@470868df3885ad93f45a2c63c648bf119a544fa4 0.X
 v0.7.0: git://github.com/hashicorp/docker-consul@470868df3885ad93f45a2c63c648bf119a544fa4 0.X
 v0.6.4: git://github.com/hashicorp/docker-consul@9a59dc1a87adc164b72ac67bc9e4364a3fc4138d 0.6


### PR DESCRIPTION
Plan forward is to not use the "v" when tagging releases.