### PR TITLE
Update elasticsearch 5.0.0-rc1, logstash 5.0.0-rc1 and kibana 5.0.0-rc1

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -36,6 +36,6 @@ Tags: 2.4.1, 2.4, 2, latest
 GitCommit: e74f9ba98e26221af4a3103d65ff519621e989d2
 Directory: 2.4
 
-Tags: 5.0.0-alpha5, 5.0.0, 5.0, 5
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
+GitCommit: 1fd8daec87672bf61b5b38f00a565220e3370c49
 Directory: 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -28,6 +28,6 @@ Tags: 4.6.1, 4.6, 4, latest
 GitCommit: e930401355dc9b268b3e7d036794263a8e0f7a82
 Directory: 4.6
 
-Tags: 5.0.0-alpha5, 5.0.0, 5.0, 5
-GitCommit: f1e01a0c5d64b1eea3c9d90a2cba93d9f3924bd0
+Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
+GitCommit: f378b797af3efc417647cde6e1965f74d156cc2e
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -28,6 +28,6 @@ Tags: 2.4.0-1, 2.4.0, 2.4, 2, latest
 GitCommit: cbcdf161825af8e9acb8eaa420750a397af6b169
 Directory: 2.4
 
-Tags: 5.0.0-alpha5-1, 5.0.0-alpha5, 5.0.0, 5.0, 5
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+Tags: 5.0.0-rc1-1, 5.0.0-rc1, 5.0.0, 5.0, 5
+GitCommit: f37e8e2ba5401760132cc3e3b98f6e61881616eb
 Directory: 5.0


### PR DESCRIPTION
PR's:
docker-library/elasticsearch/pull/123
docker-library/logstash/pull/62
docker-library/kibana/pull/57