### PR TITLE
Update for Node.js v6.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,23 +1,23 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/4029a8f71920e1e23efa79602167014f9c325ba0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/c517001982231c78bf4ce757466c9b69d02c92af/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.7.0, 6.7, 6, latest
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
-Directory: 6.7
+Tags: 6.8.0, 6.8, 6, latest
+GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Directory: 6.8
 
-Tags: 6.7.0-onbuild, 6.7-onbuild, 6-onbuild, onbuild
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
-Directory: 6.7/onbuild
+Tags: 6.8.0-onbuild, 6.8-onbuild, 6-onbuild, onbuild
+GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Directory: 6.8/onbuild
 
-Tags: 6.7.0-slim, 6.7-slim, 6-slim, slim
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
-Directory: 6.7/slim
+Tags: 6.8.0-slim, 6.8-slim, 6-slim, slim
+GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Directory: 6.8/slim
 
-Tags: 6.7.0-wheezy, 6.7-wheezy, 6-wheezy, wheezy
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
-Directory: 6.7/wheezy
+Tags: 6.8.0-wheezy, 6.8-wheezy, 6-wheezy, wheezy
+GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Directory: 6.8/wheezy
 
 Tags: 4.6.0, 4.6, 4, argon
 GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v6.8.0/
- https://github.com/nodejs/docker-node/pull/244