### PR TITLE
Add Adminer official image

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -1,0 +1,10 @@
+Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
+GitRepo: https://github.com/TimWolla/docker-adminer.git
+
+Tags: 4.2.5-standalone, 4.2-standalone, 4-standalone, standalone, 4.2.5, 4.2, 4, latest
+GitCommit: a06cb9d6b40f2a8023c72a059aa4ca723af31d0e
+Directory: 4.2
+
+Tags: 4.2.5-fastcgi, 4.2-fastcgi, 4-fastcgi, fastcgi
+GitCommit: a06cb9d6b40f2a8023c72a059aa4ca723af31d0e
+Directory: 4.2/fastcgi


### PR DESCRIPTION
[Quick link to the source repository](https://github.com/TimWolla/docker-adminer)

This adds an official image for the [adminer database management tool](https://www.adminer.org/en/).

The FastCGI version of this image received significant testing by myself, as I use it for my local development setup. The standalone version is new, but fairly similar to the FastCGI one and thus should work just fine.

As this image should not receive production like traffic levels the default standalone version uses the PHP internal develoment web server, which should work fine for any local usage. For developers running a FastCGI-capable web server anyway the FastCGI version might be preferred.

This image is opiniated in so far as it uses the host name `db` by default for the database, instead of `localhost` which obviously does not work in context of Docker.

This image differs from the very popular [`clue/adminer`](https://github.com/clue/docker-adminer/blob/master/Dockerfile) image in the following points:
- It does proper Dockerization, by not including supervisord
- It allows for repeatable builds
- It sets a default database host
- It does not modify php.ini to disable the various limits of PHP
- It does not include support for MSSQL
- It is based on Alpine

There is a PR on clue/adminer that remedies some of the points, but it heavily discussed, so I refrained from proposing my own opiniated solution there: clue/docker-adminer#21
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
-   [x] associated with or contacted upstream?
  **Not yet.**
-   [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-   [x] is it reasonably popular, or does it solve a particular use case well?
-   [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  **Yup, docker-library/docs#722**
-   [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-   [x] 2+ dockerization review?
-   [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
  **Yup. Based on the alpine versions of PHP.**
-   [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
  **Does not apply**
-   [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
