### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.15, 2.1
-GitCommit: ef57ef961003e27469b86178f0b4d184bb64d82e
+Tags: 2.1.16, 2.1
+GitCommit: 3204fb896811b4d20527b8d4a509d65189fd6913
 Directory: 2.1
 
 Tags: 2.2.8, 2.2, 2

--- a/library/docker
+++ b/library/docker
@@ -1,54 +1,30 @@
-# this file is generated via https://github.com/docker-library/docker/blob/dba6c6279614ac0a7e520f0b7f7c027250488a4f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/a7fc73eef011c47cc2518149bc77a4b9bc7f9f41/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.2-rc3, 1.12-rc, rc
-GitCommit: 9d14e3554b2b3f2beb4449182d0fdfbe7305fca4
-Directory: 1.12-rc
-
-Tags: 1.12.2-rc3-dind, 1.12-rc-dind, rc-dind
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
-Directory: 1.12-rc/dind
-
-Tags: 1.12.2-rc3-git, 1.12-rc-git, rc-git
-GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
-Directory: 1.12-rc/git
-
-Tags: 1.12.2-rc3-experimental, 1.12-rc-experimental, rc-experimental
-GitCommit: 9d14e3554b2b3f2beb4449182d0fdfbe7305fca4
-Directory: 1.12-rc/experimental
-
-Tags: 1.12.2-rc3-experimental-dind, 1.12-rc-experimental-dind, rc-experimental-dind
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
-Directory: 1.12-rc/experimental/dind
-
-Tags: 1.12.2-rc3-experimental-git, 1.12-rc-experimental-git, rc-experimental-git
-GitCommit: dba6c6279614ac0a7e520f0b7f7c027250488a4f
-Directory: 1.12-rc/experimental/git
-
-Tags: 1.12.1, 1.12, 1, latest
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
+Tags: 1.12.2, 1.12, 1, latest
+GitCommit: a7fc73eef011c47cc2518149bc77a4b9bc7f9f41
 Directory: 1.12
 
-Tags: 1.12.1-dind, 1.12-dind, 1-dind, dind
+Tags: 1.12.2-dind, 1.12-dind, 1-dind, dind
 GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
 Directory: 1.12/dind
 
-Tags: 1.12.1-git, 1.12-git, 1-git, git
+Tags: 1.12.2-git, 1.12-git, 1-git, git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
-Tags: 1.12.1-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
+Tags: 1.12.2-experimental, 1.12-experimental, 1-experimental, experimental
+GitCommit: a7fc73eef011c47cc2518149bc77a4b9bc7f9f41
 Directory: 1.12/experimental
 
-Tags: 1.12.1-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+Tags: 1.12.2-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
 GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
 Directory: 1.12/experimental/dind
 
-Tags: 1.12.1-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+Tags: 1.12.2-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
 GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 

--- a/library/drupal
+++ b/library/drupal
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.2.0-apache, 8.2-apache, 8-apache, apache, 8.2.0, 8.2, 8, latest
-GitCommit: 1b3df9afb3a949b1c8ee29b52018abc8ccc3600e
+Tags: 8.2.1-apache, 8.2-apache, 8-apache, apache, 8.2.1, 8.2, 8, latest
+GitCommit: 13f73afd9cfaabfae09340617dc25beebe4028ba
 Directory: 8.2/apache
 
-Tags: 8.2.0-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: 1b3df9afb3a949b1c8ee29b52018abc8ccc3600e
+Tags: 8.2.1-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: 13f73afd9cfaabfae09340617dc25beebe4028ba
 Directory: 8.2/fpm
 
 Tags: 7.51-apache, 7-apache, 7.51, 7

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.1, 0.11, 0, latest
-GitCommit: 8d638ab5035f7ac2d559a760f0bb4d6b4ea07264
+Tags: 0.11.2, 0.11, 0, latest
+GitCommit: 66c839be52f64d771968fff0262ebf94ff2f2886

--- a/library/logstash
+++ b/library/logstash
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 1.5.6-1, 1.5.6, 1.5, 1
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 1.5
 
 Tags: 2.0.0-1, 2.0.0, 2.0
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 2.0
 
 Tags: 2.1.3-1, 2.1.3, 2.1
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 2.1
 
 Tags: 2.2.4-1, 2.2.4, 2.2
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 2.2
 
 Tags: 2.3.4-1, 2.3.4, 2.3
-GitCommit: afa907d363949924dee64006c7c96ad70329d7c8
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 2.3
 
 Tags: 2.4.0-1, 2.4.0, 2.4, 2, latest
-GitCommit: cbcdf161825af8e9acb8eaa420750a397af6b169
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 2.4
 
 Tags: 5.0.0-rc1-1, 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: f37e8e2ba5401760132cc3e3b98f6e61881616eb
+GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
 Directory: 5.0

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.31, 1.4, 1, latest
-GitCommit: f3517ea1de0ac9ac2a86dc2670afac3874512e2b
+Tags: 1.4.32, 1.4, 1, latest
+GitCommit: 3ce070556c87bb1c9e745f5596bd54e39a3f4065
 Directory: debian
 
-Tags: 1.4.31-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: f3517ea1de0ac9ac2a86dc2670afac3874512e2b
+Tags: 1.4.32-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 3ce070556c87bb1c9e745f5596bd54e39a3f4065
 Directory: alpine

--- a/library/mysql
+++ b/library/mysql
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 5.7.15, 5.7, 5, latest
-GitCommit: 9f95658f528699d2c2017ca42ad163a9d5c5e7c1
+Tags: 5.7.16, 5.7, 5, latest
+GitCommit: 3e89b55110565908b46ed3e1b1cae6098f464965
 Directory: 5.7
 
-Tags: 5.6.33, 5.6
-GitCommit: 9fc086343ebd36af0448438622188264d1dc2e1c
+Tags: 5.6.34, 5.6
+GitCommit: a03bccc7dc259d817643b0ca0bfcf7ce52ea3906
 Directory: 5.6
 
-Tags: 5.5.52, 5.5
-GitCommit: 78c736cef063f6c69256aa34f87ee463949af34f
+Tags: 5.5.53, 5.5
+GitCommit: ae850f69e7414a7c28e8d364ae039fe0a0464e7a
 Directory: 5.5

--- a/library/opensuse
+++ b/library/opensuse
@@ -7,12 +7,12 @@ Constraints: !aufs
 
 Tags: 42.1, leap, latest
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: 5c63b0a9d2c8b13b81855751168066666d77adb1
+GitCommit: c8abb4323ef1744bfb9e5d4f127d9076083f0a6e
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 2479d8d0f90bce3c2e33dd2fc311d6599c336fdf
+GitCommit: 308dda3268f8512795c32cf0e738d5e668f2d3a1
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed
-GitCommit: 046d77c122ee04485df87870f31713f87a30c1e2
+GitCommit: 0a2809c7b06e21c055b7adfe9e90941516f3d126

--- a/library/python
+++ b/library/python
@@ -91,22 +91,22 @@ Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.0b2, 3.6
-GitCommit: aa533a4879c13944d62a5029929ffae78075d212
+GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
 Directory: 3.6
 
 Tags: 3.6.0b2-slim, 3.6-slim
-GitCommit: aa533a4879c13944d62a5029929ffae78075d212
+GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
 Directory: 3.6/slim
 
 Tags: 3.6.0b2-alpine, 3.6-alpine
-GitCommit: aa533a4879c13944d62a5029929ffae78075d212
+GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
 Directory: 3.6/alpine
 
 Tags: 3.6.0b2-onbuild, 3.6-onbuild
-GitCommit: aa533a4879c13944d62a5029929ffae78075d212
+GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
 Directory: 3.6/onbuild
 
 Tags: 3.6.0b2-windowsservercore, 3.6-windowsservercore
-GitCommit: aa533a4879c13944d62a5029929ffae78075d212
+GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: ebb58ab86991c098a1ca70b4a5969d2ba8c5c9b2
+GitCommit: 3d02e324fa5d66d116cdb8450fe18243a7f3943d
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: ebb58ab86991c098a1ca70b4a5969d2ba8c5c9b2
+GitCommit: 3d02e324fa5d66d116cdb8450fe18243a7f3943d
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: ebb58ab86991c098a1ca70b4a5969d2ba8c5c9b2
+GitCommit: 3d02e324fa5d66d116cdb8450fe18243a7f3943d
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: 91203f150b9ca4262718800c84251cf7a8e3cb27
+GitCommit: ea44e9272bb79a42d8a17104c6a4d3f0b6a5e0a7
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: 91203f150b9ca4262718800c84251cf7a8e3cb27
+GitCommit: ea44e9272bb79a42d8a17104c6a4d3f0b6a5e0a7
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 91203f150b9ca4262718800c84251cf7a8e3cb27
+GitCommit: ea44e9272bb79a42d8a17104c6a4d3f0b6a5e0a7
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: e89be7d60685ec51a193a358a8f3364b287aee3b
+GitCommit: c4ac9d7cdd4474e6e3d2154b4217f85049eadbcd
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: e89be7d60685ec51a193a358a8f3364b287aee3b
+GitCommit: c4ac9d7cdd4474e6e3d2154b4217f85049eadbcd
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: e89be7d60685ec51a193a358a8f3364b287aee3b
+GitCommit: c4ac9d7cdd4474e6e3d2154b4217f85049eadbcd
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -13,7 +13,7 @@ GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+GitCommit: 2b55df5b9feaa7b8354e8b2419a88e494a110621
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
@@ -21,41 +21,41 @@ GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+GitCommit: 2b55df5b9feaa7b8354e8b2419a88e494a110621
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
 Directory: 7/jre8-alpine
 
-Tags: 8.0.37-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.37, 8.0, 8, latest
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
+GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
 Directory: 8.0/jre7
 
-Tags: 8.0.37-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.37-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.37-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
 Directory: 8.0/jre8
 
-Tags: 8.0.37-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.5-jre8, 8.5-jre8, 8.5.5, 8.5
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
+GitCommit: e7a7901e48c2f4d4fd7e150623b9a9f44e14866e
 Directory: 8.5/jre8
 
-Tags: 8.5.5-jre8-alpine, 8.5-jre8-alpine, 8.5.5-alpine, 8.5-alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
+GitCommit: e7a7901e48c2f4d4fd7e150623b9a9f44e14866e
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M10-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M10, 9.0.0, 9.0, 9
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
+GitCommit: 6579c4d21893ec4043387a906ac6d22394a06d22
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M10-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M10-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 6579c4d21893ec4043387a906ac6d22394a06d22
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `cassandra`: 2.1.16
- `docker`: 1.12.2 (GA)
- `drupal`: 8.2.1
- `ghost`: 0.11.2
- `logstash`: update templates
- `memcached`: 1.4.32
- `mysql`: 5.5.53, 5.6.34-1debian8, 5.7.16-1debian8
- `opensuse`: newer 42.1 image (https://github.com/openSUSE/docker-containers-build/issues/16)
- `python`: 3.6.0b2 (minor commit adjustment)
- `ruby`: bundler 1.13.3
- `tomcat`: 8.5.6, 8.0.38, 9.0.0.M11

cc @flavio -- we'd discussed previously that I'd be willing to update `library/opensuse` for you, and I'd seen the issue but had actually forgotten I had the script still in my local working area, but figured I'd just add it and remove it afterwards if you object :+1: (this only updates 42.1, no adding of 42.2 yet)