### PR TITLE
Update for Node.js v6.8.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,20 +3,20 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.8.0, 6.8, 6, latest
-GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Tags: 6.8.1, 6.8, 6, latest
+GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
 Directory: 6.8
 
-Tags: 6.8.0-onbuild, 6.8-onbuild, 6-onbuild, onbuild
-GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Tags: 6.8.1-onbuild, 6.8-onbuild, 6-onbuild, onbuild
+GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
 Directory: 6.8/onbuild
 
-Tags: 6.8.0-slim, 6.8-slim, 6-slim, slim
-GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Tags: 6.8.1-slim, 6.8-slim, 6-slim, slim
+GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
 Directory: 6.8/slim
 
-Tags: 6.8.0-wheezy, 6.8-wheezy, 6-wheezy, wheezy
-GitCommit: f3c3821591765ad0727bdde2cb98f41dc1b9b4b9
+Tags: 6.8.1-wheezy, 6.8-wheezy, 6-wheezy, wheezy
+GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
 Directory: 6.8/wheezy
 
 Tags: 4.6.0, 4.6, 4, argon


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v6.8.1/
- https://github.com/nodejs/docker-node/pull/246