### PR TITLE
Update debian testing/unstable to use deb.debian.org

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -6,7 +6,7 @@ GitRepo: https://github.com/tianon/docker-brew-debian.git
 #  - 88ae210 2016-09-23 debootstraps
 
 # commits: (master..dist-unstable)
-#  - ee8b1cb 2016-09-23 debootstraps
+#  - 42df304 2016-10-17 debootstraps
 
 # commits: (master..dist-oldstable)
 #  - a687a61 2016-09-19 debootstraps
@@ -33,7 +33,7 @@ Directory: oldstable/backports
 
 Tags: sid
 GitFetch: refs/heads/dist-unstable
-GitCommit: ee8b1cb93b20e3b9afc264126f1fe9b5518735c5
+GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
 Directory: sid
 
 Tags: stable
@@ -48,17 +48,17 @@ Directory: stable/backports
 
 Tags: stretch
 GitFetch: refs/heads/dist-unstable
-GitCommit: ee8b1cb93b20e3b9afc264126f1fe9b5518735c5
+GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
 Directory: stretch
 
 Tags: testing
 GitFetch: refs/heads/dist-unstable
-GitCommit: ee8b1cb93b20e3b9afc264126f1fe9b5518735c5
+GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
 Directory: testing
 
 Tags: unstable
 GitFetch: refs/heads/dist-unstable
-GitCommit: ee8b1cb93b20e3b9afc264126f1fe9b5518735c5
+GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
 Directory: unstable
 
 Tags: 7.11, 7, wheezy


### PR DESCRIPTION
See https://github.com/tianon/docker-brew-debian/issues/37 for more context.

Essentially, `httpredir.debian.org` is barely maintained, and `deb.debian.org` is the suggested future (both services officially supported by the Debian System Administrators).

If this works well here, we'll be applying it to stable as well. :+1: