### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/celery.git
 
-Tags: 4.0.0rc4, 4.0, 4
-GitCommit: 8e10b9f6008ca34cd9ef2a74f032531bd44193b4
+Tags: 4.0.0rc5, 4.0, 4
+GitCommit: e4c163e2f174f8c12a93bdf3514d7f58781ae667
 Directory: 4.0
 
 Tags: 3.1.24, 3.1, 3, latest

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/7a502275158cac1affa4372eab937a21913cd3e0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/f5abb68ac066bfedae3822f43894cfbdbc99f4c2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 1.5.2, 1.5
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 1.5
 
 Tags: 1.6.2, 1.6
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 1.6
 
 Tags: 1.7.5, 1.7, 1
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 2.0
 
 Tags: 2.1.2, 2.1
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 2.1
 
 Tags: 2.2.2, 2.2
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 2.2
 
 Tags: 2.3.5, 2.3
-GitCommit: 2536978b4ef8b58866e933f7e6918ba7161802ac
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 2.3
 
 Tags: 2.4.1, 2.4, 2, latest
-GitCommit: e74f9ba98e26221af4a3103d65ff519621e989d2
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
 Directory: 2.4
 
 Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: 1fd8daec87672bf61b5b38f00a565220e3370c49
-Directory: 5.0
+GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+Directory: 5.0-rc

--- a/library/golang
+++ b/library/golang
@@ -22,9 +22,14 @@ GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
 Directory: 1.6/alpine
 
 Tags: 1.6.3-windowsservercore, 1.6-windowsservercore
-GitCommit: 83760719bbaadb8d778aa48d53bf2e9d9bd55741
+GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
 Directory: 1.6/windows/windowsservercore
 Constraints: windowsservercore
+
+Tags: 1.6.3-nanoserver, 1.6-nanoserver
+GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
+Directory: 1.6/windows/nanoserver
+Constraints: nanoserver
 
 Tags: 1.7.1, 1.7, 1, latest
 GitCommit: 85df9970e9548f38248d36f6f4341e2aea128515
@@ -43,6 +48,11 @@ GitCommit: 3a3e91c242b58a7d4e6022b3710b2e871f0ee5d6
 Directory: 1.7/alpine
 
 Tags: 1.7.1-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 3a3e91c242b58a7d4e6022b3710b2e871f0ee5d6
+GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
+
+Tags: 1.7.1-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
+GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
+Directory: 1.7/windows/nanoserver
+Constraints: nanoserver

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b139-jdk, 9-b139, 9-jdk, 9, openjdk-9-b139-jdk, openjdk-9-b139, openjdk-9-jdk, openjdk-9
-GitCommit: 6882089f1c079469c3e2cadca1ed8371fb8495f2
+Tags: 9-b140-jdk, 9-b140, 9-jdk, 9, openjdk-9-b140-jdk, openjdk-9-b140, openjdk-9-jdk, openjdk-9
+GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
 Directory: 9-jdk
 
-Tags: 9-b139-jre, 9-jre, openjdk-9-b139-jre, openjdk-9-jre
-GitCommit: 6882089f1c079469c3e2cadca1ed8371fb8495f2
+Tags: 9-b140-jre, 9-jre, openjdk-9-b140-jre, openjdk-9-jre
+GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
 Directory: 9-jre

--- a/library/kibana
+++ b/library/kibana
@@ -29,5 +29,5 @@ GitCommit: e930401355dc9b268b3e7d036794263a8e0f7a82
 Directory: 4.6
 
 Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: f378b797af3efc417647cde6e1965f74d156cc2e
+GitCommit: f01982e6fd068565a79822b1ff0e82d2f3d0a4f4
 Directory: 5.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,6 +12,6 @@ Tags: 10.0.27, 10.0
 GitCommit: 9d505bb93429729bcc94439cfd47fddc830ff671
 Directory: 10.0
 
-Tags: 5.5.52, 5.5, 5
-GitCommit: 9d505bb93429729bcc94439cfd47fddc830ff671
+Tags: 5.5.53, 5.5, 5
+GitCommit: 2f3b74d8c8bd102fc555cf774a5eb62dd7cb30ef
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b139-jdk, 9-b139, 9-jdk, 9
-GitCommit: 6882089f1c079469c3e2cadca1ed8371fb8495f2
+Tags: 9-b140-jdk, 9-b140, 9-jdk, 9
+GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
 Directory: 9-jdk
 
-Tags: 9-b139-jre, 9-jre
-GitCommit: 6882089f1c079469c3e2cadca1ed8371fb8495f2
+Tags: 9-b140-jre, 9-jre
+GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -1,89 +1,89 @@
-# this file is generated via https://github.com/docker-library/php/blob/6f3edbc07daf333581eb43d1c7a9149351a1f63b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/23533b71850e152e1226c578aac18ca371920f75/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.0RC3-cli, 7.1-cli, 7.1.0RC3, 7.1
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1
+Tags: 7.1.0RC3-cli, 7.1-rc-cli, rc-cli, 7.1.0RC3, 7.1-rc, rc
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc
 
-Tags: 7.1.0RC3-alpine, 7.1-alpine
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/alpine
+Tags: 7.1.0RC3-alpine, 7.1-rc-alpine, rc-alpine
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/alpine
 
-Tags: 7.1.0RC3-apache, 7.1-apache
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/apache
+Tags: 7.1.0RC3-apache, 7.1-rc-apache, rc-apache
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/apache
 
-Tags: 7.1.0RC3-fpm, 7.1-fpm
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/fpm
+Tags: 7.1.0RC3-fpm, 7.1-rc-fpm, rc-fpm
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/fpm
 
-Tags: 7.1.0RC3-fpm-alpine, 7.1-fpm-alpine
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/fpm/alpine
+Tags: 7.1.0RC3-fpm-alpine, 7.1-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/fpm/alpine
 
-Tags: 7.1.0RC3-zts, 7.1-zts
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/zts
+Tags: 7.1.0RC3-zts, 7.1-rc-zts, rc-zts
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/zts
 
-Tags: 7.1.0RC3-zts-alpine, 7.1-zts-alpine
-GitCommit: cbca335c53456146e4dc868a1dac08bd66a1b019
-Directory: 7.1/zts/alpine
+Tags: 7.1.0RC3-zts-alpine, 7.1-rc-zts-alpine, rc-zts-alpine
+GitCommit: ecde4f3843bf8e652111beb4cbdd15aabfd90d02
+Directory: 7.1-rc/zts/alpine
 
 Tags: 7.0.12-cli, 7.0-cli, 7-cli, cli, 7.0.12, 7.0, 7, latest
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0
 
 Tags: 7.0.12-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/alpine
 
 Tags: 7.0.12-apache, 7.0-apache, 7-apache, apache
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/apache
 
 Tags: 7.0.12-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/fpm
 
 Tags: 7.0.12-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.12-zts, 7.0-zts, 7-zts, zts
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/zts
 
 Tags: 7.0.12-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 9f010251157b45dab7c59b657736d97f2b29c0b5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.26-cli, 5.6-cli, 5-cli, 5.6.26, 5.6, 5
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-cli, 5.6-cli, 5-cli, 5.6.27, 5.6, 5
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6
 
-Tags: 5.6.26-alpine, 5.6-alpine, 5-alpine
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-alpine, 5.6-alpine, 5-alpine
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/alpine
 
-Tags: 5.6.26-apache, 5.6-apache, 5-apache
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-apache, 5.6-apache, 5-apache
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/apache
 
-Tags: 5.6.26-fpm, 5.6-fpm, 5-fpm
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-fpm, 5.6-fpm, 5-fpm
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/fpm
 
-Tags: 5.6.26-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.26-zts, 5.6-zts, 5-zts
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-zts, 5.6-zts, 5-zts
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/zts
 
-Tags: 5.6.26-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 1c56325a69718a3e3cf76179e75d070b7e23da62
+Tags: 5.6.27-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
 Directory: 5.6/zts/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: f5f15c9af6dc5beaae6c1b91ff2b33a39ad2bd84
+GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: f5f15c9af6dc5beaae6c1b91ff2b33a39ad2bd84
+GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: f5f15c9af6dc5beaae6c1b91ff2b33a39ad2bd84
+GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: 0119b0939a6ab075bb1b3f4423bf0e8d6c5def44
+GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: 0119b0939a6ab075bb1b3f4423bf0e8d6c5def44
+GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 0119b0939a6ab075bb1b3f4423bf0e8d6c5def44
+GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: a4261bd6b54ae67b1bed49507c0db92908785aed
+GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: a4261bd6b54ae67b1bed49507c0db92908785aed
+GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: a4261bd6b54ae67b1bed49507c0db92908785aed
+GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `celery`: 4.0.0rc5
- `elasticsearch`: refactor template (docker-library/elasticsearch#124)
- `golang`: add `nanoserver` variants (docker-library/golang#116)
- `java`: debian 9~b140-1
- `kibana`: fix `server.host` in 5+ (docker-library/kibana#60)
- `mariadb`: 5.5.53+maria-1~wheezy
- `openjdk`: debian 9~b140-1
- `php`: 5.6.27; template refactor for better pre-releases support (docker-library/php#314)
- `ruby`: bundler 1.13.5