### PR TITLE
[security] Update for Node.js v6.9.0, v4.6.1, v0.12.17 and v0.10.48

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,69 +1,69 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/c517001982231c78bf4ce757466c9b69d02c92af/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/3e7f85f2b285be63ed06fda8b8e8d8b2915fed12/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.8.1, 6.8, 6, latest
-GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
-Directory: 6.8
+Tags: 6.9.0, 6.9, 6, boron, latest
+GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Directory: 6.9
 
-Tags: 6.8.1-onbuild, 6.8-onbuild, 6-onbuild, onbuild
-GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
-Directory: 6.8/onbuild
+Tags: 6.9.0-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild, onbuild
+GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Directory: 6.9/onbuild
 
-Tags: 6.8.1-slim, 6.8-slim, 6-slim, slim
-GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
-Directory: 6.8/slim
+Tags: 6.9.0-slim, 6.9-slim, 6-slim, boron-slim, slim
+GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Directory: 6.9/slim
 
-Tags: 6.8.1-wheezy, 6.8-wheezy, 6-wheezy, wheezy
-GitCommit: a21c91d04b001525be8879f3f04b5451175af17c
-Directory: 6.8/wheezy
+Tags: 6.9.0-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy, wheezy
+GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Directory: 6.9/wheezy
 
-Tags: 4.6.0, 4.6, 4, argon
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 4.6.1, 4.6, 4, argon
+GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
 Directory: 4.6
 
-Tags: 4.6.0-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 4.6.1-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
+GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
 Directory: 4.6/onbuild
 
-Tags: 4.6.0-slim, 4.6-slim, 4-slim, argon-slim
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 4.6.1-slim, 4.6-slim, 4-slim, argon-slim
+GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
 Directory: 4.6/slim
 
-Tags: 4.6.0-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 4.6.1-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
+GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
 Directory: 4.6/wheezy
 
-Tags: 0.12.16, 0.12, 0
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.12.17, 0.12, 0
+GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12
 
-Tags: 0.12.16-onbuild, 0.12-onbuild, 0-onbuild
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.12.17-onbuild, 0.12-onbuild, 0-onbuild
+GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12/onbuild
 
-Tags: 0.12.16-slim, 0.12-slim, 0-slim
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.12.17-slim, 0.12-slim, 0-slim
+GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12/slim
 
-Tags: 0.12.16-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.12.17-wheezy, 0.12-wheezy, 0-wheezy
+GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12/wheezy
 
-Tags: 0.10.47, 0.10
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.10.48, 0.10
+GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
 Directory: 0.10
 
-Tags: 0.10.47-onbuild, 0.10-onbuild
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.10.48-onbuild, 0.10-onbuild
+GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
 Directory: 0.10/onbuild
 
-Tags: 0.10.47-slim, 0.10-slim
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.10.48-slim, 0.10-slim
+GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
 Directory: 0.10/slim
 
-Tags: 0.10.47-wheezy, 0.10-wheezy
-GitCommit: 4029a8f71920e1e23efa79602167014f9c325ba0
+Tags: 0.10.48-wheezy, 0.10-wheezy
+GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
 Directory: 0.10/wheezy
 


### PR DESCRIPTION
This is a security update for all versions of Node.js. Note that this
release  marks the beginning of the v6 LTS release line starting with
v6.9.0 (code name boron). A new "boron" tag has be added for this LTS
release.

- https://nodejs.org/en/blog/vulnerability/october-2016-security-releases/
- https://nodejs.org/en/blog/release/v6.9.0/
- https://nodejs.org/en/blog/release/v4.6.1/
- https://nodejs.org/en/blog/release/v0.12.17/
- https://nodejs.org/en/blog/release/v0.10.48/