### PR TITLE
alpine: bump 3.4.4 and fix openssl (CVE-2016-7052)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,8 +1,9 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-3.1: git://github.com/gliderlabs/docker-alpine@a9a9643b27e2c3ac5c54aa6652a465795719edf9 versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@322a7330bb18e07a71b648033f5b76e122c064d3 versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@3d320a4b32a6b19c31b4b8b36752138e442031c9 versions/library-3.3
-3.4: git://github.com/gliderlabs/docker-alpine@8f23fc2e995ab8f7f0f5960c6a1ddd12f57efd0c versions/library-3.4
-latest: git://github.com/gliderlabs/docker-alpine@8f23fc2e995ab8f7f0f5960c6a1ddd12f57efd0c versions/library-3.4
-edge: git://github.com/gliderlabs/docker-alpine@626d0f762c17632c260c7be43a953817bf986c86 versions/library-edge
+3.1: git://github.com/gliderlabs/docker-alpine@8179fe722094b8724b7e9eb1d573173baf6ca977 versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@5636e9a91b543fa507271fbbc9b5d1db59ce986f versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@bc90ea0c90880b44cc7f405cbe6ec27ed453fda7 versions/library-3.3
+3.4: git://github.com/gliderlabs/docker-alpine@a83f6c797a617f580ff717efe9e53543f7beca43 versions/library-3.4
+latest: git://github.com/gliderlabs/docker-alpine@a83f6c797a617f580ff717efe9e53543f7beca43 versions/library-3.4
+edge: git://github.com/gliderlabs/docker-alpine@64804257e6997cdc88c39e949b6a9df492621691 versions/library-edge
+


### PR DESCRIPTION
Alpine edge switched to libressl