### PR TITLE
Aerospike 3.10.0-1

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.9.1-1: git://github.com/aerospike/aerospike-server.docker@176a3b8cc79eb883052a8fb1cf3802960b82e600
-latest: git://github.com/aerospike/aerospike-server.docker@176a3b8cc79eb883052a8fb1cf3802960b82e600 
+3.10.0-1: git://github.com/aerospike/aerospike-server.docker@f8daab96b0a98f3ae31ba49763f74fe1e483e903
+latest: git://github.com/aerospike/aerospike-server.docker@f8daab96b0a98f3ae31ba49763f74fe1e483e903 


### PR DESCRIPTION
When upgrading, please follow Network Upgrade for 3.10 to make required aerospike.conf configuration changes.

http://www.aerospike.com/docs/operations/upgrade/network_to_3_10

SortedMap Operations is now GA. For more information click here.

```
Known Issue - [AER-5326] - (Cluster) During rolling upgrade, mixed-version of 3.10/none-3.10 nodes result in incomplete services list, causing undesired proxy requests. Fixed in 3.10.0.1
```

New Features

```
[AER-5190] - (Cluster) Heartbeat V3 new supported features.
    [AER-5231] - (Cluster) Support cluster-name. For more information click here.
```

Improvements

```
[AER-5092] - (KVS) Add Read / Write histograms per record size on storage benchmark.
[AER-5256] - (KVS) Partition drops now done by background thread.
[AER-5257] - (KVS) Obsolete replicas-read/replicas-write.
[AER-5270] - (KVS) Remove unneeded record reference count.
[AER-5271] - (KVS) Separate partition drop on its own queue thread.
[AER-5291] - (KVS) Partition rebalance refactoring.
[AER-5096] - (Migration) Empty migrate no longer spawn unused threads for migration.
[AER-4728] - (Cluster) Support heartbeat version change when using mesh.
[AER-5062] - (Fabric) Inbound/outbound fabric buffer now default with 1M stack memory.
[AER-5200] - (Fabric) Guard against network packets that may contain garbage.
[AER-5275] - (Fabric) Fabric benchmark instrumentation.
[AER-5264] - (SINDEX) Use client replica bitmap to check if partition is queriable.
[AER-5087] - (UDF) Scan aggregation - Improved map allocation performance.
[AER-5137], [AER-5047], [AER-3804] - (Scan) Set scan's socket send() timeout to be 10 seconds, to accommodate slow or improperly disconnected client.
Network configuration changes. For more information click here.
    [AER-5222] - (Network) Deprecate reuse-address in network section.
    [AER-5274] - (Network) Deprecated mcast-ttl and replace with multicast-ttl.
    [AER-5282] - (Network) Deprecate network.heartbeat.interface-address.
    [AER-5035] - (Network) Honor address field in network.fabric and network.info section.
    [AER-5269] - (Network) Change network.service.network-interface-name to service.node-id-interface.
    [AER-5283] - (Network) Multicast heartbeat must provide multicast-group as the group address.
    [AER-5147] - (Network) New peers list for node discovery.
```

Bug Fixes

```
[AER-5272] - (KVS) JEMalloc stats randomly truncated under systemd.
[AER-5299] - (KVS) Incorrect comparison for large void-times on cold start. Removed max_void_time stat.
[AER-5241] - (Cluster) tip-clear:all will clear both seed nodes and adjacency nodes.
[AER-5278] - (Cluster) Principal node may illegally re-enter partition_rebalance if subordinate retransmits PARTITION_SYNC_REQUEST_ACK.
[AER-5307] - (Cluster) Node crash on receiving non-conforming mesh heartbeat messages.
[AER-4273] - (UDF) Avoid unneeded reparse of UDF parameters in scan/aggregate/query.
[AER-5258] - (UDF) Invalid memory access during UDF loading on startup.
[AER-3895] - (SINDEX) querying for empty string doesn't return data, even though they are indexed.
[AER-4930] - (SINDEX) Incorrect sindex rebuilt on startup, cause missing records in query.
[AER-5238] - (SINDEX) Potential query crash on bins with List/Map while filtering query result.
[AER-4947] - (Storage) Discrepancy in device details of wb summary dump command.
[AER-5198] - (Network) Infiniband network interface does not generate meaningful node_id.
[AER-5279] - (Network) Do not advertise network interface when it is in ifdown state.
[AER-5234] - (CDT) Server crashes when sending unimplemented list/map operation commands.
[AER-5239], [AER-5303] - (CDT) Calling map.replace_items incorrectly returns success.
[AER-5285] - (CDT) Clear null map flags when persisted.
```

More info:

http://www.aerospike.com/download/server/notes.html#3.10.0.1
