### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -30,3 +30,7 @@ Directory: 3.2
 Tags: 3.1.23, 3.1
 GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
 Directory: 3.1
+
+Tags: 3.0.22, 3.0
+GitCommit: 0fb93762d52d5f73ea53557706f19a255ef990d1
+Directory: 3.0

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.1.18, 10.1, 10, latest
-GitCommit: 9d505bb93429729bcc94439cfd47fddc830ff671
+GitCommit: 92e16504a8e9840eb70937aa2da76f38ea002718
 Directory: 10.1
 
 Tags: 10.0.27, 10.0
-GitCommit: 9d505bb93429729bcc94439cfd47fddc830ff671
+GitCommit: df62c40869408e757055ccac1141ba363ef82796
 Directory: 10.0
 
 Tags: 5.5.53, 5.5, 5
-GitCommit: 2f3b74d8c8bd102fc555cf774a5eb62dd7cb30ef
+GitCommit: 110ab9c9ff42821d1459c6a45cc8c330763f724b
 Directory: 5.5

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.14, 5.7, 5, latest
-GitCommit: 9688bf1b615fd31c56273057ed170f6068908310
+GitCommit: 0a7d6078d510cdb089b1d5861171f63db1e11749
 Directory: 5.7
 
-Tags: 5.6.32, 5.6
-GitCommit: 9688bf1b615fd31c56273057ed170f6068908310
+Tags: 5.6.33, 5.6
+GitCommit: 45344545c0529281a33bf8d4cbf2284974aa6582
 Directory: 5.6
 
 Tags: 5.5.52, 5.5
-GitCommit: 3085185fcf46530ea6b2c5ff650efef3535bcea2
+GitCommit: 78efeda42ab5be066c5e7c740fe206c5a3ceb245
 Directory: 5.5

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,58 +4,58 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 6.0.45-jre7, 6.0-jre7, 6-jre7, 6.0.45, 6.0, 6
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 6.0.47-jre7, 6.0-jre7, 6-jre7, 6.0.47, 6.0, 6
+GitCommit: f4c146bcc2f16fd1d2919a392adb46c737851dc9
 Directory: 6/jre7
 
-Tags: 6.0.45-jre8, 6.0-jre8, 6-jre8
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+Tags: 6.0.47-jre8, 6.0-jre8, 6-jre8
+GitCommit: f4c146bcc2f16fd1d2919a392adb46c737851dc9
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: 2b55df5b9feaa7b8354e8b2419a88e494a110621
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: 2b55df5b9feaa7b8354e8b2419a88e494a110621
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 81c66e2e695ad5548b726841c00512a9acf18eb5
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre8-alpine
 
 Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
-GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre7
 
 Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre8
 
 Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 9440e94bb99dbb82354c6e46a86a4f3228021956
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
-GitCommit: e7a7901e48c2f4d4fd7e150623b9a9f44e14866e
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.5/jre8
 
 Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
-GitCommit: e7a7901e48c2f4d4fd7e150623b9a9f44e14866e
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
-GitCommit: 6579c4d21893ec4043387a906ac6d22394a06d22
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 6579c4d21893ec4043387a906ac6d22394a06d22
+GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `bash`: add 3.0
- `mariadb`: add newer Percona packaging key
- `percona`: 5.6.33, add newer Percona packaging key
- `tomcat`: 6.0.47, GPG handling refactoring (docker-library/tomcat#52)