### PR TITLE
Bump traefik to v1.1.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,9 +1,9 @@
-# maintainer: Emile Vauge <emile@vauge.com> (@emilevauge)
-# maintainer: Vincent Demeester <vincent@sbr.pm> (@vdemeester)
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
+             Vincent Demeester <vincent@sbr.pm> (@vdemeester)
+GitRepo: https://github.com/containous/traefik-library-image.git
 
-v1.1.0-rc1: git://github.com/containous/traefik-library-image@ac09f6208236a539d67c076ae25354d884ad5be7
-camembert: git://github.com/containous/traefik-library-image@ac09f6208236a539d67c076ae25354d884ad5be7
+Tags: v1.1.0-rc2, camembert
+GitCommit: f11e22c4b12565a12e5715e0242b8a1fae4b9dc4
 
-v1.0.3: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe
-reblochon: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe
-latest: git://github.com/containous/traefik-library-image@9d877ca7171211aabc2955ab1a301a685f6852fe
+Tags: v1.0.3, reblochon, latest
+GitCommit: 9d877ca7171211aabc2955ab1a301a685f6852fe


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.1.0-rc2 and updates the manifest file to RFC 2822.
/cc @vdemeester

Cheers