### PR TITLE
Update for Node.js v6.9.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,20 +3,20 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.9.0, 6.9, 6, boron, latest
-GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Tags: 6.9.1, 6.9, 6, boron, latest
+GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9
 
-Tags: 6.9.0-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild, onbuild
-GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild, onbuild
+GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/onbuild
 
-Tags: 6.9.0-slim, 6.9-slim, 6-slim, boron-slim, slim
-GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim, slim
+GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/slim
 
-Tags: 6.9.0-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy, wheezy
-GitCommit: 3e7f85f2b285be63ed06fda8b8e8d8b2915fed12
+Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy, wheezy
+GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/wheezy
 
 Tags: 4.6.1, 4.6, 4, argon


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v6.9.1/
- https://github.com/nodejs/docker-node/pull/254