### PR TITLE
Update Debian stable and oldstable to use "deb.debian.org" too

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -3,32 +3,32 @@ Maintainers: Tianon Gravi <tianon@debian.org> (@tianon),
 GitRepo: https://github.com/tianon/docker-brew-debian.git
 
 # commits: (master..dist-stable)
-#  - 88ae210 2016-09-23 debootstraps
+#  - 5f84ff7 2016-10-20 debootstraps
 
 # commits: (master..dist-unstable)
 #  - 42df304 2016-10-17 debootstraps
 
 # commits: (master..dist-oldstable)
-#  - a687a61 2016-09-19 debootstraps
+#  - dc2ade4 2016-10-20 debootstraps
 
 Tags: 8.6, 8, jessie, latest
 GitFetch: refs/heads/dist-stable
-GitCommit: 88ae21052affd8a14553bb969f9d41c464032122
+GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
 Directory: jessie
 
 Tags: jessie-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 88ae21052affd8a14553bb969f9d41c464032122
+GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
 Directory: jessie/backports
 
 Tags: oldstable
 GitFetch: refs/heads/dist-oldstable
-GitCommit: a687a618203e1c0891b42d684ac72a85e1f0bfa6
+GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
 Directory: oldstable
 
 Tags: oldstable-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: a687a618203e1c0891b42d684ac72a85e1f0bfa6
+GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
 Directory: oldstable/backports
 
 Tags: sid
@@ -38,12 +38,12 @@ Directory: sid
 
 Tags: stable
 GitFetch: refs/heads/dist-stable
-GitCommit: 88ae21052affd8a14553bb969f9d41c464032122
+GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
 Directory: stable
 
 Tags: stable-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 88ae21052affd8a14553bb969f9d41c464032122
+GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
 Directory: stable/backports
 
 Tags: stretch
@@ -63,12 +63,12 @@ Directory: unstable
 
 Tags: 7.11, 7, wheezy
 GitFetch: refs/heads/dist-oldstable
-GitCommit: a687a618203e1c0891b42d684ac72a85e1f0bfa6
+GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
 Directory: wheezy
 
 Tags: wheezy-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: a687a618203e1c0891b42d684ac72a85e1f0bfa6
+GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
 Directory: wheezy/backports
 
 # sid + rc-buggy


### PR DESCRIPTION
See https://github.com/tianon/docker-brew-debian/issues/37#issuecomment-255093162 and https://anonscm.debian.org/cgit/d-i/debootstrap.git/commit/?id=9e8bc60ad1ccf3a25ce7890526b70059f3e770de for more info. :+1: