### PR TITLE
Update openSUSE: Security fixes for 13.2, 42.1

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -15,4 +15,4 @@ GitCommit: c51b8abbb418e3566ff1f2299f3747e394412ace
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed
-GitCommit: bae7df3edc72a78a408df43d1f7bb34adfcf005b
+GitCommit: 851a87fa0c9217f92e3fdb6fedb37424e723be69

--- a/library/opensuse
+++ b/library/opensuse
@@ -7,11 +7,11 @@ Constraints: !aufs
 
 Tags: 42.1, leap, latest
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: c8abb4323ef1744bfb9e5d4f127d9076083f0a6e
+GitCommit: 7c5cf56668ffa49adc69c5d844ebf05aa244415e
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 308dda3268f8512795c32cf0e738d5e668f2d3a1
+GitCommit: c51b8abbb418e3566ff1f2299f3747e394412ace
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed


### PR DESCRIPTION
To resolve security issues I have updated the openSUSE references. With
that commit the images should be safe again.

Signed-off-by: Thomas Boerger <tboerger@suse.de>