### PR TITLE
Update for Node.js v7.0.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,21 +1,37 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/3e7f85f2b285be63ed06fda8b8e8d8b2915fed12/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/056200187f0ab41872084246447bd8d8a6bf4f86/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 6.9.1, 6.9, 6, boron, latest
+Tags: 7.0.0, 7.0, 7, latest
+GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+Directory: 7.0
+
+Tags: 7.0.0-onbuild, 7.0-onbuild, 7-onbuild, onbuild
+GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+Directory: 7.0/onbuild
+
+Tags: 7.0.0-slim, 7.0-slim, 7-slim, slim
+GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+Directory: 7.0/slim
+
+Tags: 7.0.0-wheezy, 7.0-wheezy, 7-wheezy, wheezy
+GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+Directory: 7.0/wheezy
+
+Tags: 6.9.1, 6.9, 6, boron
 GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9
 
-Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild, onbuild
+Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
 GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/onbuild
 
-Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim, slim
+Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim
 GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/slim
 
-Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy, wheezy
+Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
 GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/wheezy
 


### PR DESCRIPTION
This adds Node.js v7.0.0 and sets it as "latest".

See:

- https://nodejs.org/en/blog/release/v7.0.0/
- https://github.com/nodejs/docker-node/issues/256