### PR TITLE
Updated Oracle Linux 7.2/latest image/tag with updates for some CVEs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,18 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@f7f8b6772d4a0667cef5be75832a42d56ff2d5e8 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/5.11


### PR DESCRIPTION
This update addresses CVE-2016-2776 (bind-libs) and updates tzdata and curl.

Signed-off-by: Avi Miller <avi.miller@oracle.com>