### PR TITLE
Reorder python import test to use gnu dbm imports instead of generic dbm

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -1,15 +1,23 @@
 import curses
-import dbm
 import readline
 
 import bz2
 assert(bz2.decompress(bz2.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
 
 import platform
-if platform.python_implementation() != 'PyPy' and platform.python_version_tuple()[0] != '2':
-    # PyPy and Python 2 don't support lzma
-    import lzma
-    assert(lzma.decompress(lzma.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
+
+isNotPypy = platform.python_implementation() != 'PyPy'
+isCaveman = platform.python_version_tuple()[0] == '2'
+
+if isCaveman:
+    import gdbm
+else:
+    import dbm.gnu
+
+    if isNotPypy:
+        # PyPy and Python 2 don't support lzma
+        import lzma
+        assert(lzma.decompress(lzma.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
 
 import zlib
 assert(zlib.decompress(zlib.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')


### PR DESCRIPTION
Re: https://github.com/docker-library/buildpack-deps/pull/49, https://github.com/docker-library/python/issues/151