### PR TITLE
Bump traefik to v1.1.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,8 +2,8 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.1.0-rc2, camembert
-GitCommit: f11e22c4b12565a12e5715e0242b8a1fae4b9dc4
+Tags: v1.1.0-rc3, camembert
+GitCommit: c806dba0c56314dc4969e1223d7e39ea183de4ac
 
 Tags: v1.0.3, reblochon, latest
 GitCommit: 9d877ca7171211aabc2955ab1a301a685f6852fe


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.1.0-rc3.
/cc @vdemeester

Cheers