### PR TITLE
Update elasticsearch 5.0.0, logstash 5.0.0 and kibana 5.0.0

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,37 +5,37 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 1.5.2, 1.5
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 1.5
 
 Tags: 1.6.2, 1.6
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 1.6
 
 Tags: 1.7.5, 1.7, 1
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.0
 
 Tags: 2.1.2, 2.1
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.1
 
 Tags: 2.2.2, 2.2
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.2
 
 Tags: 2.3.5, 2.3
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.3
 
 Tags: 2.4.1, 2.4, 2, latest
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
+GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.4
 
-Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: e9c56dda865977051c5eceea99eeb1af9ffa4408
-Directory: 5.0-rc
+Tags: 5.0.0, 5.0
+GitCommit: acd142324bdd9b4cb06a8e08bd701b340deaa02d
+Directory: 5.0

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/f5abb68ac066bfedae3822f43894cfbdbc99f4c2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/8bb7acf80ebeff0747c998fe6b2275a9cacb3a9a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -32,10 +32,10 @@ Tags: 2.3.5, 2.3
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.3
 
-Tags: 2.4.1, 2.4, 2, latest
+Tags: 2.4.1, 2.4, 2
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.4
 
-Tags: 5.0.0, 5.0
+Tags: 5.0.0, 5.0, 5, latest
 GitCommit: acd142324bdd9b4cb06a8e08bd701b340deaa02d
 Directory: 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -28,6 +28,6 @@ Tags: 4.6.2, 4.6, 4, latest
 GitCommit: 712060cfe4782cf8c0abdadb641cd038277e8541
 Directory: 4.6
 
-Tags: 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: f01982e6fd068565a79822b1ff0e82d2f3d0a4f4
+Tags: 5.0.0, 5.0, 5
+GitCommit: 01633e0abe24d669e08bd547e04983e6cd95e551
 Directory: 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/kibana/blob/1873a075ac7df4439de535c6c85b6d3e3467579a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/kibana/blob/9f2548039934ec7183c39fbd9e513820e60845d8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,10 +24,10 @@ Tags: 4.5.4, 4.5
 GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.5
 
-Tags: 4.6.2, 4.6, 4, latest
+Tags: 4.6.2, 4.6, 4
 GitCommit: 712060cfe4782cf8c0abdadb641cd038277e8541
 Directory: 4.6
 
-Tags: 5.0.0, 5.0, 5
+Tags: 5.0.0, 5.0, 5, latest
 GitCommit: 01633e0abe24d669e08bd547e04983e6cd95e551
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 1.5.6-1, 1.5.6, 1.5, 1
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 1.5
 
 Tags: 2.0.0-1, 2.0.0, 2.0
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.0
 
 Tags: 2.1.3-1, 2.1.3, 2.1
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.1
 
 Tags: 2.2.4-1, 2.2.4, 2.2
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.2
 
 Tags: 2.3.4-1, 2.3.4, 2.3
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.3
 
 Tags: 2.4.0-1, 2.4.0, 2.4, 2, latest
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.4
 
-Tags: 5.0.0-rc1-1, 5.0.0-rc1, 5.0.0, 5.0, 5
-GitCommit: e74e696dafc84ae97fa50b5341bd2126cb66d61e
+Tags: 5.0.0-1, 5.0.0, 5.0, 5
+GitCommit: 469bbf522d1b97e67171e4800847db27e9b3f26e
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/logstash/blob/cbcdf161825af8e9acb8eaa420750a397af6b169/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/logstash/blob/0f53eec1fe093f059f7bc3aa0ee1a429378a4b00/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,10 +24,10 @@ Tags: 2.3.4-1, 2.3.4, 2.3
 GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.3
 
-Tags: 2.4.0-1, 2.4.0, 2.4, 2, latest
+Tags: 2.4.0-1, 2.4.0, 2.4, 2
 GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
 Directory: 2.4
 
-Tags: 5.0.0-1, 5.0.0, 5.0, 5
+Tags: 5.0.0-1, 5.0.0, 5.0, 5, latest
 GitCommit: 469bbf522d1b97e67171e4800847db27e9b3f26e
 Directory: 5.0


### PR DESCRIPTION
PR's:
docker-library/elasticsearch/pull/128
docker-library/logstash/pull/65
docker-library/kibana/pull/62