### PR TITLE
add composer

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -1,0 +1,12 @@
+# this file was generated using https://github.com/composer/docker/blob/4ff81ce2e854771f20205afeb474bbaf00a10363/generate-manifest.sh
+
+Maintainers: Composer (@composer), Rob Bast (@alcohol)
+GitRepo: https://github.com/composer/docker.git
+
+Tags: 1.2.2, 1.2, 1, latest
+GitCommit: 703171abd9d2a83f002beaf455af725d178a5e24
+Directory: 1.2
+
+Tags: 1.1.3, 1.1
+GitCommit: 703171abd9d2a83f002beaf455af725d178a5e24
+Directory: 1.1

--- a/test/config.sh
+++ b/test/config.sh
@@ -45,6 +45,9 @@ imageTests+=(
 	'
 	[crate]='
 	'
+	[composer]='
+		composer
+	'
 	[debian]='
 		debian-apt-get
 	'

--- a/test/tests/composer/composer.json
+++ b/test/tests/composer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "composer/composer": "^1.0"
+    }
+}

--- a/test/tests/composer/container.sh
+++ b/test/tests/composer/container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+dir="$(mktemp -d)"
+
+trap "rm -rf '$dir'" EXIT
+
+cp composer.json "$dir"
+
+cd "$dir"
+
+composer --version
+composer install

--- a/test/tests/composer/run.sh
+++ b/test/tests/composer/run.sh
@@ -1,0 +1,1 @@
+../run-sh-in-container.sh


### PR DESCRIPTION
Source https://github.com/composer/docker

This image aims to supersede https://hub.docker.com/r/composer/composer/

I think I have read through all of the relevant documentation, but there is a chance I might have missed something.

Closes https://github.com/docker-library/php/issues/177
Closes https://github.com/docker-library/php/issues/260

---

I'll get working on a docs PR as soon as it looks like this submission might get accepted.
- [x] associated with or contacted upstream?
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
- [x] is it reasonably popular, or does it solve a particular use case well?
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - See docker-library/docs#750
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
