### PR TITLE
Bump version to force a rebuild

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -1,7 +1,7 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
 0.6.0: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6
-0.6: git://github.com/hashicorp/docker-vault@3d3957180d689ecddb537aa799a878171280e8a3 0.6.2
+0.6: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2
 0.6.1: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1
-0.6.2: git://github.com/hashicorp/docker-vault@3d3957180d689ecddb537aa799a878171280e8a3 0.6.2
-latest: git://github.com/hashicorp/docker-vault@3d3957180d689ecddb537aa799a878171280e8a3 0.6.2
+0.6.2: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2
+latest: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2

--- a/library/vault
+++ b/library/vault
@@ -1,7 +1,7 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
 0.6.0: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6
-0.6: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2
+0.6: git://github.com/hashicorp/docker-vault@816a1427b5c19a4f90f6939f6ed01267ac58f22a 0.6.2
 0.6.1: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1
-0.6.2: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2
-latest: git://github.com/hashicorp/docker-vault@7f2bb1991218a66ff483f9611acb885b322547f8 0.6.2
+0.6.2: git://github.com/hashicorp/docker-vault@816a1427b5c19a4f90f6939f6ed01267ac58f22a 0.6.2
+latest: git://github.com/hashicorp/docker-vault@816a1427b5c19a4f90f6939f6ed01267ac58f22a 0.6.2


### PR DESCRIPTION
We had an issue with purging our CDN to remove an old version of the 0.6.2 package and it seems when this got built it was between when we originally created the package and when the purging was fixed.

This contains no changes, but merely updates the hash to force a rebuild in order to pull the correct/final version of 0.6.2 into the container.
