### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -13,7 +13,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
 Tags: jessie, latest
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: jessie
 
 Tags: precise-curl
@@ -25,7 +25,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: precise/scm
 
 Tags: precise
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: precise
 
 Tags: sid-curl
@@ -37,7 +37,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: sid/scm
 
 Tags: sid
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: sid
 
 Tags: stretch-curl
@@ -49,7 +49,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
 Tags: stretch
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: stretch
 
 Tags: trusty-curl
@@ -61,7 +61,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: trusty/scm
 
 Tags: trusty
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: trusty
 
 Tags: wheezy-curl
@@ -73,7 +73,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: wheezy/scm
 
 Tags: wheezy
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: wheezy
 
 Tags: xenial-curl
@@ -85,5 +85,5 @@ GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
 Directory: xenial/scm
 
 Tags: xenial
-GitCommit: f1d33d5c92e1bd2aee9f2333ceb316251e6388d4
+GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
 Directory: xenial

--- a/library/celery
+++ b/library/celery
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/celery.git
 
-Tags: 4.0.0rc5, 4.0, 4
-GitCommit: e4c163e2f174f8c12a93bdf3514d7f58781ae667
+Tags: 4.0.0rc6, 4.0, 4
+GitCommit: bbd2271378003cc3c1c3c6978cdf08267d671ef0
 Directory: 4.0
 
 Tags: 3.1.24, 3.1, 3, latest

--- a/library/docker
+++ b/library/docker
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.12.2, 1.12, 1, latest
-GitCommit: a7fc73eef011c47cc2518149bc77a4b9bc7f9f41
+Tags: 1.12.3, 1.12, 1, latest
+GitCommit: 36e2107fb879d5d5c3dbb5d8d93aeef0a2d45ac8
 Directory: 1.12
 
-Tags: 1.12.2-dind, 1.12-dind, 1-dind, dind
+Tags: 1.12.3-dind, 1.12-dind, 1-dind, dind
 GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
 Directory: 1.12/dind
 
-Tags: 1.12.2-git, 1.12-git, 1-git, git
+Tags: 1.12.3-git, 1.12-git, 1-git, git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
-Tags: 1.12.2-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: a7fc73eef011c47cc2518149bc77a4b9bc7f9f41
+Tags: 1.12.3-experimental, 1.12-experimental, 1-experimental, experimental
+GitCommit: 36e2107fb879d5d5c3dbb5d8d93aeef0a2d45ac8
 Directory: 1.12/experimental
 
-Tags: 1.12.2-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+Tags: 1.12.3-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
 GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
 Directory: 1.12/experimental/dind
 
-Tags: 1.12.2-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+Tags: 1.12.3-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
 GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 

--- a/library/java
+++ b/library/java
@@ -29,7 +29,7 @@ GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
 Directory: 7-jre/alpine
 
 Tags: 8u102-jdk, 8u102, 8-jdk, 8, jdk, latest, openjdk-8u102-jdk, openjdk-8u102, openjdk-8-jdk, openjdk-8
-GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 8-jdk
 
 Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
@@ -37,7 +37,7 @@ GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jdk/alpine
 
 Tags: 8u102-jre, 8-jre, jre, openjdk-8u102-jre, openjdk-8-jre
-GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 8-jre
 
 Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine
@@ -45,9 +45,9 @@ GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
 Tags: 9-b140-jdk, 9-b140, 9-jdk, 9, openjdk-9-b140-jdk, openjdk-9-b140, openjdk-9-jdk, openjdk-9
-GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 9-jdk
 
 Tags: 9-b140-jre, 9-jre, openjdk-9-b140-jre, openjdk-9-jre
-GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 9-jre

--- a/library/kibana
+++ b/library/kibana
@@ -29,5 +29,5 @@ GitCommit: 712060cfe4782cf8c0abdadb641cd038277e8541
 Directory: 4.6
 
 Tags: 5.0.0, 5.0, 5, latest
-GitCommit: 01633e0abe24d669e08bd547e04983e6cd95e551
+GitCommit: 75cfa3c5b20eb24a319937c0f7754ad06057d843
 Directory: 5.0

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: 00fe6e767ad74cfcc0d2ea16b84e37e8f8c33146
+GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
 Directory: 8.0
 
 Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 3e89b55110565908b46ed3e1b1cae6098f464965
+GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
 Directory: 5.7
 
 Tags: 5.6.34, 5.6
-GitCommit: a03bccc7dc259d817643b0ca0bfcf7ce52ea3906
+GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: ae850f69e7414a7c28e8d364ae039fe0a0464e7a
+GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -29,7 +29,7 @@ GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
 Directory: 7-jre/alpine
 
 Tags: 8u102-jdk, 8u102, 8-jdk, 8, jdk, latest
-GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 8-jdk
 
 Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jdk/alpine
 
 Tags: 8u102-jre, 8-jre, jre
-GitCommit: baaaf7714f9c66e4c5decf2c108a2738b7186c7f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 8-jre
 
 Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
@@ -45,9 +45,9 @@ GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
 Tags: 9-b140-jdk, 9-b140, 9-jdk, 9
-GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 9-jdk
 
 Tags: 9-b140-jre, 9-jre
-GitCommit: 2e2d5c3f7ca9303b53d9d8f8ce22c0232a152d5f
+GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
 Directory: 9-jre

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.14, 5.7, 5, latest
-GitCommit: 0a7d6078d510cdb089b1d5861171f63db1e11749
+Tags: 5.7.15, 5.7, 5, latest
+GitCommit: a1660afddeb0b59365fc1fdc72d5f417ad80a11a
 Directory: 5.7
 
 Tags: 5.6.33, 5.6

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.15, 5.7, 5, latest
-GitCommit: a1660afddeb0b59365fc1fdc72d5f417ad80a11a
+GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
 Directory: 5.7
 
 Tags: 5.6.33, 5.6
-GitCommit: 45344545c0529281a33bf8d4cbf2284974aa6582
+GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
 Directory: 5.6
 
 Tags: 5.5.52, 5.5
-GitCommit: 78efeda42ab5be066c5e7c740fe206c5a3ceb245
+GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.0RC4-cli, 7.1-rc-cli, rc-cli, 7.1.0RC4, 7.1-rc, rc
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-cli, 7.1-rc-cli, rc-cli, 7.1.0RC5, 7.1-rc, rc
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc
 
-Tags: 7.1.0RC4-alpine, 7.1-rc-alpine, rc-alpine
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-alpine, 7.1-rc-alpine, rc-alpine
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/alpine
 
-Tags: 7.1.0RC4-apache, 7.1-rc-apache, rc-apache
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-apache, 7.1-rc-apache, rc-apache
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/apache
 
-Tags: 7.1.0RC4-fpm, 7.1-rc-fpm, rc-fpm
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-fpm, 7.1-rc-fpm, rc-fpm
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/fpm
 
-Tags: 7.1.0RC4-fpm-alpine, 7.1-rc-fpm-alpine, rc-fpm-alpine
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-fpm-alpine, 7.1-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/fpm/alpine
 
-Tags: 7.1.0RC4-zts, 7.1-rc-zts, rc-zts
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-zts, 7.1-rc-zts, rc-zts
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/zts
 
-Tags: 7.1.0RC4-zts-alpine, 7.1-rc-zts-alpine, rc-zts-alpine
-GitCommit: 1c798c1d1775be867bbbaad43c7c82d94dd60340
+Tags: 7.1.0RC5-zts-alpine, 7.1-rc-zts-alpine, rc-zts-alpine
+GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
 Directory: 7.1-rc/zts/alpine
 
 Tags: 7.0.12-cli, 7.0-cli, 7-cli, cli, 7.0.12, 7.0, 7, latest

--- a/library/piwik
+++ b/library/piwik
@@ -1,5 +1,5 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 2.16.5, 2.16, 2, latest
-GitCommit: 93ad1ed911e037431200e361f9735ea8a2a44c26
+Tags: 2.17.0, 2.17, 2, latest
+GitCommit: 555a9ee606bf7cb702e8b01cdf1fceaaf8a03a89

--- a/library/postgres
+++ b/library/postgres
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 9.6.0, 9.6, 9, latest
-GitCommit: b2317dd369030a5f3f030b1daa1fc80da3cab9e0
+Tags: 9.6.1, 9.6, 9, latest
+GitCommit: e4942cb0f79b61024963dc0ac196375b26fa60dd
 Directory: 9.6
 
-Tags: 9.5.4, 9.5
-GitCommit: 1c0bc9d905d569fead777b9b8e3836e8af1c394c
+Tags: 9.5.5, 9.5
+GitCommit: db63c8c4eff2aa81c3f2c9e42f1ede447c7cf99c
 Directory: 9.5
 
-Tags: 9.4.9, 9.4
-GitCommit: fc36c25f8ac352f1fea6d0e7cf8d9bd92a4e720f
+Tags: 9.4.10, 9.4
+GitCommit: 56b1a0c47ae8361eca133e41c6ddd68ad492ac2d
 Directory: 9.4
 
-Tags: 9.3.14, 9.3
-GitCommit: fc36c25f8ac352f1fea6d0e7cf8d9bd92a4e720f
+Tags: 9.3.15, 9.3
+GitCommit: 570ca9e8ea81cb6da73ea765132755f277cd0b66
 Directory: 9.3
 
-Tags: 9.2.18, 9.2
-GitCommit: fc36c25f8ac352f1fea6d0e7cf8d9bd92a4e720f
+Tags: 9.2.19, 9.2
+GitCommit: c01405b7c324350cc796ba9e861326aee158f75e
 Directory: 9.2
 
-Tags: 9.1.23, 9.1
-GitCommit: fc36c25f8ac352f1fea6d0e7cf8d9bd92a4e720f
+Tags: 9.1.24, 9.1
+GitCommit: 2df7c179897a4a0c5dbb5a68543e46fb77215067
 Directory: 9.1

--- a/library/python
+++ b/library/python
@@ -9,7 +9,7 @@ GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
@@ -34,11 +34,11 @@ GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
@@ -54,11 +54,11 @@ GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
@@ -74,11 +74,11 @@ GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
@@ -95,11 +95,11 @@ GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
 Directory: 3.6
 
 Tags: 3.6.0b2-slim, 3.6-slim
-GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
+GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
 Directory: 3.6/slim
 
 Tags: 3.6.0b2-alpine, 3.6-alpine
-GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
+GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
 Directory: 3.6/alpine
 
 Tags: 3.6.0b2-onbuild, 3.6-onbuild

--- a/library/redis
+++ b/library/redis
@@ -16,14 +16,14 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
 Directory: 3.0/alpine
 
-Tags: 3.2.4, 3.2, 3, latest
-GitCommit: a38166e6f3430512ba8ce2cb5ebd889ee17b9dc4
+Tags: 3.2.5, 3.2, 3, latest
+GitCommit: 54ec6b70a3afd6ec62a6549621c5ca1053ece7f5
 Directory: 3.2
 
-Tags: 3.2.4-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: a38166e6f3430512ba8ce2cb5ebd889ee17b9dc4
+Tags: 3.2.5-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 54ec6b70a3afd6ec62a6549621c5ca1053ece7f5
 Directory: 3.2/32bit
 
-Tags: 3.2.4-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: a38166e6f3430512ba8ce2cb5ebd889ee17b9dc4
+Tags: 3.2.5-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 54ec6b70a3afd6ec62a6549621c5ca1053ece7f5
 Directory: 3.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.43.0, 0.43, 0, latest
-GitCommit: 8d67a13917b7fd6010c1a8f44c59da0f2f0a9555
+Tags: 0.44.0, 0.44, 0, latest
+GitCommit: 8683d484e8b09560dbf84ddce22002062ab97a18

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
+GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
+GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: e383b900db2f146d9436e08f7600e9eca9da7a44
+GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
+GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
+GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 9d92435da503a0cba5428e79bd27d4ba64237499
+GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
+GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
+GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: c4ccc4477f0f0d0a2ecf58c7696b97ebb25b5bf1
+GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.47-jre7, 6.0-jre7, 6-jre7, 6.0.47, 6.0, 6
-GitCommit: f4c146bcc2f16fd1d2919a392adb46c737851dc9
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 6/jre7
 
 Tags: 6.0.47-jre8, 6.0-jre8, 6-jre8
-GitCommit: f4c146bcc2f16fd1d2919a392adb46c737851dc9
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre8-alpine
 
 Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.0/jre7
 
 Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.0/jre8
 
 Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.5/jre8
 
 Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
@@ -53,7 +53,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine


### PR DESCRIPTION
- `buildpack-deps`: add `libgdbm-dev` (docker-library/buildpack-deps#49)
- `celery`: 4.0.0rc6
- `docker`: 1.12.3
- `java`: switch from `httpredir.debian.org` to `deb.debian.org`
- `kibana`: remove obsolete comments
- `mysql`: add `-hlocalhost` during init to avoid `MYSQL_HOST` interference (docker-library/mysql#222)
- `openjdk`: switch from `httpredir.debian.org` to `deb.debian.org`
- `percona`: 5.7.15-9-1.jessie
- `php`: 7.1.0RC5
- `piwik`: 2.17.0
- `postgres`: 9.1.24-1.pgdg80+1, 9.2.19-1.pgdg80+1, 9.3.15-1.pgdg80+1, 9.4.10-1.pgdg80+1, 9.5.5-1.pgdg80+1, 9.6.1-1.pgdg80+1
- `python`: add `gdbm-dev` to `slim` and `alpine` (docker-library/python#153)
- `redis`: 3.2.5
- `rocket.chat`: 0.44.0
- `ruby`: bundler 1.13.6
- `tomcat`: switch from `httpredir.debian.org` to `deb.debian.org`
