### PR TITLE
Odoo - add 10.0, update releases to 20161025

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,8 +1,11 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@b3d55d295954fed2c6101854f1b133340c05c767 8.0
-8: git://github.com/odoo/docker@b3d55d295954fed2c6101854f1b133340c05c767 8.0
+8.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 8.0
+8: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 8.0
 
-9.0: git://github.com/odoo/docker@b3d55d295954fed2c6101854f1b133340c05c767 9.0
-9: git://github.com/odoo/docker@b3d55d295954fed2c6101854f1b133340c05c767 9.0
-latest: git://github.com/odoo/docker@b3d55d295954fed2c6101854f1b133340c05c767 9.0
+9.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 9.0
+9: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 9.0
+
+10.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0
+10: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0
+latest: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0


### PR DESCRIPTION
Hello,

This is an update including Odoo version 10.0 and new official release 20161025 for older versions 8.0 and 9.0. I hope this can be pulled. Thanks!
