### PR TITLE
Updates to java, mariadb, openjdk, ruby

### DIFF
--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b140-jdk, 9-b140, 9-jdk, 9, openjdk-9-b140-jdk, openjdk-9-b140, openjdk-9-jdk, openjdk-9
-GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
+Tags: 9-b142-jdk, 9-b142, 9-jdk, 9, openjdk-9-b142-jdk, openjdk-9-b142, openjdk-9-jdk, openjdk-9
+GitCommit: dcb22f5eecaaa99a29a3607b2c36a60632af23f9
 Directory: 9-jdk
 
-Tags: 9-b140-jre, 9-jre, openjdk-9-b140-jre, openjdk-9-jre
-GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
+Tags: 9-b142-jre, 9-jre, openjdk-9-b142-jre, openjdk-9-jre
+GitCommit: dcb22f5eecaaa99a29a3607b2c36a60632af23f9
 Directory: 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.1.18, 10.1, 10, latest
 GitCommit: 92e16504a8e9840eb70937aa2da76f38ea002718
 Directory: 10.1
 
-Tags: 10.0.27, 10.0
-GitCommit: df62c40869408e757055ccac1141ba363ef82796
+Tags: 10.0.28, 10.0
+GitCommit: c9f0360d841db8bbb0c99d1e84059f05de3faf9e
 Directory: 10.0
 
 Tags: 5.5.53, 5.5, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b140-jdk, 9-b140, 9-jdk, 9
-GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
+Tags: 9-b142-jdk, 9-b142, 9-jdk, 9
+GitCommit: dcb22f5eecaaa99a29a3607b2c36a60632af23f9
 Directory: 9-jdk
 
-Tags: 9-b140-jre, 9-jre
-GitCommit: bbb7c0995d9ab0ffec987f02f515862925553d5e
+Tags: 9-b142-jre, 9-jre
+GitCommit: dcb22f5eecaaa99a29a3607b2c36a60632af23f9
 Directory: 9-jre

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
+GitCommit: ef8c21b5ed1f994ff080e21f02551cdf03b396c9
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
+GitCommit: ef8c21b5ed1f994ff080e21f02551cdf03b396c9
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: 48938c4878ec6f292a869f959f3b374bf8309c90
+GitCommit: ef8c21b5ed1f994ff080e21f02551cdf03b396c9
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.5, 2.2
-GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
+GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
 Directory: 2.2
 
 Tags: 2.2.5-slim, 2.2-slim
-GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
+GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
 Directory: 2.2/slim
 
 Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: d97ab7b9a91aa5b6fa6049d7d50a23e9ab612d29
+GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
 Directory: 2.2/alpine
 
 Tags: 2.2.5-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.1, 2.3, 2, latest
-GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
+GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
 Directory: 2.3
 
 Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
+GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
 Directory: 2.3/slim
 
 Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: 06c30ea7d755d291a8cd458dbdb1c33c090a6136
+GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
 Directory: 2.3/alpine
 
 Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
 - `java` bump to debian `9~b142-1`
 - `mariadb` bump to version `10.0.28+maria-1~jessie`
 - `openjdk` bump to debian `9~b142-1`
 - `ruby` bump rubygems to `2.6.8`