### PR TITLE
Update docker-library images

### DIFF
--- a/library/django
+++ b/library/django
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/django.git
 
-Tags: 1.10.2-python3, 1.10-python3, 1-python3, python3, 1.10.2, 1.10, 1, latest
-GitCommit: 55ed1a6140b7152aa96a230ddb4d5a1f45fa6e52
+Tags: 1.10.3-python3, 1.10-python3, 1-python3, python3, 1.10.3, 1.10, 1, latest
+GitCommit: 642cc5e4ccdc2f706d445b072ebc6c4193e22c10
 Directory: 3.4
 
 Tags: python3-onbuild, onbuild
 GitCommit: 4fe080675e4a85ef6ee25c811e9d3d3ef0905794
 Directory: 3.4/onbuild
 
-Tags: 1.10.2-python2, 1.10-python2, 1-python2, python2
-GitCommit: 55ed1a6140b7152aa96a230ddb4d5a1f45fa6e52
+Tags: 1.10.3-python2, 1.10-python2, 1-python2, python2
+GitCommit: 642cc5e4ccdc2f706d445b072ebc6c4193e22c10
 Directory: 2.7
 
 Tags: python2-onbuild

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.32, 1.4, 1, latest
-GitCommit: 3ce070556c87bb1c9e745f5596bd54e39a3f4065
+Tags: 1.4.33, 1.4, 1, latest
+GitCommit: 137391b8166fd61c12bc54098350181d7da378f0
 Directory: debian
 
-Tags: 1.4.32-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 3ce070556c87bb1c9e745f5596bd54e39a3f4065
+Tags: 1.4.33-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 137391b8166fd61c12bc54098350181d7da378f0
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ GitCommit: fc91d681fa5808c30c3118ce7fe3f993beccc82d
 Directory: 2.6
 
 Tags: 3.0.13, 3.0
-GitCommit: 3ef57d04d5ee528a01c3578b908e90b4177e74e9
+GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.0
 
 Tags: 3.0.13-windowsservercore, 3.0-windowsservercore
@@ -18,7 +18,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.10, 3.2, 3, latest
-GitCommit: 368cc7355471feba3071a4e0b7e44edf61401213
+GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.2
 
 Tags: 3.2.10-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
@@ -27,7 +27,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.15, 3.3
-GitCommit: 944c44b6304ab387e4640fddaa808bc93f32b176
+GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.3
 
 Tags: 3.3.15-windowsservercore, 3.3-windowsservercore
@@ -36,7 +36,7 @@ Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.0-rc2, 3.4.0, 3.4, 3.4-rc
-GitCommit: ec80a4a2218babddb8b572209e45841b96c1954c
+GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.4-rc
 
 Tags: 3.4.0-rc2-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore

--- a/library/mongo
+++ b/library/mongo
@@ -8,12 +8,12 @@ Tags: 2.6.12, 2.6, 2
 GitCommit: fc91d681fa5808c30c3118ce7fe3f993beccc82d
 Directory: 2.6
 
-Tags: 3.0.12, 3.0
-GitCommit: 4b1d085ccab5728a9b9e4b65c5ed19820420809e
+Tags: 3.0.13, 3.0
+GitCommit: 3ef57d04d5ee528a01c3578b908e90b4177e74e9
 Directory: 3.0
 
-Tags: 3.0.12-windowsservercore, 3.0-windowsservercore
-GitCommit: 89549b2b779421c057b04858477012b7aa17f498
+Tags: 3.0.13-windowsservercore, 3.0-windowsservercore
+GitCommit: 3ef57d04d5ee528a01c3578b908e90b4177e74e9
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -33,4 +33,13 @@ Directory: 3.3
 Tags: 3.3.15-windowsservercore, 3.3-windowsservercore
 GitCommit: 944c44b6304ab387e4640fddaa808bc93f32b176
 Directory: 3.3/windows/windowsservercore
+Constraints: windowsservercore
+
+Tags: 3.4.0-rc2, 3.4.0, 3.4, 3.4-rc
+GitCommit: ec80a4a2218babddb8b572209e45841b96c1954c
+Directory: 3.4-rc
+
+Tags: 3.4.0-rc2-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore
+GitCommit: ec80a4a2218babddb8b572209e45841b96c1954c
+Directory: 3.4-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
+GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
 Directory: 8.0
 
 Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
+GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
 Directory: 5.7
 
 Tags: 5.6.34, 5.6
-GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
+GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
 Directory: 5.6
 
 Tags: 5.5.53, 5.5

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.44.0, 0.44, 0, latest
-GitCommit: 8683d484e8b09560dbf84ddce22002062ab97a18
+Tags: 0.45.0, 0.45, 0, latest
+GitCommit: b457541d09b371f4def66d2e4615b8cc67c13f3e


### PR DESCRIPTION
- `django`: 1.10.3
- `memcached`: 1.4.33
- `mongo`: 3.0.13, 3.4.0-rc2
- `mysql`: introduce `docker.cnf` for docker-specific `my.cnf` additions (docker-library/mysql#232)
- `rocket.chat`: 0.45.0