### PR TITLE
version bump: otp-19.1.5

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -3,15 +3,15 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-Tags: 19.1, 19, latest
-GitCommit: 9be249effe93e3c61fa0749078e55ef8d050a16e
+Tags: 19.1.5, 19.1, 19, latest
+GitCommit: 5e1399b65a48c81595b5ec58b0e3f70444c3067f
 Directory: 19
 
-Tags: 19.1-slim, 19-slim, slim
-GitCommit: 9be249effe93e3c61fa0749078e55ef8d050a16e
+Tags: 19.1.5-slim, 19.1-slim, 19-slim, slim
+GitCommit: 5e1399b65a48c81595b5ec58b0e3f70444c3067f
 Directory: 19/slim
 
-Tags: 19.1-onbuild, 19-onbuild, onbuild
+Tags: 19.1.5-onbuild, 19.1-onbuild, 19-onbuild, onbuild
 GitCommit: 9be249effe93e3c61fa0749078e55ef8d050a16e
 Directory: 19/onbuild
 


### PR DESCRIPTION
from https://github.com/c0b/docker-erlang-otp/pull/27#issuecomment-257760510