### PR TITLE
Update Debian, especially for CVE-2016-6321 (tar extract pathname bypass)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -3,72 +3,72 @@ Maintainers: Tianon Gravi <tianon@debian.org> (@tianon),
 GitRepo: https://github.com/tianon/docker-brew-debian.git
 
 # commits: (master..dist-stable)
-#  - 5f84ff7 2016-10-20 debootstraps
+#  - 9639ba6 2016-11-02 debootstraps
 
 # commits: (master..dist-unstable)
-#  - 42df304 2016-10-17 debootstraps
+#  - 424fa20 2016-11-02 debootstraps
 
 # commits: (master..dist-oldstable)
-#  - dc2ade4 2016-10-20 debootstraps
+#  - a80c27b 2016-11-02 debootstraps
 
 Tags: 8.6, 8, jessie, latest
 GitFetch: refs/heads/dist-stable
-GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
+GitCommit: 9639ba69fb9e0c7bdc9d751087cb2e181d077b15
 Directory: jessie
 
 Tags: jessie-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
+GitCommit: 9639ba69fb9e0c7bdc9d751087cb2e181d077b15
 Directory: jessie/backports
 
 Tags: oldstable
 GitFetch: refs/heads/dist-oldstable
-GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
+GitCommit: a80c27bc779be7452e39b7a7d5e075bea2c3805d
 Directory: oldstable
 
 Tags: oldstable-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
+GitCommit: a80c27bc779be7452e39b7a7d5e075bea2c3805d
 Directory: oldstable/backports
 
 Tags: sid
 GitFetch: refs/heads/dist-unstable
-GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
+GitCommit: 424fa20308a692148a83b55d3c4bb9bafbdac642
 Directory: sid
 
 Tags: stable
 GitFetch: refs/heads/dist-stable
-GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
+GitCommit: 9639ba69fb9e0c7bdc9d751087cb2e181d077b15
 Directory: stable
 
 Tags: stable-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 5f84ff77365de2ee50655978edad2ba5004c1321
+GitCommit: 9639ba69fb9e0c7bdc9d751087cb2e181d077b15
 Directory: stable/backports
 
 Tags: stretch
 GitFetch: refs/heads/dist-unstable
-GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
+GitCommit: 424fa20308a692148a83b55d3c4bb9bafbdac642
 Directory: stretch
 
 Tags: testing
 GitFetch: refs/heads/dist-unstable
-GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
+GitCommit: 424fa20308a692148a83b55d3c4bb9bafbdac642
 Directory: testing
 
 Tags: unstable
 GitFetch: refs/heads/dist-unstable
-GitCommit: 42df3048e98cdd2f849abab65a29719ae6189923
+GitCommit: 424fa20308a692148a83b55d3c4bb9bafbdac642
 Directory: unstable
 
 Tags: 7.11, 7, wheezy
 GitFetch: refs/heads/dist-oldstable
-GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
+GitCommit: a80c27bc779be7452e39b7a7d5e075bea2c3805d
 Directory: wheezy
 
 Tags: wheezy-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: dc2ade4473b0bc2c1664c2e2636a9c494709333b
+GitCommit: a80c27bc779be7452e39b7a7d5e075bea2c3805d
 Directory: wheezy/backports
 
 # sid + rc-buggy


### PR DESCRIPTION
https://security-tracker.debian.org/tracker/CVE-2016-6321