### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,10 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 1.5.2, 1.5
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
-Directory: 1.5
-
 Tags: 1.6.2, 1.6
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 1.6

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.2, 0.11, 0, latest
-GitCommit: 66c839be52f64d771968fff0262ebf94ff2f2886
+Tags: 0.11.3, 0.11, 0, latest
+GitCommit: 9e9522838f378c6c4acaf87a5fabaceab34cd2e0

--- a/library/mongo
+++ b/library/mongo
@@ -1,12 +1,8 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/89549b2b779421c057b04858477012b7aa17f498/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/3dfba3285da24f724b4b8d51f8db54769ed323e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
-
-Tags: 2.6.12, 2.6, 2
-GitCommit: fc91d681fa5808c30c3118ce7fe3f993beccc82d
-Directory: 2.6
 
 Tags: 3.0.13, 3.0
 GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
@@ -26,20 +22,20 @@ GitCommit: 368cc7355471feba3071a4e0b7e44edf61401213
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.15, 3.3
+Tags: 3.3.15, 3.3, unstable
 GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.3
 
-Tags: 3.3.15-windowsservercore, 3.3-windowsservercore
+Tags: 3.3.15-windowsservercore, 3.3-windowsservercore, unstable-windowsservercore
 GitCommit: 944c44b6304ab387e4640fddaa808bc93f32b176
 Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.0-rc2, 3.4.0, 3.4, 3.4-rc
+Tags: 3.4.0-rc2, 3.4.0, 3.4, 3.4-rc, rc
 GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.4-rc
 
-Tags: 3.4.0-rc2-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore
+Tags: 3.4.0-rc2-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
 GitCommit: ec80a4a2218babddb8b572209e45841b96c1954c
 Directory: 3.4-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/postgres
+++ b/library/postgres
@@ -23,7 +23,3 @@ Directory: 9.3
 Tags: 9.2.19, 9.2
 GitCommit: c01405b7c324350cc796ba9e861326aee158f75e
 Directory: 9.2
-
-Tags: 9.1.24, 9.1
-GitCommit: 2df7c179897a4a0c5dbb5a68543e46fb77215067
-Directory: 9.1


### PR DESCRIPTION
- `elasticsearch`: remove 1.5 (EOL, 2016-09-23, https://www.elastic.co/support/eol)
- `ghost`: 0.11.3
- `mongo`: add more aliases (docker-library/mongo#119), remove 2.6 (EOL, October 2016, https://www.mongodb.com/support-policy)
- `postgres`: remove 9.1 (EOL, September 2016, https://www.postgresql.org/support/versioning/)