### PR TITLE
Odoo - 20161103 releases, environment variables refactoring

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,11 +1,11 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 8.0
-8: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 8.0
+8.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 8.0
+8: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 8.0
 
-9.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 9.0
-9: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 9.0
+9.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 9.0
+9: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 9.0
 
-10.0: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0
-10: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0
-latest: git://github.com/odoo/docker@6da3a1848f302d7c019b2bda44cd662ace304d97 10.0
+10.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0
+10: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0
+latest: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0


### PR DESCRIPTION
This upgrade brings a refactoring of the use of environment variables
in order to allow the use of docker compose and to workaround some
issues with the postgresql connection. We also update the Odoo codebase
to the 20161103 version.

Revision [1] allows to link Odoo with a non-linked postgres container by
checking new environment variables defining the credentials if the linked
ones aren't present. Along revision [2], they define new default values
for these credentials, allowing to write a short docker-compose.yml.

We also discovered issues in the Odoo codebase with the use of the PG*
environment variables in order to connect to the postgresql host. This
is explained in [3]. These issues aren't fixable due do our stable
policy, so we decided to not rely on them but instead to pass the
postgresql credentials to odoo as argument. In this case, everything is
working as expected. This is done in [4] and [5].

More informations are available on the commit themselves. These changes
should be backward compatibles.

[1] https://github.com/odoo/docker/commit/9621c46392924e46e6ddd20c7c2da6429dbba624
[2] https://github.com/odoo/docker/commit/13fba407e1e2cbd192760298f160f8f0f6f5665d
[3] https://github.com/odoo/docker/pull/74#issuecomment-256956274
[4] https://github.com/odoo/docker/commit/a3d207f2d49c3a0eb0e959fbf2cb33909c382a3f
[5] https://github.com/odoo/docker/commit/ab612f290f3a802a617b66a308c179fb1b0fc1f9