### PR TITLE
Update for Node.js Docker images: Add a non-root "node" user

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,7 +4,7 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.0.0, 7.0, 7, latest
-GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 7.0
 
 Tags: 7.0.0-onbuild, 7.0-onbuild, 7-onbuild, onbuild
@@ -12,15 +12,15 @@ GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
 Directory: 7.0/onbuild
 
 Tags: 7.0.0-slim, 7.0-slim, 7-slim, slim
-GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 7.0/slim
 
 Tags: 7.0.0-wheezy, 7.0-wheezy, 7-wheezy, wheezy
-GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 7.0/wheezy
 
 Tags: 6.9.1, 6.9, 6, boron
-GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 6.9
 
 Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
@@ -28,15 +28,15 @@ GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/onbuild
 
 Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 6.9/slim
 
 Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 6.9/wheezy
 
 Tags: 4.6.1, 4.6, 4, argon
-GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 4.6
 
 Tags: 4.6.1-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
@@ -44,15 +44,15 @@ GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
 Directory: 4.6/onbuild
 
 Tags: 4.6.1-slim, 4.6-slim, 4-slim, argon-slim
-GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 4.6/slim
 
 Tags: 4.6.1-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
-GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 4.6/wheezy
 
 Tags: 0.12.17, 0.12, 0
-GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.12
 
 Tags: 0.12.17-onbuild, 0.12-onbuild, 0-onbuild
@@ -60,15 +60,15 @@ GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12/onbuild
 
 Tags: 0.12.17-slim, 0.12-slim, 0-slim
-GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.12/slim
 
 Tags: 0.12.17-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.12/wheezy
 
 Tags: 0.10.48, 0.10
-GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.10
 
 Tags: 0.10.48-onbuild, 0.10-onbuild
@@ -76,10 +76,10 @@ GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
 Directory: 0.10/onbuild
 
 Tags: 0.10.48-slim, 0.10-slim
-GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.10/slim
 
 Tags: 0.10.48-wheezy, 0.10-wheezy
-GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
+GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.10/wheezy
 


### PR DESCRIPTION
This is for an update where all the Docker Node.js images now have an non-root "node" user added.

See: 

- https://github.com/nodejs/docker-node/pull/258
- https://github.com/nodejs/docker-node/pull/261