### PR TITLE
Add Amazon Linux base image (2016.09.0.20161028)

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,0 +1,12 @@
+Maintainers: Amazon Linux Team <amazon-linux-ami@amazon.com> (@aws),
+             Ian Weller (@ianweller),
+             Praveen K Paladugu (@praveen-pk)
+GitRepo: https://github.com/aws/amazon-linux-docker-images.git
+
+Tags: 2016.09.0.20161028, 2016.09, latest
+GitFetch: refs/heads/2016.09
+GitCommit: 6f395b3e97b9adfb1f1a304f09be26fa77d79858
+
+Tags: 2016.09.0.20161028-with-sources, 2016.09-with-sources, with-sources
+GitFetch: refs/heads/2016.09-with-sources
+GitCommit: d2b4eaf7fd80f410f65ad8bd5c3392196ba330db


### PR DESCRIPTION
Hello from the Amazon Linux team! :)

On Tuesday we launched Amazon Linux container images available in the EC2 Container Registry. We're hoping to also be able to get the same images added to the official library.

Currently, the git repository where the image is stored is private. We're looking to make it public as soon as it's possible from our end. In the meantime, @tianon has let me know of the usernames needed to be added to read the repository.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
  - https://github.com/aws
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/issues/742
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
