### PR TITLE
upgrade r-base to R 3.3.2 released last Monday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.3.1: git://github.com/rocker-org/rocker@118be9ab285173237441836d84bab714c0920cca r-base
-latest: git://github.com/rocker-org/rocker@118be9ab285173237441836d84bab714c0920cca r-base
+3.3.2: git://github.com/rocker-org/rocker@b2cdaad0026645c6cb3ed78f460042ed2197449a r-base
+latest: git://github.com/rocker-org/rocker@b2cdaad0026645c6cb3ed78f460042ed2197449a r-base


### PR DESCRIPTION
just another R minor release update which came out last Monday, which I pushed to Debian last Monday, which is now in Debian testing -- and which has worked for us as rocker/r-base as well