### PR TITLE
Updated Oracle Linux 6.8 image to patch CVE-2016-6313

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,18 +1,18 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
-7: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
-7.2: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/7.2
+7: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/7.2
+7.2: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@fcfe1626a9a66f13845cde0bb830e15a251d5aad OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@92965f8b3296d5b236656f49c0e97aa1c59d46dc OracleLinux/5.11


### PR DESCRIPTION
http://linux.oracle.com/errata/ELSA-2016-2674.html

[1.4.5-12]
- fix CVE-2016-6313 - predictable PRNG output (#1366105)

Signed-off-by: Avi Miller <avi.miller@oracle.com>