### PR TITLE
Update for Node.js v7.1.0 and v4.6.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,23 +1,23 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/056200187f0ab41872084246447bd8d8a6bf4f86/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/655aea9585318c5a0509fa673f989c3b7d9df7ee/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.0.0, 7.0, 7, latest
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 7.0
+Tags: 7.1.0, 7.1, 7, latest
+GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
+Directory: 7.1
 
-Tags: 7.0.0-onbuild, 7.0-onbuild, 7-onbuild, onbuild
-GitCommit: 056200187f0ab41872084246447bd8d8a6bf4f86
-Directory: 7.0/onbuild
+Tags: 7.1.0-onbuild, 7.1-onbuild, 7-onbuild, onbuild
+GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
+Directory: 7.1/onbuild
 
-Tags: 7.0.0-slim, 7.0-slim, 7-slim, slim
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 7.0/slim
+Tags: 7.1.0-slim, 7.1-slim, 7-slim, slim
+GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
+Directory: 7.1/slim
 
-Tags: 7.0.0-wheezy, 7.0-wheezy, 7-wheezy, wheezy
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 7.0/wheezy
+Tags: 7.1.0-wheezy, 7.1-wheezy, 7-wheezy, wheezy
+GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
+Directory: 7.1/wheezy
 
 Tags: 6.9.1, 6.9, 6, boron
 GitCommit: b18c441de44515015f7670d7be0186503ae156ec
@@ -35,20 +35,20 @@ Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
 GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 6.9/wheezy
 
-Tags: 4.6.1, 4.6, 4, argon
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+Tags: 4.6.2, 4.6, 4, argon
+GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
 Directory: 4.6
 
-Tags: 4.6.1-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
-GitCommit: a37f33d34909d9e700b2875c684b8e728b236dc4
+Tags: 4.6.2-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
 Directory: 4.6/onbuild
 
-Tags: 4.6.1-slim, 4.6-slim, 4-slim, argon-slim
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+Tags: 4.6.2-slim, 4.6-slim, 4-slim, argon-slim
+GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
 Directory: 4.6/slim
 
-Tags: 4.6.1-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+Tags: 4.6.2-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
 Directory: 4.6/wheezy
 
 Tags: 0.12.17, 0.12, 0


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.1.0/
- https://nodejs.org/en/blog/release/v4.6.2/
- https://github.com/nodejs/docker-node/issues/265
- https://github.com/nodejs/docker-node/pull/266