### PR TITLE
Add an Alpine variant for Node.js docker images

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,8 +4,12 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.1.0, 7.1, 7, latest
-GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
 Directory: 7.1
+
+Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+Directory: 7.1/alpine
 
 Tags: 7.1.0-onbuild, 7.1-onbuild, 7-onbuild, onbuild
 GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
@@ -20,8 +24,12 @@ GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
 Directory: 7.1/wheezy
 
 Tags: 6.9.1, 6.9, 6, boron
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
 Directory: 6.9
+
+Tags: 6.9.1-alpine, 6.9-alpine, 6-alpine, boron-alpine
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+Directory: 6.9/alpine
 
 Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
 GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
@@ -36,8 +44,12 @@ GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 6.9/wheezy
 
 Tags: 4.6.2, 4.6, 4, argon
-GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
 Directory: 4.6
+
+Tags: 4.6.2-alpine, 4.6-alpine, 4-alpine, argon-alpine
+GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+Directory: 4.6/alpine
 
 Tags: 4.6.2-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
 GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8


### PR DESCRIPTION
Note that this only adds an Alpine variant for the v7, v6 and v4
versions. The v0.10 and v0.12 releases are either EOL or will be later
this year and will no longer be updated.

Reference:

- https://github.com/nodejs/docker-node/pull/156
- https://github.com/nodejs/docker-node/issues/46