### PR TITLE
Removed unsupported Docker image versions for Consul.

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -2,6 +2,3 @@
 
 latest: git://github.com/hashicorp/docker-consul@2c2873f9d619220d1eef0bc46ec78443f55a10b5 0.X
 0.7.1: git://github.com/hashicorp/docker-consul@2c2873f9d619220d1eef0bc46ec78443f55a10b5 0.X
-0.7.0: git://github.com/hashicorp/docker-consul@470868df3885ad93f45a2c63c648bf119a544fa4 0.X
-v0.7.0: git://github.com/hashicorp/docker-consul@470868df3885ad93f45a2c63c648bf119a544fa4 0.X
-v0.6.4: git://github.com/hashicorp/docker-consul@9a59dc1a87adc164b72ac67bc9e4364a3fc4138d 0.6


### PR DESCRIPTION
Removing images we no longer intend to update per https://github.com/docker-library/official-images/pull/2336#discussion_r87662974. These should remain in Docker Hub but we will never release any updates to them.