### PR TITLE
Update mongo-express to version 0.32.0

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.31.5: git://github.com/mongo-express/mongo-express-docker@74a6862ded6e8827da9677e60d5b1910f40e9a45
-0.31: git://github.com/mongo-express/mongo-express-docker@74a6862ded6e8827da9677e60d5b1910f40e9a45
-latest: git://github.com/mongo-express/mongo-express-docker@74a6862ded6e8827da9677e60d5b1910f40e9a45
+0.32.0: git://github.com/mongo-express/mongo-express-docker@b080000a8c03ef81455fa6aca8c0c8d1a35ef365
+0.32: git://github.com/mongo-express/mongo-express-docker@b080000a8c03ef81455fa6aca8c0c8d1a35ef365
+latest: git://github.com/mongo-express/mongo-express-docker@b080000a8c03ef81455fa6aca8c0c8d1a35ef365


### PR DESCRIPTION
This mongo-express update includes the following updates:

* Support MongoDB replica sets through the command line
* Implement index management
* Implement export as csv
* Allow hex string in place of ObjectID in search field
* Run code through eslint
* Fix spelling mistakes

https://github.com/mongo-express/mongo-express-docker/commit/b080000a8c03ef81455fa6aca8c0c8d1a35ef365