### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,8 +3,8 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.0, 4.4, 4, latest
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+Tags: 4.4.5, 4.4, 4, latest
+GitCommit: d3283a47fbb92419b7b6fc1fccd30b95d75e9ab6
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/cassandra
+++ b/library/cassandra
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.16, 2.1
-GitCommit: 3204fb896811b4d20527b8d4a509d65189fd6913
+GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
 Directory: 2.1
 
 Tags: 2.2.8, 2.2, 2
-GitCommit: ef57ef961003e27469b86178f0b4d184bb64d82e
+GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
 Directory: 2.2
 
 Tags: 3.0.9, 3.0
-GitCommit: ef57ef961003e27469b86178f0b4d184bb64d82e
+GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
 Directory: 3.0
 
 Tags: 3.9, 3, latest
-GitCommit: ce8566d1ce825d2d0e16b2b0b76befed1defe62c
+GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
 Directory: 3.9

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjd
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b143-jdk, 9-b143, 9-jdk, 9, openjdk-9-b143-jdk, openjdk-9-b143, openjdk-9-jdk, openjdk-9
-GitCommit: c5febc686f445910ce2075d8b2434c7ec23ffc6c
+Tags: 9-b144-jdk, 9-b144, 9-jdk, 9, openjdk-9-b144-jdk, openjdk-9-b144, openjdk-9-jdk, openjdk-9
+GitCommit: a2d46845f90bd841871419063cf12ebe4c2e2b72
 Directory: 9-jdk
 
-Tags: 9-b143-jre, 9-jre, openjdk-9-b143-jre, openjdk-9-jre
-GitCommit: c5febc686f445910ce2075d8b2434c7ec23ffc6c
+Tags: 9-b144-jre, 9-jre, openjdk-9-b144-jre, openjdk-9-jre
+GitCommit: a2d46845f90bd841871419063cf12ebe4c2e2b72
 Directory: 9-jre

--- a/library/logstash
+++ b/library/logstash
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 1.5.6-1, 1.5.6, 1.5, 1
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 1.5
 
 Tags: 2.0.0-1, 2.0.0, 2.0
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.0
 
 Tags: 2.1.3-1, 2.1.3, 2.1
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.1
 
 Tags: 2.2.4-1, 2.2.4, 2.2
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.2
 
 Tags: 2.3.4-1, 2.3.4, 2.3
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.3
 
 Tags: 2.4.0-1, 2.4.0, 2.4, 2
-GitCommit: 569134d7447dd0f9076046cdb05a2387b7c30c90
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.4
 
 Tags: 5.0.0-1, 5.0.0, 5.0, 5, latest
-GitCommit: 469bbf522d1b97e67171e4800847db27e9b3f26e
+GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 5.0

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ GitCommit: b37a4891feffeafb77febd2833d96b59cf28d6a8
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
-GitCommit: b37a4891feffeafb77febd2833d96b59cf28d6a8
+GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -18,7 +18,7 @@ GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.2
 
 Tags: 3.2.10-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 368cc7355471feba3071a4e0b7e44edf61401213
+GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -27,15 +27,15 @@ GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
 Directory: 3.3
 
 Tags: 3.3.15-windowsservercore, 3.3-windowsservercore, unstable-windowsservercore
-GitCommit: 944c44b6304ab387e4640fddaa808bc93f32b176
+GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.0-rc2, 3.4.0, 3.4, 3.4-rc, rc
-GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
+Tags: 3.4.0-rc3, 3.4.0, 3.4, 3.4-rc, rc
+GitCommit: 9729bf2e22760d7d261eed7328f821b1b9d4aece
 Directory: 3.4-rc
 
-Tags: 3.4.0-rc2-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
-GitCommit: ec80a4a2218babddb8b572209e45841b96c1954c
+Tags: 3.4.0-rc3-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
+GitCommit: 9729bf2e22760d7d261eed7328f821b1b9d4aece
 Directory: 3.4-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
 Directory: 8-jre/alpine
 
-Tags: 9-b143-jdk, 9-b143, 9-jdk, 9
-GitCommit: c5febc686f445910ce2075d8b2434c7ec23ffc6c
+Tags: 9-b144-jdk, 9-b144, 9-jdk, 9
+GitCommit: a2d46845f90bd841871419063cf12ebe4c2e2b72
 Directory: 9-jdk
 
-Tags: 9-b143-jre, 9-jre
-GitCommit: c5febc686f445910ce2075d8b2434c7ec23ffc6c
+Tags: 9-b144-jre, 9-jre
+GitCommit: a2d46845f90bd841871419063cf12ebe4c2e2b72
 Directory: 9-jre

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,42 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 8.0.15-apache, 8.0-apache, 8.0.15, 8.0
-GitCommit: 12b61400b292cfdef89ae568f726798f197ec409
+Tags: 8.0.16-apache, 8.0-apache, 8.0.16, 8.0
+GitCommit: 2c9fddfe6a17a2c1d631dd7a6f1c7f87763f7d10
 Directory: 8.0/apache
 
-Tags: 8.0.15-fpm, 8.0-fpm
-GitCommit: 12b61400b292cfdef89ae568f726798f197ec409
+Tags: 8.0.16-fpm, 8.0-fpm
+GitCommit: 2c9fddfe6a17a2c1d631dd7a6f1c7f87763f7d10
 Directory: 8.0/fpm
 
-Tags: 8.1.10-apache, 8.1-apache, 8.1.10, 8.1
-GitCommit: 066a4f1d22f703605b00d70178dd7bb71b7d7140
+Tags: 8.1.11-apache, 8.1-apache, 8.1.11, 8.1
+GitCommit: 11331ee6c9af343e4b25efd62135742fe4a48259
 Directory: 8.1/apache
 
-Tags: 8.1.10-fpm, 8.1-fpm
-GitCommit: 066a4f1d22f703605b00d70178dd7bb71b7d7140
+Tags: 8.1.11-fpm, 8.1-fpm
+GitCommit: 11331ee6c9af343e4b25efd62135742fe4a48259
 Directory: 8.1/fpm
 
-Tags: 8.2.8-apache, 8.2-apache, 8-apache, 8.2.8, 8.2, 8
-GitCommit: f73b5dc1306f54c0744ad3dce726cbd7fb0530a7
+Tags: 8.2.9-apache, 8.2-apache, 8-apache, 8.2.9, 8.2, 8
+GitCommit: ff9352a1c798b21f93fdca4b31165be91e879665
 Directory: 8.2/apache
 
-Tags: 8.2.8-fpm, 8.2-fpm, 8-fpm
-GitCommit: f73b5dc1306f54c0744ad3dce726cbd7fb0530a7
+Tags: 8.2.9-fpm, 8.2-fpm, 8-fpm
+GitCommit: ff9352a1c798b21f93fdca4b31165be91e879665
 Directory: 8.2/fpm
 
-Tags: 9.0.5-apache, 9.0-apache, 9.0.5, 9.0
-GitCommit: 92727b0d210b489161340f740b3693eb87915e16
+Tags: 9.0.6-apache, 9.0-apache, 9.0.6, 9.0
+GitCommit: 375db22095df9a8d5b27f9f656eff92fcfad3b2e
 Directory: 9.0/apache
 
-Tags: 9.0.5-fpm, 9.0-fpm
-GitCommit: 92727b0d210b489161340f740b3693eb87915e16
+Tags: 9.0.6-fpm, 9.0-fpm
+GitCommit: 375db22095df9a8d5b27f9f656eff92fcfad3b2e
 Directory: 9.0/fpm
 
-Tags: 9.1.1-apache, 9.1-apache, 9-apache, apache, 9.1.1, 9.1, 9, latest
-GitCommit: 51ba952ab82bdc0755275d31fc288af39ac1ba74
+Tags: 9.1.2-apache, 9.1-apache, 9-apache, apache, 9.1.2, 9.1, 9, latest
+GitCommit: 373a10dfe09623b32510f64912d2188c6395f64e
 Directory: 9.1/apache
 
-Tags: 9.1.1-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 51ba952ab82bdc0755275d31fc288af39ac1ba74
+Tags: 9.1.2-fpm, 9.1-fpm, 9-fpm, fpm
+GitCommit: 373a10dfe09623b32510f64912d2188c6395f64e
 Directory: 9.1/fpm

--- a/library/php
+++ b/library/php
@@ -4,86 +4,86 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.0RC5-cli, 7.1-rc-cli, rc-cli, 7.1.0RC5, 7.1-rc, rc
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-cli, 7.1-rc-cli, rc-cli, 7.1.0RC6, 7.1-rc, rc
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc
 
-Tags: 7.1.0RC5-alpine, 7.1-rc-alpine, rc-alpine
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-alpine, 7.1-rc-alpine, rc-alpine
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/alpine
 
-Tags: 7.1.0RC5-apache, 7.1-rc-apache, rc-apache
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-apache, 7.1-rc-apache, rc-apache
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/apache
 
-Tags: 7.1.0RC5-fpm, 7.1-rc-fpm, rc-fpm
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-fpm, 7.1-rc-fpm, rc-fpm
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/fpm
 
-Tags: 7.1.0RC5-fpm-alpine, 7.1-rc-fpm-alpine, rc-fpm-alpine
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-fpm-alpine, 7.1-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/fpm/alpine
 
-Tags: 7.1.0RC5-zts, 7.1-rc-zts, rc-zts
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-zts, 7.1-rc-zts, rc-zts
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/zts
 
-Tags: 7.1.0RC5-zts-alpine, 7.1-rc-zts-alpine, rc-zts-alpine
-GitCommit: 602289eafdd16fe0a4026f6a2b833b209f3b4cab
+Tags: 7.1.0RC6-zts-alpine, 7.1-rc-zts-alpine, rc-zts-alpine
+GitCommit: 4ea9e241d26b245fa04896a608c73e84522f8689
 Directory: 7.1-rc/zts/alpine
 
-Tags: 7.0.12-cli, 7.0-cli, 7-cli, cli, 7.0.12, 7.0, 7, latest
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-cli, 7.0-cli, 7-cli, cli, 7.0.13, 7.0, 7, latest
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0
 
-Tags: 7.0.12-alpine, 7.0-alpine, 7-alpine, alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-alpine, 7.0-alpine, 7-alpine, alpine
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/alpine
 
-Tags: 7.0.12-apache, 7.0-apache, 7-apache, apache
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-apache, 7.0-apache, 7-apache, apache
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/apache
 
-Tags: 7.0.12-fpm, 7.0-fpm, 7-fpm, fpm
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-fpm, 7.0-fpm, 7-fpm, fpm
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/fpm
 
-Tags: 7.0.12-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.12-zts, 7.0-zts, 7-zts, zts
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-zts, 7.0-zts, 7-zts, zts
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/zts
 
-Tags: 7.0.12-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 7.0.13-zts-alpine, 7.0-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: b208b3bd750feea2c236af0586e544dd1daad8a2
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.27-cli, 5.6-cli, 5-cli, 5.6.27, 5.6, 5
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-cli, 5.6-cli, 5-cli, 5.6.28, 5.6, 5
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6
 
-Tags: 5.6.27-alpine, 5.6-alpine, 5-alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-alpine, 5.6-alpine, 5-alpine
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/alpine
 
-Tags: 5.6.27-apache, 5.6-apache, 5-apache
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-apache, 5.6-apache, 5-apache
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/apache
 
-Tags: 5.6.27-fpm, 5.6-fpm, 5-fpm
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-fpm, 5.6-fpm, 5-fpm
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/fpm
 
-Tags: 5.6.27-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.27-zts, 5.6-zts, 5-zts
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-zts, 5.6-zts, 5-zts
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/zts
 
-Tags: 5.6.27-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 3cb02a21164bc2bdb8b25ec48886ffcb7e195510
+Tags: 5.6.28-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 7d058f79e6fdf7b8e97d5004d1098c436d348a47
 Directory: 5.6/zts/alpine

--- a/library/piwik
+++ b/library/piwik
@@ -1,5 +1,5 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 2.17.0, 2.17, 2, latest
-GitCommit: 555a9ee606bf7cb702e8b01cdf1fceaaf8a03a89
+Tags: 2.17.1, 2.17, 2, latest
+GitCommit: 0586742bf49f12fb99cba2acb997418aa26d0166

--- a/library/postgres
+++ b/library/postgres
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/69bc540ecfffecce72d49fa7e4a46680350037f9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/a9c1b15a7adf7cb2bc42fac776656aff7dd7994e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -8,18 +8,38 @@ Tags: 9.6.1, 9.6, 9, latest
 GitCommit: e4942cb0f79b61024963dc0ac196375b26fa60dd
 Directory: 9.6
 
+Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
+GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+Directory: 9.6/alpine
+
 Tags: 9.5.5, 9.5
 GitCommit: db63c8c4eff2aa81c3f2c9e42f1ede447c7cf99c
 Directory: 9.5
+
+Tags: 9.5.5-alpine, 9.5-alpine
+GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
 GitCommit: 56b1a0c47ae8361eca133e41c6ddd68ad492ac2d
 Directory: 9.4
 
+Tags: 9.4.10-alpine, 9.4-alpine
+GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+Directory: 9.4/alpine
+
 Tags: 9.3.15, 9.3
 GitCommit: 570ca9e8ea81cb6da73ea765132755f277cd0b66
 Directory: 9.3
 
+Tags: 9.3.15-alpine, 9.3-alpine
+GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+Directory: 9.3/alpine
+
 Tags: 9.2.19, 9.2
 GitCommit: c01405b7c324350cc796ba9e861326aee158f75e
 Directory: 9.2
+
+Tags: 9.2.19-alpine, 9.2-alpine
+GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+Directory: 9.2/alpine

--- a/library/pypy
+++ b/library/pypy
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.4.1, 2-5.4, 2-5, 2
-GitCommit: 1ac033f2edcaace74052e2ebefc8dae47cefff46
+Tags: 2-5.6.0, 2-5.6, 2-5, 2
+GitCommit: 491b6dc82d4275a452d48b800ee7a91e48ef9991
 Directory: 2
 
-Tags: 2-5.4.1-slim, 2-5.4-slim, 2-5-slim, 2-slim
-GitCommit: 95f6702ded19c44f5dc872ff5ea0374138804829
+Tags: 2-5.6.0-slim, 2-5.6-slim, 2-5-slim, 2-slim
+GitCommit: 491b6dc82d4275a452d48b800ee7a91e48ef9991
 Directory: 2/slim
 
-Tags: 2-5.4.1-onbuild, 2-5.4-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.6.0-onbuild, 2-5.6-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.47-jre7, 6.0-jre7, 6-jre7, 6.0.47, 6.0, 6
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 6/jre7
 
 Tags: 6.0.47-jre8, 6.0-jre8, 6-jre8
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre8-alpine
 
 Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.0/jre7
 
 Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.0/jre8
 
 Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 8.5/jre8
 
 Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
@@ -53,7 +53,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
-GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
+GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.47-jre7, 6.0-jre7, 6-jre7, 6.0.47, 6.0, 6
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 6/jre7
 
 Tags: 6.0.47-jre8, 6.0-jre8, 6-jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 6/jre8
 
 Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 7/jre7
 
 Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre7-alpine
 
 Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 7/jre8
 
 Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 7/jre8-alpine
 
 Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 8.0/jre7
 
 Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 8.0/jre8
 
 Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 8.5/jre8
 
 Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
@@ -53,7 +53,7 @@ GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+GitCommit: 06a7e79e30595058df3c2fec9c769e47e2bca56d
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine


### PR DESCRIPTION
- `bash`: 4.4, patch level 5
- `cassandra`: add `jemalloc` (docker-library/cassandra#87)
- `java`: debian 9~b144-1
- `logstash`: update config for stdout logs (docker-library/logstash#67)
- `mongo`: 3.4.0-rc3, reduce `windowsservercore` image size (docker-library/mongo#120)
- `openjdk`: debian 9~b144-1
- `owncloud`: 8.0.16, 8.1.11, 8.2.9, 9.0.6, 9.1.2
- `php`: 5.6.28, 7.0.13, 7.1.0RC6
- `piwik`: 2.17.1, add `opcache` (piwik/docker-piwik#44)
- `postgres`: add `alpine` variants (docker-library/postgres#216)
- `pypy`: 5.6.0
- ~~`tomcat`: switch from `unstable` to `stretch` for `openssl` (docker-library/tomcat#56)~~