### PR TITLE
updating notary releases

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,8 +1,12 @@
 # maintainer: David Lawrence <david.lawrence@docker.com> (@endophage)
 
-server: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-server
+server: git://github.com/docker/notary-official-images@v0.5.0 notary-server
+server-0.5.0: git://github.com/docker/notary-official-images@v0.5.0 notary-server
+signer: git://github.com/docker/notary-official-images@v0.5.0 notary-signer
+signer-0.5.0: git://github.com/docker/notary-official-images@v0.5.0 notary-signer
+server-0.4.2: git://github.com/docker/notary-official-images@v0.4.2 notary-server
+signer-0.4.2: git://github.com/docker/notary-official-images@v0.4.2 notary-signer
 server-0.3.0: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-server
-signer: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-signer
 signer-0.3.0: git://github.com/docker/notary-official-images@5fbf22ada9e5167fe4e9340ac947e8b3110aceba notary-signer
 server-0.2.0: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-server
 signer-0.2.0: git://github.com/docker/notary-official-images@3ea5b74928929415f2faaa5df574c4745bf6d286 notary-signer


### PR DESCRIPTION
Official images for notary 0.4.2 and 0.5.0

We skipped over 0.4.0 and 0.4.1 because we cut those then found build compatibility issues with other docker tools that depended on notary.