### PR TITLE
Update Solr to 6.3.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,44 +1,50 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3
-5.3: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3
+5.3.2: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3
+5.3: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.3/alpine
+5.3.2-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3/alpine
+5.3-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4
-5.4: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4
+5.4.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4
+5.4: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.4/alpine
+5.4.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4/alpine
+5.4-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4/alpine
 
-5.5.3: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
-5.5: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
-5: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5
+5.5.3: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
+5.5: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
+5: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
 
-5.5.3-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 5.5/alpine
+5.5.3-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
 
-6.0.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0
-6.0: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0
+6.0.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0
+6.0: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0
 
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.0/alpine
+6.0.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0/alpine
+6.0-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0/alpine
 
-6.1.0: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1
-6.1: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1
+6.1.0: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1
+6.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1
 
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@dfe2c80ca10ca9191ae8ce7c6193ecd47c6c0b5f 6.1/alpine
+6.1.0-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1/alpine
+6.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1/alpine
 
-6.2.1: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
-6.2: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
-6: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
-latest: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2
+6.2.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2
+6.2: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2
 
-6.2.1-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
-6.2-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
-alpine: git://github.com/docker-solr/docker-solr@5f01cda7259bf25170d48bdb36c4ac268a749454 6.2/alpine
+6.2.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2/alpine
+6.2-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2/alpine
+
+6.3.0: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
+6.3: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
+6: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
+latest: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
+
+6.3.0-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
+6.3-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
+alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine


### PR DESCRIPTION
Update Solr to 6.3.

- Announcement: http://mail-archives.apache.org/mod_mbox/lucene-general/201611.mbox/%3cCAOOKt51=9nAzaUXJZgE5M04JyoZYeD7WdWvan3jAE=z0UD49BA@mail.gmail.com%3e
- Changes: https://lucene.apache.org/solr/6_2_1/changes/Changes.html

On the docker-solr side:

- https://github.com/docker-solr/docker-solr/issues/82 Add Solr 6.3
- https://github.com/docker-solr/docker-solr/issues/74 You can specify a different SOLR_HOME, and have default configuration copied over automatically. See https://github.com/docker-solr/docker-solr/blob/master/Docker-FAQ.md#can-i-use-volumes-with-solr_home. 
- https://github.com/docker-solr/docker-solr/issues/71 That CMD handling is more specific, such that you can run solr for non-daemon purposes. See examples on https://github.com/docker-solr/docker-solr/blob/master/Docker-FAQ.md#im-confused-about-the-different-invocations-of-solr----help
- https://github.com/docker-solr/docker-solr/issues/75 docker-entrypoint-initdb.d is now run before all solr commands
- Some build system improvements and documentation improvements. CI passes: https://travis-ci.org/docker-solr/docker-solr/builds/176040091