### PR TITLE
Updated Oracle Linux 6.8 for CVE-2016-7545

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,19 +1,19 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.3
-7: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.3
-7.3: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.3
-7.2: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.3
+7: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.3
+7.3: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.3
+7.2: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@c15d45ecc92e5b37e5303cbf6db426a57bdf43b4 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@083e94e970f97c2bc509e11acb3de08352f18c98 OracleLinux/5.11


### PR DESCRIPTION
Description of changes for policycoreutils-2.0.83-30.1.0.1.el6_8.x86_64.rpm:

[2.5-9.0.1]
- Lazy unmount private, shared entry (Joe Jin) [orabug 12560705]

[2.5-9]
- sandbox: create a new session for sandboxed processes - CVE-2016-7545
- sandbox: do not try to setup directories without -X or -M

Signed-off-by: Avi Miller <avi.miller@oracle.com>