### PR TITLE
Update elasticsearch 5.0.1 and kibana 5.0.1, 4.6.3

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -32,6 +32,6 @@ Tags: 2.4.1, 2.4, 2
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.4
 
-Tags: 5.0.0, 5.0, 5, latest
-GitCommit: acd142324bdd9b4cb06a8e08bd701b340deaa02d
+Tags: 5.0.1, 5.0, 5, latest
+GitCommit: 605ca406cbd254f70872af0df8fecf524d126c53
 Directory: 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -24,10 +24,10 @@ Tags: 4.5.4, 4.5
 GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
 Directory: 4.5
 
-Tags: 4.6.2, 4.6, 4
-GitCommit: 712060cfe4782cf8c0abdadb641cd038277e8541
+Tags: 4.6.3, 4.6, 4
+GitCommit: 43644e6ae40c53c05d94165506094035f0463ea6
 Directory: 4.6
 
-Tags: 5.0.0, 5.0, 5, latest
-GitCommit: 75cfa3c5b20eb24a319937c0f7754ad06057d843
+Tags: 5.0.1, 5.0, 5, latest
+GitCommit: 43644e6ae40c53c05d94165506094035f0463ea6
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -24,10 +24,10 @@ Tags: 2.3.4-1, 2.3.4, 2.3
 GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
 Directory: 2.3
 
-Tags: 2.4.0-1, 2.4.0, 2.4, 2
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+Tags: 2.4.1-1, 2.4.1, 2.4, 2
+GitCommit: 60506b52e56e262851b01df1875ee9f24b81c4c1
 Directory: 2.4
 
-Tags: 5.0.0-1, 5.0.0, 5.0, 5, latest
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+Tags: 5.0.1-1, 5.0.1, 5.0, 5, latest
+GitCommit: 61c818c07bcecf7733dc821a4e4f4770f7e136ce
 Directory: 5.0


### PR DESCRIPTION
PR: 
docker-library/elasticsearch/pull/139
docker-library/kibana/pull/64