### PR TITLE
Drop Node.js v0.10

### DIFF
--- a/library/node
+++ b/library/node
@@ -79,19 +79,3 @@ Tags: 0.12.17-wheezy, 0.12-wheezy, 0-wheezy
 GitCommit: b18c441de44515015f7670d7be0186503ae156ec
 Directory: 0.12/wheezy
 
-Tags: 0.10.48, 0.10
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 0.10
-
-Tags: 0.10.48-onbuild, 0.10-onbuild
-GitCommit: 2716d804bd63f85a46e5fecbb36323a5d06ea5f6
-Directory: 0.10/onbuild
-
-Tags: 0.10.48-slim, 0.10-slim
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 0.10/slim
-
-Tags: 0.10.48-wheezy, 0.10-wheezy
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
-Directory: 0.10/wheezy
-


### PR DESCRIPTION
The v0.10 release line of Node.js reached EOL at the end of October and
is no longer being updated.

See:

- https://github.com/nodejs/docker-node/issues/240
- https://github.com/nodejs/docker-node/pull/268