### PR TITLE
Update "build-and-push.sh" to explicitly group by repo when building/pushing

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,48 +1,70 @@
 #!/bin/bash
 set -eu -o pipefail
 
+# set "$0" so that tmux shows something more useful than "bash" in the statusbar
 desired0='b-a-p'
 if ! grep -q "$desired0" "/proc/$$/cmdline"; then
 	exec -a "$desired0" "$SHELL" -- "$BASH_SOURCE" "$@"
 fi
 
+if [ "$#" -eq 0 ]; then
+	self="$(basename "$0")"
+	cat >&2 <<-EOF
+		error: missing arguments
+		usage: $self <build args>
+		   ie: $self debian ubuntu
+	EOF
+	exit 1
+fi
+
+# allow for specifying an alternate path to "bashbrew"
 : "${BASHBREW:=bashbrew}"
 
+# normalize "$@" to be the "--uniq" versions (and deduplicate)
+# also grab the list of associated repos in explicit build order (so we can build/push grouped by repo)
 IFS=$'\n'
-set -- $("$BASHBREW" list --uniq --repos --build-order "$@")
+set -- $("$BASHBREW" list --uniq --repos "$@" | sort -u | xargs "$BASHBREW" list --uniq --repos --build-order)
+repos=( $(echo "$*" | cut -d: -f1 | xargs "$BASHBREW" list --repos --build-order) )
 unset IFS
 
-# set -- buildpack-deps; comm -13 <(bashbrew list "$@" | sort) <(bashbrew children "$@" | sort) | xargs bashbrew list --uniq | sort -u | xargs bashbrew list --uniq --build-order
+declare -A repoTags=()
+for repoTag; do
+	repo="${repoTag%%:*}"
+	repoTags[$repo]+=" $repoTag"
+done
+
 children="$("$(dirname "$BASH_SOURCE")/children.sh" "$@")"
-: "${children:=<none>}"
 
 echo
 echo
 echo "Children: (of $*)"
-echo "$children"
+echo "${children:-<none>}"
 echo
 echo
 
-for repo; do
+for repo in "${repos[@]}"; do
+	tags=( ${repoTags[$repo]} )
 	(
 		set -x
-		time "$BASHBREW" build "$repo"
-		time "$BASHBREW" tag "$repo"
-		time "$BASHBREW" push "$repo"
+		time "$BASHBREW" build "${tags[@]}"
+		time "$BASHBREW" tag "${tags[@]}"
+		time "$BASHBREW" push "${tags[@]}"
 	)
 done
 
 echo
 echo
 echo "Children: (of $*)"
-echo "$children"
+echo "${children:-<none>}"
 echo
 echo
 
-if [ "$children" != '<none>' ]; then
+if [ "$children" ]; then
 	echo 'Suggested command:'
 	echo "  ./children.sh $* | xargs ./build-and-push.sh"
 	echo
 fi
 
+# end by printing only warnings (stderr) for images we skipped (such as "windowsservercore" when building on Linux)
+# this helps remind us to switch BASHBREW or servers
 "$BASHBREW" list --apply-constraints "$@" > /dev/null


### PR DESCRIPTION
This helps cut down on the load to the automated builds system (since they'll coalesce build triggers for the same repo within close sequence).