### PR TITLE
Update Ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -8,28 +8,28 @@ GitFetch: refs/heads/dist
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - 188bcce Update tarballs
-#    - `ubuntu:precise`: 20160923.1
-#    - `ubuntu:trusty`: 20161006
-#    - `ubuntu:xenial`: 20161010
-#    - `ubuntu:yakkety`: 20161013
+#  - 4c7620d Update tarballs
+#    - `ubuntu:precise`: 20161102
+#    - `ubuntu:trusty`: 20161101
+#    - `ubuntu:xenial`: 20161114
+#    - `ubuntu:yakkety`: 20161104
 
-# 20160923.1
-Tags: 12.04.5, 12.04, precise-20160923.1, precise
-GitCommit: 188bcceb999c0c465b3053efefd4e1a03d3fc47e
+# 20161102
+Tags: 12.04.5, 12.04, precise-20161102, precise
+GitCommit: 4c7620da47ebd6e82febf6d01881943c9b219ebb
 Directory: precise
 
-# 20161006
-Tags: 14.04.5, 14.04, trusty-20161006, trusty
-GitCommit: 188bcceb999c0c465b3053efefd4e1a03d3fc47e
+# 20161101
+Tags: 14.04.5, 14.04, trusty-20161101, trusty
+GitCommit: 4c7620da47ebd6e82febf6d01881943c9b219ebb
 Directory: trusty
 
-# 20161010
-Tags: 16.04, xenial-20161010, xenial, latest
-GitCommit: 188bcceb999c0c465b3053efefd4e1a03d3fc47e
+# 20161114
+Tags: 16.04, xenial-20161114, xenial, latest
+GitCommit: 4c7620da47ebd6e82febf6d01881943c9b219ebb
 Directory: xenial
 
-# 20161013
-Tags: 16.10, yakkety-20161013, yakkety, devel
-GitCommit: 188bcceb999c0c465b3053efefd4e1a03d3fc47e
+# 20161104
+Tags: 16.10, yakkety-20161104, yakkety
+GitCommit: 4c7620da47ebd6e82febf6d01881943c9b219ebb
 Directory: yakkety


### PR DESCRIPTION
- `ubuntu:precise`: 20161102
- `ubuntu:trusty`: 20161101
- `ubuntu:xenial`: 20161114
- `ubuntu:yakkety`: 20161104

I wanted to include "zesty" here, but the upstream tarballs aren't ready to consume yet. :disappointed:

This will also remove the "devel" alias entirely for now (to be added back once "zesty" is properly consumable).