### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -12,8 +12,8 @@ Tags: 2.2.8, 2.2, 2
 GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
 Directory: 2.2
 
-Tags: 3.0.9, 3.0
-GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
+Tags: 3.0.10, 3.0
+GitCommit: d3a91560b21e73994235a72a4c3153e775e1654d
 Directory: 3.0
 
 Tags: 3.9, 3, latest

--- a/library/docker
+++ b/library/docker
@@ -4,12 +4,24 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
+Tags: 1.13.0-rc1, 1.13-rc, rc
+GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
+Directory: 1.13-rc
+
+Tags: 1.13.0-rc1-dind, 1.13-rc-dind, rc-dind
+GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
+Directory: 1.13-rc/dind
+
+Tags: 1.13.0-rc1-git, 1.13-rc-git, rc-git
+GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
+Directory: 1.13-rc/git
+
 Tags: 1.12.3, 1.12, 1, latest
 GitCommit: 36e2107fb879d5d5c3dbb5d8d93aeef0a2d45ac8
 Directory: 1.12
 
 Tags: 1.12.3-dind, 1.12-dind, 1-dind, dind
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
+GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/dind
 
 Tags: 1.12.3-git, 1.12-git, 1-git, git
@@ -21,7 +33,7 @@ GitCommit: 36e2107fb879d5d5c3dbb5d8d93aeef0a2d45ac8
 Directory: 1.12/experimental
 
 Tags: 1.12.3-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
+GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/experimental/dind
 
 Tags: 1.12.3-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git

--- a/library/drupal
+++ b/library/drupal
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.2.2-apache, 8.2-apache, 8-apache, apache, 8.2.2, 8.2, 8, latest
-GitCommit: 9cd16801643ce9a8373bd74c74ff1a1565842795
+Tags: 8.2.3-apache, 8.2-apache, 8-apache, apache, 8.2.3, 8.2, 8, latest
+GitCommit: 1c6f01397baf322b81a6cade18685aa57aa5c1f0
 Directory: 8.2/apache
 
-Tags: 8.2.2-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: 9cd16801643ce9a8373bd74c74ff1a1565842795
+Tags: 8.2.3-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: 1c6f01397baf322b81a6cade18685aa57aa5c1f0
 Directory: 8.2/fpm
 
-Tags: 7.51-apache, 7-apache, 7.51, 7
-GitCommit: 814261d4b2d82854c50746c3e480dd514d5aa1d0
+Tags: 7.52-apache, 7-apache, 7.52, 7
+GitCommit: efb88fb830fe538727d71bbe309dc869778ba45c
 Directory: 7/apache
 
-Tags: 7.51-fpm, 7-fpm
-GitCommit: 814261d4b2d82854c50746c3e480dd514d5aa1d0
+Tags: 7.52-fpm, 7-fpm
+GitCommit: efb88fb830fe538727d71bbe309dc869778ba45c
 Directory: 7/fpm

--- a/library/java
+++ b/library/java
@@ -16,32 +16,32 @@ Tags: 7u111-jdk, 7u111, 7-jdk, 7, openjdk-7u111-jdk, openjdk-7u111, openjdk-7-jd
 GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jdk
 
-Tags: 7u111-jdk-alpine, 7u111-alpine, 7-jdk-alpine, 7-alpine, openjdk-7u111-jdk-alpine, openjdk-7u111-alpine, openjdk-7-jdk-alpine, openjdk-7-alpine
-GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
+Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine, openjdk-7u121-jdk-alpine, openjdk-7u121-alpine, openjdk-7-jdk-alpine, openjdk-7-alpine
+GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
 Directory: 7-jdk/alpine
 
 Tags: 7u111-jre, 7-jre, openjdk-7u111-jre, openjdk-7-jre
 GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jre
 
-Tags: 7u111-jre-alpine, 7-jre-alpine, openjdk-7u111-jre-alpine, openjdk-7-jre-alpine
-GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
+Tags: 7u121-jre-alpine, 7-jre-alpine, openjdk-7u121-jre-alpine, openjdk-7-jre-alpine
+GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
 Directory: 7-jre/alpine
 
 Tags: 8u111-jdk, 8u111, 8-jdk, 8, jdk, latest, openjdk-8u111-jdk, openjdk-8u111, openjdk-8-jdk, openjdk-8
 GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jdk
 
-Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u92-jdk-alpine, openjdk-8u92-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
-GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
+Tags: 8u111-jdk-alpine, 8u111-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine, openjdk-8u111-jdk-alpine, openjdk-8u111-alpine, openjdk-8-jdk-alpine, openjdk-8-alpine
+GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jdk/alpine
 
 Tags: 8u111-jre, 8-jre, jre, openjdk-8u111-jre, openjdk-8-jre
 GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jre
 
-Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u92-jre-alpine, openjdk-8-jre-alpine
-GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
+Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u111-jre-alpine, openjdk-8-jre-alpine
+GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
 Tags: 9-b144-jdk, 9-b144, 9-jdk, 9, openjdk-9-b144-jdk, openjdk-9-b144, openjdk-9-jdk, openjdk-9

--- a/library/openjdk
+++ b/library/openjdk
@@ -16,32 +16,32 @@ Tags: 7u111-jdk, 7u111, 7-jdk, 7
 GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jdk
 
-Tags: 7u111-jdk-alpine, 7u111-alpine, 7-jdk-alpine, 7-alpine
-GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
+Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
+GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
 Directory: 7-jdk/alpine
 
 Tags: 7u111-jre, 7-jre
 GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jre
 
-Tags: 7u111-jre-alpine, 7-jre-alpine
-GitCommit: fb0dd5fe5842959f774c60da6195e2d61b813fdd
+Tags: 7u121-jre-alpine, 7-jre-alpine
+GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
 Directory: 7-jre/alpine
 
 Tags: 8u111-jdk, 8u111, 8-jdk, 8, jdk, latest
 GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jdk
 
-Tags: 8u92-jdk-alpine, 8u92-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
+Tags: 8u111-jdk-alpine, 8u111-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jdk/alpine
 
 Tags: 8u111-jre, 8-jre, jre
 GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jre
 
-Tags: 8u92-jre-alpine, 8-jre-alpine, jre-alpine
-GitCommit: 54c64cf47d2b705418feb68b811419a223c5a040
+Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
+GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
 Tags: 9-b144-jdk, 9-b144, 9-jdk, 9

--- a/library/python
+++ b/library/python
@@ -1,23 +1,23 @@
-# this file is generated via https://github.com/docker-library/python/blob/1ad743decae71db424840812eb8dd49557aed9d0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/b16ff405101a9f6c6540fb3467ca25baa9610174/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.12, 2.7, 2
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 2.7
 
 Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 2.7/slim
 
 Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 2.7/alpine
 
 Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 2.7/wheezy
 
 Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,24 +25,24 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 2.7.12-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
-GitCommit: 1ad743decae71db424840812eb8dd49557aed9d0
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -50,19 +50,19 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.5, 3.4
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4
 
 Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/wheezy
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -70,15 +70,15 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.2, 3.5, 3, latest
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5
 
 Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
-GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
-GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
@@ -86,27 +86,27 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
 Tags: 3.5.2-windowsservercore, 3.5-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 855b85c8309e925814dfa97d61310080dcd08db6
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.0b2, 3.6
-GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
-Directory: 3.6
+Tags: 3.6.0b3, 3.6-rc, rc
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Directory: 3.6-rc
 
-Tags: 3.6.0b2-slim, 3.6-slim
-GitCommit: 6b24d8cd0ad4c5a01874d094d92cd79518b3d490
-Directory: 3.6/slim
+Tags: 3.6.0b3-slim, 3.6-rc-slim, rc-slim
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Directory: 3.6-rc/slim
 
-Tags: 3.6.0b2-alpine, 3.6-alpine
-GitCommit: 83b8e044aa38ab97b5427a9591e0537464e976e6
-Directory: 3.6/alpine
+Tags: 3.6.0b3-alpine, 3.6-rc-alpine, rc-alpine
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Directory: 3.6-rc/alpine
 
-Tags: 3.6.0b2-onbuild, 3.6-onbuild
-GitCommit: 635ea5d58b53d165f7bedae90f8933c720a58150
-Directory: 3.6/onbuild
+Tags: 3.6.0b3-onbuild, 3.6-rc-onbuild, rc-onbuild
+GitCommit: b16ff405101a9f6c6540fb3467ca25baa9610174
+Directory: 3.6-rc/onbuild
 
-Tags: 3.6.0b2-windowsservercore, 3.6-windowsservercore
-GitCommit: a29d327288ff02b2f54be0d2b7340736e2329bdc
-Directory: 3.6/windows/windowsservercore
+Tags: 3.6.0b3-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
+GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Directory: 3.6-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/ruby
+++ b/library/ruby
@@ -20,34 +20,34 @@ Tags: 2.1.10-onbuild, 2.1-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
-Tags: 2.2.5, 2.2
-GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
+Tags: 2.2.6, 2.2
+GitCommit: 1913ca0a1268c9a3d18ca5771a85ec3428c9cb3d
 Directory: 2.2
 
-Tags: 2.2.5-slim, 2.2-slim
-GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
+Tags: 2.2.6-slim, 2.2-slim
+GitCommit: 1913ca0a1268c9a3d18ca5771a85ec3428c9cb3d
 Directory: 2.2/slim
 
-Tags: 2.2.5-alpine, 2.2-alpine
-GitCommit: 9898bab20a28b2df0b279dcca4b8dee399a4b4d0
+Tags: 2.2.6-alpine, 2.2-alpine
+GitCommit: 1913ca0a1268c9a3d18ca5771a85ec3428c9cb3d
 Directory: 2.2/alpine
 
-Tags: 2.2.5-onbuild, 2.2-onbuild
+Tags: 2.2.6-onbuild, 2.2-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
-Tags: 2.3.1, 2.3, 2, latest
-GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
+Tags: 2.3.2, 2.3, 2, latest
+GitCommit: 9b3ffd5380f085847c4d0d885bc366f58a85a64a
 Directory: 2.3
 
-Tags: 2.3.1-slim, 2.3-slim, 2-slim, slim
-GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
+Tags: 2.3.2-slim, 2.3-slim, 2-slim, slim
+GitCommit: 9b3ffd5380f085847c4d0d885bc366f58a85a64a
 Directory: 2.3/slim
 
-Tags: 2.3.1-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: ec068a416df98e3c01b47f07a314b12a6412cfc5
+Tags: 2.3.2-alpine, 2.3-alpine, 2-alpine, alpine
+GitCommit: 9b3ffd5380f085847c4d0d885bc366f58a85a64a
 Directory: 2.3/alpine
 
-Tags: 2.3.1-onbuild, 2.3-onbuild, 2-onbuild, onbuild
+Tags: 2.3.2-onbuild, 2.3-onbuild, 2-onbuild, onbuild
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,58 +4,58 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 6.0.47-jre7, 6.0-jre7, 6-jre7, 6.0.47, 6.0, 6
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 6.0.48-jre7, 6.0-jre7, 6-jre7, 6.0.48, 6.0, 6
+GitCommit: e31b8a805c2e4d6e5c98abb640c5e74cb334033b
 Directory: 6/jre7
 
-Tags: 6.0.47-jre8, 6.0-jre8, 6-jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 6.0.48-jre8, 6.0-jre8, 6-jre8
+GitCommit: e31b8a805c2e4d6e5c98abb640c5e74cb334033b
 Directory: 6/jre8
 
-Tags: 7.0.72-jre7, 7.0-jre7, 7-jre7, 7.0.72, 7.0, 7
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 7.0.73-jre7, 7.0-jre7, 7-jre7, 7.0.73, 7.0, 7
+GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre7
 
-Tags: 7.0.72-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.72-alpine, 7.0-alpine, 7-alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 7.0.73-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.73-alpine, 7.0-alpine, 7-alpine
+GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre7-alpine
 
-Tags: 7.0.72-jre8, 7.0-jre8, 7-jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 7.0.73-jre8, 7.0-jre8, 7-jre8
+GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre8
 
-Tags: 7.0.72-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 7.0.73-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre8-alpine
 
-Tags: 8.0.38-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.38, 8.0, 8, latest
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 8.0.39-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.39, 8.0, 8, latest
+GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre7
 
-Tags: 8.0.38-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.38-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 8.0.39-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.39-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.38-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 8.0.39-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre8
 
-Tags: 8.0.38-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 8.0.39-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.6-jre8, 8.5-jre8, 8.5.6, 8.5
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 8.5.8-jre8, 8.5-jre8, 8.5.8, 8.5
+GitCommit: d44c35d4ec4907263cdfad76d6c56e6676ddd382
 Directory: 8.5/jre8
 
-Tags: 8.5.6-jre8-alpine, 8.5-jre8-alpine, 8.5.6-alpine, 8.5-alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 8.5.8-jre8-alpine, 8.5-jre8-alpine, 8.5.8-alpine, 8.5-alpine
+GitCommit: d44c35d4ec4907263cdfad76d6c56e6676ddd382
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M11-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M11, 9.0.0, 9.0, 9
-GitCommit: f26c14147f9affae8f32100430130271fc82bd3e
+Tags: 9.0.0.M13-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M13, 9.0.0, 9.0, 9
+GitCommit: 29f8484d577632d5124082f87719d7ee28ab939e
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M11-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M11-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 749fadf61fa96e5a6b6d95bb70624e5a5b37080a
+Tags: 9.0.0.M13-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M13-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 29f8484d577632d5124082f87719d7ee28ab939e
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest, 4.6.1-php5.6-apache, 4.6-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.6.1-php5.6, 4.6-php5.6, 4-php5.6, php5.6
-GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
 Directory: php5.6/apache
 
 Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm, 4.6.1-php5.6-fpm, 4.6-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
 Directory: php5.6/fpm
 
 Tags: 4.6.1-php7.0-apache, 4.6-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.6.1-php7.0, 4.6-php7.0, 4-php7.0, php7.0
-GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
 Directory: php7.0/apache
 
 Tags: 4.6.1-php7.0-fpm, 4.6-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 7d40c4237f01892bb6dbc67d1a82f5b15f807ca1
+GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
 Directory: php7.0/fpm


### PR DESCRIPTION
- `cassandra`: 3.0.10
- `docker`: 1.13.0-rc1 (currently failing the `override-cmd` test; see https://github.com/docker/docker/issues/28329), `docker daemon` -> `dockerd` (docker-library/docker#31)
- `drupal`: 8.2.3
- `java`: alpine 7.121.2.6.8-r0, 8.111.14-r0
- `openjdk`: alpine 7.121.2.6.8-r0, 8.111.14-r0
- `python`: 3.6.0b3 (docker-library/python#157), pip 9.0.1 (docker-library/python#154)
- `ruby`: 2.3.2, 2.2.6
- `tomcat`: 6.0.48, 7.0.73, 8.0.39, 8.5.8, 9.0.0.M13
- `wordpress`: add `WORDPRESS_*_FILE` support for passing parameters via files especially for [Docker secrets](https://github.com/docker/docker/pull/27794) (docker-library/wordpress#186)