### PR TITLE
Update bashbrew Constraints logic with several fixes

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -12,7 +12,7 @@ func cmdBuild(c *cli.Context) error {
 		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
 	}
 
-	repos, err = sortRepos(repos)
+	repos, err = sortRepos(repos, true)
 	if err != nil {
 		return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`, err))
 	}
@@ -33,7 +33,7 @@ func cmdBuild(c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 
-		entries, err := r.SortedEntries()
+		entries, err := r.SortedEntries(true)
 		if err != nil {
 			return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 		}

--- a/bashbrew/go/src/bashbrew/cmd-deps.go
+++ b/bashbrew/go/src/bashbrew/cmd-deps.go
@@ -40,6 +40,10 @@ func cmdFamily(parents bool, c *cli.Context) error {
 		}
 
 		for _, entry := range r.Entries() {
+			if applyConstraints && r.SkipConstraints(entry) {
+				continue
+			}
+
 			for _, tag := range r.Tags("", false, entry) {
 				network.AddNode(tag, entry)
 			}
@@ -53,6 +57,10 @@ func cmdFamily(parents bool, c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 		for _, entry := range r.Entries() {
+			if applyConstraints && r.SkipConstraints(entry) {
+				continue
+			}
+
 			from, err := r.DockerFrom(&entry)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed fetching/scraping FROM for %q (tags %q)`, r.RepoName, entry.TagsString()), err)

--- a/bashbrew/go/src/bashbrew/cmd-from.go
+++ b/bashbrew/go/src/bashbrew/cmd-from.go
@@ -14,6 +14,7 @@ func cmdFrom(c *cli.Context) error {
 
 	uniq := c.Bool("uniq")
 	namespace := ""
+	applyConstraints := c.Bool("apply-constraints")
 
 	for _, repo := range repos {
 		r, err := fetch(repo)
@@ -22,6 +23,10 @@ func cmdFrom(c *cli.Context) error {
 		}
 
 		for _, entry := range r.Entries() {
+			if applyConstraints && r.SkipConstraints(entry) {
+				continue
+			}
+
 			from, err := r.DockerFrom(&entry)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed fetching/scraping FROM for %q (tags %q)`, r.RepoName, entry.TagsString()), err)

--- a/bashbrew/go/src/bashbrew/cmd-list.go
+++ b/bashbrew/go/src/bashbrew/cmd-list.go
@@ -13,18 +13,18 @@ func cmdList(c *cli.Context) error {
 		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
 	}
 
-	buildOrder := c.Bool("build-order")
-	if buildOrder {
-		repos, err = sortRepos(repos)
-		if err != nil {
-			return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
-		}
-	}
-
 	uniq := c.Bool("uniq")
 	namespace := ""
 	applyConstraints := c.Bool("apply-constraints")
 	onlyRepos := c.Bool("repos")
+
+	buildOrder := c.Bool("build-order")
+	if buildOrder {
+		repos, err = sortRepos(repos, applyConstraints)
+		if err != nil {
+			return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
+		}
+	}
 
 	for _, repo := range repos {
 		r, err := fetch(repo)
@@ -45,7 +45,7 @@ func cmdList(c *cli.Context) error {
 
 		var entries []manifest.Manifest2822Entry
 		if buildOrder {
-			entries, err = r.SortedEntries()
+			entries, err = r.SortedEntries(applyConstraints)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 			}

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -157,6 +157,10 @@ func main() {
 			Name:  "namespace",
 			Usage: "a repo namespace to act upon/in",
 		},
+		"apply-constraints": cli.BoolFlag{
+			Name:  "apply-constraints",
+			Usage: "apply Constraints as if repos were building",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -167,13 +171,10 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
+				commonFlags["apply-constraints"],
 				cli.BoolFlag{
 					Name:  "build-order",
 					Usage: "sort by the order repos would need to build (topsort)",
-				},
-				cli.BoolFlag{
-					Name:  "apply-constraints",
-					Usage: "apply Constraints as if repos were building",
 				},
 				cli.BoolFlag{
 					Name:  "repos",
@@ -230,7 +231,9 @@ func main() {
 				"progeny",
 			},
 			Usage:  `print the repos built FROM a given repo or repo:tag`,
-			Flags:  []cli.Flag{},
+			Flags:  []cli.Flag{
+				commonFlags["apply-constraints"],
+			},
 			Before: subcommandBeforeFactory("children"),
 			Action: cmdOffspring,
 
@@ -243,7 +246,9 @@ func main() {
 				"progenitors",
 			},
 			Usage:  `print the repos this repo or repo:tag is FROM`,
-			Flags:  []cli.Flag{},
+			Flags:  []cli.Flag{
+				commonFlags["apply-constraints"],
+			},
 			Before: subcommandBeforeFactory("parents"),
 			Action: cmdParents,
 
@@ -277,6 +282,7 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
+				commonFlags["apply-constraints"],
 			},
 			Before: subcommandBeforeFactory("from"),
 			Action: cmdFrom,

--- a/bashbrew/go/src/bashbrew/repo.go
+++ b/bashbrew/go/src/bashbrew/repo.go
@@ -74,12 +74,17 @@ func (r Repo) EntryRepo(entry *manifest.Manifest2822Entry) *Repo {
 	}
 }
 
+var haveOutputSkippedMessage = map[string]bool{}
+
 func (r Repo) SkipConstraints(entry manifest.Manifest2822Entry) bool {
 	repoTag := r.RepoName + ":" + entry.Tags[0]
 
 	if len(entry.Constraints) == 0 {
 		if exclusiveConstraints {
-			fmt.Fprintf(os.Stderr, "skipping %q (due to exclusive constraints)\n", repoTag)
+			if !haveOutputSkippedMessage[repoTag] {
+				fmt.Fprintf(os.Stderr, "skipping %q (due to exclusive constraints)\n", repoTag)
+				haveOutputSkippedMessage[repoTag] = true
+			}
 		}
 		return exclusiveConstraints
 	}
@@ -111,7 +116,10 @@ NextConstraint:
 	}
 
 	if len(unsatisfactory) > 0 {
-		fmt.Fprintf(os.Stderr, "skipping %q (due to unsatisfactory constraints %q)\n", repoTag, unsatisfactory)
+		if !haveOutputSkippedMessage[repoTag] {
+			fmt.Fprintf(os.Stderr, "skipping %q (due to unsatisfactory constraints %q)\n", repoTag, unsatisfactory)
+			haveOutputSkippedMessage[repoTag] = true
+		}
 		return true
 	}
 

--- a/bashbrew/go/src/bashbrew/sort.go
+++ b/bashbrew/go/src/bashbrew/sort.go
@@ -5,7 +5,7 @@ import (
 	"pault.ag/go/topsort"
 )
 
-func sortRepos(repos []string) ([]string, error) {
+func sortRepos(repos []string, applyConstraints bool) ([]string, error) {
 	rs := []*Repo{}
 	rsMap := map[*Repo]string{}
 	for _, repo := range repos {
@@ -26,7 +26,7 @@ func sortRepos(repos []string) ([]string, error) {
 		return repos, nil
 	}
 
-	rs, err := sortRepoObjects(rs)
+	rs, err := sortRepoObjects(rs, applyConstraints)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func sortRepos(repos []string) ([]string, error) {
 	return ret, nil
 }
 
-func (r Repo) SortedEntries() ([]manifest.Manifest2822Entry, error) {
+func (r Repo) SortedEntries(applyConstraints bool) ([]manifest.Manifest2822Entry, error) {
 	entries := r.Entries()
 
 	// short circuit if we don't have to go further
@@ -52,7 +52,7 @@ func (r Repo) SortedEntries() ([]manifest.Manifest2822Entry, error) {
 		rs = append(rs, r.EntryRepo(&entries[i]))
 	}
 
-	rs, err := sortRepoObjects(rs)
+	rs, err := sortRepoObjects(rs, applyConstraints)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (r Repo) SortedEntries() ([]manifest.Manifest2822Entry, error) {
 	return ret, nil
 }
 
-func sortRepoObjects(rs []*Repo) ([]*Repo, error) {
+func sortRepoObjects(rs []*Repo, applyConstraints bool) ([]*Repo, error) {
 	// short circuit if we don't have to go further
 	if noSortFlag || len(rs) <= 1 {
 		return rs, nil
@@ -94,6 +94,10 @@ func sortRepoObjects(rs []*Repo) ([]*Repo, error) {
 
 	for _, r := range rs {
 		for _, entry := range r.Entries() {
+			if applyConstraints && r.SkipConstraints(entry) {
+				continue
+			}
+
 			from, err := r.DockerFrom(&entry)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
- only print a Constraints-related "skipping" warning for a given "repo:tag" once per session
- apply constraints while sorting too (so that `bashbrew build --all` on Windows doesn't try to `git fetch` Linux rootfs tarballs only to skip them during build, for example)
- add `--apply-constraints` flag to `from`, `children`, and `parents` subcommands