### PR TITLE
Adjust override-cmd to no longer require override (test for "echo" via "--entrypoint" before actually running the real test)

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -190,12 +190,6 @@ globalExcludeTests+=(
 	[swarm_no-hard-coded-passwords]=1
 	[traefik_no-hard-coded-passwords]=1
 
-	[hello-world_override-cmd]=1
-	[nats_override-cmd]=1
-	[nats-streaming_override-cmd]=1
-	[swarm_override-cmd]=1
-	[traefik_override-cmd]=1
-
 	# clearlinux has no /etc/password
 	# https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477
 	[clearlinux_no-hard-coded-passwords]=1

--- a/test/tests/override-cmd/run.sh
+++ b/test/tests/override-cmd/run.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
-
 set -eo pipefail
 
 image="$1"
 
-# Test that we can override the CMD with echo
+# test that we can override the CMD with echo
+# https://github.com/docker-library/official-images/blob/d28cb89e79417cac50c2a8ae163a9b3b79167f79/README.md#consistency
+
 hello="world-$RANDOM-$RANDOM"
+
+# test first with --entrypoint to verify that we even have echo (tests for single-binary images FROM scratch, essentially)
+if ! testOutput="$(docker run --rm --entrypoint echo "$image" "Hello $hello" 2>/dev/null)"; then
+	echo >&2 'image does not appear to contain "echo" -- assuming single-binary image'
+	exit
+fi
+[ "$testOutput" = "Hello $hello" ]
+
+# now test with normal command to verify the default entrypoint is OK
 output="$(docker run --rm "$image" echo "Hello $hello")"
 [ "$output" = "Hello $hello" ]


### PR DESCRIPTION
Noticed this loophole while reviewing https://github.com/docker-library/official-images/pull/2367 :disappointed: (but also realized there was a relatively easy way to fix the test via `--entrypoint` like we do for the shellshock test)