### PR TITLE
Aerospike 3.10.1

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,4 +1,4 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
-3.10.0.3: git://github.com/aerospike/aerospike-server.docker@33a4dade9e13ebd34c7bc879d491ce6904bc52fa
-latest: git://github.com/aerospike/aerospike-server.docker@33a4dade9e13ebd34c7bc879d491ce6904bc52fa
+3.10.1: git://github.com/aerospike/aerospike-server.docker@1f478e53cc4fa724afeb952ede41a3d8622cf823
+latest: git://github.com/aerospike/aerospike-server.docker@1f478e53cc4fa724afeb952ede41a3d8622cf823


### PR DESCRIPTION
Release Notes:

http://www.aerospike.com/download/server/notes.html#3.10.1


New Features

    [AER-3261] - (KVS) Special TTL value of '-2' now means record's TTL is unchanged when record is updated.

Improvements

    [AER-5038] - (KVS) Upgrade to jemalloc version 4. Improve long term memory allocation to improve fragmentation. New statistics to monitor jemalloc heap efficiency.
    [AER-5161] - (KVS) Improve log when server assert occurs.
    [AER-5273] - (KVS) Read duplicate resolution should only be done when repeatable read is turned on.
    [AER-5332] - (KVS) Better logging when no active network interfaces are available.
    [AER-5335] - (KVS) Read transactions relying on system default timeout (transaction-max-ms) will now return error code TIMEOUT (error code=9) instead of closing socket.
    [AER-5356] - (KVS) Add transaction retry statistics.
    [AER-5370] - (KVS) Remove unnecessary request-hash processing when cluster state changes.
    [AER-5363] - (Migration) Default for migrate-max-num-incoming is now 4.
    [AER-5364] - (Migration) Reduce likelihood of multiple migrations to same node.
    [AER-5365] - (Migration) Retransmit tuning and tracking - migrate-retransmit-ms now on namespace level, default of 5 second.
    [AER-5295] - (Storage) Improved storage name detection to set device scheduler "noop".

Bug Fixes

    [AER-5327] - (KVS) Access-address no longer support loopback 127.0.0.1
    [AER-5354] - (KVS) In mixed version cluster, 3.10's peers-list will now also include peer-nodes which are on previous releases.
    [AER-5379] - (KVS) obj-size-hist-max not returned when querying namespace config.
    [AER-5304] - (Cluster) Incorrect fabric network address used when changing heartbeat protocol version from v3 back to v2.
    [AER-5309] - (Cluster) Rare cluster integrity caused by incorrectly rejecting new principal node's paxos message.
    [AER-5340] - (Cluster) In mesh network, split cluster may not re-form due to incorrectly losing "isSeed" info.
    [AER-5315] - (UDF) Memory stomp caused by UDF creating list with null elements.
    [AER-5312] - (AGGR) Memory leak of records caused by aggregation, if records are later deleted.
    [AER-5353] - (Telemetry) On rpm systems, telemetry daemon not stopped if server not running.