### PR TITLE
fix entrypoint script in docker container

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -14,6 +14,6 @@
 3.0: git://github.com/arangodb/arangodb-docker@b71073b2e36acff7d0660b7f73e659f16facbf99 jessie/3.0.10
 3.0.10: git://github.com/arangodb/arangodb-docker@b71073b2e36acff7d0660b7f73e659f16facbf99 jessie/3.0.10
 
-3.1: git://github.com/arangodb/arangodb-docker@039f5444a9c637b97b7dd40cbdf03bafb6287197 jessie/3.1.1
-3.1.1: git://github.com/arangodb/arangodb-docker@039f5444a9c637b97b7dd40cbdf03bafb6287197 jessie/3.1.1
-latest: git://github.com/arangodb/arangodb-docker@039f5444a9c637b97b7dd40cbdf03bafb6287197 jessie/3.1.1
+3.1: git://github.com/arangodb/arangodb-docker@66d3eccbb2bbe85c190658d4863652c26089d1b7 jessie/3.1.1
+3.1.1: git://github.com/arangodb/arangodb-docker@66d3eccbb2bbe85c190658d4863652c26089d1b7 jessie/3.1.1
+latest: git://github.com/arangodb/arangodb-docker@66d3eccbb2bbe85c190658d4863652c26089d1b7 jessie/3.1.1


### PR DESCRIPTION
The script had timing problems which unveiled with arangodb 3.1 - please push the tag for the official arangodb 3.1.1 forward as done by this PR.