### PR TITLE
Bump traefik to v1.1.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,8 +2,12 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.1.0-rc4, camembert
-GitCommit: c8760c0b023570d7fff14934fa340759f8174e00
+Tags: v1.1.0, camembert, latest
+GitCommit: 22634bd4df4e1ee0f7b32fbdbf96ee3f87e06bb5
 
-Tags: v1.0.3, reblochon, latest
+Tags: v1.1.0-alpine, camembert-alpine
+GitCommit: 22634bd4df4e1ee0f7b32fbdbf96ee3f87e06bb5
+Directory: alpine
+
+Tags: v1.0.3, reblochon
 GitCommit: 9d877ca7171211aabc2955ab1a301a685f6852fe


### PR DESCRIPTION
Hello,

Following #2367, this PR updates traefik to v1.1.0.
It also adds an alpine image version.

/cc @vdemeester @tianon 

Cheers

Signed-off-by: Emile Vauge <emile@vauge.com>