### PR TITLE
Updating OL5, OL6 and OL7 images for CVE updates.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,19 +1,19 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.3
-7: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.3
-7.3: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.3
-7.2: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.3
+7: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.3
+7.3: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.3
+7.2: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@9d621d43b010338d70582c013d4caa811d529926 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@01591341c8f2155f32cb0b7b6afa665474beb735 OracleLinux/5.11


### PR DESCRIPTION
https://linux.oracle.com/errata/ELSA-2016-2779.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>