### PR TITLE
Odoo - 20161123 releases, fixes in entrypoint

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,11 +1,11 @@
 # maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
 
-8.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 8.0
-8: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 8.0
+8.0: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 8.0
+8: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 8.0
 
-9.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 9.0
-9: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 9.0
+9.0: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 9.0
+9: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 9.0
 
-10.0: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0
-10: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0
-latest: git://github.com/odoo/docker@ea050e938ba153b39987a8a5d446210d8383aa46 10.0
+10.0: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 10.0
+10: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 10.0
+latest: git://github.com/odoo/docker@d780e6fe363a65856dc1a36955fec6becdd2f41e 10.0


### PR DESCRIPTION
The refactoring of environment variables introduced in [1] introduced
two bugs: the crendentials of the configuration file were ignored [2]
and the subcommands were broken [3]. These bugs are now fixed and we
take advantage of this commit to upgrade the odoo releases at the date
of today.

[1] https://github.com/odoo/docker-official-images/commit/5c26243b103ffb660a5bf5032ee92fba7b6e583b
[2] https://github.com/odoo/docker/commit/b8e9cd478a5e37db2584c7aa05eb98a3e48e4ab5
[3] https://github.com/odoo/docker/commit/a2559e47d5bca392652f121ec24abb4348551def