### PR TITLE
[security] Update for Node.js v7.2.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/655aea9585318c5a0509fa673f989c3b7d9df7ee/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/62183100a090a33d1c284855d753a9d35d0abfa8/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.1.0, 7.1, 7, latest
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
-Directory: 7.1
+Tags: 7.2.0, 7.2, 7, latest
+GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Directory: 7.2
 
-Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
-Directory: 7.1/alpine
+Tags: 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
+GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Directory: 7.2/alpine
 
-Tags: 7.1.0-onbuild, 7.1-onbuild, 7-onbuild, onbuild
-GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
-Directory: 7.1/onbuild
+Tags: 7.2.0-onbuild, 7.2-onbuild, 7-onbuild, onbuild
+GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Directory: 7.2/onbuild
 
-Tags: 7.1.0-slim, 7.1-slim, 7-slim, slim
-GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
-Directory: 7.1/slim
+Tags: 7.2.0-slim, 7.2-slim, 7-slim, slim
+GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Directory: 7.2/slim
 
-Tags: 7.1.0-wheezy, 7.1-wheezy, 7-wheezy, wheezy
-GitCommit: 2c1bba840c6c64869755f67dafe2cd8f608dfc75
-Directory: 7.1/wheezy
+Tags: 7.2.0-wheezy, 7.2-wheezy, 7-wheezy, wheezy
+GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Directory: 7.2/wheezy
 
 Tags: 6.9.1, 6.9, 6, boron
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 6.9
 
 Tags: 6.9.1-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 6.9/alpine
 
 Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
@@ -36,19 +36,19 @@ GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
 Directory: 6.9/onbuild
 
 Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 6.9/slim
 
 Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 6.9/wheezy
 
 Tags: 4.6.2, 4.6, 4, argon
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 4.6
 
 Tags: 4.6.2-alpine, 4.6-alpine, 4-alpine, argon-alpine
-GitCommit: d20d305f0bf5935385a32558501f3a5c65e34878
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 4.6/alpine
 
 Tags: 4.6.2-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
@@ -56,15 +56,15 @@ GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
 Directory: 4.6/onbuild
 
 Tags: 4.6.2-slim, 4.6-slim, 4-slim, argon-slim
-GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 4.6/slim
 
 Tags: 4.6.2-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 4.6/wheezy
 
 Tags: 0.12.17, 0.12, 0
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 0.12
 
 Tags: 0.12.17-onbuild, 0.12-onbuild, 0-onbuild
@@ -72,10 +72,10 @@ GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
 Directory: 0.12/onbuild
 
 Tags: 0.12.17-slim, 0.12-slim, 0-slim
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 0.12/slim
 
 Tags: 0.12.17-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: b18c441de44515015f7670d7be0186503ae156ec
+GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 0.12/wheezy
 


### PR DESCRIPTION
This update includes is a security fix for v7 (v7.2.0) that fixes a
potential buffer overflow when writing data to console on Windows 10.

This update also includes the addition of a node group/user with
gid/uid 1000, a home directory and sets bash as the default shell for
the node user (except the Alpine variant).

Reference:

- https://nodejs.org/en/blog/release/v7.2.0/
- https://github.com/nodejs/docker-node/pull/274
- https://github.com/nodejs/docker-node/pull/275
- https://github.com/nodejs/docker-node/issues/273
- https://github.com/nodejs/docker-node/pull/263