### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,8 +8,8 @@ Tags: 1.6.2, 1.6
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 1.6
 
-Tags: 1.7.5, 1.7, 1
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+Tags: 1.7.6, 1.7, 1
+GitCommit: e7bc23dc00f0ddbaa57cb8c035f08955d9d9e680
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
@@ -28,8 +28,8 @@ Tags: 2.3.5, 2.3
 GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
 Directory: 2.3
 
-Tags: 2.4.1, 2.4, 2
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+Tags: 2.4.2, 2.4, 2
+GitCommit: dc045380f272db31d5a9993501bc410f667946cc
 Directory: 2.4
 
 Tags: 5.0.1, 5.0, 5, latest

--- a/library/mongo
+++ b/library/mongo
@@ -31,11 +31,11 @@ GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.3/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.0-rc4, 3.4.0, 3.4, 3.4-rc, rc
-GitCommit: af08171f377164a3e996e660dd26d16dd7a00321
+Tags: 3.4.0-rc5, 3.4.0, 3.4, 3.4-rc, rc
+GitCommit: f5a955ece2dc3da903c804115c75a9b0b5bc2edf
 Directory: 3.4-rc
 
-Tags: 3.4.0-rc4-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
-GitCommit: e3bc09e3a6fc447168d94a860caadc445b7364ba
+Tags: 3.4.0-rc5-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
+GitCommit: 0e4966760ba48fb611d3efb3975484444b5def1e
 Directory: 3.4-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
+GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
 Directory: 8.0
 
 Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
+GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
 Directory: 5.7
 
 Tags: 5.6.34, 5.6
-GitCommit: 10eb5eab8d3d793c49a701ed7a42e1e5d1c9bb59
+GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: 8b08921b27f9505f738cc61c551e776815e50d5b
+GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
 Directory: 5.5

--- a/library/percona
+++ b/library/percona
@@ -13,5 +13,5 @@ GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: 54b666e4e5942e43fc0ecbc67be7a24ac0bc00c7
+GitCommit: c5ca3f7af21b68a093bdd4f8bdcc7a93cd8d26de
 Directory: 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.1, 9.6, 9, latest
-GitCommit: e4942cb0f79b61024963dc0ac196375b26fa60dd
+GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
-GitCommit: db63c8c4eff2aa81c3f2c9e42f1ede447c7cf99c
+GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
-GitCommit: 56b1a0c47ae8361eca133e41c6ddd68ad492ac2d
+GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
-GitCommit: 570ca9e8ea81cb6da73ea765132755f277cd0b66
+GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
-GitCommit: c01405b7c324350cc796ba9e861326aee158f75e
+GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: 797fadcad2239919ea98aa7a3d14d32b4e8fc525
+GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -90,23 +90,23 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.0b3, 3.6-rc, rc
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.6.0b4, 3.6-rc, rc
+GitCommit: d8aac61bc3abddfd7ba58724446cf9b0e949ffa4
 Directory: 3.6-rc
 
-Tags: 3.6.0b3-slim, 3.6-rc-slim, rc-slim
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.6.0b4-slim, 3.6-rc-slim, rc-slim
+GitCommit: d8aac61bc3abddfd7ba58724446cf9b0e949ffa4
 Directory: 3.6-rc/slim
 
-Tags: 3.6.0b3-alpine, 3.6-rc-alpine, rc-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.6.0b4-alpine, 3.6-rc-alpine, rc-alpine
+GitCommit: d8aac61bc3abddfd7ba58724446cf9b0e949ffa4
 Directory: 3.6-rc/alpine
 
-Tags: 3.6.0b3-onbuild, 3.6-rc-onbuild, rc-onbuild
+Tags: 3.6.0b4-onbuild, 3.6-rc-onbuild, rc-onbuild
 GitCommit: b16ff405101a9f6c6540fb3467ca25baa9610174
 Directory: 3.6-rc/onbuild
 
-Tags: 3.6.0b3-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.6.0b4-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
+GitCommit: d8aac61bc3abddfd7ba58724446cf9b0e949ffa4
 Directory: 3.6-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.5, 3.6, 3, latest
-GitCommit: 29121864d4892b2481706df023a53e31fececd02
+Tags: 3.6.6, 3.6, 3, latest
+GitCommit: 003537013a42e6939f7687c495de1129939f69af
 
-Tags: 3.6.5-management, 3.6-management, 3-management, management
+Tags: 3.6.6-management, 3.6-management, 3-management, management
 GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d
 Directory: management

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.1.7, 3.1
-GitCommit: d564a3b0d78016b2f24af2d74bcdace26a1ac0a3
+GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
@@ -13,7 +13,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.1/passenger
 
 Tags: 3.2.4, 3.2
-GitCommit: 2fea678a49fab933aff1217f2f9b31e14080df7a
+GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.2
 
 Tags: 3.2.4-passenger, 3.2-passenger
@@ -21,7 +21,7 @@ GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
 Directory: 3.2/passenger
 
 Tags: 3.3.1, 3.3, 3, latest
-GitCommit: d2e2fb6ae2311e6f07f3aee999b7e8dff4131549
+GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.3
 
 Tags: 3.3.1-passenger, 3.3-passenger, 3-passenger, passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.45.0, 0.45, 0, latest
-GitCommit: b457541d09b371f4def66d2e4615b8cc67c13f3e
+Tags: 0.46.0, 0.46, 0, latest
+GitCommit: 4c08bce89aa76cad7c6f4424eed2f1f7aa09bfc5


### PR DESCRIPTION
- `elasticsearch`: 1.7.6, 2.4.2
- `mongo`: 3.4.0-rc5
- `mysql`: add `file_env` support (docker-library/mysql#237)
- `percona`: 5.5.53-rel38.5-1.jessie
- `postgres`: add `tzdata` to alpine variant (docker-library/postgres#226), add `file_env` support (docker-library/postgres#225)
- `python`: 3.6.0b4
- `rabbitmq`: 3.6.6
- `redmine`: add `file_env` support (docker-library/redmine#43)
- `rocket.chat`: 0.46.0