### PR TITLE
Update Node.js Alpine variant

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,11 +4,11 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.2.0, 7.2, 7, latest
-GitCommit: 718102a587e7f02748402551b51407332384c1b3
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 7.2
 
 Tags: 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
-GitCommit: 718102a587e7f02748402551b51407332384c1b3
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 7.2/alpine
 
 Tags: 7.2.0-onbuild, 7.2-onbuild, 7-onbuild, onbuild
@@ -24,11 +24,11 @@ GitCommit: 718102a587e7f02748402551b51407332384c1b3
 Directory: 7.2/wheezy
 
 Tags: 6.9.1, 6.9, 6, boron
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 6.9
 
 Tags: 6.9.1-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 6.9/alpine
 
 Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
@@ -44,11 +44,11 @@ GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
 Directory: 6.9/wheezy
 
 Tags: 4.6.2, 4.6, 4, argon
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 4.6
 
 Tags: 4.6.2-alpine, 4.6-alpine, 4-alpine, argon-alpine
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
 Directory: 4.6/alpine
 
 Tags: 4.6.2-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild


### PR DESCRIPTION
This includes a few improvements to the Alpine variant of the Node.js
image:

- Omit the tar package in the Alpine variant since it's not required
- Use xz instead of gz to get src tarball for Alpine variant

See:

- https://github.com/nodejs/docker-node/pull/278