### PR TITLE
Update docker-library images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/d5ab9779df0320470577033f158a2d3fa03be8b2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/6c318716176795fcd2784b9996bae18a4fbd34e6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -20,10 +20,18 @@ Tags: 1.5.18-alpine, 1.5-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.5/alpine
 
-Tags: 1.6.10, 1.6, 1, latest
+Tags: 1.6.10, 1.6
 GitCommit: 3f825ac60d7af1739f65897f64241c5577dfc31e
 Directory: 1.6
 
-Tags: 1.6.10-alpine, 1.6-alpine, 1-alpine, alpine
+Tags: 1.6.10-alpine, 1.6-alpine
 GitCommit: 3f825ac60d7af1739f65897f64241c5577dfc31e
 Directory: 1.6/alpine
+
+Tags: 1.7.0, 1.7, 1, latest
+GitCommit: a5840a9a7025365059aac0f7d15149f4553b3f44
+Directory: 1.7
+
+Tags: 1.7.0-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: a5840a9a7025365059aac0f7d15149f4553b3f44
+Directory: 1.7/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.31, 2.2
-GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
+GitCommit: 4510328d3a80c227a74ec2ba50ea20879270b860
 Directory: 2.2
 
 Tags: 2.2.31-alpine, 2.2-alpine
-GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
+GitCommit: 4510328d3a80c227a74ec2ba50ea20879270b860
 Directory: 2.2/alpine
 
 Tags: 2.4.23, 2.4, 2, latest
-GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
+GitCommit: 03b4873b5ef386ea4d97ee719167d79e319ee253
 Directory: 2.4
 
 Tags: 2.4.23-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: b13054c7de5c74bbaa6d595dbe38969e6d4f860c
+GitCommit: 03b4873b5ef386ea4d97ee719167d79e319ee253
 Directory: 2.4/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.1.19, 10.1, 10, latest
-GitCommit: 2538af1bad7f05ac2c23dc6eb35e8cba6356fc43
+GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
 Directory: 10.1
 
 Tags: 10.0.28, 10.0
-GitCommit: c9f0360d841db8bbb0c99d1e84059f05de3faf9e
+GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
 Directory: 10.0
 
 Tags: 5.5.53, 5.5, 5
-GitCommit: 110ab9c9ff42821d1459c6a45cc8c330763f724b
+GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
 Directory: 5.5

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.15, 5.7, 5, latest
-GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
+GitCommit: ab693a100d0b91ac3ddfd404ca38b4a07df37643
 Directory: 5.7
 
-Tags: 5.6.33, 5.6
-GitCommit: 0366da072fe5dc95af26d8a9f9ace48c72670720
+Tags: 5.6.34, 5.6
+GitCommit: e72ee9b01ff3848590d110bfab255e3a8bfe8ead
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: c5ca3f7af21b68a093bdd4f8bdcc7a93cd8d26de
+GitCommit: ab693a100d0b91ac3ddfd404ca38b4a07df37643
 Directory: 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -2,4 +2,4 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 2.17.1, 2.17, 2, latest
-GitCommit: 0586742bf49f12fb99cba2acb997418aa26d0166
+GitCommit: b511e57a17ab57d9f2e947fc391f004990d7f1d3


### PR DESCRIPTION
- `haproxy`: add 1.7 (docker-library/haproxy#35)
- `httpd`: add `mod_http2`, `mod_lua`, `mod_proxy_html`, and `mod_xml2enc` (docker-library/httpd#34)
- `mariadb`: add `file_env` support (docker-library/mariadb#89)
- `percona`: add `file_env` support (docker-library/percona#34); 5.6.34-79.1-1.jessie
- `piwik`: remove `ssmtp`