### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 1.6.2, 1.6
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 1.6
 
 Tags: 1.7.6, 1.7, 1
-GitCommit: e7bc23dc00f0ddbaa57cb8c035f08955d9d9e680
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 1.7
 
 Tags: 2.0.2, 2.0
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 2.0
 
 Tags: 2.1.2, 2.1
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 2.1
 
 Tags: 2.2.2, 2.2
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 2.2
 
 Tags: 2.3.5, 2.3
-GitCommit: 8347a4697d32878dbacd7086b34f76a9e19113ae
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 2.3
 
 Tags: 2.4.2, 2.4, 2
-GitCommit: dc045380f272db31d5a9993501bc410f667946cc
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 2.4
 
-Tags: 5.0.1, 5.0, 5, latest
-GitCommit: 605ca406cbd254f70872af0df8fecf524d126c53
+Tags: 5.0.2, 5.0, 5, latest
+GitCommit: e31caa41f494770b9029063f02df6be532c6a248
 Directory: 5.0

--- a/library/kibana
+++ b/library/kibana
@@ -28,6 +28,6 @@ Tags: 4.6.3, 4.6, 4
 GitCommit: 43644e6ae40c53c05d94165506094035f0463ea6
 Directory: 4.6
 
-Tags: 5.0.1, 5.0, 5, latest
-GitCommit: 43644e6ae40c53c05d94165506094035f0463ea6
+Tags: 5.0.2, 5.0, 5, latest
+GitCommit: 960d3f8e41828a75585dbabc528d5e226b1adc3c
 Directory: 5.0

--- a/library/logstash
+++ b/library/logstash
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 1.5.6-1, 1.5.6, 1.5, 1
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 1.5
 
 Tags: 2.0.0-1, 2.0.0, 2.0
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 2.0
 
 Tags: 2.1.3-1, 2.1.3, 2.1
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 2.1
 
 Tags: 2.2.4-1, 2.2.4, 2.2
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 2.2
 
 Tags: 2.3.4-1, 2.3.4, 2.3
-GitCommit: 09b1537c0a0c912c87639b816da61323752cabd8
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 2.3
 
 Tags: 2.4.1-1, 2.4.1, 2.4, 2
-GitCommit: 60506b52e56e262851b01df1875ee9f24b81c4c1
+GitCommit: f4cb56f776ea44cc2b10cb8a670ecf6309baf3d7
 Directory: 2.4
 
-Tags: 5.0.1-1, 5.0.1, 5.0, 5, latest
-GitCommit: 61c818c07bcecf7733dc821a4e4f4770f7e136ce
+Tags: 5.0.2-1, 5.0.2, 5.0, 5, latest
+GitCommit: 79bc3b0c32cb559654228ca79cc9ed4b0f1b158c
 Directory: 5.0

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/3dfba3285da24f724b4b8d51f8db54769ed323e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/5f4bcf4bec163ef05b4fc67d5c92762989dbde06/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -13,29 +13,20 @@ GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.11, 3.2, 3, latest
+Tags: 3.2.11, 3.2
 GitCommit: 21a6f6cf3eff13a39b20c86224730a29823370ca
 Directory: 3.2
 
-Tags: 3.2.11-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.2.11-windowsservercore, 3.2-windowsservercore
 GitCommit: 21a6f6cf3eff13a39b20c86224730a29823370ca
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.15, 3.3, unstable
-GitCommit: 0ac2867637ef5989e4dc051efa0ae296010e58c9
-Directory: 3.3
+Tags: 3.4.0, 3.4, 3, latest
+GitCommit: 5f4bcf4bec163ef05b4fc67d5c92762989dbde06
+Directory: 3.4
 
-Tags: 3.3.15-windowsservercore, 3.3-windowsservercore, unstable-windowsservercore
-GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
-Directory: 3.3/windows/windowsservercore
-Constraints: windowsservercore
-
-Tags: 3.4.0-rc5, 3.4.0, 3.4, 3.4-rc, rc
-GitCommit: f5a955ece2dc3da903c804115c75a9b0b5bc2edf
-Directory: 3.4-rc
-
-Tags: 3.4.0-rc5-windowsservercore, 3.4.0-windowsservercore, 3.4-windowsservercore, 3.4-rc-windowsservercore, rc-windowsservercore
-GitCommit: 0e4966760ba48fb611d3efb3975484444b5def1e
-Directory: 3.4-rc/windows/windowsservercore
+Tags: 3.4.0-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 5f4bcf4bec163ef05b4fc67d5c92762989dbde06
+Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.15, 5.7, 5, latest
-GitCommit: ab693a100d0b91ac3ddfd404ca38b4a07df37643
+Tags: 5.7.16, 5.7, 5, latest
+GitCommit: 19d875937db2775a623cadedb4d5f4599bb9a0d8
 Directory: 5.7
 
 Tags: 5.6.34, 5.6


### PR DESCRIPTION
- `elasticsearch`: 5.0.2 (docker-library/elasticsearch#145)
- `kibana`: 5.0.2
- `logstash`: 5.0.2, 5.1.0, allow arbitrary `--user` values (docker-library/logstash#70)
- `mongo`: 3.4.0 GA (remove 3.3 development series)
- `percona`: 5.6.34-79.1-1.jessie, 5.7.16-10-1.jessie