### PR TITLE
Update to Go 1.6.4, 1.7.4 (security)

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,55 +5,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.6.3, 1.6
-GitCommit: 85df9970e9548f38248d36f6f4341e2aea128515
+Tags: 1.6.4, 1.6
+GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6
 
-Tags: 1.6.3-onbuild, 1.6-onbuild
+Tags: 1.6.4-onbuild, 1.6-onbuild
 GitCommit: ce284e14cdee73fbaa8fb680011a812f272eae2e
 Directory: 1.6/onbuild
 
-Tags: 1.6.3-wheezy, 1.6-wheezy
-GitCommit: 85df9970e9548f38248d36f6f4341e2aea128515
+Tags: 1.6.4-wheezy, 1.6-wheezy
+GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/wheezy
 
-Tags: 1.6.3-alpine, 1.6-alpine
-GitCommit: 9f666dc2f4f51df564613f787d28b3a2353243e0
+Tags: 1.6.4-alpine, 1.6-alpine
+GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/alpine
 
-Tags: 1.6.3-windowsservercore, 1.6-windowsservercore
-GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
+Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
+GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.6.3-nanoserver, 1.6-nanoserver
-GitCommit: cba64e4f78b2ef64b2938caaa33d699cbca4f9a4
+Tags: 1.6.4-nanoserver, 1.6-nanoserver
+GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.7.3, 1.7, 1, latest
-GitCommit: 4fd5df86eea53623b1009b3621b40a97f9f359e5
+Tags: 1.7.4, 1.7, 1, latest
+GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7
 
-Tags: 1.7.3-onbuild, 1.7-onbuild, 1-onbuild, onbuild
+Tags: 1.7.4-onbuild, 1.7-onbuild, 1-onbuild, onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7.3-wheezy, 1.7-wheezy, 1-wheezy, wheezy
-GitCommit: 4fd5df86eea53623b1009b3621b40a97f9f359e5
+Tags: 1.7.4-wheezy, 1.7-wheezy, 1-wheezy, wheezy
+GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/wheezy
 
-Tags: 1.7.3-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 4fd5df86eea53623b1009b3621b40a97f9f359e5
+Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/alpine
 
-Tags: 1.7.3-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 4fd5df86eea53623b1009b3621b40a97f9f359e5
+Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
+GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.7.3-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
-GitCommit: 4fd5df86eea53623b1009b3621b40a97f9f359e5
+Tags: 1.7.4-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
+GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
@@ -74,11 +74,11 @@ GitCommit: 7a5e33ec522b17dffa51c2763610a2967475529d
 Directory: 1.8/alpine
 
 Tags: 1.8beta1-windowsservercore, 1.8-windowsservercore
-GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
+GitCommit: 803439af1f04d215135fff8ca406761ead9f06af
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 1.8beta1-nanoserver, 1.8-nanoserver
-GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
+GitCommit: 803439af1f04d215135fff8ca406761ead9f06af
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
See also https://groups.google.com/d/topic/golang-announce/2lP5z9i9ySY/discussion

This also includes the minor `$ProgressPreference` change from https://github.com/docker-library/golang/pull/124.