### PR TITLE
Sentry 8.11

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/8e4ec0e019a9cfc653f09b16531cef507e015af1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/60d4b0e5ad293ceabfd0d00ec4bc08c5d353ca2c/generate-stackbrew-library.sh
 
-Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
+Maintainers: Matt Robenolt <matt@sentry.io> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
 
-Tags: 8.10.0, 8.10, 8, latest
+Tags: 8.10.0, 8.10
 GitCommit: 71597dc5f0532721a3bd24405021e273df471866
 Directory: 8.10
 
-Tags: 8.10.0-onbuild, 8.10-onbuild, 8-onbuild, onbuild
+Tags: 8.10.0-onbuild, 8.10-onbuild
 GitCommit: 8e4ec0e019a9cfc653f09b16531cef507e015af1
 Directory: 8.10/onbuild
 
-Tags: 8.9.0, 8.9
-GitCommit: 06d750bddc0e6499446e73ca22fbd4c915b29cbd
-Directory: 8.9
+Tags: 8.11.0, 8.11, 8, latest
+GitCommit: 60d4b0e5ad293ceabfd0d00ec4bc08c5d353ca2c
+Directory: 8.11
 
-Tags: 8.9.0-onbuild, 8.9-onbuild
-GitCommit: 06d750bddc0e6499446e73ca22fbd4c915b29cbd
-Directory: 8.9/onbuild
+Tags: 8.11.0-onbuild, 8.11-onbuild, 8-onbuild, onbuild
+GitCommit: 60d4b0e5ad293ceabfd0d00ec4bc08c5d353ca2c
+Directory: 8.11/onbuild


### PR DESCRIPTION
:cake: https://github.com/getsentry/sentry/releases/tag/8.11.0 :cake: