### PR TITLE
composer - update 1.2.x series to release 1.2.3

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -3,8 +3,8 @@
 Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
-Tags: 1.2.2, 1.2, 1, latest
-GitCommit: be6ecf58913f704399d11a352818b22951832a60
+Tags: 1.2.3, 1.2, 1, latest
+GitCommit: f9ee1f61cad16269132e24e93f08e60915b9f431
 Directory: 1.2
 
 Tags: 1.1.3, 1.1


### PR DESCRIPTION
Can someone confirm this is the right way to keep track of tags? Up the patch version in the Dockerfile for a major.minor series? Or should we have a Dockerfile for each major.minor.patch version?