### PR TITLE
Update for Node.js v6.9.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -23,24 +23,24 @@ Tags: 7.2.0-wheezy, 7.2-wheezy, 7-wheezy, wheezy
 GitCommit: 718102a587e7f02748402551b51407332384c1b3
 Directory: 7.2/wheezy
 
-Tags: 6.9.1, 6.9, 6, boron
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
+Tags: 6.9.2, 6.9, 6, boron
+GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9
 
-Tags: 6.9.1-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
+Tags: 6.9.2-alpine, 6.9-alpine, 6-alpine, boron-alpine
+GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9/alpine
 
-Tags: 6.9.1-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 613d09a89a63c916883a9cf6d17000ab4c784aec
+Tags: 6.9.2-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
+GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9/onbuild
 
-Tags: 6.9.1-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+Tags: 6.9.2-slim, 6.9-slim, 6-slim, boron-slim
+GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9/slim
 
-Tags: 6.9.1-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+Tags: 6.9.2-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9/wheezy
 
 Tags: 4.6.2, 4.6, 4, argon


### PR DESCRIPTION
See:

- https://github.com/nodejs/docker-node/pull/283
- https://nodejs.org/en/blog/release/v6.9.2/