### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -22,7 +22,7 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/alpine
 
 Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
-GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
+GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
 Directory: 1.6/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -48,7 +48,7 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/alpine
 
 Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
+GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -74,7 +74,7 @@ GitCommit: 7a5e33ec522b17dffa51c2763610a2967475529d
 Directory: 1.8/alpine
 
 Tags: 1.8beta1-windowsservercore, 1.8-windowsservercore
-GitCommit: 803439af1f04d215135fff8ca406761ead9f06af
+GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.0-cli, 7.1-cli, 7-cli, cli, 7.1.0, 7.1, 7, latest
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/alpine
 
 Tags: 7.1.0-apache, 7.1-apache, 7-apache, apache
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/apache
 
 Tags: 7.1.0-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/fpm
 
 Tags: 7.1.0-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.0-zts, 7.1-zts, 7-zts, zts
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/zts
 
 Tags: 7.1.0-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.13-cli, 7.0-cli, 7.0.13, 7.0
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0
 
 Tags: 7.0.13-alpine, 7.0-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/alpine
 
 Tags: 7.0.13-apache, 7.0-apache
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/apache
 
 Tags: 7.0.13-fpm, 7.0-fpm
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/fpm
 
 Tags: 7.0.13-fpm-alpine, 7.0-fpm-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.13-zts, 7.0-zts
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/zts
 
 Tags: 7.0.13-zts-alpine, 7.0-zts-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.28-cli, 5.6-cli, 5-cli, 5.6.28, 5.6, 5
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6
 
 Tags: 5.6.28-alpine, 5.6-alpine, 5-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/alpine
 
 Tags: 5.6.28-apache, 5.6-apache, 5-apache
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/apache
 
 Tags: 5.6.28-fpm, 5.6-fpm, 5-fpm
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/fpm
 
 Tags: 5.6.28-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.28-zts, 5.6-zts, 5-zts
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/zts
 
 Tags: 5.6.28-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 03112824453df03f5eec51db546a4bdf7dcef127
+GitCommit: 173945670390f6595da8f93ae46b442167ff05be
 Directory: 5.6/zts/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.1, 9.6, 9, latest
-GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
-GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
-GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
-GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
-GitCommit: edd455e5b1dbfddc280beb244228054374f2f3dd
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: d2b38544770a63fed430694a7aed33de3ad8b808
+GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
 Directory: 9.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.46.0, 0.46, 0, latest
-GitCommit: 4c08bce89aa76cad7c6f4424eed2f1f7aa09bfc5
+Tags: 0.47.0, 0.47, 0, latest
+GitCommit: ec5871f54c004ee50122a3d9c2c5f30eea16676d

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.6.1-apache, 4.6-apache, 4-apache, apache, 4.6.1, 4.6, 4, latest, 4.6.1-php5.6-apache, 4.6-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.6.1-php5.6, 4.6-php5.6, 4-php5.6, php5.6
-GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
+Tags: 4.7.0-apache, 4.7-apache, 4-apache, apache, 4.7.0, 4.7, 4, latest, 4.7.0-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.0-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
 Directory: php5.6/apache
 
-Tags: 4.6.1-fpm, 4.6-fpm, 4-fpm, fpm, 4.6.1-php5.6-fpm, 4.6-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
+Tags: 4.7.0-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.0-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
 Directory: php5.6/fpm
 
-Tags: 4.6.1-php7.0-apache, 4.6-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.6.1-php7.0, 4.6-php7.0, 4-php7.0, php7.0
-GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
+Tags: 4.7.0-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.0-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
 Directory: php7.0/apache
 
-Tags: 4.6.1-php7.0-fpm, 4.6-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 8ab70dd61a996d58c0addf4867a768efe649bf65
+Tags: 4.7.0-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
 Directory: php7.0/fpm


### PR DESCRIPTION
- `golang`: update Windows Git to 2.11.0 (docker-library/golang#126)
- `php`: fix subshell usage (docker-library/php#334)
- `postgres`: update `pg_hba.conf` for IPv6 support (docker-library/postgres#202)
- `rocket.chat`: 0.47.0
- `wordpress`: 4.7