### PR TITLE
update composer 1.2.x release series

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -3,8 +3,8 @@
 Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
-Tags: 1.2.3, 1.2, 1, latest
-GitCommit: f9ee1f61cad16269132e24e93f08e60915b9f431
+Tags: 1.2.4, 1.2, 1, latest
+GitCommit: 690f3d623ac1ba30be337a254b2126584e6e2aa5
 Directory: 1.2
 
 Tags: 1.1.3, 1.1


### PR DESCRIPTION
### [1.2.4](https://github.com/composer/composer/compare/1.2.3...1.2.4) - 2016-12-06

  * Fixed regression in output handling of scripts from 1.2.3
  * Fixed support for LibreSSL detection as lib-openssl
  * Fixed issue with Zend Guard in the autoloader bootstrapping
  * Fixed support for loading partial provider repositories