### PR TITLE
Update for Node.js v7.2.1 and v4.7.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,26 +1,26 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/62183100a090a33d1c284855d753a9d35d0abfa8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/cee890b875e72c867eaeecb47c0602b10b643a7d/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.2.0, 7.2, 7, latest
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
+Tags: 7.2.1, 7.2, 7, latest
+GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
 Directory: 7.2
 
-Tags: 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
+Tags: 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
+GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
 Directory: 7.2/alpine
 
-Tags: 7.2.0-onbuild, 7.2-onbuild, 7-onbuild, onbuild
-GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Tags: 7.2.1-onbuild, 7.2-onbuild, 7-onbuild, onbuild
+GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
 Directory: 7.2/onbuild
 
-Tags: 7.2.0-slim, 7.2-slim, 7-slim, slim
-GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Tags: 7.2.1-slim, 7.2-slim, 7-slim, slim
+GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
 Directory: 7.2/slim
 
-Tags: 7.2.0-wheezy, 7.2-wheezy, 7-wheezy, wheezy
-GitCommit: 718102a587e7f02748402551b51407332384c1b3
+Tags: 7.2.1-wheezy, 7.2-wheezy, 7-wheezy, wheezy
+GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
 Directory: 7.2/wheezy
 
 Tags: 6.9.2, 6.9, 6, boron
@@ -43,25 +43,25 @@ Tags: 6.9.2-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
 GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
 Directory: 6.9/wheezy
 
-Tags: 4.6.2, 4.6, 4, argon
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
-Directory: 4.6
+Tags: 4.7.0, 4.7, 4, argon
+GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Directory: 4.7
 
-Tags: 4.6.2-alpine, 4.6-alpine, 4-alpine, argon-alpine
-GitCommit: a3489450fcd506538ab84174ebedb3cc5c908bc7
-Directory: 4.6/alpine
+Tags: 4.7.0-alpine, 4.7-alpine, 4-alpine, argon-alpine
+GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Directory: 4.7/alpine
 
-Tags: 4.6.2-onbuild, 4.6-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 1d00e55ede1c9b6023b0473b5cf9399375d73fc8
-Directory: 4.6/onbuild
+Tags: 4.7.0-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Directory: 4.7/onbuild
 
-Tags: 4.6.2-slim, 4.6-slim, 4-slim, argon-slim
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
-Directory: 4.6/slim
+Tags: 4.7.0-slim, 4.7-slim, 4-slim, argon-slim
+GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Directory: 4.7/slim
 
-Tags: 4.6.2-wheezy, 4.6-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
-Directory: 4.6/wheezy
+Tags: 4.7.0-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Directory: 4.7/wheezy
 
 Tags: 0.12.17, 0.12, 0
 GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463


### PR DESCRIPTION
See:

- https://github.com/nodejs/docker-node/pull/284
- https://nodejs.org/en/blog/release/v7.2.1/
- https://nodejs.org/en/blog/release/v4.7.0/