### PR TITLE
Update Ghost download URL

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,4 +5,4 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 0.11.3, 0.11, 0, latest
-GitCommit: 9e9522838f378c6c4acaf87a5fabaceab34cd2e0
+GitCommit: 4afb4dbe3b4306056b16b3aa7fc8f7aca2b1d281


### PR DESCRIPTION
(old URLs suffer from bad redirects now, and https://ghost.org/developers/ points users directly to this GitHub URL now)