### PR TITLE
[nats-streaming] Update to v0.3.4

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,6 +1,6 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 
-Tags: 0.3.0, latest
+Tags: 0.3.4, latest
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 1fcbfd456264c5da5888e279d9ea865166eeb3cf
+GitCommit: 5ba3680f2232ea7ef652aaaab8992e891894e7d3
 


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.3.4)