### PR TITLE
Fix "No such image, container or task" for "docker-build.sh" when the "FROM" does not exist yet

### DIFF
--- a/test/tests/docker-build.sh
+++ b/test/tests/docker-build.sh
@@ -24,6 +24,10 @@ trap "rm -rf '$tmp'" EXIT
 cat > "$tmp/Dockerfile"
 
 from="$(awk -F '[ \t]+' 'toupper($1) == "FROM" { print $2; exit }' "$tmp/Dockerfile")"
+if ! docker inspect "$from" &> /dev/null; then
+	docker pull "$from" > /dev/null
+fi
+
 onbuilds="$(docker inspect -f '{{len .Config.OnBuild}}' "$from")"
 if [ "$onbuilds" -gt 0 ]; then
 	# crap, the image we want to build has some ONBUILD instructions


### PR DESCRIPTION
See https://travis-ci.org/docker-library/wordpress/jobs/182926495#L869.