### PR TITLE
Update docker-library images

### DIFF
--- a/library/celery
+++ b/library/celery
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/celery.git
 
-Tags: 4.0.0rc7, 4.0, 4
-GitCommit: b09801f4d59adda61b58d4c0d90c1d10a717dd9b
+Tags: 4.0.1, 4.0, 4
+GitCommit: 5082d1515a4562d668eaaa3eb189ddb28b36fb85
 Directory: 4.0
 
 Tags: 3.1.25, 3.1, 3, latest

--- a/library/docker
+++ b/library/docker
@@ -16,27 +16,27 @@ Tags: 1.13.0-rc3-git, 1.13-rc-git, rc-git
 GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 
-Tags: 1.12.3, 1.12, 1, latest
-GitCommit: 0c44c1c6c25a34eb9abe320805e0f89bf5b0ace2
+Tags: 1.12.4, 1.12, 1, latest
+GitCommit: 1c73734649299a17d1472fb206b992a544bd1777
 Directory: 1.12
 
-Tags: 1.12.3-dind, 1.12-dind, 1-dind, dind
+Tags: 1.12.4-dind, 1.12-dind, 1-dind, dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/dind
 
-Tags: 1.12.3-git, 1.12-git, 1-git, git
+Tags: 1.12.4-git, 1.12-git, 1-git, git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
-Tags: 1.12.3-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: 36e2107fb879d5d5c3dbb5d8d93aeef0a2d45ac8
+Tags: 1.12.4-experimental, 1.12-experimental, 1-experimental, experimental
+GitCommit: 1c73734649299a17d1472fb206b992a544bd1777
 Directory: 1.12/experimental
 
-Tags: 1.12.3-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+Tags: 1.12.4-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/experimental/dind
 
-Tags: 1.12.3-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+Tags: 1.12.4-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
 GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,17 +1,29 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/9ad14fa8d565865caecdb006dff57f5b5f6679fc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 71cfc2cf6a383e8667954b88283cf07de64c8013
+GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
 Directory: 5
 
+Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
+GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+Directory: 5/alpine
+
 Tags: 2.4.2, 2.4, 2
-GitCommit: e31caa41f494770b9029063f02df6be532c6a248
+GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
 Directory: 2.4
 
+Tags: 2.4.2-alpine, 2.4-alpine, 2-alpine
+GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+Directory: 2.4/alpine
+
 Tags: 1.7.6, 1.7, 1
-GitCommit: e31caa41f494770b9029063f02df6be532c6a248
+GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
 Directory: 1.7
+
+Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine
+GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+Directory: 1.7/alpine

--- a/library/ghost
+++ b/library/ghost
@@ -5,4 +5,4 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 0.11.3, 0.11, 0, latest
-GitCommit: 4afb4dbe3b4306056b16b3aa7fc8f7aca2b1d281
+GitCommit: 3aae08aeeb4d14d681a36742a5ab5e46366a5fe1

--- a/library/haproxy
+++ b/library/haproxy
@@ -28,10 +28,10 @@ Tags: 1.6.10-alpine, 1.6-alpine
 GitCommit: 3f825ac60d7af1739f65897f64241c5577dfc31e
 Directory: 1.6/alpine
 
-Tags: 1.7.0, 1.7, 1, latest
-GitCommit: a5840a9a7025365059aac0f7d15149f4553b3f44
+Tags: 1.7.1, 1.7, 1, latest
+GitCommit: 84fa05e8980f556b0330d69f5c756633a5a85f8b
 Directory: 1.7
 
-Tags: 1.7.0-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: a5840a9a7025365059aac0f7d15149f4553b3f44
+Tags: 1.7.1-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: 84fa05e8980f556b0330d69f5c756633a5a85f8b
 Directory: 1.7/alpine

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u111-jre-alpine, open
 GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
-Tags: 9-b147-jdk, 9-b147, 9-jdk, 9, openjdk-9-b147-jdk, openjdk-9-b147, openjdk-9-jdk, openjdk-9
-GitCommit: 2ec4f3ac935c208117752da22d61d9bb0be319c5
+Tags: 9-b148-jdk, 9-b148, 9-jdk, 9, openjdk-9-b148-jdk, openjdk-9-b148, openjdk-9-jdk, openjdk-9
+GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
 Directory: 9-jdk
 
-Tags: 9-b147-jre, 9-jre, openjdk-9-b147-jre, openjdk-9-jre
-GitCommit: 2ec4f3ac935c208117752da22d61d9bb0be319c5
+Tags: 9-b148-jre, 9-jre, openjdk-9-b148-jre, openjdk-9-jre
+GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
 Directory: 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.1.19, 10.1, 10, latest
-GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
+GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
 Directory: 10.1
 
 Tags: 10.0.28, 10.0
-GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
+GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
 Directory: 10.0
 
 Tags: 5.5.53, 5.5, 5
-GitCommit: 6452a881b90283f46c88925b08c2d580a49a27cc
+GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
 Directory: 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -8,14 +8,14 @@ Tags: 8.0.0, 8.0, 8
 GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
 Directory: 8.0
 
-Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
+Tags: 5.7.17, 5.7, 5, latest
+GitCommit: c207cc19a272a6bfe1916c964ed8df47f18479e7
 Directory: 5.7
 
-Tags: 5.6.34, 5.6
-GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
+Tags: 5.6.35, 5.6
+GitCommit: fd3bdabe513643b62fc379f365b2b5dd10886311
 Directory: 5.6
 
-Tags: 5.5.53, 5.5
-GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
+Tags: 5.5.54, 5.5
+GitCommit: ee989d0666458d08dd79c55f7abb62be29a9cb3d
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
-Tags: 9-b147-jdk, 9-b147, 9-jdk, 9
-GitCommit: 2ec4f3ac935c208117752da22d61d9bb0be319c5
+Tags: 9-b148-jdk, 9-b148, 9-jdk, 9
+GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
 Directory: 9-jdk
 
-Tags: 9-b147-jre, 9-jre
-GitCommit: 2ec4f3ac935c208117752da22d61d9bb0be319c5
+Tags: 9-b148-jre, 9-jre
+GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
 Directory: 9-jre

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 19d875937db2775a623cadedb4d5f4599bb9a0d8
+GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
 Directory: 5.7
 
 Tags: 5.6.34, 5.6
-GitCommit: e72ee9b01ff3848590d110bfab255e3a8bfe8ead
+GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: ab693a100d0b91ac3ddfd404ca38b4a07df37643
+GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.0-cli, 7.1-cli, 7-cli, cli, 7.1.0, 7.1, 7, latest
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/alpine
 
 Tags: 7.1.0-apache, 7.1-apache, 7-apache, apache
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/apache
 
 Tags: 7.1.0-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/fpm
 
 Tags: 7.1.0-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.0-zts, 7.1-zts, 7-zts, zts
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/zts
 
 Tags: 7.1.0-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.14-cli, 7.0-cli, 7.0.14, 7.0
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0
 
 Tags: 7.0.14-alpine, 7.0-alpine
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/alpine
 
 Tags: 7.0.14-apache, 7.0-apache
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/apache
 
 Tags: 7.0.14-fpm, 7.0-fpm
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/fpm
 
 Tags: 7.0.14-fpm-alpine, 7.0-fpm-alpine
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.14-zts, 7.0-zts
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/zts
 
 Tags: 7.0.14-zts-alpine, 7.0-zts-alpine
-GitCommit: 61d8a2dd65f433c261c4b48dcb1e1a04cdcace56
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.28-cli, 5.6-cli, 5-cli, 5.6.28, 5.6, 5
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-cli, 5.6-cli, 5-cli, 5.6.29, 5.6, 5
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6
 
-Tags: 5.6.28-alpine, 5.6-alpine, 5-alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-alpine, 5.6-alpine, 5-alpine
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/alpine
 
-Tags: 5.6.28-apache, 5.6-apache, 5-apache
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-apache, 5.6-apache, 5-apache
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/apache
 
-Tags: 5.6.28-fpm, 5.6-fpm, 5-fpm
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-fpm, 5.6-fpm, 5-fpm
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/fpm
 
-Tags: 5.6.28-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.28-zts, 5.6-zts, 5-zts
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-zts, 5.6-zts, 5-zts
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/zts
 
-Tags: 5.6.28-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 173945670390f6595da8f93ae46b442167ff05be
+Tags: 5.6.29-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
 Directory: 5.6/zts/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.1, 9.6, 9, latest
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: a00e979002aaa80840d58a5f8cc541342e06788f
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: 5e7d985129d82e8757ac21c4c15cf51703d3477f
+GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.47.0, 0.47, 0, latest
-GitCommit: ec5871f54c004ee50122a3d9c2c5f30eea16676d
+Tags: 0.48.1, 0.48, 0, latest
+GitCommit: 02f32774437d9f621652e6b87320af7c4ac6c54a

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.48-jre7, 6.0-jre7, 6-jre7, 6.0.48, 6.0, 6
-GitCommit: e31b8a805c2e4d6e5c98abb640c5e74cb334033b
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 6/jre7
 
 Tags: 6.0.48-jre8, 6.0-jre8, 6-jre8
-GitCommit: e31b8a805c2e4d6e5c98abb640c5e74cb334033b
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 6/jre8
 
 Tags: 7.0.73-jre7, 7.0-jre7, 7-jre7, 7.0.73, 7.0, 7
-GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 7/jre7
 
 Tags: 7.0.73-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.73-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre7-alpine
 
 Tags: 7.0.73-jre8, 7.0-jre8, 7-jre8
-GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 7/jre8
 
 Tags: 7.0.73-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre8-alpine
 
 Tags: 8.0.39-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.39, 8.0, 8, latest
-GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 8.0/jre7
 
 Tags: 8.0.39-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.39-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,25 +37,25 @@ GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.39-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
+GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
 Directory: 8.0/jre8
 
 Tags: 8.0.39-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
 GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.8-jre8, 8.5-jre8, 8.5.8, 8.5
-GitCommit: d44c35d4ec4907263cdfad76d6c56e6676ddd382
+Tags: 8.5.9-jre8, 8.5-jre8, 8.5.9, 8.5
+GitCommit: 9c280294942795515740cb6d78b1d51d95b31928
 Directory: 8.5/jre8
 
-Tags: 8.5.8-jre8-alpine, 8.5-jre8-alpine, 8.5.8-alpine, 8.5-alpine
-GitCommit: d44c35d4ec4907263cdfad76d6c56e6676ddd382
+Tags: 8.5.9-jre8-alpine, 8.5-jre8-alpine, 8.5.9-alpine, 8.5-alpine
+GitCommit: 9c280294942795515740cb6d78b1d51d95b31928
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M13-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M13, 9.0.0, 9.0, 9
-GitCommit: 29f8484d577632d5124082f87719d7ee28ab939e
+Tags: 9.0.0.M15-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M15, 9.0.0, 9.0, 9
+GitCommit: 9fcf1c13eb901de73aa3abdfc36d1989a1154365
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M13-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M13-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 29f8484d577632d5124082f87719d7ee28ab939e
+Tags: 9.0.0.M15-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M15-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 9fcf1c13eb901de73aa3abdfc36d1989a1154365
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,21 +1,29 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/9c8f5d09839868b8e1a4adb4534429628c2e9b59/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/637afb53dc03b4af19149a0880e796346f97c137/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.7.0-apache, 4.7-apache, 4-apache, apache, 4.7.0, 4.7, 4, latest, 4.7.0-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.0-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
 Directory: php5.6/apache
 
 Tags: 4.7.0-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.0-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
 Directory: php5.6/fpm
 
+Tags: 4.7.0-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.0-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Directory: php5.6/fpm-alpine
+
 Tags: 4.7.0-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.0-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
 Directory: php7.0/apache
 
 Tags: 4.7.0-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 0b87be9b04ba34a20551bd50640780e2f87cd83d
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
 Directory: php7.0/fpm
+
+Tags: 4.7.0-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Directory: php7.0/fpm-alpine


### PR DESCRIPTION
- `celery`: 4.0.1
- `docker`: 1.12.4
- `elasticsearch`: add Alpine variants (docker-library/elasticsearch#149)
- `ghost`: allow arbitrary `--user` values (docker-library/ghost#54)
- `haproxy`: 1.7.1
- `java`: debian 9~b148-1
- `mariadb`: add explicit `--socket` (docker-library/mariadb#92)
- `mysql`: 5.7.17-1debian8, 5.6.35-1debian8, 5.5.54
- `openjdk`: debian 9~b148-1
- `percona`: add explicit `--socket` (docker-library/percona#37)
- `php`: move `CFLAGS` (and friends) to `PHP_CFLAGS`, add `-pie` (docker-library/php#352)
- `postgres`: 9.6.1-2.pgdg80+1, use `pgsql -f ...` instead of `pgsql < ...` for relative includes (docker-library/postgres#234)
- `rocket.chat`: 0.48.1
- `tomcat`: 8.5.9, 9.0.0.M15
- `wordpress`: add `fpm-alpine` variant (docker-library/wordpress#190)