### PR TITLE
[security] Update Ubuntu (especially for apt CVE-2016-1252)

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -8,34 +8,34 @@ GitFetch: refs/heads/dist
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - cf9d7a2 Update tarballs
-#    - `ubuntu:precise`: 20161123
-#    - `ubuntu:trusty`: 20161123
-#    - `ubuntu:xenial`: 20161121
-#    - `ubuntu:yakkety`: 20161121
-#    - `ubuntu:zesty`: 20161129.1
+#  - 9c78896 Update tarballs
+#    - `ubuntu:precise`: 20161209
+#    - `ubuntu:trusty`: 20161214
+#    - `ubuntu:xenial`: 20161213
+#    - `ubuntu:yakkety`: 20161213
+#    - `ubuntu:zesty`: 20161212
 
-# 20161123
-Tags: 12.04.5, 12.04, precise-20161123, precise
-GitCommit: cf9d7a2ee20c8a4706a05d1d7f1a1e25ae32ed39
+# 20161209
+Tags: 12.04.5, 12.04, precise-20161209, precise
+GitCommit: 9c78896fe39d5be95cc4a6ae6c0475599a1bc396
 Directory: precise
 
-# 20161123
-Tags: 14.04.5, 14.04, trusty-20161123, trusty
-GitCommit: cf9d7a2ee20c8a4706a05d1d7f1a1e25ae32ed39
+# 20161214
+Tags: 14.04.5, 14.04, trusty-20161214, trusty
+GitCommit: 9c78896fe39d5be95cc4a6ae6c0475599a1bc396
 Directory: trusty
 
-# 20161121
-Tags: 16.04, xenial-20161121, xenial, latest
-GitCommit: cf9d7a2ee20c8a4706a05d1d7f1a1e25ae32ed39
+# 20161213
+Tags: 16.04, xenial-20161213, xenial, latest
+GitCommit: 9c78896fe39d5be95cc4a6ae6c0475599a1bc396
 Directory: xenial
 
-# 20161121
-Tags: 16.10, yakkety-20161121, yakkety
-GitCommit: cf9d7a2ee20c8a4706a05d1d7f1a1e25ae32ed39
+# 20161213
+Tags: 16.10, yakkety-20161213, yakkety
+GitCommit: 9c78896fe39d5be95cc4a6ae6c0475599a1bc396
 Directory: yakkety
 
-# 20161129.1
-Tags: 17.04, zesty-20161129.1, zesty, devel
-GitCommit: cf9d7a2ee20c8a4706a05d1d7f1a1e25ae32ed39
+# 20161212
+Tags: 17.04, zesty-20161212, zesty, devel
+GitCommit: 9c78896fe39d5be95cc4a6ae6c0475599a1bc396
 Directory: zesty


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/pull/2444, https://www.ubuntu.com/usn/usn-3156-1/, and https://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-1252.html.