### PR TITLE
Add CentOS 7.3.1611 to manifest

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -15,6 +15,10 @@ Tags: centos5, 5
 GitFetch: refs/heads/CentOS-5
 GitCommit: 4bf8330498e1c10cf365aff31d2a8a5c3254c2cf
 
+Tags: centos7.3.1611, 7.3.1611
+GitFetch: refs/heads/CentOS-7.3.1611
+GitCommit: 5bbaef9f60ab9e3eeb61acec631c2d91f8714fff
+
 Tags: centos7.2.1511, 7.2.1511
 GitFetch: refs/heads/CentOS-7.2.1511
 GitCommit: a3c59bd4e98a7f9c063d993955c8ec19c5b1ceff


### PR DESCRIPTION
I noticed an appropriate tag for CentOS 7.3 was missing.