### PR TITLE
[nats] Release v0.9.6

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,7 +2,7 @@ Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
              Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
              Waldemar Salinas <wally@apcera.com> (@wallyqs)
 
-Tags: 0.9.4, latest
+Tags: 0.9.6, latest
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: d37917c2830bfe3b54de8d92ac36b62cc1309cfc
+GitCommit: b2c678c7bcc6bc8d68fb33cb1f169f4b66db308d 
 


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v0.9.6)