### PR TITLE
Bump 0.6.3 and add 0.6.4

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -1,8 +1,9 @@
 # maintainer: Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 
 0.6.0: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6
-0.6: git://github.com/hashicorp/docker-vault@f9a97ab152b51d39f54ab51136b2819305f70caf 0.6.3
+0.6: git://github.com/hashicorp/docker-vault@7bbdde58de683a2bb6e384e4c20e30308b4ff882 0.6.4
 0.6.1: git://github.com/hashicorp/docker-vault@3d12aa78cdbdce22b3d3e30f1093843f21b0a8fa 0.6.1
 0.6.2: git://github.com/hashicorp/docker-vault@3d3957180d689ecddb537aa799a878171280e8a3 0.6.2
-0.6.3: git://github.com/hashicorp/docker-vault@f9a97ab152b51d39f54ab51136b2819305f70caf 0.6.3
-latest: git://github.com/hashicorp/docker-vault@f9a97ab152b51d39f54ab51136b2819305f70caf 0.6.3
+0.6.3: git://github.com/hashicorp/docker-vault@7bbdde58de683a2bb6e384e4c20e30308b4ff882 0.6.3
+0.6.4: git://github.com/hashicorp/docker-vault@7bbdde58de683a2bb6e384e4c20e30308b4ff882 0.6.4
+latest: git://github.com/hashicorp/docker-vault@7bbdde58de683a2bb6e384e4c20e30308b4ff882 0.6.4


### PR DESCRIPTION
This updates permission handling for 0.6.3 closer to the scheme in Consul, and adds the 0.6.4 release.