### PR TITLE
Update clojure alpine builds to latest

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,10 +3,10 @@
 
 latest: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724
 onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 onbuild
-alpine: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 alpine
-alpine-onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 alpine-onbuild
+alpine: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine
+alpine-onbuild: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine-onbuild
 
 lein-2.7.1: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724
 lein-2.7.1-onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 onbuild
-lein-2.7.1-alpine: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 alpine
-lein-2.7.1-alpine-onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 alpine-onbuild
+lein-2.7.1-alpine: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine
+lein-2.7.1-alpine-onbuild: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine-onbuild


### PR DESCRIPTION
I updated them to be based on the upstream openjdk 8u111 (from 8u92 previously).