### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -99,3 +99,15 @@ Directory: yakkety/scm
 Tags: yakkety
 GitCommit: a94a81caf4d56853baade2cdd794dbe0c93396b2
 Directory: yakkety
+
+Tags: zesty-curl
+GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
+Directory: zesty/curl
+
+Tags: zesty-scm
+GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
+Directory: zesty/scm
+
+Tags: zesty
+GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
+Directory: zesty

--- a/library/celery
+++ b/library/celery
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/celery.git
 
-Tags: 4.0.1, 4.0, 4
-GitCommit: 5082d1515a4562d668eaaa3eb189ddb28b36fb85
+Tags: 4.0.2, 4.0, 4
+GitCommit: 96de4372507fc4eb147f43b8c4f207da3d95bcd1
 Directory: 4.0
 
 Tags: 3.1.25, 3.1, 3, latest

--- a/library/docker
+++ b/library/docker
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0-rc3, 1.13-rc, rc
-GitCommit: e3d26cada8093a8a6814e7b341f03298d1b276fb
+Tags: 1.13.0-rc4, 1.13-rc, rc
+GitCommit: 5ab6e7f0188981d0c3db235265d4e1b74940a4f8
 Directory: 1.13-rc
 
-Tags: 1.13.0-rc3-dind, 1.13-rc-dind, rc-dind
+Tags: 1.13.0-rc4-dind, 1.13-rc-dind, rc-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.13-rc/dind
 
-Tags: 1.13.0-rc3-git, 1.13-rc-git, rc-git
+Tags: 1.13.0-rc4-git, 1.13-rc-git, rc-git
 GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 
-Tags: 1.12.4, 1.12, 1, latest
-GitCommit: 1c73734649299a17d1472fb206b992a544bd1777
+Tags: 1.12.5, 1.12, 1, latest
+GitCommit: 04d634220102faa132092232b46958102d07bcd9
 Directory: 1.12
 
-Tags: 1.12.4-dind, 1.12-dind, 1-dind, dind
+Tags: 1.12.5-dind, 1.12-dind, 1-dind, dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/dind
 
-Tags: 1.12.4-git, 1.12-git, 1-git, git
+Tags: 1.12.5-git, 1.12-git, 1-git, git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
-Tags: 1.12.4-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: 1c73734649299a17d1472fb206b992a544bd1777
+Tags: 1.12.5-experimental, 1.12-experimental, 1-experimental, experimental
+GitCommit: 04d634220102faa132092232b46958102d07bcd9
 Directory: 1.12/experimental
 
-Tags: 1.12.4-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+Tags: 1.12.5-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/experimental/dind
 
-Tags: 1.12.4-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+Tags: 1.12.5-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
 GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -12,12 +12,12 @@ Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
 GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
 Directory: 5/alpine
 
-Tags: 2.4.2, 2.4, 2
-GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
+Tags: 2.4.3, 2.4, 2
+GitCommit: 1a539d229073ccde66f94487889d17d939f9689c
 Directory: 2.4
 
-Tags: 2.4.2-alpine, 2.4-alpine, 2-alpine
-GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+Tags: 2.4.3-alpine, 2.4-alpine, 2-alpine
+GitCommit: 1a539d229073ccde66f94487889d17d939f9689c
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1

--- a/library/golang
+++ b/library/golang
@@ -57,28 +57,28 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8beta1, 1.8
-GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
+Tags: 1.8beta2, 1.8
+GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8
 
-Tags: 1.8beta1-onbuild, 1.8-onbuild
+Tags: 1.8beta2-onbuild, 1.8-onbuild
 GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
 Directory: 1.8/onbuild
 
-Tags: 1.8beta1-wheezy, 1.8-wheezy
-GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
+Tags: 1.8beta2-wheezy, 1.8-wheezy
+GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8/wheezy
 
-Tags: 1.8beta1-alpine, 1.8-alpine
-GitCommit: 7a5e33ec522b17dffa51c2763610a2967475529d
+Tags: 1.8beta2-alpine, 1.8-alpine
+GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8/alpine
 
-Tags: 1.8beta1-windowsservercore, 1.8-windowsservercore
-GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
+Tags: 1.8beta2-windowsservercore, 1.8-windowsservercore
+GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8beta1-nanoserver, 1.8-nanoserver
-GitCommit: 803439af1f04d215135fff8ca406761ead9f06af
+Tags: 1.8beta2-nanoserver, 1.8-nanoserver
+GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/java
+++ b/library/java
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine, openjdk-8u111-jre-alpine, open
 GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
-Tags: 9-b148-jdk, 9-b148, 9-jdk, 9, openjdk-9-b148-jdk, openjdk-9-b148, openjdk-9-jdk, openjdk-9
-GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
+Tags: 9-b149-jdk, 9-b149, 9-jdk, 9, openjdk-9-b149-jdk, openjdk-9-b149, openjdk-9-jdk, openjdk-9
+GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
 Directory: 9-jdk
 
-Tags: 9-b148-jre, 9-jre, openjdk-9-b148-jre, openjdk-9-jre
-GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
+Tags: 9-b149-jre, 9-jre, openjdk-9-b149-jre, openjdk-9-jre
+GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
 Directory: 9-jre

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.19, 10.1, 10, latest
-GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
+Tags: 10.1.20, 10.1, 10, latest
+GitCommit: c31e557088187e8ac7a7d4b13e7bd0c052386f94
 Directory: 10.1
 
 Tags: 10.0.28, 10.0

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
 Directory: 8-jre/alpine
 
-Tags: 9-b148-jdk, 9-b148, 9-jdk, 9
-GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
+Tags: 9-b149-jdk, 9-b149, 9-jdk, 9
+GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
 Directory: 9-jdk
 
-Tags: 9-b148-jre, 9-jre
-GitCommit: e1981fe71526d3c568cdad28fe7607a5d258fcd3
+Tags: 9-b149-jre, 9-jre
+GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
 Directory: 9-jre

--- a/library/owncloud
+++ b/library/owncloud
@@ -28,18 +28,18 @@ Tags: 8.2.9-fpm, 8.2-fpm, 8-fpm
 GitCommit: ff9352a1c798b21f93fdca4b31165be91e879665
 Directory: 8.2/fpm
 
-Tags: 9.0.6-apache, 9.0-apache, 9.0.6, 9.0
-GitCommit: 375db22095df9a8d5b27f9f656eff92fcfad3b2e
+Tags: 9.0.7-apache, 9.0-apache, 9.0.7, 9.0
+GitCommit: 7f7809eab60b49eca0830428d94e160a5a7d8f40
 Directory: 9.0/apache
 
-Tags: 9.0.6-fpm, 9.0-fpm
-GitCommit: 375db22095df9a8d5b27f9f656eff92fcfad3b2e
+Tags: 9.0.7-fpm, 9.0-fpm
+GitCommit: 7f7809eab60b49eca0830428d94e160a5a7d8f40
 Directory: 9.0/fpm
 
-Tags: 9.1.2-apache, 9.1-apache, 9-apache, apache, 9.1.2, 9.1, 9, latest
-GitCommit: 373a10dfe09623b32510f64912d2188c6395f64e
+Tags: 9.1.3-apache, 9.1-apache, 9-apache, apache, 9.1.3, 9.1, 9, latest
+GitCommit: 9f8859808568395b04d870673d41ec50889d09f4
 Directory: 9.1/apache
 
-Tags: 9.1.2-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 373a10dfe09623b32510f64912d2188c6395f64e
+Tags: 9.1.3-fpm, 9.1-fpm, 9-fpm, fpm
+GitCommit: 9f8859808568395b04d870673d41ec50889d09f4
 Directory: 9.1/fpm

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.0-cli, 7.1-cli, 7-cli, cli, 7.1.0, 7.1, 7, latest
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/alpine
 
 Tags: 7.1.0-apache, 7.1-apache, 7-apache, apache
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/apache
 
 Tags: 7.1.0-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/fpm
 
 Tags: 7.1.0-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.0-zts, 7.1-zts, 7-zts, zts
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/zts
 
 Tags: 7.1.0-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.14-cli, 7.0-cli, 7.0.14, 7.0
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0
 
 Tags: 7.0.14-alpine, 7.0-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/alpine
 
 Tags: 7.0.14-apache, 7.0-apache
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/apache
 
 Tags: 7.0.14-fpm, 7.0-fpm
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/fpm
 
 Tags: 7.0.14-fpm-alpine, 7.0-fpm-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.14-zts, 7.0-zts
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/zts
 
 Tags: 7.0.14-zts-alpine, 7.0-zts-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.29-cli, 5.6-cli, 5-cli, 5.6.29, 5.6, 5
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6
 
 Tags: 5.6.29-alpine, 5.6-alpine, 5-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/alpine
 
 Tags: 5.6.29-apache, 5.6-apache, 5-apache
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/apache
 
 Tags: 5.6.29-fpm, 5.6-fpm, 5-fpm
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/fpm
 
 Tags: 5.6.29-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.29-zts, 5.6-zts, 5-zts
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/zts
 
 Tags: 5.6.29-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 9f2e76eeba464f20798faaea172416340e3099c1
+GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -90,23 +90,23 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.0rc1, 3.6-rc, rc
-GitCommit: 12bf960914ceaec59562cf49cf048b971e54399a
+Tags: 3.6.0rc2, 3.6-rc, rc
+GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
 Directory: 3.6-rc
 
-Tags: 3.6.0rc1-slim, 3.6-rc-slim, rc-slim
-GitCommit: 12bf960914ceaec59562cf49cf048b971e54399a
+Tags: 3.6.0rc2-slim, 3.6-rc-slim, rc-slim
+GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
 Directory: 3.6-rc/slim
 
-Tags: 3.6.0rc1-alpine, 3.6-rc-alpine, rc-alpine
-GitCommit: 12bf960914ceaec59562cf49cf048b971e54399a
+Tags: 3.6.0rc2-alpine, 3.6-rc-alpine, rc-alpine
+GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
 Directory: 3.6-rc/alpine
 
-Tags: 3.6.0rc1-onbuild, 3.6-rc-onbuild, rc-onbuild
+Tags: 3.6.0rc2-onbuild, 3.6-rc-onbuild, rc-onbuild
 GitCommit: b16ff405101a9f6c6540fb3467ca25baa9610174
 Directory: 3.6-rc/onbuild
 
-Tags: 3.6.0rc1-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
-GitCommit: 12bf960914ceaec59562cf49cf048b971e54399a
+Tags: 3.6.0rc2-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
+GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
 Directory: 3.6-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
+GitCommit: 21468d57e1227ce287d764ab027af6feac309508
 Directory: 3.1/passenger
 
 Tags: 3.2.4, 3.2
@@ -17,7 +17,7 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.2
 
 Tags: 3.2.4-passenger, 3.2-passenger
-GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
+GitCommit: 21468d57e1227ce287d764ab027af6feac309508
 Directory: 3.2/passenger
 
 Tags: 3.3.1, 3.3, 3, latest
@@ -25,5 +25,5 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.3
 
 Tags: 3.3.1-passenger, 3.3-passenger, 3-passenger, passenger
-GitCommit: 31ec3c8963424bbc1730806a65d9914c84df17de
+GitCommit: 21468d57e1227ce287d764ab027af6feac309508
 Directory: 3.3/passenger


### PR DESCRIPTION
- `buildpack-deps`: add `zesty` (docker-library/buildpack-deps#54)
- `celery`: 4.0.2
- `docker`: 1.12.5, 1.13.0-rc4
- `elasticsearch`: 2.4.3
- `golang`: 1.8beta2
- `java`: debian 9~b149-1
- `mariadb`: 10.1.20+maria-1~jessie
- `openjdk`: debian 9~b149-1
- `owncloud`: 9.0.7, 9.1.3
- `php`: add simple entrypoint (docker-library/php#349)
- `python`: 3.6.0rc2
- `redmine`: passenger 5.1.0