### PR TITLE
[nats-streaming] Release v0.3.6

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,6 +1,6 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 
-Tags: 0.3.4, latest
+Tags: 0.3.6, latest
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 5ba3680f2232ea7ef652aaaab8992e891894e7d3
+GitCommit: d4c16d81cdfb43b502983473c4d4f53eb15cdad2
 


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.3.6)