### PR TITLE
Update for Node.js v0.12.18 and Node.js v7.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,27 +1,27 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/cee890b875e72c867eaeecb47c0602b10b643a7d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/57f7537d35c0988bd0e74abbf16989557c1481ad/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.2.1, 7.2, 7, latest
-GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
-Directory: 7.2
+Tags: 7.3.0, 7.3, 7, latest
+GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
+Directory: 7.3
 
-Tags: 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
-GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
-Directory: 7.2/alpine
+Tags: 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
+GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
+Directory: 7.3/alpine
 
-Tags: 7.2.1-onbuild, 7.2-onbuild, 7-onbuild, onbuild
-GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
-Directory: 7.2/onbuild
+Tags: 7.3.0-onbuild, 7.3-onbuild, 7-onbuild, onbuild
+GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
+Directory: 7.3/onbuild
 
-Tags: 7.2.1-slim, 7.2-slim, 7-slim, slim
-GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
-Directory: 7.2/slim
+Tags: 7.3.0-slim, 7.3-slim, 7-slim, slim
+GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
+Directory: 7.3/slim
 
-Tags: 7.2.1-wheezy, 7.2-wheezy, 7-wheezy, wheezy
-GitCommit: 5ac624bae8adf7f20314b503f8592760a683d935
-Directory: 7.2/wheezy
+Tags: 7.3.0-wheezy, 7.3-wheezy, 7-wheezy, wheezy
+GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
+Directory: 7.3/wheezy
 
 Tags: 6.9.2, 6.9, 6, boron
 GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
@@ -63,19 +63,19 @@ Tags: 4.7.0-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
 GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
 Directory: 4.7/wheezy
 
-Tags: 0.12.17, 0.12, 0
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+Tags: 0.12.18, 0.12, 0
+GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
 Directory: 0.12
 
-Tags: 0.12.17-onbuild, 0.12-onbuild, 0-onbuild
-GitCommit: c3ff7866303b4c595ab07529cdf35f9df58f5b21
+Tags: 0.12.18-onbuild, 0.12-onbuild, 0-onbuild
+GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
 Directory: 0.12/onbuild
 
-Tags: 0.12.17-slim, 0.12-slim, 0-slim
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+Tags: 0.12.18-slim, 0.12-slim, 0-slim
+GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
 Directory: 0.12/slim
 
-Tags: 0.12.17-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: 4a722c29c0e52624af8b72b4711ebeba8ea39463
+Tags: 0.12.18-wheezy, 0.12-wheezy, 0-wheezy
+GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
 Directory: 0.12/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v0.12.18/
- https://github.com/nodejs/docker-node/pull/293
- https://nodejs.org/en/blog/release/v7.3.0/
- https://github.com/nodejs/docker-node/pull/291