### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -6,14 +6,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
-Tags: 1.25.1-glibc, 1.25-glibc, 1-glibc, glibc
-GitCommit: ad6b0303b320f64e63fef9291fcac5a4742c0855
+Tags: 1.26.0-glibc, 1.26-glibc, 1-glibc, glibc
+GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
 Directory: glibc
 
-Tags: 1.25.1-musl, 1.25-musl, 1-musl, musl
-GitCommit: ad6b0303b320f64e63fef9291fcac5a4742c0855
+Tags: 1.26.0-musl, 1.26-musl, 1-musl, musl
+GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
 Directory: musl
 
-Tags: 1.25.1-uclibc, 1.25-uclibc, 1-uclibc, uclibc, 1.25.1, 1.25, 1, latest
-GitCommit: ad6b0303b320f64e63fef9291fcac5a4742c0855
+Tags: 1.26.0-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.0, 1.26, 1, latest
+GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
 Directory: uclibc

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,25 +5,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 5
 
 Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 5/alpine
 
 Tags: 2.4.3, 2.4, 2
-GitCommit: 1a539d229073ccde66f94487889d17d939f9689c
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 2.4
 
 Tags: 2.4.3-alpine, 2.4-alpine, 2-alpine
-GitCommit: 1a539d229073ccde66f94487889d17d939f9689c
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1
-GitCommit: 4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 1.7
 
 Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine
-GitCommit: e0d91f112e9b145a36bcaeff866e25853f5e965c
+GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 1.7/alpine

--- a/library/gcc
+++ b/library/gcc
@@ -16,8 +16,8 @@ GitCommit: 8c7687860cdd4ef9227c249ca4587984e2636a55
 Directory: 5
 # Docker EOL: 2017-06-03
 
-# Last Modified: 2016-08-22
-Tags: 6.2.0, 6.2, 6, latest
-GitCommit: 8c7687860cdd4ef9227c249ca4587984e2636a55
+# Last Modified: 2016-12-21
+Tags: 6.3.0, 6.3, 6, latest
+GitCommit: 758ef9b4b4978a3a06ea84422a76ed906c94c606
 Directory: 6
-# Docker EOL: 2017-08-22
+# Docker EOL: 2017-12-21

--- a/library/golang
+++ b/library/golang
@@ -18,7 +18,7 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/wheezy
 
 Tags: 1.6.4-alpine, 1.6-alpine
-GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
+GitCommit: fd163e2eb23f4c01f8e5721029c768a5ba48bad1
 Directory: 1.6/alpine
 
 Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
@@ -44,7 +44,7 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/wheezy
 
 Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
+GitCommit: fd163e2eb23f4c01f8e5721029c768a5ba48bad1
 Directory: 1.7/alpine
 
 Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore

--- a/library/httpd
+++ b/library/httpd
@@ -12,10 +12,10 @@ Tags: 2.2.31-alpine, 2.2-alpine
 GitCommit: fa5223d83a5225aa3fd5b23229b785c7764142bf
 Directory: 2.2/alpine
 
-Tags: 2.4.23, 2.4, 2, latest
-GitCommit: abcf2cd7064bd5b29347eb4b42c1530fb41f757f
+Tags: 2.4.25, 2.4, 2, latest
+GitCommit: 1990a58d6acaf056dd24b10d5923a60c27eda949
 Directory: 2.4
 
-Tags: 2.4.23-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: fa5223d83a5225aa3fd5b23229b785c7764142bf
+Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
+GitCommit: 0e4a0b59e1f4e2a5a14ca197516beb2d4df1ffb8
 Directory: 2.4/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/kibana.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 03f657e02f2fc3f3487dfe98cc98f9870eaaa5c4
+GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
 Directory: 5
 
 Tags: 4.6.3, 4.6, 4
-GitCommit: 43644e6ae40c53c05d94165506094035f0463ea6
+GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
 Directory: 4.6
 
 Tags: 4.1.11, 4.1
-GitCommit: 7ce21f8aa1e58443c3031fdbdf83a08ce34e49a4
+GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
 Directory: 4.1

--- a/library/mongo
+++ b/library/mongo
@@ -22,11 +22,11 @@ GitCommit: 21a6f6cf3eff13a39b20c86224730a29823370ca
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.0, 3.4, 3, latest
-GitCommit: 5f4bcf4bec163ef05b4fc67d5c92762989dbde06
+Tags: 3.4.1, 3.4, 3, latest
+GitCommit: 6f548652b0139ff50182c56d3c74efd875f6fb5c
 Directory: 3.4
 
-Tags: 3.4.0-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 5f4bcf4bec163ef05b4fc67d5c92762989dbde06
+Tags: 3.4.1-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 6f548652b0139ff50182c56d3c74efd875f6fb5c
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: a00e979002aaa80840d58a5f8cc541342e06788f
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
@@ -17,7 +17,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
@@ -25,7 +25,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
@@ -33,7 +33,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
@@ -41,5 +41,5 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -4,28 +4,28 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 2.7.12, 2.7, 2
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 2.7.13, 2.7, 2
+GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7
 
-Tags: 2.7.12-slim, 2.7-slim, 2-slim
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 2.7.13-slim, 2.7-slim, 2-slim
+GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/slim
 
-Tags: 2.7.12-alpine, 2.7-alpine, 2-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
+GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/alpine
 
-Tags: 2.7.12-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
+GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/wheezy
 
-Tags: 2.7.12-onbuild, 2.7-onbuild, 2-onbuild
+Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
-Tags: 2.7.12-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 2.7.13-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
+GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/rails
+++ b/library/rails
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rails.git
 
-Tags: 5.0.0.1, 5.0.0, 5.0, 5, latest
-GitCommit: 74262f5482517f779681590b0194758ff75cf77c
+Tags: 5.0.1, 5.0, 5, latest
+GitCommit: e16e955a67f48c1e8dc0af87ba6c0b7f8302bad2
 
 Tags: onbuild
 GitCommit: 9df9b5e6b1519faf22e1565c2caaebf7cc1c665b

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.48.1, 0.48, 0, latest
-GitCommit: 02f32774437d9f621652e6b87320af7c4ac6c54a
+Tags: 0.48.2, 0.48, 0, latest
+GitCommit: 65ca59ce402400d6e57c5b497011ce3572cae9b3

--- a/library/ruby
+++ b/library/ruby
@@ -52,18 +52,18 @@ Tags: 2.3.3-onbuild, 2.3-onbuild, 2-onbuild, onbuild
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
-Tags: 2.4.0-preview3, 2.4-rc
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+Tags: 2.4.0-rc1, 2.4-rc
+GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
 Directory: 2.4-rc
 
-Tags: 2.4.0-preview3-slim, 2.4-rc-slim
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+Tags: 2.4.0-rc1-slim, 2.4-rc-slim
+GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
 Directory: 2.4-rc/slim
 
-Tags: 2.4.0-preview3-alpine, 2.4-rc-alpine
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+Tags: 2.4.0-rc1-alpine, 2.4-rc-alpine
+GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
 Directory: 2.4-rc/alpine
 
-Tags: 2.4.0-preview3-onbuild, 2.4-rc-onbuild
+Tags: 2.4.0-rc1-onbuild, 2.4-rc-onbuild
 GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
 Directory: 2.4-rc/onbuild


### PR DESCRIPTION
- `busybox`: 1.26.0 (docker-library/busybox#16)
- `elasticsearch`: chown logs at runtime (docker-library/elasticsearch#150)
- `gcc`: 6.3.0
- `golang`: more PIE fixes (docker-library/golang#128)
- `httpd`: 2.4.25
- `kibana`: add packages for phantomjs to work (docker-library/kibana#67)
- `mongo`: 3.4.1
- `postgres`: remove `doc` and `man` directories in Alpine for size (docker-library/postgres#243)
- `python`: 2.7.13 (docker-library/python#164)
- `rails`: 5.0.1
- `rocket.chat`: 0.48.2
- `ruby`: 2.4.0-rc1