### PR TITLE
Updated OL 6.8 and 7.3 images for CVE-2016-1248

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,19 +1,19 @@
 # maintainer: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Djelibeybi)
 
 # Oracle Linux 7
-latest: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.3
-7: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.3
-7.3: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.3
-7.2: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.2
-7.1: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.1
-7.0: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/7.0
+latest: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.3
+7: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.3
+7.3: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.3
+7.2: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.2
+7.1: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.1
+7.0: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/7.0
 
 # Oracle Linux 6
-6: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/6.8
-6.8: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/6.8
-6.7: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/6.7
-6.6: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/6.6
+6: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/6.8
+6.8: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/6.8
+6.7: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/6.7
+6.6: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/6.6
 
 # Oracle Linux 5
-5: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/5.11
-5.11: git://github.com/oracle/docker-images.git@f84cba841527a9371d92c854c3b8c73125a76173 OracleLinux/5.11
+5: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/5.11
+5.11: git://github.com/oracle/docker-images.git@b1be3916f864e8e3dd2589cc390c59a5f7a30237 OracleLinux/5.11


### PR DESCRIPTION
Errata notification: https://linux.oracle.com/errata/ELSA-2016-2972.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>