### PR TITLE
Update Amazon Linux image to 2016.09.1.20161221

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -3,10 +3,10 @@ Maintainers: Amazon Linux Team <amazon-linux-ami@amazon.com> (@aws),
              Praveen K Paladugu (@praveen-pk)
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
 
-Tags: 2016.09.0.20161118, 2016.09, latest
+Tags: 2016.09.1.20161221, 2016.09, latest
 GitFetch: refs/heads/2016.09
-GitCommit: 11dffca07aebe78c254fac1e4e38b4d04bafb85c
+GitCommit: e1b56e68ebd2b274c64e0a0a18ae0a9a8122822d
 
-Tags: 2016.09.0.20161118-with-sources, 2016.09-with-sources, with-sources
+Tags: 2016.09.1.20161221-with-sources, 2016.09-with-sources, with-sources
 GitFetch: refs/heads/2016.09-with-sources
-GitCommit: a9962fe03d732b19f744aeba9b19fe3783b248a0
+GitCommit: 2de60e8c98421694c293639659a88ed81ce29298


### PR DESCRIPTION
Now with `yum-plugin-ovl` so that yum installations actually work on the overlay storage driver :)

Security updates:
* nss nss-util nss-softokn ([ALAS-2016-774](https://alas.aws.amazon.com/ALAS-2016-774.html) and a curl rebuild)
* expat ([ALAS-2016-775](https://alas.aws.amazon.com/ALAS-2016-775.html))

Other updates:
* tzdata 2016j