### PR TITLE
Update docker-library images

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,33 +37,33 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3, 2, latest
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim, 2-slim, slim
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine, 2-alpine, alpine
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
+GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild, 2-onbuild, onbuild
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
-Tags: 2.4.0-rc1, 2.4-rc
-GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
-Directory: 2.4-rc
+Tags: 2.4.0, 2.4
+GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+Directory: 2.4
 
-Tags: 2.4.0-rc1-slim, 2.4-rc-slim
-GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
-Directory: 2.4-rc/slim
+Tags: 2.4.0-slim, 2.4-slim
+GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+Directory: 2.4/slim
 
-Tags: 2.4.0-rc1-alpine, 2.4-rc-alpine
-GitCommit: 6103b0a0779fdbc9906ee6d14b118a807114d32d
-Directory: 2.4-rc/alpine
+Tags: 2.4.0-alpine, 2.4-alpine
+GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+Directory: 2.4/alpine
 
-Tags: 2.4.0-rc1-onbuild, 2.4-rc-onbuild
-GitCommit: c9208def0c430de0144408e16140bd49254c4ca9
-Directory: 2.4-rc/onbuild
+Tags: 2.4.0-onbuild, 2.4-onbuild
+GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
+Directory: 2.4/onbuild


### PR DESCRIPTION
- `ruby`: 2.4.0 (https://github.com/docker-library/ruby/pull/97)