### PR TITLE
Update mariadb, python, and redmine

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -12,6 +12,6 @@ Tags: 10.0.28, 10.0
 GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
 Directory: 10.0
 
-Tags: 5.5.53, 5.5, 5
-GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
+Tags: 5.5.54, 5.5, 5
+GitCommit: b2dd0ba9f4b025d67fa21c5753c5e410b5801d0e
 Directory: 5.5

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/b16ff405101a9f6c6540fb3467ca25baa9610174/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/c5b36c38823ca6a1301ad39cbf3ece75d77c5600/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -69,44 +69,44 @@ Tags: 3.4.5-onbuild, 3.4-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
-Tags: 3.5.2, 3.5, 3, latest
+Tags: 3.5.2, 3.5
 GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5
 
-Tags: 3.5.2-slim, 3.5-slim, 3-slim, slim
+Tags: 3.5.2-slim, 3.5-slim
 GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/slim
 
-Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
+Tags: 3.5.2-alpine, 3.5-alpine
 GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/alpine
 
-Tags: 3.5.2-onbuild, 3.5-onbuild, 3-onbuild, onbuild
+Tags: 3.5.2-onbuild, 3.5-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
-Tags: 3.5.2-windowsservercore, 3.5-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.5.2-windowsservercore, 3.5-windowsservercore
 GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.0rc2, 3.6-rc, rc
-GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
-Directory: 3.6-rc
+Tags: 3.6.0, 3.6, 3, latest
+GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+Directory: 3.6
 
-Tags: 3.6.0rc2-slim, 3.6-rc-slim, rc-slim
-GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
-Directory: 3.6-rc/slim
+Tags: 3.6.0-slim, 3.6-slim, 3-slim, slim
+GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+Directory: 3.6/slim
 
-Tags: 3.6.0rc2-alpine, 3.6-rc-alpine, rc-alpine
-GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
-Directory: 3.6-rc/alpine
+Tags: 3.6.0-alpine, 3.6-alpine, 3-alpine, alpine
+GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+Directory: 3.6/alpine
 
-Tags: 3.6.0rc2-onbuild, 3.6-rc-onbuild, rc-onbuild
-GitCommit: b16ff405101a9f6c6540fb3467ca25baa9610174
-Directory: 3.6-rc/onbuild
+Tags: 3.6.0-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+Directory: 3.6/onbuild
 
-Tags: 3.6.0rc2-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
-GitCommit: 26ac1ac8c63ddd479c869845c16261c527fe9945
-Directory: 3.6-rc/windows/windowsservercore
+Tags: 3.6.0-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: 21468d57e1227ce287d764ab027af6feac309508
+GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.1/passenger
 
 Tags: 3.2.4, 3.2
@@ -17,7 +17,7 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.2
 
 Tags: 3.2.4-passenger, 3.2-passenger
-GitCommit: 21468d57e1227ce287d764ab027af6feac309508
+GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.2/passenger
 
 Tags: 3.3.1, 3.3, 3, latest
@@ -25,5 +25,5 @@ GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
 Directory: 3.3
 
 Tags: 3.3.1-passenger, 3.3-passenger, 3-passenger, passenger
-GitCommit: 21468d57e1227ce287d764ab027af6feac309508
+GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.3/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/2dabbe3334950b9df116a7816aca915d606a45cd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/230d21cfe8280d4f154b94681eab3e22065f4ea6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -36,34 +36,34 @@ Tags: 2.2.6-onbuild, 2.2-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
-Tags: 2.3.3, 2.3, 2, latest
+Tags: 2.3.3, 2.3
 GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3
 
-Tags: 2.3.3-slim, 2.3-slim, 2-slim, slim
+Tags: 2.3.3-slim, 2.3-slim
 GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3/slim
 
-Tags: 2.3.3-alpine, 2.3-alpine, 2-alpine, alpine
+Tags: 2.3.3-alpine, 2.3-alpine
 GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
 Directory: 2.3/alpine
 
-Tags: 2.3.3-onbuild, 2.3-onbuild, 2-onbuild, onbuild
+Tags: 2.3.3-onbuild, 2.3-onbuild
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
-Tags: 2.4.0, 2.4
+Tags: 2.4.0, 2.4, 2, latest
 GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
 Directory: 2.4
 
-Tags: 2.4.0-slim, 2.4-slim
+Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
 GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
 Directory: 2.4/slim
 
-Tags: 2.4.0-alpine, 2.4-alpine
+Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
 GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
 Directory: 2.4/alpine
 
-Tags: 2.4.0-onbuild, 2.4-onbuild
+Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild
 GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
 Directory: 2.4/onbuild


### PR DESCRIPTION
- `mariadb` bump to `5.5.54`
- `python` GA release for `3.6.0`
- `redmine` passenger 5.1.1

(can incorporate/carry #2494 if necessary)