### PR TITLE
Update haproxy, redmine

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -12,20 +12,20 @@ Tags: 1.4.27-alpine, 1.4-alpine
 GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
 Directory: 1.4/alpine
 
-Tags: 1.5.18, 1.5
-GitCommit: e128fc85947f0de7213185c9f948150e39cbc766
+Tags: 1.5.19, 1.5
+GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
 Directory: 1.5
 
-Tags: 1.5.18-alpine, 1.5-alpine
-GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+Tags: 1.5.19-alpine, 1.5-alpine
+GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
 Directory: 1.5/alpine
 
-Tags: 1.6.10, 1.6
-GitCommit: 3f825ac60d7af1739f65897f64241c5577dfc31e
+Tags: 1.6.11, 1.6
+GitCommit: 12dae72c28e152ac9dcd499f156cb0ab79d7c23f
 Directory: 1.6
 
-Tags: 1.6.10-alpine, 1.6-alpine
-GitCommit: 3f825ac60d7af1739f65897f64241c5577dfc31e
+Tags: 1.6.11-alpine, 1.6-alpine
+GitCommit: 12dae72c28e152ac9dcd499f156cb0ab79d7c23f
 Directory: 1.6/alpine
 
 Tags: 1.7.1, 1.7, 1, latest

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.1.7, 3.1
-GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
+GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
@@ -13,7 +13,7 @@ GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.1/passenger
 
 Tags: 3.2.4, 3.2
-GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
+GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
 Directory: 3.2
 
 Tags: 3.2.4-passenger, 3.2-passenger
@@ -21,7 +21,7 @@ GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.2/passenger
 
 Tags: 3.3.1, 3.3, 3, latest
-GitCommit: e75fd00870dcd47a848532abf999f7ec13bb0262
+GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
 Directory: 3.3
 
 Tags: 3.3.1-passenger, 3.3-passenger, 3-passenger, passenger


### PR DESCRIPTION
- `haproxy` `1.6.11` and `1.5.19`
- `redmine` https://github.com/docker-library/redmine/pull/50