### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.5, 4.4, 4, latest
-GitCommit: d3283a47fbb92419b7b6fc1fccd30b95d75e9ab6
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
-GitCommit: 2f7c9c45567b18b74c321f0ff1e460ae1117a9b5
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
-GitCommit: 4813d8692c050fab37ce67f205977b11c4eea42c
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
-GitCommit: 0fb93762d52d5f73ea53557706f19a255ef990d1
+GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
 Directory: 3.0

--- a/library/docker
+++ b/library/docker
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 1.13.0-rc4, 1.13-rc, rc
-GitCommit: 5ab6e7f0188981d0c3db235265d4e1b74940a4f8
+GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
 Directory: 1.13-rc
 
 Tags: 1.13.0-rc4-dind, 1.13-rc-dind, rc-dind
@@ -17,7 +17,7 @@ GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 
 Tags: 1.12.5, 1.12, 1, latest
-GitCommit: 04d634220102faa132092232b46958102d07bcd9
+GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
 Directory: 1.12
 
 Tags: 1.12.5-dind, 1.12-dind, 1-dind, dind
@@ -29,7 +29,7 @@ GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
 Tags: 1.12.5-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: 04d634220102faa132092232b46958102d07bcd9
+GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
 Directory: 1.12/experimental
 
 Tags: 1.12.5-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
@@ -41,7 +41,7 @@ GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 
 Tags: 1.11.2, 1.11
-GitCommit: 0c44c1c6c25a34eb9abe320805e0f89bf5b0ace2
+GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
 Directory: 1.11
 
 Tags: 1.11.2-dind, 1.11-dind

--- a/library/drupal
+++ b/library/drupal
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.2.4-apache, 8.2-apache, 8-apache, apache, 8.2.4, 8.2, 8, latest
-GitCommit: aa623002a920a130a638b4b30d664aa59a662d2d
+Tags: 8.2.5-apache, 8.2-apache, 8-apache, apache, 8.2.5, 8.2, 8, latest
+GitCommit: a2832ca75e94580be81aafffdfc330c1713b519d
 Directory: 8.2/apache
 
-Tags: 8.2.4-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: aa623002a920a130a638b4b30d664aa59a662d2d
+Tags: 8.2.5-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: a2832ca75e94580be81aafffdfc330c1713b519d
 Directory: 8.2/fpm
 
 Tags: 7.53-apache, 7-apache, 7.53, 7

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/389d5dcc78e78b700b5485d4608b9f094b2e485b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/d384adf6b4f01c158340cd601809a2a8d60aa8ec/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -18,7 +18,7 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/wheezy
 
 Tags: 1.6.4-alpine, 1.6-alpine
-GitCommit: fd163e2eb23f4c01f8e5721029c768a5ba48bad1
+GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
 Directory: 1.6/alpine
 
 Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
@@ -44,7 +44,7 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/wheezy
 
 Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: fd163e2eb23f4c01f8e5721029c768a5ba48bad1
+GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
 Directory: 1.7/alpine
 
 Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
@@ -70,7 +70,7 @@ GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
 Directory: 1.8/wheezy
 
 Tags: 1.8beta2-alpine, 1.8-alpine
-GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
+GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
 Directory: 1.8/alpine
 
 Tags: 1.8beta2-windowsservercore, 1.8-windowsservercore

--- a/library/haproxy
+++ b/library/haproxy
@@ -9,7 +9,7 @@ GitCommit: a11db1597f9be5365028673df4d05b2ea854b3ed
 Directory: 1.4
 
 Tags: 1.4.27-alpine, 1.4-alpine
-GitCommit: 667427cf0ac38b7ff7d9fcbd29493b54adf9d53d
+GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.4/alpine
 
 Tags: 1.5.19, 1.5
@@ -17,7 +17,7 @@ GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
-GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
+GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
 Tags: 1.6.11, 1.6
@@ -25,7 +25,7 @@ GitCommit: 12dae72c28e152ac9dcd499f156cb0ab79d7c23f
 Directory: 1.6
 
 Tags: 1.6.11-alpine, 1.6-alpine
-GitCommit: 12dae72c28e152ac9dcd499f156cb0ab79d7c23f
+GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.6/alpine
 
 Tags: 1.7.1, 1.7, 1, latest
@@ -33,5 +33,5 @@ GitCommit: 84fa05e8980f556b0330d69f5c756633a5a85f8b
 Directory: 1.7
 
 Tags: 1.7.1-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 84fa05e8980f556b0330d69f5c756633a5a85f8b
+GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.7/alpine

--- a/library/irssi
+++ b/library/irssi
@@ -1,16 +1,13 @@
-# maintainer: Jessie Frazelle <acidburn@google.com> (@jessfraz)
-# maintainer: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+# this file is generated via https://github.com/jessfraz/irssi/blob/b8e0a2171a759a9c34783557261727b0697f3f62/generate-stackbrew-library.sh
 
-0.8.20: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-0.8: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-0: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-latest: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-0.8.20-debian: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-0.8-debian: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-0-debian: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
-debian: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 debian
+Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
+             Tianon Gravi <admwiggin@gmail.com> (@tianon)
+GitRepo: https://github.com/jessfraz/irssi.git
 
-0.8.20-alpine: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
-0.8-alpine: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
-0-alpine: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
-alpine: git://github.com/jessfraz/irssi@af1a8245096671eed463d0108c0e786349c31710 alpine
+Tags: 0.8.20, 0.8, 0, latest
+GitCommit: af1a8245096671eed463d0108c0e786349c31710
+Directory: debian
+
+Tags: 0.8.20-alpine, 0.8-alpine, 0-alpine, alpine
+GitCommit: e8fbade97dc6ca76f6f80e2b67a4a18649acdb63
+Directory: alpine

--- a/library/memcached
+++ b/library/memcached
@@ -9,5 +9,5 @@ GitCommit: 137391b8166fd61c12bc54098350181d7da378f0
 Directory: debian
 
 Tags: 1.4.33-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 137391b8166fd61c12bc54098350181d7da378f0
+GitCommit: 83cb3846229ce562c2584ee8f9d924db5b04f85b
 Directory: alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -17,7 +17,7 @@ GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jdk
 
 Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
-GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
+GitCommit: fd4ce4b1cd4188dc7803afdedda8a6f97f16b605
 Directory: 7-jdk/alpine
 
 Tags: 7u111-jre, 7-jre
@@ -25,7 +25,7 @@ GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jre
 
 Tags: 7u121-jre-alpine, 7-jre-alpine
-GitCommit: 5257acb51a1230a2dc46b1c349d674a725562f9d
+GitCommit: fd4ce4b1cd4188dc7803afdedda8a6f97f16b605
 Directory: 7-jre/alpine
 
 Tags: 8u111-jdk, 8u111, 8-jdk, 8, jdk, latest
@@ -33,7 +33,7 @@ GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jdk
 
 Tags: 8u111-jdk-alpine, 8u111-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
+GitCommit: a2b245fc1ab64df2de145b87e631b5e89ca67388
 Directory: 8-jdk/alpine
 
 Tags: 8u111-jre, 8-jre, jre
@@ -41,7 +41,7 @@ GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jre
 
 Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
-GitCommit: 9a0822673dffd3e5ba66f18a8547aa60faed6d08
+GitCommit: a2b245fc1ab64df2de145b87e631b5e89ca67388
 Directory: 8-jre/alpine
 
 Tags: 9-b149-jdk, 9-b149, 9-jdk, 9

--- a/library/piwik
+++ b/library/piwik
@@ -2,4 +2,4 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 3.0.0, 3.0, 3, latest
-GitCommit: e6b01e5b10499fadece3754d1dd0460cbc960928
+GitCommit: 864ad02f7f84d7d4c44bf3ee839fc0383eb8dad7

--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: a00e979002aaa80840d58a5f8cc541342e06788f
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
+GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
@@ -17,7 +17,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
+GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
@@ -25,7 +25,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
+GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
@@ -33,7 +33,7 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
+GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
@@ -41,5 +41,5 @@ GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: a7ba7f2b2de177069e185e748adaa76ff444d921
+GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -13,7 +13,7 @@ GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 2.7/alpine
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
@@ -38,7 +38,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
@@ -58,7 +58,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
@@ -78,7 +78,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild
@@ -99,7 +99,7 @@ GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/slim
 
 Tags: 3.6.0-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.6/alpine
 
 Tags: 3.6.0-onbuild, 3.6-onbuild, 3-onbuild, onbuild

--- a/library/redis
+++ b/library/redis
@@ -13,7 +13,7 @@ GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
 Directory: 3.0/32bit
 
 Tags: 3.0.7-alpine, 3.0-alpine
-GitCommit: c49a42f6efcd2b971e43e93116a976b058035544
+GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
 Directory: 3.0/alpine
 
 Tags: 3.2.6, 3.2, 3, latest
@@ -25,5 +25,5 @@ GitCommit: 2e14b84ea86939438834a453090966a9bd4367fb
 Directory: 3.2/32bit
 
 Tags: 3.2.6-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 2e14b84ea86939438834a453090966a9bd4367fb
+GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
 Directory: 3.2/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: a684313c1187b2955e0f822b9ed7cc22f50c0c45
+GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 22fcd2eda0bb8cab0ca674881c5112e8627b3d43
+GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 64121ac0a34d07ff1c7341651f8775476cba6c41
+GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: b2f84d6b678e22d60995398746d14df79ab6b850
+GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `bash`: Alpine 3.5
- `docker`: Alpine 3.5
- `drupal`: 8.2.5
- `golang`: Alpine 3.5
- `haproxy`: Alpine 3.5
- `irssi`: Alpine 3.5
- `memcached`: Alpine 3.5
- `openjdk`: Alpine 3.5
- `piwik`: remove `sendmail_path` configuration
- `postgres`: Alpine 3.5
- `python`: Alpine 3.5
- `redis`: Alpine 3.5
- `ruby`: Alpine 3.5