### PR TITLE
Update for Node.js v4.7.1, v6.9.3 and v7.4.0; EOL v0.12

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,81 +1,65 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/57f7537d35c0988bd0e74abbf16989557c1481ad/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/28425ed95cebaea2ff589c1516d79c60181983b2/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.3.0, 7.3, 7, latest
-GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
-Directory: 7.3
+Tags: 7.4.0, 7.4, 7, latest
+GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
+Directory: 7.4
 
-Tags: 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
-GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
-Directory: 7.3/alpine
+Tags: 7.4.0-alpine, 7.4-alpine, 7-alpine, alpine
+GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
+Directory: 7.4/alpine
 
-Tags: 7.3.0-onbuild, 7.3-onbuild, 7-onbuild, onbuild
-GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
-Directory: 7.3/onbuild
+Tags: 7.4.0-onbuild, 7.4-onbuild, 7-onbuild, onbuild
+GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
+Directory: 7.4/onbuild
 
-Tags: 7.3.0-slim, 7.3-slim, 7-slim, slim
-GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
-Directory: 7.3/slim
+Tags: 7.4.0-slim, 7.4-slim, 7-slim, slim
+GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
+Directory: 7.4/slim
 
-Tags: 7.3.0-wheezy, 7.3-wheezy, 7-wheezy, wheezy
-GitCommit: 57f7537d35c0988bd0e74abbf16989557c1481ad
-Directory: 7.3/wheezy
+Tags: 7.4.0-wheezy, 7.4-wheezy, 7-wheezy, wheezy
+GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
+Directory: 7.4/wheezy
 
-Tags: 6.9.2, 6.9, 6, boron
-GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
+Tags: 6.9.3, 6.9, 6, boron
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 6.9
 
-Tags: 6.9.2-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
+Tags: 6.9.3-alpine, 6.9-alpine, 6-alpine, boron-alpine
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 6.9/alpine
 
-Tags: 6.9.2-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
+Tags: 6.9.3-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 6.9/onbuild
 
-Tags: 6.9.2-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
+Tags: 6.9.3-slim, 6.9-slim, 6-slim, boron-slim
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 6.9/slim
 
-Tags: 6.9.2-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 6948057bbd9cc1469ca0e5e64d3bd5f000d4dc97
+Tags: 6.9.3-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 6.9/wheezy
 
-Tags: 4.7.0, 4.7, 4, argon
-GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Tags: 4.7.1, 4.7, 4, argon
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 4.7
 
-Tags: 4.7.0-alpine, 4.7-alpine, 4-alpine, argon-alpine
-GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Tags: 4.7.1-alpine, 4.7-alpine, 4-alpine, argon-alpine
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 4.7/alpine
 
-Tags: 4.7.0-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Tags: 4.7.1-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 4.7/onbuild
 
-Tags: 4.7.0-slim, 4.7-slim, 4-slim, argon-slim
-GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Tags: 4.7.1-slim, 4.7-slim, 4-slim, argon-slim
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 4.7/slim
 
-Tags: 4.7.0-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 926106f27e3a6961191d7b802af6896a1ac892e3
+Tags: 4.7.1-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
 Directory: 4.7/wheezy
-
-Tags: 0.12.18, 0.12, 0
-GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
-Directory: 0.12
-
-Tags: 0.12.18-onbuild, 0.12-onbuild, 0-onbuild
-GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
-Directory: 0.12/onbuild
-
-Tags: 0.12.18-slim, 0.12-slim, 0-slim
-GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
-Directory: 0.12/slim
-
-Tags: 0.12.18-wheezy, 0.12-wheezy, 0-wheezy
-GitCommit: 38829d6654a9da4bb6fdb140286b5a47737cb1f3
-Directory: 0.12/wheezy
 


### PR DESCRIPTION
This is an update for Node.js v4.7.1, v6.9.3 and v7.4.0.

See:

- https://github.com/nodejs/docker-node/pull/302
- https://github.com/nodejs/docker-node/pull/304
- https://nodejs.org/en/blog/release/v4.7.1/
- https://nodejs.org/en/blog/release/v6.9.3/
- https://nodejs.org/en/blog/release/v7.4.0/

This update also removes the v0.12 image as it has now reached
end-of-life:

- https://github.com/nodejs/LTS/#lts-schedule
- https://github.com/nodejs/docker-node/pull/301