### PR TITLE
Update to latest commit & add boot variants

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,12 +1,15 @@
 # maintainer: Paul Lam <paul@quantisan.com> (@Quantisan)
 # maintainer: Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 
-latest: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724
-onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 onbuild
-alpine: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine
-alpine-onbuild: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine-onbuild
+latest: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e
+onbuild: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e onbuild
+alpine: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e alpine
+alpine-onbuild: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e alpine-onbuild
 
-lein-2.7.1: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724
-lein-2.7.1-onbuild: git://github.com/Quantisan/docker-clojure@c77c13529de02183433da15e8227eba63cc96724 onbuild
-lein-2.7.1-alpine: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine
-lein-2.7.1-alpine-onbuild: git://github.com/Quantisan/docker-clojure@2a0ab08313a24effa5d7b93b1ced8204763e6628 alpine-onbuild
+lein-2.7.1: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e
+lein-2.7.1-onbuild: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e onbuild
+lein-2.7.1-alpine: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e alpine
+lein-2.7.1-alpine-onbuild: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e alpine-onbuild
+
+boot-2.7.1: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e
+boot-2.7.1-alpine: git://github.com/Quantisan/docker-clojure@deaa211052211b693c8fca9e5652cc7239e6fd1e alpine


### PR DESCRIPTION
I setup a new build process for the clojure images (including `build` and `post_push` hooks) that adds variants that use the boot build tool instead of leiningen, for those who prefer that.