### PR TITLE
Revert many of the Alpine 3.5 upgrades

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -17,7 +17,7 @@ GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 
 Tags: 1.12.5, 1.12, 1, latest
-GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
+GitCommit: b7f1d172ede348d109f04e732f2b65af7663883c
 Directory: 1.12
 
 Tags: 1.12.5-dind, 1.12-dind, 1-dind, dind
@@ -29,7 +29,7 @@ GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
 Tags: 1.12.5-experimental, 1.12-experimental, 1-experimental, experimental
-GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
+GitCommit: b7f1d172ede348d109f04e732f2b65af7663883c
 Directory: 1.12/experimental
 
 Tags: 1.12.5-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
@@ -41,7 +41,7 @@ GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
 
 Tags: 1.11.2, 1.11
-GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
+GitCommit: b7f1d172ede348d109f04e732f2b65af7663883c
 Directory: 1.11
 
 Tags: 1.11.2-dind, 1.11-dind

--- a/library/golang
+++ b/library/golang
@@ -18,7 +18,7 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/wheezy
 
 Tags: 1.6.4-alpine, 1.6-alpine
-GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
+GitCommit: bfbd521de2942d10d96b14f99c491536490db018
 Directory: 1.6/alpine
 
 Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
@@ -44,7 +44,7 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/wheezy
 
 Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
+GitCommit: bfbd521de2942d10d96b14f99c491536490db018
 Directory: 1.7/alpine
 
 Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore

--- a/library/httpd
+++ b/library/httpd
@@ -9,7 +9,7 @@ GitCommit: fa5223d83a5225aa3fd5b23229b785c7764142bf
 Directory: 2.2
 
 Tags: 2.2.31-alpine, 2.2-alpine
-GitCommit: fa5223d83a5225aa3fd5b23229b785c7764142bf
+GitCommit: 41d8483def4933a805bc6413b5a60df17a94b949
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
@@ -17,5 +17,5 @@ GitCommit: 1990a58d6acaf056dd24b10d5923a60c27eda949
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 0e4a0b59e1f4e2a5a14ca197516beb2d4df1ffb8
+GitCommit: b95f1aba991d613f971fe8c66dc23fb4d8f3e9a7
 Directory: 2.4/alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -17,7 +17,7 @@ GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jdk
 
 Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
-GitCommit: fd4ce4b1cd4188dc7803afdedda8a6f97f16b605
+GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jdk/alpine
 
 Tags: 7u111-jre, 7-jre
@@ -25,7 +25,7 @@ GitCommit: 054cea7585e6c0e4e98d133378ea38061a2ae3ac
 Directory: 7-jre
 
 Tags: 7u121-jre-alpine, 7-jre-alpine
-GitCommit: fd4ce4b1cd4188dc7803afdedda8a6f97f16b605
+GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jre/alpine
 
 Tags: 8u111-jdk, 8u111, 8-jdk, 8, jdk, latest
@@ -33,7 +33,7 @@ GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jdk
 
 Tags: 8u111-jdk-alpine, 8u111-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-GitCommit: a2b245fc1ab64df2de145b87e631b5e89ca67388
+GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 8-jdk/alpine
 
 Tags: 8u111-jre, 8-jre, jre
@@ -41,7 +41,7 @@ GitCommit: e6e9cf8b21516ba764189916d35be57486203c95
 Directory: 8-jre
 
 Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
-GitCommit: a2b245fc1ab64df2de145b87e631b5e89ca67388
+GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 8-jre/alpine
 
 Tags: 9-b149-jdk, 9-b149, 9-jdk, 9

--- a/library/php
+++ b/library/php
@@ -9,7 +9,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.1/alpine
 
 Tags: 7.1.0-apache, 7.1-apache, 7-apache, apache
@@ -21,7 +21,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/fpm
 
 Tags: 7.1.0-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.0-zts, 7.1-zts, 7-zts, zts
@@ -29,7 +29,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.1/zts
 
 Tags: 7.1.0-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.14-cli, 7.0-cli, 7.0.14, 7.0
@@ -37,7 +37,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0
 
 Tags: 7.0.14-alpine, 7.0-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.0/alpine
 
 Tags: 7.0.14-apache, 7.0-apache
@@ -49,7 +49,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/fpm
 
 Tags: 7.0.14-fpm-alpine, 7.0-fpm-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.14-zts, 7.0-zts
@@ -57,7 +57,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 7.0/zts
 
 Tags: 7.0.14-zts-alpine, 7.0-zts-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.29-cli, 5.6-cli, 5-cli, 5.6.29, 5.6, 5
@@ -65,7 +65,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6
 
 Tags: 5.6.29-alpine, 5.6-alpine, 5-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 5.6/alpine
 
 Tags: 5.6.29-apache, 5.6-apache, 5-apache
@@ -77,7 +77,7 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/fpm
 
 Tags: 5.6.29-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.29-zts, 5.6-zts, 5-zts
@@ -85,5 +85,5 @@ GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
 Directory: 5.6/zts
 
 Tags: 5.6.29-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -13,7 +13,7 @@ GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
+GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
 Directory: 2.7/alpine
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
@@ -38,7 +38,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
+GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
@@ -58,7 +58,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
+GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
@@ -78,7 +78,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine
-GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
+GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild
@@ -99,7 +99,7 @@ GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/slim
 
 Tags: 3.6.0-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
+GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
 Directory: 3.6/alpine
 
 Tags: 3.6.0-onbuild, 3.6-onbuild, 3-onbuild, onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -13,7 +13,7 @@ GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
+GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -29,7 +29,7 @@ GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
+GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -45,7 +45,7 @@ GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
+GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -61,7 +61,7 @@ GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 24c59d34339317b9bc7e3d45f034fc09d1d02871
+GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `docker`: keep 3.5 on 1.13
- `golang`: keep 3.5 on 1.8
- `httpd`: update to Alpine 3.5
- `openjdk`: keep 3.5 on 9
- `php`: revert all (revisit for 7.2 release)
- `python`: revert all (revisit for 3.7 release)
- `ruby`: revert all (revisit for 2.5 release)