### PR TITLE
Update for Node.js v4.7.2 and v6.9.4

### DIFF
--- a/library/node
+++ b/library/node
@@ -23,43 +23,43 @@ Tags: 7.4.0-wheezy, 7.4-wheezy, 7-wheezy, wheezy
 GitCommit: 28425ed95cebaea2ff589c1516d79c60181983b2
 Directory: 7.4/wheezy
 
-Tags: 6.9.3, 6.9, 6, boron
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 6.9.4, 6.9, 6, boron
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 6.9
 
-Tags: 6.9.3-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 6.9.4-alpine, 6.9-alpine, 6-alpine, boron-alpine
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 6.9/alpine
 
-Tags: 6.9.3-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 6.9.4-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 6.9/onbuild
 
-Tags: 6.9.3-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 6.9.4-slim, 6.9-slim, 6-slim, boron-slim
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 6.9/slim
 
-Tags: 6.9.3-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 6.9.4-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 6.9/wheezy
 
-Tags: 4.7.1, 4.7, 4, argon
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 4.7.2, 4.7, 4, argon
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 4.7
 
-Tags: 4.7.1-alpine, 4.7-alpine, 4-alpine, argon-alpine
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 4.7.2-alpine, 4.7-alpine, 4-alpine, argon-alpine
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 4.7/alpine
 
-Tags: 4.7.1-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 4.7.2-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 4.7/onbuild
 
-Tags: 4.7.1-slim, 4.7-slim, 4-slim, argon-slim
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 4.7.2-slim, 4.7-slim, 4-slim, argon-slim
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 4.7/slim
 
-Tags: 4.7.1-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 369c41c80fc5312625ad61175814b93dc24d0939
+Tags: 4.7.2-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
+GitCommit: ad54b39ef23e0c7e0df3ac4234c3ee77b58c3f5d
 Directory: 4.7/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v4.7.2/
- https://nodejs.org/en/blog/release/v6.9.4/
- https://github.com/nodejs/build/issues/586
- https://github.com/nodejs/docker-node/pull/306