### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -6,14 +6,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
-Tags: 1.26.0-glibc, 1.26-glibc, 1-glibc, glibc
-GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
+Tags: 1.26.1-glibc, 1.26-glibc, 1-glibc, glibc
+GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
 Directory: glibc
 
-Tags: 1.26.0-musl, 1.26-musl, 1-musl, musl
-GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
+Tags: 1.26.1-musl, 1.26-musl, 1-musl, musl
+GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
 Directory: musl
 
-Tags: 1.26.0-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.0, 1.26, 1, latest
-GitCommit: 5abf0d09083c916fa5d3dc109d9d0681f9640703
+Tags: 1.26.1-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.1, 1.26, 1, latest
+GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
 Directory: uclibc

--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0-rc4, 1.13-rc, rc
-GitCommit: ede8a0d268951ed3a732601c94a1d983e6e19508
+Tags: 1.13.0-rc5, 1.13-rc, rc
+GitCommit: ee49c1bacae27314f4b1baf40145a3a8714f1eab
 Directory: 1.13-rc
 
-Tags: 1.13.0-rc4-dind, 1.13-rc-dind, rc-dind
+Tags: 1.13.0-rc5-dind, 1.13-rc-dind, rc-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.13-rc/dind
 
-Tags: 1.13.0-rc4-git, 1.13-rc-git, rc-git
+Tags: 1.13.0-rc5-git, 1.13-rc-git, rc-git
 GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: 4dd33136c4739667a223d39b6f829beb27b235cf
+GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
 Directory: 8.0
 
 Tags: 5.7.17, 5.7, 5, latest
-GitCommit: c207cc19a272a6bfe1916c964ed8df47f18479e7
+GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
 Directory: 5.7
 
 Tags: 5.6.35, 5.6
-GitCommit: fd3bdabe513643b62fc379f365b2b5dd10886311
+GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
 Directory: 5.6
 
 Tags: 5.5.54, 5.5
-GitCommit: ee989d0666458d08dd79c55f7abb62be29a9cb3d
+GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
 Directory: 5.5

--- a/library/ruby
+++ b/library/ruby
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
@@ -21,7 +21,7 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
@@ -37,7 +37,7 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
@@ -53,7 +53,7 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -27,3 +27,15 @@ Directory: php7.0/fpm
 Tags: 4.7.0-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
 Directory: php7.0/fpm-alpine
+
+Tags: 4.7.0-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.0-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Directory: php7.1/apache
+
+Tags: 4.7.0-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Directory: php7.1/fpm
+
+Tags: 4.7.0-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Directory: php7.1/fpm-alpine


### PR DESCRIPTION
- `busybox`: 1.26.1 (docker-library/busybox#22)
- `docker`: 1.13.0-rc5
- `mysql`: add `MYSQL_ROOT_HOST` support (docker-library/mysql#249)
- `ruby`: put `xz-utils` back in non-slim (docker-library/ruby#109)
- `wordpress`: add `php7.1` variants (docker-library/wordpress#193)