### PR TITLE
Neo4j: Convert from "java" (deprecated) to "openjdk" base image.

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -11,180 +11,180 @@ Maintainers: Ben Butler-Cole <ben@neotechnology.com> (@benbc),
 
 Tags: 3.1.0, 3.1, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 52a00eb0a7d6236ca05fff62ec2956493b13a4cd
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.1.0/community
 
 Tags: 3.1.0-enterprise, 3.1-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 52a00eb0a7d6236ca05fff62ec2956493b13a4cd
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.1.0/enterprise
 
 Tags: 3.0.7, 3.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 56ac90c26a96f570ba8090c37b8dfcd613fd537f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.7/community
 
 Tags: 3.0.7-enterprise, 3.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 56ac90c26a96f570ba8090c37b8dfcd613fd537f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.7/enterprise
 
 Tags: 3.0.6
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 22114d5022d6bd414fc7d34046b7a5f9cfdc930c
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.6/community
 
 Tags: 3.0.6-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 22114d5022d6bd414fc7d34046b7a5f9cfdc930c
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.6/enterprise
 
 Tags: 3.0.5
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 22114d5022d6bd414fc7d34046b7a5f9cfdc930c
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.5/community
 
 Tags: 3.0.5-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 22114d5022d6bd414fc7d34046b7a5f9cfdc930c
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.5/enterprise
 
 Tags: 3.0.4
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 1ad894c32a9cf2a7147f4bdd76eb7a52f8df9d12
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.4/community
 
 Tags: 3.0.4-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 1ad894c32a9cf2a7147f4bdd76eb7a52f8df9d12
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.4/enterprise
 
 Tags: 3.0.3
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.3/community
 
 Tags: 3.0.3-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.3/enterprise
 
 Tags: 3.0.2
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.2/community
 
 Tags: 3.0.2-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.2/enterprise
 
 Tags: 3.0.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.1/community
 
 Tags: 3.0.1-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.1/enterprise
 
 Tags: 3.0.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.0/community
 
 Tags: 3.0.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.0/enterprise
 
 Tags: 2.3.8, 2.3
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: f6e2919c1a22a83cc4b32b6bf31719b3cb7f5ade
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.8/community
 
 Tags: 2.3.8-enterprise, 2.3-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: f6e2919c1a22a83cc4b32b6bf31719b3cb7f5ade
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.7/enterprise
 
 Tags: 2.3.7
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 16bcec79c48349daf23a9fc635bfc0647dd580c5
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.7/community
 
 Tags: 2.3.7-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 16bcec79c48349daf23a9fc635bfc0647dd580c5
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.7/enterprise
 
 Tags: 2.3.6
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 3be2e1ae6ec47195c6ac9226de8793d5f4fd8162
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.6/community
 
 Tags: 2.3.6-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 3be2e1ae6ec47195c6ac9226de8793d5f4fd8162
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.6/enterprise
 
 Tags: 2.3.5
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.5/community
 
 Tags: 2.3.5-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.5/enterprise
 
 Tags: 2.3.4
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.4/community
 
 Tags: 2.3.4-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.4/enterprise
 
 Tags: 2.3.3
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.3/community
 
 Tags: 2.3.3-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.3/enterprise
 
 Tags: 2.3.2
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.2/community
 
 Tags: 2.3.2-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.2/enterprise
 
 Tags: 2.3.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.1/community
 
 Tags: 2.3.1-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e93e47d841dbcd93793c44c393195803ba60b16f
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.1/enterprise
 
 Tags: 2.3.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: be3136e85d255ccd695b0bfb352304c40f05fc84
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.0/community
 
 Tags: 2.3.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: be3136e85d255ccd695b0bfb352304c40f05fc84
+GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 2.3.0/enterprise


### PR DESCRIPTION
For changes made here: https://github.com/neo4j/docker-neo4j-publish/pull/2 by @tianon 