### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.16, 2.1
-GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
+GitCommit: 3ca0a18a575ae318f753ab1ecf01d54c93192681
 Directory: 2.1
 
 Tags: 2.2.8, 2.2, 2
-GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
+GitCommit: 3ca0a18a575ae318f753ab1ecf01d54c93192681
 Directory: 2.2
 
 Tags: 3.0.10, 3.0
-GitCommit: d3a91560b21e73994235a72a4c3153e775e1654d
+GitCommit: 3ca0a18a575ae318f753ab1ecf01d54c93192681
 Directory: 3.0
 
 Tags: 3.9, 3, latest
-GitCommit: 4bb926527d4a9eb534508fe0bbae604dee81f40a
+GitCommit: 3ca0a18a575ae318f753ab1ecf01d54c93192681
 Directory: 3.9

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+GitCommit: 9648a7bfb4f0b6aef7da619c60826e102293a7d5
 Directory: 5
 
 Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+GitCommit: 9648a7bfb4f0b6aef7da619c60826e102293a7d5
 Directory: 5/alpine
 
 Tags: 2.4.3, 2.4, 2
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+GitCommit: ffd7a19f1e68329cc310f145c232e83abec09067
 Directory: 2.4
 
 Tags: 2.4.3-alpine, 2.4-alpine, 2-alpine
@@ -21,7 +21,7 @@ GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+GitCommit: ffd7a19f1e68329cc310f145c232e83abec09067
 Directory: 1.7
 
 Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/d384adf6b4f01c158340cd601809a2a8d60aa8ec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/6c5f2993c210854b077ad07c9a94334f8c82fbb1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -47,6 +47,10 @@ Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
 GitCommit: bfbd521de2942d10d96b14f99c491536490db018
 Directory: 1.7/alpine
 
+Tags: 1.7.4-alpine3.5, 1.7-alpine3.5, 1-alpine3.5, alpine3.5
+GitCommit: 6c5f2993c210854b077ad07c9a94334f8c82fbb1
+Directory: 1.7/alpine3.5
+
 Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
 GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
 Directory: 1.7/windows/windowsservercore
@@ -57,28 +61,28 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8beta2, 1.8
-GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
+Tags: 1.8rc1, 1.8
+GitCommit: b819b526131d44c03f02942816f616067d389037
 Directory: 1.8
 
-Tags: 1.8beta2-onbuild, 1.8-onbuild
+Tags: 1.8rc1-onbuild, 1.8-onbuild
 GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
 Directory: 1.8/onbuild
 
-Tags: 1.8beta2-wheezy, 1.8-wheezy
-GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
+Tags: 1.8rc1-wheezy, 1.8-wheezy
+GitCommit: b819b526131d44c03f02942816f616067d389037
 Directory: 1.8/wheezy
 
-Tags: 1.8beta2-alpine, 1.8-alpine
-GitCommit: dcc5daf40298da271abb97677d5c78d4b5433b02
+Tags: 1.8rc1-alpine, 1.8-alpine
+GitCommit: b819b526131d44c03f02942816f616067d389037
 Directory: 1.8/alpine
 
-Tags: 1.8beta2-windowsservercore, 1.8-windowsservercore
-GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
+Tags: 1.8rc1-windowsservercore, 1.8-windowsservercore
+GitCommit: b819b526131d44c03f02942816f616067d389037
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8beta2-nanoserver, 1.8-nanoserver
-GitCommit: f98d9b6d5d34efa8ba52426358d00d950f9daaec
+Tags: 1.8rc1-nanoserver, 1.8-nanoserver
+GitCommit: b819b526131d44c03f02942816f616067d389037
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/kibana
+++ b/library/kibana
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/kibana.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
+GitCommit: f660339999bbb4afe519ea748a32f948a997f3e6
 Directory: 5
 
 Tags: 4.6.3, 4.6, 4
-GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
+GitCommit: f660339999bbb4afe519ea748a32f948a997f3e6
 Directory: 4.6
 
 Tags: 4.1.11, 4.1

--- a/library/logstash
+++ b/library/logstash
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/logstash.git
 
 Tags: 5.1.1, 5.1, 5, latest
-GitCommit: aa556fc3ae9d6cadc26390d8c57bc94710122b7d
+GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
 Directory: 5
 
 Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
@@ -13,7 +13,7 @@ GitCommit: aa556fc3ae9d6cadc26390d8c57bc94710122b7d
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2
-GitCommit: 93d338f878f4adb1e4e8fa31407d9b4263c41932
+GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
 Directory: 2.4
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine
@@ -21,7 +21,7 @@ GitCommit: 93d338f878f4adb1e4e8fa31407d9b4263c41932
 Directory: 2.4/alpine
 
 Tags: 1.5.6, 1.5, 1
-GitCommit: 93d338f878f4adb1e4e8fa31407d9b4263c41932
+GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
 Directory: 1.5
 
 Tags: 1.5.6-alpine, 1.5-alpine, 1-alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.1.20, 10.1, 10, latest
-GitCommit: c31e557088187e8ac7a7d4b13e7bd0c052386f94
+GitCommit: b26cb74f2c213b4b852067937198d924517e387f
 Directory: 10.1
 
 Tags: 10.0.28, 10.0
-GitCommit: 2b065acb53b18eb44e1d78a1a41f0a46f829c291
+GitCommit: b26cb74f2c213b4b852067937198d924517e387f
 Directory: 10.0
 
 Tags: 5.5.54, 5.5, 5
-GitCommit: b2dd0ba9f4b025d67fa21c5753c5e410b5801d0e
+GitCommit: b26cb74f2c213b4b852067937198d924517e387f
 Directory: 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.33, 1.4, 1, latest
-GitCommit: 137391b8166fd61c12bc54098350181d7da378f0
+Tags: 1.4.34, 1.4, 1, latest
+GitCommit: 53b91f1cfb308fe4946a79bd1d23ceaa3d18e250
 Directory: debian
 
-Tags: 1.4.33-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 83cb3846229ce562c2584ee8f9d924db5b04f85b
+Tags: 1.4.34-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 53b91f1cfb308fe4946a79bd1d23ceaa3d18e250
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.14, 3.0
-GitCommit: b37a4891feffeafb77febd2833d96b59cf28d6a8
+GitCommit: 30d09dbd6343d3cbd1bbea2d6afde49f5d9a9295
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.11, 3.2
-GitCommit: 21a6f6cf3eff13a39b20c86224730a29823370ca
+GitCommit: 30d09dbd6343d3cbd1bbea2d6afde49f5d9a9295
 Directory: 3.2
 
 Tags: 3.2.11-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.1, 3.4, 3, latest
-GitCommit: 6f548652b0139ff50182c56d3c74efd875f6fb5c
+GitCommit: 30d09dbd6343d3cbd1bbea2d6afde49f5d9a9295
 Directory: 3.4
 
 Tags: 3.4.1-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 8-jre/alpine
 
-Tags: 9-b149-jdk, 9-b149, 9-jdk, 9
-GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
+Tags: 9-b151-jdk, 9-b151, 9-jdk, 9
+GitCommit: 11af1a181763751cce50f383f6b4b023fd5d2255
 Directory: 9-jdk
 
-Tags: 9-b149-jre, 9-jre
-GitCommit: e2c8648d39ef1492df3482de3fda0ee3f8955fb1
+Tags: 9-b151-jre, 9-jre
+GitCommit: 11af1a181763751cce50f383f6b4b023fd5d2255
 Directory: 9-jre

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.16, 5.7, 5, latest
-GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
+GitCommit: 6c829dccb3b3ec43289b5721bf48b55801b49cdd
 Directory: 5.7
 
 Tags: 5.6.34, 5.6
-GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
+GitCommit: 6c829dccb3b3ec43289b5721bf48b55801b49cdd
 Directory: 5.6
 
 Tags: 5.5.53, 5.5
-GitCommit: 4f8e829e7d0f8929225a3b042177dbe604c75755
+GitCommit: 6c829dccb3b3ec43289b5721bf48b55801b49cdd
 Directory: 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -1,5 +1,5 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.0.0, 3.0, 3, latest
-GitCommit: 864ad02f7f84d7d4c44bf3ee839fc0383eb8dad7
+Tags: 3.0.1, 3.0, 3, latest
+GitCommit: b38670f41cce0b02b63ce6478ebbb0cbd3122eac

--- a/library/postgres
+++ b/library/postgres
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.1, 9.6, 9, latest
-GitCommit: a00e979002aaa80840d58a5f8cc541342e06788f
+GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
@@ -13,7 +13,7 @@ GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
@@ -21,7 +21,7 @@ GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
@@ -29,7 +29,7 @@ GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
@@ -37,7 +37,7 @@ GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
-GitCommit: 4f3238cf60b514d5c20e86096817718474f53d73
+GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.6, 3.6, 3, latest
-GitCommit: c766dd4dad64dd1c5550febff7e19ab763b7c5a4
+GitCommit: 2016a3de7f3c9663208bd11a9bd49b2af49c13bc
 
 Tags: 3.6.6-management, 3.6-management, 3-management, management
 GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d

--- a/library/redmine
+++ b/library/redmine
@@ -12,18 +12,18 @@ Tags: 3.1.7-passenger, 3.1-passenger
 GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.1/passenger
 
-Tags: 3.2.4, 3.2
-GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
+Tags: 3.2.5, 3.2
+GitCommit: d03bfc8dda6aba04d47abcc4d91c9a022be3ffef
 Directory: 3.2
 
-Tags: 3.2.4-passenger, 3.2-passenger
+Tags: 3.2.5-passenger, 3.2-passenger
 GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.2/passenger
 
-Tags: 3.3.1, 3.3, 3, latest
-GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
+Tags: 3.3.2, 3.3, 3, latest
+GitCommit: 751dc04d76bdec5b92238a6acaa31df610b7d651
 Directory: 3.3
 
-Tags: 3.3.1-passenger, 3.3-passenger, 3-passenger, passenger
+Tags: 3.3.2-passenger, 3.3-passenger, 3-passenger, passenger
 GitCommit: e803be4f45b5db05ea950d2e2831f1811df8f488
 Directory: 3.3/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.48-jre7, 6.0-jre7, 6-jre7, 6.0.48, 6.0, 6
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 6/jre7
 
 Tags: 6.0.48-jre8, 6.0-jre8, 6-jre8
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 6/jre8
 
 Tags: 7.0.73-jre7, 7.0-jre7, 7-jre7, 7.0.73, 7.0, 7
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 7/jre7
 
 Tags: 7.0.73-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.73-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre7-alpine
 
 Tags: 7.0.73-jre8, 7.0-jre8, 7-jre8
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 7/jre8
 
 Tags: 7.0.73-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
 Directory: 7/jre8-alpine
 
 Tags: 8.0.39-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.39, 8.0, 8, latest
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 8.0/jre7
 
 Tags: 8.0.39-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.39-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.39-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 9ef39e44020d9ac03c8c15bae5e5b0ba96faa128
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 8.0/jre8
 
 Tags: 8.0.39-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.9-jre8, 8.5-jre8, 8.5.9, 8.5
-GitCommit: 9c280294942795515740cb6d78b1d51d95b31928
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 8.5/jre8
 
 Tags: 8.5.9-jre8-alpine, 8.5-jre8-alpine, 8.5.9-alpine, 8.5-alpine
@@ -53,7 +53,7 @@ GitCommit: 9c280294942795515740cb6d78b1d51d95b31928
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M15-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M15, 9.0.0, 9.0, 9
-GitCommit: 9fcf1c13eb901de73aa3abdfc36d1989a1154365
+GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M15-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M15-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.0-apache, 4.7-apache, 4-apache, apache, 4.7.0, 4.7, 4, latest, 4.7.0-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.0-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-apache, 4.7-apache, 4-apache, apache, 4.7.1, 4.7, 4, latest, 4.7.1-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.1-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php5.6/apache
 
-Tags: 4.7.0-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.0-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.1-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php5.6/fpm
 
-Tags: 4.7.0-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.0-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.1-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.0-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.0-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.1-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.0/apache
 
-Tags: 4.7.0-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.0/fpm
 
-Tags: 4.7.0-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: 637afb53dc03b4af19149a0880e796346f97c137
+Tags: 4.7.1-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.0-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.0-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Tags: 4.7.1-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.1-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.1/apache
 
-Tags: 4.7.0-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Tags: 4.7.1-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.1/fpm
 
-Tags: 4.7.0-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: f56ccb5de179757eeb043ef5fedea6c3cf4e3bf2
+Tags: 4.7.1-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
 Directory: php7.1/fpm-alpine


### PR DESCRIPTION
- `cassandra`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/cassandra#91)
- `elasticsearch`: avoid bootstrap checks by using `http.host` instead of `network.host` (docker-library/elasticsearch#153), use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/elasticsearch#152)
- `golang`: 1.8rc1, explicit Alpine 3.5 variant of Go 1.7 (docker-library/golang#134)
- `kibana`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/kibana#69)
- `logstash`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/logstash#78)
- `mariadb`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/mariadb#93)
- `memcached`: 1.4.34
- `mongo`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/mongo#132)
- `openjdk`: debian 9~b151-2
- `percona`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/percona#39)
- `piwik`: 3.0.1
- `postgres`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/postgres#246)
- `rabbitmq`: allow custom definitions file (docker-library/rabbitmq#112), use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/rabbitmq#133)
- `redmine`: 3.2.5, 3.3.2
- `tomcat`: improve OpenSSL comments (docker-library/tomcat#59)
- `wordpress`: 4.7.1, fix Windows-newlines `sed` (docker-library/wordpress#197)