### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -6,14 +6,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
-Tags: 1.26.1-glibc, 1.26-glibc, 1-glibc, glibc
-GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
+Tags: 1.26.2-glibc, 1.26-glibc, 1-glibc, glibc
+GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
 Directory: glibc
 
-Tags: 1.26.1-musl, 1.26-musl, 1-musl, musl
-GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
+Tags: 1.26.2-musl, 1.26-musl, 1-musl, musl
+GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
 Directory: musl
 
-Tags: 1.26.1-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.1, 1.26, 1, latest
-GitCommit: 257261b9e1acf1285f6cc3282b4ae5c5c30a2d82
+Tags: 1.26.2-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.2, 1.26, 1, latest
+GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
 Directory: uclibc

--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0-rc5, 1.13-rc, rc
-GitCommit: ee49c1bacae27314f4b1baf40145a3a8714f1eab
+Tags: 1.13.0-rc6, 1.13-rc, rc
+GitCommit: a6d2bce76d8f8e0d4b5c65aedf5f0dccf9a17e66
 Directory: 1.13-rc
 
-Tags: 1.13.0-rc5-dind, 1.13-rc-dind, rc-dind
+Tags: 1.13.0-rc6-dind, 1.13-rc-dind, rc-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.13-rc/dind
 
-Tags: 1.13.0-rc5-git, 1.13-rc-git, rc-git
+Tags: 1.13.0-rc6-git, 1.13-rc-git, rc-git
 GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 9648a7bfb4f0b6aef7da619c60826e102293a7d5
+Tags: 5.1.2, 5.1, 5, latest
+GitCommit: f2e19796b765e2e448d0e8c651d51be992b56d08
 Directory: 5
 
-Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: 9648a7bfb4f0b6aef7da619c60826e102293a7d5
+Tags: 5.1.2-alpine, 5.1-alpine, 5-alpine, alpine
+GitCommit: f2e19796b765e2e448d0e8c651d51be992b56d08
 Directory: 5/alpine
 
-Tags: 2.4.3, 2.4, 2
-GitCommit: ffd7a19f1e68329cc310f145c232e83abec09067
+Tags: 2.4.4, 2.4, 2
+GitCommit: 8f00ad520c1c33b879a715700905d3c25c526331
 Directory: 2.4
 
-Tags: 2.4.3-alpine, 2.4-alpine, 2-alpine
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+Tags: 2.4.4-alpine, 2.4-alpine, 2-alpine
+GitCommit: 8f00ad520c1c33b879a715700905d3c25c526331
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.3, 0.11, 0, latest
-GitCommit: 3aae08aeeb4d14d681a36742a5ab5e46366a5fe1
+Tags: 0.11.4, 0.11, 0, latest
+GitCommit: 2abbd2be17b1f1418b2195ee60801585149d7b4a

--- a/library/haproxy
+++ b/library/haproxy
@@ -28,10 +28,10 @@ Tags: 1.6.11-alpine, 1.6-alpine
 GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.6/alpine
 
-Tags: 1.7.1, 1.7, 1, latest
-GitCommit: 84fa05e8980f556b0330d69f5c756633a5a85f8b
+Tags: 1.7.2, 1.7, 1, latest
+GitCommit: d704d453c6ab9cdaa5498c1e14b6e5d0622e629d
 Directory: 1.7
 
-Tags: 1.7.1-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
+Tags: 1.7.2-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: d704d453c6ab9cdaa5498c1e14b6e5d0622e629d
 Directory: 1.7/alpine

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -5,10 +5,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/hello-world.git
 
 Tags: latest
-GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d
+GitCommit: bdee60d7ff6b98037657dc34a10e9ca4ffd6785f
 Directory: hello-seattle
 
 Tags: nanoserver
-GitCommit: 0f30176f82bc9984e7a75f96205f86dc3758e2e8
+GitCommit: 1f13a5bc3b787747eeefb3b0051d8d29f851260d
 Directory: hello-seattle/nanoserver
 Constraints: nanoserver

--- a/library/hello-world
+++ b/library/hello-world
@@ -5,10 +5,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/hello-world.git
 
 Tags: latest
-GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d
+GitCommit: bdee60d7ff6b98037657dc34a10e9ca4ffd6785f
 Directory: hello-world
 
 Tags: nanoserver
-GitCommit: 0f30176f82bc9984e7a75f96205f86dc3758e2e8
+GitCommit: 1f13a5bc3b787747eeefb3b0051d8d29f851260d
 Directory: hello-world/nanoserver
 Constraints: nanoserver

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -5,10 +5,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/hello-world.git
 
 Tags: latest
-GitCommit: 85fd7ab65e079b08019032479a3f306964a28f4d
+GitCommit: bdee60d7ff6b98037657dc34a10e9ca4ffd6785f
 Directory: hola-mundo
 
 Tags: nanoserver
-GitCommit: 0f30176f82bc9984e7a75f96205f86dc3758e2e8
+GitCommit: 1f13a5bc3b787747eeefb3b0051d8d29f851260d
 Directory: hola-mundo/nanoserver
 Constraints: nanoserver

--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.2.31, 2.2
-GitCommit: fa5223d83a5225aa3fd5b23229b785c7764142bf
+Tags: 2.2.32, 2.2
+GitCommit: a5ab6fb434c13a3578a2e7e6ce2cf30d66c625bc
 Directory: 2.2
 
-Tags: 2.2.31-alpine, 2.2-alpine
-GitCommit: 41d8483def4933a805bc6413b5a60df17a94b949
+Tags: 2.2.32-alpine, 2.2-alpine
+GitCommit: a5ab6fb434c13a3578a2e7e6ce2cf30d66c625bc
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.1.1, 5.1, 5, latest
-GitCommit: f660339999bbb4afe519ea748a32f948a997f3e6
+Tags: 5.1.2, 5.1, 5, latest
+GitCommit: efb58738202ae0b107dd0114e227d87f59323f80
 Directory: 5
 
-Tags: 4.6.3, 4.6, 4
-GitCommit: f660339999bbb4afe519ea748a32f948a997f3e6
+Tags: 4.6.4, 4.6, 4
+GitCommit: 902581f626cba60693e32ca54f91f487b6be7e98
 Directory: 4.6
 
 Tags: 4.1.11, 4.1

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.1.1, 5.1, 5, latest
-GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
+Tags: 5.1.2, 5.1, 5, latest
+GitCommit: e667720b9e8c5c6c369843a7368742e55ae22e0a
 Directory: 5
 
-Tags: 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: aa556fc3ae9d6cadc26390d8c57bc94710122b7d
+Tags: 5.1.2-alpine, 5.1-alpine, 5-alpine, alpine
+GitCommit: e667720b9e8c5c6c369843a7368742e55ae22e0a
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.1.20, 10.1, 10, latest
 GitCommit: b26cb74f2c213b4b852067937198d924517e387f
 Directory: 10.1
 
-Tags: 10.0.28, 10.0
-GitCommit: b26cb74f2c213b4b852067937198d924517e387f
+Tags: 10.0.29, 10.0
+GitCommit: b8a9bd6870bb327db7b238dc6efe909e5e7b399f
 Directory: 10.0
 
 Tags: 5.5.54, 5.5, 5

--- a/library/mysql
+++ b/library/mysql
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
+GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
 Directory: 8.0
 
 Tags: 5.7.17, 5.7, 5, latest
-GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
+GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
 Directory: 5.7
 
 Tags: 5.6.35, 5.6
-GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
+GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
 Directory: 5.6
 
 Tags: 5.5.54, 5.5

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.48.2, 0.48, 0, latest
-GitCommit: 65ca59ce402400d6e57c5b497011ce3572cae9b3
+Tags: 0.49.0, 0.49, 0, latest
+GitCommit: 1aef86c073c520e8b164732c88b83c0fd041d9a1


### PR DESCRIPTION
- `busybox`: 1.26.2
- `docker`: 1.13.0-rc6
- `elasticsearch`: 5.1.2, 2.4.4
- `ghost`: 0.11.4
- `haproxy`: 1.7.2
- `hello-seattle`: Hub->Cloud, Account->ID (docker-library/hello-world#25)
- `hello-world`: Hub->Cloud, Account->ID (docker-library/hello-world#25)
- `hola-mundo`: Hub->Cloud, Account->ID (docker-library/hello-world#25)
- `httpd`: 2.2.32
- `kibana`: 5.1.2, 4.6.4
- `logstash`: 5.1.2
- `mariadb`: 10.0.29+maria-1~jessie
- `mysql`: use `/etc/apt/trusted.gpg.d` instead of `apt-key adv` (docker-library/mysql#254)
- `rocket.chat`: 0.49.0