### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0-rc6, 1.13-rc, rc
-GitCommit: a6d2bce76d8f8e0d4b5c65aedf5f0dccf9a17e66
+Tags: 1.13.0-rc7, 1.13-rc, rc
+GitCommit: 9e0b4db74358f601e7fa26671e49ddcd847689fb
 Directory: 1.13-rc
 
-Tags: 1.13.0-rc6-dind, 1.13-rc-dind, rc-dind
+Tags: 1.13.0-rc7-dind, 1.13-rc-dind, rc-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.13-rc/dind
 
-Tags: 1.13.0-rc6-git, 1.13-rc-git, rc-git
+Tags: 1.13.0-rc7-git, 1.13-rc-git, rc-git
 GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
 Directory: 1.13-rc/git
 

--- a/library/httpd
+++ b/library/httpd
@@ -13,7 +13,7 @@ GitCommit: a5ab6fb434c13a3578a2e7e6ce2cf30d66c625bc
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
-GitCommit: 1990a58d6acaf056dd24b10d5923a60c27eda949
+GitCommit: aa1a6b699929b59627d39a8940f2810709956cdf
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.49.0, 0.49, 0, latest
-GitCommit: 1aef86c073c520e8b164732c88b83c0fd041d9a1
+Tags: 0.49.1, 0.49, 0, latest
+GitCommit: d771f1028b3f39946fd4168e31a9b2469ea4dad3


### PR DESCRIPTION
- `docker`: 1.13.0-rc7
- `httpd`: fix http2 support in 2.4 (docker-library/httpd#43)
- `rocket.chat`: 0.49.1