### PR TITLE
Add a short test to verify basic push/pull functionality with a registry

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -53,6 +53,7 @@ imageTests+=(
 	'
 	[docker:dind]='
 		docker-dind
+		docker-registry-push-pull
 	'
 	[django]='
 	'
@@ -158,6 +159,9 @@ imageTests+=(
 		redis-basics
 		redis-basics-config
 		redis-basics-persistent
+	'
+	[registry]='
+		docker-registry-push-pull
 	'
 	[rethinkdb]='
 	'

--- a/test/tests/docker-registry-push-pull/run.sh
+++ b/test/tests/docker-registry-push-pull/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+case "${image##*/}" in
+	docker:*dind*)
+		dockerImage="$image"
+		registryImage='registry'
+		;;
+	registry:*|registry)
+		registryImage="$image"
+		dockerImage='docker:dind'
+		;;
+	*)
+		echo >&2 "error: unable to determine whether '$image' is registry or docker:dind"
+		exit 1
+		;;
+esac
+
+rhostname='reg.example.com'
+rnamespace="${rhostname}:5000"
+
+rcname="docker-registry-container-$RANDOM-$RANDOM"
+rcid="$(
+	docker run -d -it \
+		--hostname "$rhostname" \
+		--name "$rcname" \
+		"$registryImage"
+)"
+trap "docker rm -vf $rcid > /dev/null" EXIT
+
+dcname="docker-daemon-container-$RANDOM-$RANDOM"
+dcid="$(
+	docker run -d -it \
+		--privileged \
+		--link "$rcid":"$rhostname" \
+		--name "$dcname" \
+		"$dockerImage" \
+		--insecure-registry "$rnamespace"
+)"
+trap "docker rm -vf $rcid $dcid > /dev/null" EXIT
+
+docker_() {
+	docker run --rm -i \
+		--link "$dcid":docker \
+		--entrypoint docker-entrypoint.sh \
+		"$dockerImage" \
+		"$@"
+}
+
+. "$dir/../../retry.sh" 'docker_ version'
+
+[ "$(docker_ images -q | wc -l)" = '0' ]
+docker_ pull busybox
+[ "$(docker_ images -q | wc -l)" = '1' ]
+
+docker_ tag busybox "$rnamespace/busybox"
+docker_ push "$rnamespace/busybox"
+
+docker_ rmi busybox "$rnamespace/busybox"
+[ "$(docker_ images -q | wc -l)" = '0' ]
+docker_ pull "$rnamespace/busybox"
+[ "$(docker_ images -q | wc -l)" = '1' ]
+
+docker_ run --rm "$rnamespace/busybox" true


### PR DESCRIPTION
This adds a new `docker-registry-push-pull` test which simply:

- launches a local Registry instance (using either `registry:latest` or the image-under-test depending on whether image-under-test is `registry:*` or `docker:*dind*`)
- launches a Docker-in-Docker instance (using either `docker:dind` or the image-under-test depending on the inverse of the previous conditional)
- `docker pull busybox`
- `docker tag busybox .../busybox`
- `docker push .../busybox`
- `docker rmi busybox ../busybox`
- `docker pull .../busybox`
- `docker run --rm .../busybox true`

This test will be run for both `library/registry` PRs and `library/docker` PRs just as an additional simple smoke test (especially since this is essentially the bare-minimum functionality we just documented over in https://github.com/docker-library/docs/pull/796).

cc @yosifkit @stevvooe @dmp42 @RichardScothern @aaronlehmann @dmcgowan (explicit request for comment / FYI :heart:)