### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,53 +1,41 @@
-# this file is generated via https://github.com/docker-library/docker/blob/a7fc73eef011c47cc2518149bc77a4b9bc7f9f41/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/b202ec7e529f5426e2ad7e8c0a8b82cacd406573/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0-rc7, 1.13-rc, rc
-GitCommit: 9e0b4db74358f601e7fa26671e49ddcd847689fb
-Directory: 1.13-rc
+Tags: 1.13.0, 1.13, 1, latest
+GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
+Directory: 1.13
 
-Tags: 1.13.0-rc7-dind, 1.13-rc-dind, rc-dind
-GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
-Directory: 1.13-rc/dind
+Tags: 1.13.0-dind, 1.13-dind, 1-dind, dind
+GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
+Directory: 1.13/dind
 
-Tags: 1.13.0-rc7-git, 1.13-rc-git, rc-git
-GitCommit: 737f83092a47b012d09a0cbf0ed72759550301cb
-Directory: 1.13-rc/git
+Tags: 1.13.0-git, 1.13-git, 1-git, git
+GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
+Directory: 1.13/git
 
-Tags: 1.12.6, 1.12, 1, latest
+Tags: 1.12.6, 1.12
 GitCommit: 05678f7f3198d0787d78de9bdc084dcffccf7276
 Directory: 1.12
 
-Tags: 1.12.6-dind, 1.12-dind, 1-dind, dind
+Tags: 1.12.6-dind, 1.12-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/dind
 
-Tags: 1.12.6-git, 1.12-git, 1-git, git
+Tags: 1.12.6-git, 1.12-git
 GitCommit: 746d9052066ccfbcb98df7d9ae71cf05d8877419
 Directory: 1.12/git
 
-Tags: 1.12.6-experimental, 1.12-experimental, 1-experimental, experimental
+Tags: 1.12.6-experimental, 1.12-experimental
 GitCommit: 05678f7f3198d0787d78de9bdc084dcffccf7276
 Directory: 1.12/experimental
 
-Tags: 1.12.6-experimental-dind, 1.12-experimental-dind, 1-experimental-dind, experimental-dind
+Tags: 1.12.6-experimental-dind, 1.12-experimental-dind
 GitCommit: c1af76ec4c97ff24dcf6675b55b12105216dc711
 Directory: 1.12/experimental/dind
 
-Tags: 1.12.6-experimental-git, 1.12-experimental-git, 1-experimental-git, experimental-git
+Tags: 1.12.6-experimental-git, 1.12-experimental-git
 GitCommit: eb714a73e7e3f87705f468c3c6e9f4e316136bf5
 Directory: 1.12/experimental/git
-
-Tags: 1.11.2, 1.11
-GitCommit: b7f1d172ede348d109f04e732f2b65af7663883c
-Directory: 1.11
-
-Tags: 1.11.2-dind, 1.11-dind
-GitCommit: 5e30187978ad75d0f2ae5fc6c2a0b668bdf16885
-Directory: 1.11/dind
-
-Tags: 1.11.2-git, 1.11-git
-GitCommit: 866c3fbd87e8eeed524fdf19ba2d63288ad49cd2
-Directory: 1.11/git

--- a/library/hylang
+++ b/library/hylang
@@ -1,7 +1,7 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag)
 
-# https://github.com/hylang/hy/tree/0.11.1
-Tags: 0.11.1, 0.11, 0, latest
+# https://github.com/hylang/hy/tree/0.12.0
+Tags: 0.12.0, 0.12, 0, latest
 GitRepo: https://github.com/hylang/hy.git
-GitFetch: refs/tags/0.11.1
-GitCommit: 54b13955d1f98f8a7d835a4ed8f452bb9f1135bc
+GitFetch: refs/tags/0.12.0
+GitCommit: dda456ddd9d76560db869f2b6dd65a04d073c1bd

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.20, 10.1, 10, latest
-GitCommit: b26cb74f2c213b4b852067937198d924517e387f
+Tags: 10.1.21, 10.1, 10, latest
+GitCommit: b558f64b736650b94df9a90e68ff9e3bc03d4bdb
 Directory: 10.1
 
 Tags: 10.0.29, 10.0

--- a/library/redis
+++ b/library/redis
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redis/blob/5169c4beff205f6523b16aaa17d8297f5ebcf9f9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/6fd47f9cb134a4bf492a1038ef48257f6c93a101/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,6 +16,16 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
 Directory: 3.0/alpine
 
+Tags: 3.0.7-windowsservercore, 3.0-windowsservercore
+GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
+Directory: 3.0/windows/windowsservercore
+Constraints: windowsservercore
+
+Tags: 3.0.7-nanoserver, 3.0-nanoserver
+GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
+Directory: 3.0/windows/nanoserver
+Constraints: nanoserver
+
 Tags: 3.2.6, 3.2, 3, latest
 GitCommit: 2e14b84ea86939438834a453090966a9bd4367fb
 Directory: 3.2
@@ -27,3 +37,13 @@ Directory: 3.2/32bit
 Tags: 3.2.6-alpine, 3.2-alpine, 3-alpine, alpine
 GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
 Directory: 3.2/alpine
+
+Tags: 3.2.6-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 709e6a8df205f73afcc6f6257cab104175de1f5f
+Directory: 3.2/windows/windowsservercore
+Constraints: windowsservercore
+
+Tags: 3.2.6-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
+GitCommit: 2daf4fd7d858c8f2ad9694c4f460b8c6a7f782aa
+Directory: 3.2/windows/nanoserver
+Constraints: nanoserver

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.49.1, 0.49, 0, latest
-GitCommit: d771f1028b3f39946fd4168e31a9b2469ea4dad3
+Tags: 0.49.3, 0.49, 0, latest
+GitCommit: b13cb486f02c5ff199d1b4ace0b91fbfc37aa530

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,18 +44,18 @@ Tags: 8.0.39-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
 GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.9-jre8, 8.5-jre8, 8.5.9, 8.5
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 8.5.11-jre8, 8.5-jre8, 8.5.11, 8.5
+GitCommit: 023eb5126ff70b769f1f84b28c440fb6128bffe7
 Directory: 8.5/jre8
 
-Tags: 8.5.9-jre8-alpine, 8.5-jre8-alpine, 8.5.9-alpine, 8.5-alpine
-GitCommit: 9c280294942795515740cb6d78b1d51d95b31928
+Tags: 8.5.11-jre8-alpine, 8.5-jre8-alpine, 8.5.11-alpine, 8.5-alpine
+GitCommit: 023eb5126ff70b769f1f84b28c440fb6128bffe7
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M15-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M15, 9.0.0, 9.0, 9
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 9.0.0.M17-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M17, 9.0.0, 9.0, 9
+GitCommit: 075a394e34f7329415e87ad5f0d77d46aac24876
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M15-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M15-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 9fcf1c13eb901de73aa3abdfc36d1989a1154365
+Tags: 9.0.0.M17-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M17-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 075a394e34f7329415e87ad5f0d77d46aac24876
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `docker`: 1.13.0
- `hylang`: 0.12.0
- `mariadb`: 10.1.21+maria-1~jessie
- `redis`: add Windows Server Core and Nano Server variants (docker-library/redis#78)
- `rocket.chat`: 0.49.3
- `tomcat`: 8.5.11, 9.0.0.M17