### PR TITLE
[nats-streaming] Release v0.3.8

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,6 +1,6 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 
-Tags: 0.3.6, latest
+Tags: 0.3.8, latest
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: d4c16d81cdfb43b502983473c4d4f53eb15cdad2
+GitCommit: 8c51cccfe250cb144becd082e3ccdf531a31b30a
 


### PR DESCRIPTION
Essentially a bug fix release.

Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.3.8)