### PR TITLE
Update python-hy test

### DIFF
--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Hy doesn't work on 3.6+ :(
-if ! python -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 6) or sys.version_info[0] > 3)'; then
+if ! python -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 7) or sys.version_info[0] > 3)'; then
 	# TypeError: required field "is_async" missing from comprehension
 	echo >&2 'skipping Hy test -- no workie on Python 3.6+'
 	cat expected-std-out.txt # cheaters gunna cheat


### PR DESCRIPTION
New hylang `0.12.0` seems to work with python 3.6.

cc @tianon, @paultag