### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,8 +3,8 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.5, 4.4, 4, latest
-GitCommit: f9be0e9789a3852ff28b16e3f739df1bb2130377
+Tags: 4.4.7, 4.4, 4, latest
+GitCommit: cb4f2c9fe2bcda141fb24aa402149399c58b2941
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/golang
+++ b/library/golang
@@ -61,28 +61,28 @@ GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8rc1, 1.8
-GitCommit: b819b526131d44c03f02942816f616067d389037
+Tags: 1.8rc2, 1.8
+GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
 Directory: 1.8
 
-Tags: 1.8rc1-onbuild, 1.8-onbuild
+Tags: 1.8rc2-onbuild, 1.8-onbuild
 GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
 Directory: 1.8/onbuild
 
-Tags: 1.8rc1-wheezy, 1.8-wheezy
-GitCommit: b819b526131d44c03f02942816f616067d389037
+Tags: 1.8rc2-wheezy, 1.8-wheezy
+GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
 Directory: 1.8/wheezy
 
-Tags: 1.8rc1-alpine, 1.8-alpine
-GitCommit: b819b526131d44c03f02942816f616067d389037
+Tags: 1.8rc2-alpine, 1.8-alpine
+GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
 Directory: 1.8/alpine
 
-Tags: 1.8rc1-windowsservercore, 1.8-windowsservercore
-GitCommit: b819b526131d44c03f02942816f616067d389037
+Tags: 1.8rc2-windowsservercore, 1.8-windowsservercore
+GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8rc1-nanoserver, 1.8-nanoserver
-GitCommit: b819b526131d44c03f02942816f616067d389037
+Tags: 1.8rc2-nanoserver, 1.8-nanoserver
+GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/haproxy
+++ b/library/haproxy
@@ -21,17 +21,17 @@ GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
 Tags: 1.6.11, 1.6
-GitCommit: 12dae72c28e152ac9dcd499f156cb0ab79d7c23f
+GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.6
 
 Tags: 1.6.11-alpine, 1.6-alpine
-GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
+GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.6/alpine
 
 Tags: 1.7.2, 1.7, 1, latest
-GitCommit: d704d453c6ab9cdaa5498c1e14b6e5d0622e629d
+GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.7
 
 Tags: 1.7.2-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: d704d453c6ab9cdaa5498c1e14b6e5d0622e629d
+GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.7/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.1, 9.6, 9, latest
-GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
-GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
-GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
-GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
-GitCommit: ea6f466b258ad42a87a753a10dc84272d56ab699
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: bcf8da33d85f2a558ae1611cb310d27fe8359fea
+GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -49,23 +49,23 @@ Tags: 3.3.6-onbuild, 3.3-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
-Tags: 3.4.5, 3.4
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.4.6, 3.4
+GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
 Directory: 3.4
 
-Tags: 3.4.5-slim, 3.4-slim
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.4.6-slim, 3.4-slim
+GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
 Directory: 3.4/slim
 
-Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
+Tags: 3.4.6-alpine, 3.4-alpine
+GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
 Directory: 3.4/alpine
 
-Tags: 3.4.5-wheezy, 3.4-wheezy
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.4.6-wheezy, 3.4-wheezy
+GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
 Directory: 3.4/wheezy
 
-Tags: 3.4.5-onbuild, 3.4-onbuild
+Tags: 3.4.6-onbuild, 3.4-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 


### PR DESCRIPTION
- `bash`: 4.4.7
- `golang`: 1.8rc2
- `haproxy`: add Lua support (docker-library/haproxy#38)
- `postgres`: (mostly) arbitrary `--user` support (docker-library/postgres#253)
- `python`: 3.4.6