### PR TITLE
Update Solr to 6.4.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,50 +1,26 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.3.2: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3
-5.3: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3
+5.5.3: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5
+5.5: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5
+5: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5
 
-5.3.2-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3/alpine
-5.3-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.3/alpine
+5.5.3-alpine: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 5.5/alpine
 
-5.4.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4
-5.4: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4
+6.3.0: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 6.3
+6.3: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 6.3
 
-5.4.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4/alpine
-5.4-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.4/alpine
+6.3.0-alpine: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 6.3/alpine
+6.3-alpine: git://github.com/docker-solr/docker-solr@12d5055645cc18a0837da641ed8778a7b30e1c37 6.3/alpine
 
-5.5.3: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
-5.5: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
-5: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5
+6.4.0: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4
+6.4: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4
+6: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4
+latest: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4
 
-5.5.3-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 5.5/alpine
-
-6.0.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0
-6.0: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0
-
-6.0.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0/alpine
-6.0-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.0/alpine
-
-6.1.0: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1
-6.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1
-
-6.1.0-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1/alpine
-6.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.1/alpine
-
-6.2.1: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2
-6.2: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2
-
-6.2.1-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2/alpine
-6.2-alpine: git://github.com/docker-solr/docker-solr@2dc20bf2b71c0cfee2e6956b11dafa329025b412 6.2/alpine
-
-6.3.0: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
-6.3: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
-6: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
-latest: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3
-
-6.3.0-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
-6.3-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
-alpine: git://github.com/docker-solr/docker-solr@b7960dec349778ffbf23c5042b7bb7f6f26ced79 6.3/alpine
+6.4.0-alpine: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4/alpine
+6.4-alpine: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4/alpine
+alpine: git://github.com/docker-solr/docker-solr@fe036661d9d800dfc718b2d6e6644d79ced8c5bd 6.4/alpine


### PR DESCRIPTION
See the Solr 6.4.0 announcement https://www.mail-archive.com/solr-user@lucene.apache.org/msg127703.html

On the docker-solr side:
- Older versions 5.3, 5.4, 2.0, 6.1, 6.2 have been retired. We're retaining the latest version on the previous 5 version, and the current and previous versions on the current 6 version. This simplifies management, and encourages recommended upgrades.
- The docker-entrypoint.sh commands have been split into scripts. This improves re-use and composition by users with custom images and requirements.
- We've documented environment variable passing, in particular for setting the solr heap size, as this is a common use-case. 
- The "from" image has changed from the now-deprecated "java" image to "openjdk". This is a change across official docker images.

The test build passed https://travis-ci.org/docker-solr/docker-solr/builds/194442705