### PR TITLE
Add the xwiki official image

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -2,10 +2,10 @@ Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
 Tags: latest, mysql-tomcat
-GitCommit: 1f845295f650ce5c755712b801b84ad8198b9d7b
+GitCommit: 52b982b1c18ed06b87b20d33c677a3efb7b361f6
 Directory: xwiki-mysql-tomcat
 
 Tags: 8, 8-mysql-tomcat
-GitCommit: e8ad90aa6d119301bd4b810a88ed71b2f8a0e224
+GitCommit: 56aa09e5859e22b370a950ec08f9c3a04067915e
 GitFetch: refs/heads/8.x
 Directory: xwiki-mysql-tomcat

--- a/library/xwiki
+++ b/library/xwiki
@@ -1,0 +1,6 @@
+Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
+GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
+
+Tags: latest, 8.x
+GitCommit: 6c234442c9c5cd858c44a56f9766917f7e214894
+Directory: xwiki-mysql-tomcat

--- a/library/xwiki
+++ b/library/xwiki
@@ -1,10 +1,11 @@
 Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
-Tags: latest, latest-mysql-tomcat
+Tags: latest, mysql-tomcat
 GitCommit: 1f845295f650ce5c755712b801b84ad8198b9d7b
 Directory: xwiki-mysql-tomcat
 
 Tags: 8, 8-mysql-tomcat
 GitCommit: e8ad90aa6d119301bd4b810a88ed71b2f8a0e224
+GitFetch: refs/heads/8.x
 Directory: xwiki-mysql-tomcat

--- a/library/xwiki
+++ b/library/xwiki
@@ -2,9 +2,9 @@ Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
 Tags: latest, latest-mysql-tomcat
-GitCommit: f12105946de0ec0fe2b319ddd5a1c2c807bf00fb
+GitCommit: 1f845295f650ce5c755712b801b84ad8198b9d7b
 Directory: xwiki-mysql-tomcat
 
 Tags: 8, 8-mysql-tomcat
-GitCommit: 7ab5cfafc4ffec3fed180ef950f747226a3312ca
+GitCommit: e8ad90aa6d119301bd4b810a88ed71b2f8a0e224
 Directory: xwiki-mysql-tomcat

--- a/library/xwiki
+++ b/library/xwiki
@@ -2,10 +2,10 @@ Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
 Tags: latest, mysql-tomcat
-GitCommit: 52b982b1c18ed06b87b20d33c677a3efb7b361f6
+GitCommit: 6c386ede3706ca0bff2a65d6559e15497d8e4a30
 Directory: xwiki-mysql-tomcat
 
 Tags: 8, 8-mysql-tomcat
-GitCommit: 56aa09e5859e22b370a950ec08f9c3a04067915e
+GitCommit: 44b586d58e03d569c731519edfb6f6e7175d5c82
 GitFetch: refs/heads/8.x
 Directory: xwiki-mysql-tomcat

--- a/library/xwiki
+++ b/library/xwiki
@@ -1,6 +1,10 @@
 Maintainers: Vincent Massol <vincent@massol.net> (@vmassol)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
-Tags: latest, 8.x
-GitCommit: 6c234442c9c5cd858c44a56f9766917f7e214894
+Tags: latest, latest-mysql-tomcat
+GitCommit: f12105946de0ec0fe2b319ddd5a1c2c807bf00fb
+Directory: xwiki-mysql-tomcat
+
+Tags: 8, 8-mysql-tomcat
+GitCommit: 7ab5cfafc4ffec3fed180ef950f747226a3312ca
 Directory: xwiki-mysql-tomcat


### PR DESCRIPTION
Documentation is in the following PR: https://github.com/docker-library/docs/pull/804

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/xwiki-contrib (location for "official" community projects)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/804
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)