### PR TITLE
Add a lein tag to clojure image

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
 GitRepo: https://github.com/Quantisan/docker-clojure.git
 GitCommit: f0fd68d6a197b4d1852aefab698b35ce1ea9881e
 
-Tags: lein-2.7.1, latest
+Tags: lein-2.7.1, lein, latest
 Directory: debian/lein
 
 Tags: lein-2.7.1-onbuild, onbuild

--- a/library/clojure
+++ b/library/clojure
@@ -6,7 +6,7 @@ GitCommit: f0fd68d6a197b4d1852aefab698b35ce1ea9881e
 Tags: lein-2.7.1, lein, latest
 Directory: debian/lein
 
-Tags: lein-2.7.1-onbuild, onbuild
+Tags: lein-2.7.1-onbuild, lein-onbuild, onbuild
 Directory: debian/lein/onbuild
 
 Tags: lein-2.7.1-alpine, lein-alpine, alpine


### PR DESCRIPTION
...for completness with new boot tag.

Now that we have both boot and lein variants, it makes sense to have a tag that means "just give me the latest version w/ lein."