### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,8 +3,8 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.7, 4.4, 4, latest
-GitCommit: cb4f2c9fe2bcda141fb24aa402149399c58b2941
+Tags: 4.4.11, 4.4, 4, latest
+GitCommit: 465c38c723ef6c358bdc74f5f5a9b22a46b0365a
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 8-jre/alpine
 
-Tags: 9-b151-jdk, 9-b151, 9-jdk, 9
-GitCommit: 11af1a181763751cce50f383f6b4b023fd5d2255
+Tags: 9-b153-jdk, 9-b153, 9-jdk, 9
+GitCommit: 9bf9b29f73334c172d151d9a615d7cd52b74defe
 Directory: 9-jdk
 
-Tags: 9-b151-jre, 9-jre
-GitCommit: 11af1a181763751cce50f383f6b4b023fd5d2255
+Tags: 9-b153-jre, 9-jre
+GitCommit: 9bf9b29f73334c172d151d9a615d7cd52b74defe
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -4,86 +4,86 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.0-cli, 7.1-cli, 7-cli, cli, 7.1.0, 7.1, 7, latest
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.1.1-cli, 7.1-cli, 7-cli, cli, 7.1.1, 7.1, 7, latest
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1
 
-Tags: 7.1.0-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.1.1-alpine, 7.1-alpine, 7-alpine, alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/alpine
 
-Tags: 7.1.0-apache, 7.1-apache, 7-apache, apache
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.1.1-apache, 7.1-apache, 7-apache, apache
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/apache
 
-Tags: 7.1.0-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.1.1-fpm, 7.1-fpm, 7-fpm, fpm
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/fpm
 
-Tags: 7.1.0-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.1.1-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/fpm/alpine
 
-Tags: 7.1.0-zts, 7.1-zts, 7-zts, zts
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.1.1-zts, 7.1-zts, 7-zts, zts
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/zts
 
-Tags: 7.1.0-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.1.1-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/zts/alpine
 
-Tags: 7.0.14-cli, 7.0-cli, 7.0.14, 7.0
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.0.15-cli, 7.0-cli, 7.0.15, 7.0
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0
 
-Tags: 7.0.14-alpine, 7.0-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.0.15-alpine, 7.0-alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/alpine
 
-Tags: 7.0.14-apache, 7.0-apache
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.0.15-apache, 7.0-apache
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/apache
 
-Tags: 7.0.14-fpm, 7.0-fpm
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.0.15-fpm, 7.0-fpm
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/fpm
 
-Tags: 7.0.14-fpm-alpine, 7.0-fpm-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.0.15-fpm-alpine, 7.0-fpm-alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.14-zts, 7.0-zts
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 7.0.15-zts, 7.0-zts
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/zts
 
-Tags: 7.0.14-zts-alpine, 7.0-zts-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 7.0.15-zts-alpine, 7.0-zts-alpine
+GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.29-cli, 5.6-cli, 5-cli, 5.6.29, 5.6, 5
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 5.6.30-cli, 5.6-cli, 5-cli, 5.6.30, 5.6, 5
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6
 
-Tags: 5.6.29-alpine, 5.6-alpine, 5-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 5.6.30-alpine, 5.6-alpine, 5-alpine
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/alpine
 
-Tags: 5.6.29-apache, 5.6-apache, 5-apache
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 5.6.30-apache, 5.6-apache, 5-apache
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/apache
 
-Tags: 5.6.29-fpm, 5.6-fpm, 5-fpm
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/fpm
 
-Tags: 5.6.29-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 5.6.30-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.29-zts, 5.6-zts, 5-zts
-GitCommit: b66c0fa0286d0abbb8a36653e26e6992bb71b858
+Tags: 5.6.30-zts, 5.6-zts, 5-zts
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/zts
 
-Tags: 5.6.29-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 3ac528cf10d42f3f47dcb9ded3477781fb11f714
+Tags: 5.6.30-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -69,24 +69,24 @@ Tags: 3.4.6-onbuild, 3.4-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
-Tags: 3.5.2, 3.5
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.5.3, 3.5
+GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
 Directory: 3.5
 
-Tags: 3.5.2-slim, 3.5-slim
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.5.3-slim, 3.5-slim
+GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
 Directory: 3.5/slim
 
-Tags: 3.5.2-alpine, 3.5-alpine
-GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
+Tags: 3.5.3-alpine, 3.5-alpine
+GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
 Directory: 3.5/alpine
 
-Tags: 3.5.2-onbuild, 3.5-onbuild
+Tags: 3.5.3-onbuild, 3.5-onbuild
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
-Tags: 3.5.2-windowsservercore, 3.5-windowsservercore
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
+GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.49.3, 0.49, 0, latest
-GitCommit: b13cb486f02c5ff199d1b4ace0b91fbfc37aa530
+Tags: 0.49.4, 0.49, 0, latest
+GitCommit: 0efaaef2c3db81c9d951210b9035eb639edba9cb

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
+GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
+GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
+GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
+GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
+GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
+GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: c1d5f251adad058eec8bc3b6476ab204f2e6dba1
+GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: 6e2934a351adb67fd95aed1a669ad54d758834a0
+GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: bfc7a48724ceb1917ddbcb713b24c835eca584c8
+GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `bash`: 4.4.11
- `openjdk`: debian 9~b153-2
- `php`: 7.1.1, 7.0.15, 5.6.30 (docker-library/php#367)
- `python`: 3.5.3 (docker-library/python#172)
- `rocket.chat`: 0.49.4
- `ruby`: bundler 1.14.2