### PR TITLE
[security] Update ruby, tomcat images

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
+GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
+GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: d1f2b81094df1d7e1dc172326d41e6320bfbabe7
+GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
+GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
+GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 35fe076eec1b7c6fb1f462e88fb977ef2ca68b64
+GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
+GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
+GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 6d5468ba40dcc7208f4d567785445f6a2d6d6d61
+GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
+GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
+GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: fe1bbc3fea52b5543426be32b6bc39cd988927a3
+GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -12,36 +12,36 @@ Tags: 6.0.48-jre8, 6.0-jre8, 6-jre8
 GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
 Directory: 6/jre8
 
-Tags: 7.0.73-jre7, 7.0-jre7, 7-jre7, 7.0.73, 7.0, 7
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 7.0.75-jre7, 7.0-jre7, 7-jre7, 7.0.75, 7.0, 7
+GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre7
 
-Tags: 7.0.73-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.73-alpine, 7.0-alpine, 7-alpine
-GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
+Tags: 7.0.75-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.75-alpine, 7.0-alpine, 7-alpine
+GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre7-alpine
 
-Tags: 7.0.73-jre8, 7.0-jre8, 7-jre8
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 7.0.75-jre8, 7.0-jre8, 7-jre8
+GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre8
 
-Tags: 7.0.73-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 1651e929e7d4c9785b602cb93cdd2503573c3834
+Tags: 7.0.75-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre8-alpine
 
-Tags: 8.0.39-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.39, 8.0, 8, latest
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 8.0.41-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.41, 8.0, 8, latest
+GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre7
 
-Tags: 8.0.39-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.39-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
+Tags: 8.0.41-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.41-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.39-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+Tags: 8.0.41-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre8
 
-Tags: 8.0.39-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 3c72bd6721ab6645badc72c164cbe6f3a8970bdb
+Tags: 8.0.41-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.11-jre8, 8.5-jre8, 8.5.11, 8.5


### PR DESCRIPTION
- `ruby` bump bundler `1.14.3`
- `tomcat` bump `7.0.75` `8.0.41` (especially CVE-2016-8745)

Fixes https://github.com/docker-library/official-images/issues/2576