### PR TITLE
Update "python-hy" test to 0.12.1 (and thus move the maximum Python up to 3.6) and adjust the test comments/output language to be more positive

### DIFF
--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -14,13 +14,13 @@ if [ -z "$python" ]; then
 	exit 1
 fi
 
-# Hy doesn't work on 3.6+ :(
-if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 6) or sys.version_info[0] > 3)'; then
-	# TypeError: required field "is_async" missing from comprehension
-	echo >&2 'skipping Hy test -- no workie on Python 3.6+'
+# Hy is complicated, and uses Python's internal AST representation directly, and thus Hy releases usually lag behind a little on major Python releases (and we don't want that to gum up our tests)
+# see https://github.com/hylang/hy/issues/1111 for example breakage
+if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 7) or sys.version_info[0] > 3)'; then
+	echo >&2 'skipping Hy test -- not allowed on Python 3.7+ (yet!)'
 	cat expected-std-out.txt # cheaters gunna cheat
 	exit
 fi
 
-pip install -q 'hy==0.11.*'
+pip install -q 'hy==0.12.1'
 hy ./container.hy


### PR DESCRIPTION
This is a follow-up to https://github.com/docker-library/official-images/pull/2556 and https://github.com/docker-library/official-images/pull/2551.

cc @paultag