### PR TITLE
[ROS] Small Dockerfile changes

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,25 +1,25 @@
-# maintainer: Dirk Thomas <dthomas+buildfarm@osrfoundation.org> (@dirk-thomas)
+# maintainer: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 
-indigo-ros-core:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/indigo/indigo-ros-base
+indigo-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-core
+indigo-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
+indigo-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-robot
+indigo-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-perception
+indigo:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
 # Docker EOL: 2019-04
 # LTS
 
-jade-ros-core:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@e4ba7284358c569ebb7818b85e8520fbe9157269 ros/jade/jade-ros-base
+jade-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
 # Docker EOL: 2017-04
 
-kinetic-ros-core:    git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-ros-core
-kinetic-ros-base:    git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-ros-base
-kinetic-robot:       git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-robot
-kinetic-perception:  git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-perception
-kinetic:             git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-ros-base
-latest:              git://github.com/osrf/docker_images@bf5219b2ae079b65896232dd0c345a8bc75bc5df ros/kinetic/kinetic-ros-base
+kinetic-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-core
+kinetic-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
+kinetic-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-robot
+kinetic-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-perception
+kinetic:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
+latest:              git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
 # Docker EOL: 2021-04
 # LTS


### PR DESCRIPTION
Omitting depricated MAINTAINER field
Moving Tully as maintainer contact in library file instead