### PR TITLE
[Gazebo] Adding Gazebo v8 and version bump for v5, v6, and v7

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -1,18 +1,22 @@
 # maintainer: Nate Koenig <nkoenig@osrfoundation.org> (@nkoenig)
 
-gzserver4:      git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo4/gzserver4
-libgazebo4:     git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo4/libgazebo4
+gzserver4:      git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo4/gzserver4
+libgazebo4:     git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo4/libgazebo4
 # Docker EOL: 2016-01-25
 
-gzserver5:      git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo5/gzserver5
-libgazebo5:     git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo5/libgazebo5
+gzserver5:      git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo5/gzserver5
+libgazebo5:     git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo5/libgazebo5
 # Docker EOL: 2017-01-25
 
-gzserver6:      git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo6/gzserver6
-libgazebo6:     git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo6/libgazebo6
+gzserver6:      git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo6/gzserver6
+libgazebo6:     git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo6/libgazebo6
 # Docker EOL: 2017-01-25
 
-gzserver7:      git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo7/gzserver7
-libgazebo7:     git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo7/libgazebo7
-latest:         git://github.com/osrf/docker_images@32010a4955ccbfb2427063e67a75d13617749963 gazebo/gazebo7/libgazebo7
+gzserver7:      git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo7/gzserver7
+libgazebo7:     git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo7/libgazebo7
 # Docker EOL: 2021-01-25
+
+gzserver8:      git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo8/gzserver8
+libgazebo8:     git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo8/libgazebo8
+latest:         git://github.com/osrf/docker_images@4bef0d70d4855205d86528899a6686c098fb7fc0 gazebo/gazebo8/libgazebo8
+# Docker EOL: 2019-01-25


### PR DESCRIPTION
Adding new release of Gazebo 8
Version bump for Gazebo 5.3->5.4, 6.6->6.7, 7.4->7.5
Also omitting deprecated MAINTAINER field