### PR TITLE
Update a few library files, especially for "java" -> "openjdk"

### DIFF
--- a/library/lightstreamer
+++ b/library/lightstreamer
@@ -1,7 +1,7 @@
 # maintainer: Lightstreamer Server Development Team <support@lightreamer.com> (@lightstreamer)
 
-6.0.3: git://github.com/Lightstreamer/Docker@784b417d4415e12f1bb1b15f7f697273de3a7ded 6.0
-6.0: git://github.com/Lightstreamer/Docker@784b417d4415e12f1bb1b15f7f697273de3a7ded 6.0
+6.0.3: git://github.com/Lightstreamer/Docker@5cb379d682574ad2170166d93306124c633a644f 6.0
+6.0: git://github.com/Lightstreamer/Docker@5cb379d682574ad2170166d93306124c633a644f 6.0
 
 6.1.0: git://github.com/Lightstreamer/Docker@94415d471c10c4e64ca1bae2d753cbe94fd5fa61 6.1
 6.1: git://github.com/Lightstreamer/Docker@94415d471c10c4e64ca1bae2d753cbe94fd5fa61 6.1

--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,27 +1,19 @@
 Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
              Arnaud Kervern <akervern@nuxeo.com> (@akervern)
+GitRepo: https://github.com/nuxeo/docker-nuxeo.git
+GitCommit: 537f17593e1c3348f3163ae6986b603168e59fc5
 
 Tags: latest, LTS, LTS-2016, 8, 8.10, FT
-GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: 4c45ac6f74a5571dd23ee86a00fb85aadbece05c
 Directory: 8.10
 
 Tags: 8.3
-GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: d7252d23d06e0ade25a0054a7ae940e8537a99b2
 Directory: 8.3
 
 Tags: 8.2
-GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: a02183111045dadb357e68e11e93c5551c570c43
 Directory: 8.2
 
 Tags: LTS-2015, 7, 7.10
-GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: a02183111045dadb357e68e11e93c5551c570c43
 Directory: 7.10
 
 Tags: LTS-2014, 6, 6.0
-GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: 8535464e476b39e10001242ad7c885519fadc2a6
 Directory: 6.0

--- a/library/orientdb
+++ b/library/orientdb
@@ -1,8 +1,8 @@
 # maintainer: Roberto Franchini <r.franchini@orientdb.com> (@robfrank)
 
-2.0.18: git://github.com/orientechnologies/orientdb-docker@a43637b03a105ceb1104cbf5e42e93e1ffed0944 2.0
+2.0.18: git://github.com/orientechnologies/orientdb-docker@8a9633c19fa9c53a5446b9b62997ff389813e785 2.0
 
-2.1.25: git://github.com/orientechnologies/orientdb-docker@eb9c688528d4ce7d50eec34391a3cbb4fea88868 2.1
+2.1.25: git://github.com/orientechnologies/orientdb-docker@8a9633c19fa9c53a5446b9b62997ff389813e785 2.1
 
 2.2.15: git://github.com/orientechnologies/orientdb-docker@8a9633c19fa9c53a5446b9b62997ff389813e785 2.2/x86_64/alpine
 


### PR DESCRIPTION
After this, only `tomee` (https://github.com/tomitribe/docker-tomee/pull/9) and `rapidoid` (https://github.com/rapidoid/docker-rapidoid/pull/2) should be remaining that still `FROM java:...`.

`lightstreamer` cc @gfinocchiaro
`nuxeo` cc @dmetzler @akervern
`orientdb` cc @robfrank