### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,8 +3,8 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.11, 4.4, 4, latest
-GitCommit: 465c38c723ef6c358bdc74f5f5a9b22a46b0365a
+Tags: 4.4.12, 4.4, 4, latest
+GitCommit: b95678dfe99c4cdcfb2f197ecad421564f1119d2
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/golang
+++ b/library/golang
@@ -31,58 +31,58 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.7.4, 1.7, 1, latest
-GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
+Tags: 1.7.5, 1.7, 1, latest
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7
 
-Tags: 1.7.4-onbuild, 1.7-onbuild, 1-onbuild, onbuild
+Tags: 1.7.5-onbuild, 1.7-onbuild, 1-onbuild, onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7.4-wheezy, 1.7-wheezy, 1-wheezy, wheezy
-GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
+Tags: 1.7.5-wheezy, 1.7-wheezy, 1-wheezy, wheezy
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/wheezy
 
-Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: bfbd521de2942d10d96b14f99c491536490db018
+Tags: 1.7.5-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/alpine
 
-Tags: 1.7.4-alpine3.5, 1.7-alpine3.5, 1-alpine3.5, alpine3.5
-GitCommit: 6c5f2993c210854b077ad07c9a94334f8c82fbb1
+Tags: 1.7.5-alpine3.5, 1.7-alpine3.5, 1-alpine3.5, alpine3.5
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/alpine3.5
 
-Tags: 1.7.4-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
+Tags: 1.7.5-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.7.4-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
-GitCommit: 18ee81a2ec649dd7b3d5126b24eef86bc9c86d80
+Tags: 1.7.5-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
+GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8rc2, 1.8
-GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
+Tags: 1.8rc3, 1.8
+GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
 Directory: 1.8
 
-Tags: 1.8rc2-onbuild, 1.8-onbuild
+Tags: 1.8rc3-onbuild, 1.8-onbuild
 GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
 Directory: 1.8/onbuild
 
-Tags: 1.8rc2-wheezy, 1.8-wheezy
-GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
+Tags: 1.8rc3-wheezy, 1.8-wheezy
+GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
 Directory: 1.8/wheezy
 
-Tags: 1.8rc2-alpine, 1.8-alpine
-GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
+Tags: 1.8rc3-alpine, 1.8-alpine
+GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
 Directory: 1.8/alpine
 
-Tags: 1.8rc2-windowsservercore, 1.8-windowsservercore
-GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
+Tags: 1.8rc3-windowsservercore, 1.8-windowsservercore
+GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8rc2-nanoserver, 1.8-nanoserver
-GitCommit: da6e73b4fa5b3094a23202cca088dd11b74ed110
+Tags: 1.8rc3-nanoserver, 1.8-nanoserver
+GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/mysql
+++ b/library/mysql
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
+GitCommit: eeb0c33dfcad3db46a0dfb24c352d2a1601c7667
 Directory: 8.0
 
 Tags: 5.7.17, 5.7, 5, latest
-GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
+GitCommit: eeb0c33dfcad3db46a0dfb24c352d2a1601c7667
 Directory: 5.7
 
 Tags: 5.6.35, 5.6

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,10 +44,10 @@ Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 8-jre/alpine
 
-Tags: 9-b153-jdk, 9-b153, 9-jdk, 9
-GitCommit: 9bf9b29f73334c172d151d9a615d7cd52b74defe
+Tags: 9-b154-jdk, 9-b154, 9-jdk, 9
+GitCommit: 1c98a9032d1a19122074c4009326eade264903b7
 Directory: 9-jdk
 
-Tags: 9-b153-jre, 9-jre
-GitCommit: 9bf9b29f73334c172d151d9a615d7cd52b74defe
+Tags: 9-b154-jre, 9-jre
+GitCommit: 1c98a9032d1a19122074c4009326eade264903b7
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -13,7 +13,7 @@ GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.1/alpine
 
 Tags: 7.1.1-apache, 7.1-apache, 7-apache, apache
-GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
+GitCommit: e573f8f7fda5d7378bae9c6a936a298b850c4076
 Directory: 7.1/apache
 
 Tags: 7.1.1-fpm, 7.1-fpm, 7-fpm, fpm
@@ -41,7 +41,7 @@ GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
 Directory: 7.0/alpine
 
 Tags: 7.0.15-apache, 7.0-apache
-GitCommit: 9abc1efe542b56aa93835e4987d5d4a88171b232
+GitCommit: e573f8f7fda5d7378bae9c6a936a298b850c4076
 Directory: 7.0/apache
 
 Tags: 7.0.15-fpm, 7.0-fpm
@@ -69,7 +69,7 @@ GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
 Directory: 5.6/alpine
 
 Tags: 5.6.30-apache, 5.6-apache, 5-apache
-GitCommit: 75854bb7e97d3e01c9b3597674450be43521e296
+GitCommit: e573f8f7fda5d7378bae9c6a936a298b850c4076
 Directory: 5.6/apache
 
 Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm

--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.6
 
 Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
 Directory: 9.6/alpine
 
 Tags: 9.5.5, 9.5
@@ -17,7 +17,7 @@ GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.5
 
 Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
 Directory: 9.5/alpine
 
 Tags: 9.4.10, 9.4
@@ -25,7 +25,7 @@ GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.4
 
 Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
 Directory: 9.4/alpine
 
 Tags: 9.3.15, 9.3
@@ -33,7 +33,7 @@ GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.3
 
 Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
 Directory: 9.3/alpine
 
 Tags: 9.2.19, 9.2
@@ -41,5 +41,5 @@ GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
 Directory: 9.2
 
 Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
 Directory: 9.2/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,12 +1,21 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/6d3777cae4ac310b4801b954413692ee4d853927/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/74a9d28d4882360eab74a1b9d78ec67143cef345/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.6, 3.6, 3, latest
-GitCommit: 2016a3de7f3c9663208bd11a9bd49b2af49c13bc
+GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
+Directory: debian
 
 Tags: 3.6.6-management, 3.6-management, 3-management, management
-GitCommit: dc712681dcaeadb0371be66be5e96563be364e5d
-Directory: management
+GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
+Directory: debian/management
+
+Tags: 3.6.6-alpine, 3.6-alpine, 3-alpine, alpine
+GitCommit: 370d42f7ff049b8194637668d972216026c3d144
+Directory: alpine
+
+Tags: 3.6.6-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+GitCommit: 74a9d28d4882360eab74a1b9d78ec67143cef345
+Directory: alpine/management

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.1-apache, 4.7-apache, 4-apache, apache, 4.7.1, 4.7, 4, latest, 4.7.1-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.1-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-apache, 4.7-apache, 4-apache, apache, 4.7.2, 4.7, 4, latest, 4.7.2-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.2-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php5.6/apache
 
-Tags: 4.7.1-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.1-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.2-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php5.6/fpm
 
-Tags: 4.7.1-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.1-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.2-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.1-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.1-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.2-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.0/apache
 
-Tags: 4.7.1-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.0/fpm
 
-Tags: 4.7.1-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.1-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.1-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.2-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.1/apache
 
-Tags: 4.7.1-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.1/fpm
 
-Tags: 4.7.1-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: 0966763fa39385f2eaddd5b35ee91c40d3a1f4ac
+Tags: 4.7.2-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
 Directory: php7.1/fpm-alpine


### PR DESCRIPTION
- `bash`: 4.4.12
- `golang`: 1.7.5, 1.8rc3
- `mysql`: add automatic SSL support matching upstream behavior (docker-library/mysql#259)
- `openjdk`: debian 9~b154-1
- `php`: auto-create `APACHE_RUN_DIR` and `APACHE_LOCK_DIR` at runtime if necessary (docker-library/php#330)
- `postgres`: keep `include` for building against (docker-library/postgres#247)
- `rabbitmq`: add Alpine variant (docker-library/rabbitmq#137)
- `wordpress`: 4.7.2