### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.1.2, 5.1, 5, latest
-GitCommit: f2e19796b765e2e448d0e8c651d51be992b56d08
+Tags: 5.2.0, 5.2, 5, latest
+GitCommit: ffaaf3283e47dcb732e90288a58757b87a8439a7
 Directory: 5
 
-Tags: 5.1.2-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: f2e19796b765e2e448d0e8c651d51be992b56d08
+Tags: 5.2.0-alpine, 5.2-alpine, 5-alpine, alpine
+GitCommit: ffaaf3283e47dcb732e90288a58757b87a8439a7
 Directory: 5/alpine
 
 Tags: 2.4.4, 2.4, 2

--- a/library/httpd
+++ b/library/httpd
@@ -13,7 +13,7 @@ GitCommit: a5ab6fb434c13a3578a2e7e6ce2cf30d66c625bc
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
-GitCommit: aa1a6b699929b59627d39a8940f2810709956cdf
+GitCommit: e885c0d63078153dc89fa0212314e590fec7fc93
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.1.2, 5.1, 5, latest
-GitCommit: e667720b9e8c5c6c369843a7368742e55ae22e0a
+Tags: 5.2.0, 5.2, 5, latest
+GitCommit: 3e0af5d894e622dadf08ec849386ed64da23bb4b
 Directory: 5
 
-Tags: 5.1.2-alpine, 5.1-alpine, 5-alpine, alpine
-GitCommit: e667720b9e8c5c6c369843a7368742e55ae22e0a
+Tags: 5.2.0-alpine, 5.2-alpine, 5-alpine, alpine
+GitCommit: 3e0af5d894e622dadf08ec849386ed64da23bb4b
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/redis
+++ b/library/redis
@@ -26,24 +26,24 @@ GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 3.2.6, 3.2, 3, latest
-GitCommit: 2e14b84ea86939438834a453090966a9bd4367fb
+Tags: 3.2.7, 3.2, 3, latest
+GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
 Directory: 3.2
 
-Tags: 3.2.6-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 2e14b84ea86939438834a453090966a9bd4367fb
+Tags: 3.2.7-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
 Directory: 3.2/32bit
 
-Tags: 3.2.6-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
+Tags: 3.2.7-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
 Directory: 3.2/alpine
 
-Tags: 3.2.6-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.2.7-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
 GitCommit: 709e6a8df205f73afcc6f6257cab104175de1f5f
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.6-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
+Tags: 3.2.7-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
 GitCommit: 2daf4fd7d858c8f2ad9694c4f460b8c6a7f782aa
 Directory: 3.2/windows/nanoserver
 Constraints: nanoserver

--- a/library/redis
+++ b/library/redis
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redis/blob/6fd47f9cb134a4bf492a1038ef48257f6c93a101/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/9db642535f941a70f033c82ab82da58c3e1d23a2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,12 +16,12 @@ Tags: 3.0.7-alpine, 3.0-alpine
 GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
 Directory: 3.0/alpine
 
-Tags: 3.0.7-windowsservercore, 3.0-windowsservercore
+Tags: 3.0.504-windowsservercore, 3.0-windowsservercore
 GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.0.7-nanoserver, 3.0-nanoserver
+Tags: 3.0.504-nanoserver, 3.0-nanoserver
 GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
@@ -38,12 +38,12 @@ Tags: 3.2.7-alpine, 3.2-alpine, 3-alpine, alpine
 GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
 Directory: 3.2/alpine
 
-Tags: 3.2.7-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.2.100-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
 GitCommit: 709e6a8df205f73afcc6f6257cab104175de1f5f
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.7-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
+Tags: 3.2.100-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
 GitCommit: 2daf4fd7d858c8f2ad9694c4f460b8c6a7f782aa
 Directory: 3.2/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
- `elasticsearch`: 5.2.0
- `httpd`: nghttp2 1.18.1-1, openssl 1.0.2k-1~bpo8+1
- `logstash`: 5.2.0
- `redis`: 3.2.7