### PR TITLE
haxe 3.4.0

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -2,7 +2,7 @@ Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.1.3, 3.1
-GitCommit: f7115fe92fa20ad354904646b50a5265bd8e8ad5
+GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
 Directory: 3.1
 
 Tags: 3.1.3-onbuild, 3.1-onbuild
@@ -10,7 +10,7 @@ GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.1/onbuild
 
 Tags: 3.2.1, 3.2
-GitCommit: f7115fe92fa20ad354904646b50a5265bd8e8ad5
+GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
 Directory: 3.2
 
 Tags: 3.2.1-onbuild, 3.2-onbuild
@@ -18,18 +18,18 @@ GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.2/onbuild
 
 Tags: 3.3.0-rc.1, 3.3.0, 3.3
-GitCommit: f7115fe92fa20ad354904646b50a5265bd8e8ad5
+GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
 Directory: 3.3
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
 GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.3/onbuild
 
-Tags: 3.4.0-rc.2, 3.4.0, 3.4, latest
-GitCommit: f7115fe92fa20ad354904646b50a5265bd8e8ad5
+Tags: 3.4.0, 3.4, latest
+GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
 Directory: 3.4
 
-Tags: 3.4.0-rc.2-onbuild, 3.4.0-onbuild, 3.4-onbuild
-GitCommit: 7639aa99b780cb72712548294a7b60e673f237e8
+Tags: 3.4.0-onbuild, 3.4-onbuild
+GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
 Directory: 3.4/onbuild
 


### PR DESCRIPTION
Haxe 3.4.0 has just been released. This bumps the 3.4 images from 3.4.0-rc.2 to 3.4.0.

Changes to the Dockerfiles: https://github.com/HaxeFoundation/docker-library-haxe/commit/0f4f8783c73fb791c0265680df8bc851727d2297