### PR TITLE
Add very simple new "ghost-basics" test to verify that Ghost starts up properly

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -74,6 +74,9 @@ imageTests+=(
 		gcc-cpp-hello-world
 		golang-hello-world
 	'
+	[ghost]='
+		ghost-basics
+	'
 	[golang]='
 		golang-hello-world
 	'

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+serverImage="$1"
+
+# Use a client image with curl for testing
+clientImage='buildpack-deps:jessie-curl'
+
+# Create an instance of the container-under-test
+cid="$(docker run -d "$serverImage")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+_request() {
+	local method="$1"
+	shift
+
+	local url="${1#/}"
+	shift
+
+	docker run --rm --link "$cid":ghost "$clientImage" \
+		curl -fs -X"$method" "$@" "http://ghost:2368/$url"
+}
+
+# Make sure that Ghost is listening and ready
+. "$dir/../../retry.sh" '_request GET / --output /dev/null'
+
+# Check that /ghost/ redirects to setup (the image is unconfigured by default)
+_request GET '/ghost/' -I | grep -q '^Location: .*setup'


### PR DESCRIPTION
Closes #593
Refs https://github.com/docker-library/ghost/pull/59

This adds a simple test which is similar to several others we've got (jetty, wordpress, etc) which launches the Ghost image, waits for it to be ready for requests, then ensures that a request to `/ghost/` redirects to setup (since our image is unconfigured by default), and I think automating the configuration for this test would be a bit complex (although if it's possible to do so in a way that won't be super fragile, I'm definitely game for doing so! :smile:)

The main benefit of adding the test here rather than directly in the https://github.com/docker-library/ghost repo (as https://github.com/docker-library/ghost/pull/59 does) is that it then gets run as part of the official images vetting process as well before image updates get released.  These tests are also run by the CI attached to the https://github.com/docker-library/ghost repo, so once we get this dialed in and merged, it'll be run automatically for all commits/PRs to the Ghost image repo too (see https://github.com/docker-library/ghost/blob/2abbd2be17b1f1418b2195ee60801585149d7b4a/.travis.yml#L13).

What makes this preferable to what's proposed over in https://github.com/docker-library/ghost/pull/59 is that it actually launches the application we're interested in testing, and verifies at least some of the functionality (both that it listens properly, and responds to HTTP requests), where the test there only verifies that several of the binaries included in the image seem to perform some function (which we have covered by other tests, such as `utc` running `date`, `cve-2014--shellshock` running `bash`, `no-hard-coded-passwords` running `cut`, and `override-cmd` running `echo`).

cc @pascalandy @kevinansfield @ErisDS (would love more thoughts -- this was based partially on @ErisDS's comment in https://github.com/docker-library/ghost/pull/59#issuecomment-276619024 :heart:)