### PR TITLE
Update Drupal 8.2.6 and 7.54

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.2.5-apache, 8.2-apache, 8-apache, apache, 8.2.5, 8.2, 8, latest
-GitCommit: a2832ca75e94580be81aafffdfc330c1713b519d
+Tags: 8.2.6-apache, 8.2-apache, 8-apache, apache, 8.2.6, 8.2, 8, latest
+GitCommit: 1ad01e8c9b0b34d8525e277dc6b4a6aaaddf020f
 Directory: 8.2/apache
 
-Tags: 8.2.5-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: a2832ca75e94580be81aafffdfc330c1713b519d
+Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: 1ad01e8c9b0b34d8525e277dc6b4a6aaaddf020f
 Directory: 8.2/fpm
 
-Tags: 7.53-apache, 7-apache, 7.53, 7
-GitCommit: 5dd56ed77e995f2cad08b6206d9e335c3a150168
+Tags: 7.54-apache, 7-apache, 7.54, 7
+GitCommit: aac79bfa92b93b484bd1d459adef02789ac2e011
 Directory: 7/apache
 
-Tags: 7.53-fpm, 7-fpm
-GitCommit: 5dd56ed77e995f2cad08b6206d9e335c3a150168
+Tags: 7.54-fpm, 7-fpm
+GitCommit: aac79bfa92b93b484bd1d459adef02789ac2e011
 Directory: 7/fpm


### PR DESCRIPTION
Update official Drupal docker-library image to use versions 8.2.6 and 7.54 of Drupal.