### PR TITLE
jetty: Add Jetty 9.4

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -2,11 +2,19 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.3.15, 9.3, 9, 9.3.15-jre8, 9.3-jre8, 9-jre8, latest, jre8
+Tags: 9.4.1, 9.4, 9, 9.4.1-jre8, 9.4-jre8, 9-jre8, latest, jre8
+Directory: 9.4-jre8
+GitCommit: 826ba540362814dd327ea4d7d839dd110a548d90
+
+Tags: 9.4.1-alpine, 9.4-alpine, 9-alpine, 9.4.1-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
+Directory: 9.4-jre8/alpine
+GitCommit: 826ba540362814dd327ea4d7d839dd110a548d90
+
+Tags: 9.3.15, 9.3, 9.3.15-jre8, 9.3-jre8
 Directory: 9.3-jre8
 GitCommit: ff1e2d71b69960326a4b11a34a60fbbb4386ce94
 
-Tags: 9.3.15-alpine, 9.3-alpine, 9-alpine, 9.3.15-jre8-alpine, 9.3-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
+Tags: 9.3.15-alpine, 9.3-alpine, 9.3.15-jre8-alpine, 9.3-jre8-alpine
 Directory: 9.3-jre8/alpine
 GitCommit: ff1e2d71b69960326a4b11a34a60fbbb4386ce94
 


### PR DESCRIPTION
Update the "latest", "jre8", and "alpine" tags to point to 9.4

See https://github.com/appropriate/docker-jetty/pull/51