### PR TITLE
Updated to the ArangoDB Release 3.1.10-2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -12,6 +12,6 @@
 2.8.11: git://github.com/arangodb/arangodb-docker@05366cb4c6a6aab8e1ff9ca74c81b09d9a57b5b5 jessie/2.8.11
 
 
-3.1: git://github.com/arangodb/arangodb-docker@c57d56ab9818ead2b4697c56b425ed377f18f6a8 jessie/3.1.10
-3.1.10: git://github.com/arangodb/arangodb-docker@c57d56ab9818ead2b4697c56b425ed377f18f6a8 jessie/3.1.10
-latest: git://github.com/arangodb/arangodb-docker@c57d56ab9818ead2b4697c56b425ed377f18f6a8 jessie/3.1.10
+3.1: git://github.com/arangodb/arangodb-docker@626e19d0c13b9804db414ec3e190fa83bf012692 jessie/3.1.10
+3.1.10: git://github.com/arangodb/arangodb-docker@626e19d0c13b9804db414ec3e190fa83bf012692 jessie/3.1.10
+latest: git://github.com/arangodb/arangodb-docker@626e19d0c13b9804db414ec3e190fa83bf012692 jessie/3.1.10


### PR DESCRIPTION
The arangodb 3.1.10 debian package contained an error and has been replace by arangodb 3.1.10-2