### PR TITLE
Bump traefik to v1.2.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,12 +2,16 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.1.2, camembert, latest
-GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
+Tags: v1.2.0-rc1, 1.2.0-rc1, morbier
+GitCommit: 134b33b66a8baf086557d9cca58b68f74e09e4b6
 
-Tags: v1.1.2-alpine, camembert-alpine
-GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
+Tags: v1.2.0-rc1-alpine, 1.2.0-rc1-alpine, morbier-alpine
+GitCommit: 134b33b66a8baf086557d9cca58b68f74e09e4b6
 Directory: alpine
 
-Tags: v1.0.3, reblochon
-GitCommit: 9d877ca7171211aabc2955ab1a301a685f6852fe
+Tags: v1.1.2, 1.1.2, camembert, latest
+GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
+
+Tags: v1.1.2-alpine, 1.1.2-alpine, camembert-alpine
+GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
+Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.2.0-rc1.
/cc @vdemeester

Cheers