### PR TITLE
Add simple new "redmine-basics" test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -167,6 +167,9 @@ imageTests+=(
 		redis-basics-config
 		redis-basics-persistent
 	'
+	[redmine]='
+		redmine-basics
+	'
 	[registry]='
 		docker-registry-push-pull
 	'

--- a/test/tests/redmine-basics/run.sh
+++ b/test/tests/redmine-basics/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+serverImage="$1"
+
+# Use a client image with curl for testing
+clientImage='buildpack-deps:jessie-curl'
+
+# Create an instance of the container-under-test
+cid="$(docker run -d "$serverImage")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+_request() {
+	local method="$1"
+	shift
+
+	local url="${1#/}"
+	shift
+
+	docker run --rm --link "$cid":redmine "$clientImage" \
+		curl -fs -X"$method" "$@" "http://redmine:3000/$url"
+}
+
+# Make sure that Redmine is listening and ready
+# (give it plenty of time, since it needs to do a lot of database migrations)
+. "$dir/../../retry.sh" --tries 40 '_request GET / --output /dev/null'
+
+# Check that / include the text "Redmine" somewhere
+_request GET '/' | grep -q Redmine
+
+# Check that /account/register include the text "Password" somewhere
+_request GET '/account/register' | grep -q Password


### PR DESCRIPTION
The goal is to catch issues like https://github.com/docker-library/redmine/issues/54 sooner (so the `passenger` variants of Redmine are likely to be failing this test already). :cry: