### PR TITLE
latest updates for opensuse distributions

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -7,16 +7,16 @@ Constraints: !aufs
 
 Tags: 42.2, leap, latest
 GitFetch: refs/heads/openSUSE-42.2
-GitCommit: b61d3d4383a1b3553ffeb27a13d6c487e0684e1d
+GitCommit: a8957648fda4fe9628021c45d3d9937641d74d77
 
 Tags: 42.1
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: 421f76f25f0621f883bfcd2155a2998e6b53d3b4
+GitCommit: 2395f4feda48485ee61d0d3582dd875a6400831e
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 1c1bf2b38c4757f5d1e8c4cdefb4fdc0104ea7cc
+GitCommit: 4d42cf8daf415e9e9c732ffa7532857a67f3ab5f
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed
-GitCommit: 512ffef9e22be7f5069352574053abd9836ca742
+GitCommit: 888608e52b0b3fe54dcafb6e82e78235bb252fb9


### PR DESCRIPTION
Apply following updates to 42.2
-------------------------------
 Security update for util-linux
 Security update for pcre
 Recommended update for systemd
 Recommended update for systemd
 Security update for systemd
 Recommended update for kmod
 Security update for cpio
 Recommended update for sg3_utils
 Security update for zlib
 Recommended update for dirmngr

Apply following updates to 42.1
-------------------------------
 Recommended update for dirmngr
 Recommended update for dpkg
 Recommended update for kmod
 Security update for cpio

Apply following updates to 13.2
------------------------------
 Recommended update for dpkg
 Recommended update for gcc48
 Recommended update for util-linux
 Security update for zlib
 Recommended update for systemd
 Recommended update for apparmor

Update packages to the latest version in Tumbleweed