### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.14, 3.0
-GitCommit: 30d09dbd6343d3cbd1bbea2d6afde49f5d9a9295
+GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.12, 3.2
-GitCommit: 5c0e43ac8eba7c2fb8cc3de9542f48b31c48da14
+GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
 Directory: 3.2
 
 Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: 310529fb5cb2ba79e9b28e94af76740a8edbd8a7
+GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
 Directory: 3.4
 
 Tags: 3.4.2-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore

--- a/library/percona
+++ b/library/percona
@@ -8,8 +8,8 @@ Tags: 5.7.17, 5.7, 5, latest
 GitCommit: 2ae90072239e8fd56bb9dbff13b3f3a2b0f82b83
 Directory: 5.7
 
-Tags: 5.6.34, 5.6
-GitCommit: 6c829dccb3b3ec43289b5721bf48b55801b49cdd
+Tags: 5.6.35, 5.6
+GitCommit: ab9ff984082a30195b16bb4d5f635ba1b248fecb
 Directory: 5.6
 
 Tags: 5.5.54, 5.5

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: 6fa0f95398d439c53d5c6a86f8f6ebc44d8b1fe0
+GitCommit: 06af4923eb88ca34909dc0fa4c2be77e6e80064d
 Directory: 3.1/passenger
 
 Tags: 3.2.5, 3.2
@@ -17,7 +17,7 @@ GitCommit: d03bfc8dda6aba04d47abcc4d91c9a022be3ffef
 Directory: 3.2
 
 Tags: 3.2.5-passenger, 3.2-passenger
-GitCommit: 6fa0f95398d439c53d5c6a86f8f6ebc44d8b1fe0
+GitCommit: 06af4923eb88ca34909dc0fa4c2be77e6e80064d
 Directory: 3.2/passenger
 
 Tags: 3.3.2, 3.3, 3, latest
@@ -25,5 +25,5 @@ GitCommit: 751dc04d76bdec5b92238a6acaa31df610b7d651
 Directory: 3.3
 
 Tags: 3.3.2-passenger, 3.3-passenger, 3-passenger, passenger
-GitCommit: 6fa0f95398d439c53d5c6a86f8f6ebc44d8b1fe0
+GitCommit: 06af4923eb88ca34909dc0fa4c2be77e6e80064d
 Directory: 3.3/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.50.1, 0.50, 0, latest
-GitCommit: c14050f02078c5f882f4b2692141e1ee799df7d6
+Tags: 0.51.0, 0.51, 0, latest
+GitCommit: 17522f568af6ec96f182d4db9b47edb8f93cd831


### PR DESCRIPTION
- `mongo`: use `numactl` for `mongos` too (docker-library/mongo#138)
- `percona`: 5.6.35-80.0-1.jessie
- `redmine`: fix `passenger` variants (docker-library/redmine#56)
- `rocket.chat`: 0.51.0