### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -13,7 +13,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
 Tags: jessie, latest
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: jessie
 
 Tags: precise-curl
@@ -25,7 +25,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: precise/scm
 
 Tags: precise
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: precise
 
 Tags: sid-curl
@@ -37,7 +37,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: sid/scm
 
 Tags: sid
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: sid
 
 Tags: stretch-curl
@@ -49,7 +49,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
 Tags: stretch
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: stretch
 
 Tags: trusty-curl
@@ -61,7 +61,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: trusty/scm
 
 Tags: trusty
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: trusty
 
 Tags: wheezy-curl
@@ -73,7 +73,7 @@ GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: wheezy/scm
 
 Tags: wheezy
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: wheezy
 
 Tags: xenial-curl
@@ -85,7 +85,7 @@ GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
 Directory: xenial/scm
 
 Tags: xenial
-GitCommit: 11492c68d993221fd5cd4d8a980354634fc165dd
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: xenial
 
 Tags: yakkety-curl
@@ -97,7 +97,7 @@ GitCommit: a94a81caf4d56853baade2cdd794dbe0c93396b2
 Directory: yakkety/scm
 
 Tags: yakkety
-GitCommit: a94a81caf4d56853baade2cdd794dbe0c93396b2
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: yakkety
 
 Tags: zesty-curl
@@ -109,5 +109,5 @@ GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
 Directory: zesty/scm
 
 Tags: zesty
-GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
+GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: zesty


### PR DESCRIPTION
Switch to `default-libmysqlclient-dev` where appropriate (https://github.com/docker-library/buildpack-deps/pull/58).