### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 1.13.0, 1.13, 1, latest
-GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
+Tags: 1.13.1, 1.13, 1, latest
+GitCommit: 50ec917e1b7601d655daee8893567e8cfd213248
 Directory: 1.13
 
-Tags: 1.13.0-dind, 1.13-dind, 1-dind, dind
+Tags: 1.13.1-dind, 1.13-dind, 1-dind, dind
 GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
 Directory: 1.13/dind
 
-Tags: 1.13.0-git, 1.13-git, 1-git, git
+Tags: 1.13.1-git, 1.13-git, 1-git, git
 GitCommit: b202ec7e529f5426e2ad7e8c0a8b82cacd406573
 Directory: 1.13/git
 

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/6c5f2993c210854b077ad07c9a94334f8c82fbb1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/f4a3691372cedcc546d7da35e30d961aec9ab04e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -61,28 +61,24 @@ GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8rc3, 1.8
-GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
-Directory: 1.8
+Tags: 1.8rc3, 1.8-rc, 1.8, rc
+GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+Directory: 1.8-rc
 
-Tags: 1.8rc3-onbuild, 1.8-onbuild
-GitCommit: 7319cccdf0c2b8cbcb4ea214f310e8d15fe5c1dd
-Directory: 1.8/onbuild
+Tags: 1.8rc3-onbuild, 1.8-rc-onbuild, 1.8-onbuild, rc-onbuild
+GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+Directory: 1.8-rc/onbuild
 
-Tags: 1.8rc3-wheezy, 1.8-wheezy
-GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
-Directory: 1.8/wheezy
+Tags: 1.8rc3-alpine, 1.8-rc-alpine, 1.8-alpine, rc-alpine
+GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+Directory: 1.8-rc/alpine
 
-Tags: 1.8rc3-alpine, 1.8-alpine
-GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
-Directory: 1.8/alpine
-
-Tags: 1.8rc3-windowsservercore, 1.8-windowsservercore
-GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
-Directory: 1.8/windows/windowsservercore
+Tags: 1.8rc3-windowsservercore, 1.8-rc-windowsservercore, 1.8-windowsservercore, rc-windowsservercore
+GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+Directory: 1.8-rc/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8rc3-nanoserver, 1.8-nanoserver
-GitCommit: 0912df2945653aa6b03a136302b4f2556081a7e5
-Directory: 1.8/windows/nanoserver
+Tags: 1.8rc3-nanoserver, 1.8-rc-nanoserver, 1.8-nanoserver, rc-nanoserver
+GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+Directory: 1.8-rc/windows/nanoserver
 Constraints: nanoserver

--- a/library/irssi
+++ b/library/irssi
@@ -5,9 +5,9 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
 GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.0.1, 1.0, 1, latest
-GitCommit: 062d081e278c43458c27586bbd2f0e2ba5321fa1
+GitCommit: 02529da6afd7846e0024c9a8b72ab6a32b4cd402
 Directory: debian
 
 Tags: 1.0.1-alpine, 1.0-alpine, 1-alpine, alpine
-GitCommit: 062d081e278c43458c27586bbd2f0e2ba5321fa1
+GitCommit: 02529da6afd7846e0024c9a8b72ab6a32b4cd402
 Directory: alpine

--- a/library/postgres
+++ b/library/postgres
@@ -4,42 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 9.6.1, 9.6, 9, latest
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+Tags: 9.6.2, 9.6, 9, latest
+GitCommit: 5159417968c6a08e2ed784498cba28f22a74b03e
 Directory: 9.6
 
-Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
+Tags: 9.6.2-alpine, 9.6-alpine, 9-alpine, alpine
+GitCommit: dd88d2f02ad0f9852a7b33a8b542e14f5867b0c1
 Directory: 9.6/alpine
 
-Tags: 9.5.5, 9.5
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+Tags: 9.5.6, 9.5
+GitCommit: a869eeccfb98c9653fca9f135f3bafa758c6f4f7
 Directory: 9.5
 
-Tags: 9.5.5-alpine, 9.5-alpine
-GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
+Tags: 9.5.6-alpine, 9.5-alpine
+GitCommit: 738ec9015ca92fa79e541514f51b37a8d69e4979
 Directory: 9.5/alpine
 
-Tags: 9.4.10, 9.4
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+Tags: 9.4.11, 9.4
+GitCommit: 1e7af691a3981ec1c86d23d585dcebd9154d1cd0
 Directory: 9.4
 
-Tags: 9.4.10-alpine, 9.4-alpine
-GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
+Tags: 9.4.11-alpine, 9.4-alpine
+GitCommit: 5408eaec65c84374dd6a8f2f2e900197d50cf6c4
 Directory: 9.4/alpine
 
-Tags: 9.3.15, 9.3
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+Tags: 9.3.16, 9.3
+GitCommit: 6870d3db740a321699ef49c8068c3d812b9681e1
 Directory: 9.3
 
-Tags: 9.3.15-alpine, 9.3-alpine
-GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
+Tags: 9.3.16-alpine, 9.3-alpine
+GitCommit: a3b8f2bf53b603713ad84344e0cfc79587507d4b
 Directory: 9.3/alpine
 
-Tags: 9.2.19, 9.2
-GitCommit: d7accc9c8c7d740ad756b887225fe31286d98f64
+Tags: 9.2.20, 9.2
+GitCommit: 8c03e6aed7046c4bacbc1b7c356edd81bd72c6d5
 Directory: 9.2
 
-Tags: 9.2.19-alpine, 9.2-alpine
-GitCommit: e43016225fea0cdf47ae1df0888885ae02a8a7f4
+Tags: 9.2.20-alpine, 9.2-alpine
+GitCommit: 86ef6fa873cdc310e9f23a127ae2865b1d8745ba
 Directory: 9.2/alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,37 +5,37 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.7.2-apache, 4.7-apache, 4-apache, apache, 4.7.2, 4.7, 4, latest, 4.7.2-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.2-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php5.6/apache
 
 Tags: 4.7.2-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.2-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php5.6/fpm
 
 Tags: 4.7.2-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.2-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php5.6/fpm-alpine
 
 Tags: 4.7.2-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.2-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.0/apache
 
 Tags: 4.7.2-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.0/fpm
 
 Tags: 4.7.2-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.0/fpm-alpine
 
 Tags: 4.7.2-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.2-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.1/apache
 
 Tags: 4.7.2-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.1/fpm
 
 Tags: 4.7.2-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: d8e5577dcc7096d2b694dda433e2b5c7c4561a82
+GitCommit: b807f1285869a220a5f72b935901603e5bde8822
 Directory: php7.1/fpm-alpine


### PR DESCRIPTION
- `docker`: 1.13.1
- `golang`: remove `wheezy` for 1.8 (docker-library/golang#144), update `1.8-rc` to be explicit about tracking pre-releases (docker-library/golang#145)
- `irssi`: remove `VOLUME` (jessfraz/irssi#13)
- `postgres`: 9.6.2, 9.3.16, 9.4.11, 9.5.6, 9.2.20, put `docker-entrypoint.sh` explicitly in `PATH` (docker-library/postgres#260)
- `wordpress`: update `wp-config.php` handling to only generate/munge configuration upon user request and to unset all related environment variables explicitly (docker-library/wordpress#206)