### PR TITLE
Revert "Bump Java version to 1.8.0_sr4 (8.0-4.0)."

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -1,14 +1,14 @@
 # maintainer: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-8-jre: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/ubuntu
-jre: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/ubuntu
-8: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/ubuntu
-latest: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/ubuntu
-8-jre-alpine: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/alpine
-jre-alpine: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-jre/x86_64/alpine
-8-sfj: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sfj/x86_64/ubuntu
-sfj: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sfj/x86_64/ubuntu
-8-sfj-alpine: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sfj/x86_64/alpine
-sfj-alpine: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sfj/x86_64/alpine
-8-sdk: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sdk/x86_64/ubuntu
-sdk: git://github.com/ibmruntimes/ci.docker@3042461027dfb7a19b9ae7c7d41e777889caaa9d ibmjava/8-sdk/x86_64/ubuntu
+8-jre: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/ubuntu
+jre: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/ubuntu
+8: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/ubuntu
+latest: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/ubuntu
+8-jre-alpine: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/alpine
+jre-alpine: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-jre/x86_64/alpine
+8-sfj: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sfj/x86_64/ubuntu
+sfj: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sfj/x86_64/ubuntu
+8-sfj-alpine: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sfj/x86_64/alpine
+sfj-alpine: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sfj/x86_64/alpine
+8-sdk: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sdk/x86_64/ubuntu
+sdk: git://github.com/ibmruntimes/ci.docker@55b323f6e498d302239926d163c9ef04eb0d92b9 ibmjava/8-sdk/x86_64/ubuntu


### PR DESCRIPTION
Reverts docker-library/official-images#2635. Due to an issue with the latest JDK (1.8.0_sr4) this change needs to be reverted to the previous level (1.8.0_sr3fp22).