### PR TITLE
Update haskell to 8.0.2.

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,8 +1,8 @@
-# maintainer: Darin Morrison <darinmorrison+git@gmail.com> (@darinmorrison)
-# maintainer: Peter Salvatore <peter@psftw.com> (@psftw)
-# maintainer: Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi)
+Maintainers: Darin Morrison <darinmorrison+git@gmail.com> (@freebroccolo),
+             Peter Salvatore <peter@psftw.com> (@psftw),
+             Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi)
+GitRepo: https://github.com/freebroccolo/docker-haskell
 
-8.0.1: git://github.com/freebroccolo/docker-haskell@e0efde5504642864811a7697ab945067bb6a042e 8.0
-8.0: git://github.com/freebroccolo/docker-haskell@e0efde5504642864811a7697ab945067bb6a042e 8.0
-8: git://github.com/freebroccolo/docker-haskell@e0efde5504642864811a7697ab945067bb6a042e 8.0
-latest: git://github.com/freebroccolo/docker-haskell@e0efde5504642864811a7697ab945067bb6a042e 8.0
+Tags: 8.0.2, 8.0, 8, latest
+GitCommit: 5f1ae82bd27501322100b915c9ae6cc9f9aea129
+Directory: 8.0


### PR DESCRIPTION
Besides the version bump, we are changed how the "stack" tool (library manager plus much more) is installed.  A PR was sent by an upstream "stack" developer since they are deprecating the current install method (hosted debian packages).  Details at https://github.com/freebroccolo/docker-haskell/pull/57