### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -22,7 +22,7 @@ GitCommit: bfbd521de2942d10d96b14f99c491536490db018
 Directory: 1.6/alpine
 
 Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
-GitCommit: 9ef22bd9eac98c3ed12a48c953922e2bab8485ef
+GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
 Directory: 1.6/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -52,7 +52,7 @@ GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/alpine3.5
 
 Tags: 1.7.5-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -78,7 +78,7 @@ GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
 Directory: 1.8-rc/alpine
 
 Tags: 1.8rc3-windowsservercore, 1.8-rc-windowsservercore, 1.8-windowsservercore, rc-windowsservercore
-GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
+GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
 Directory: 1.8-rc/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/redis
+++ b/library/redis
@@ -26,16 +26,16 @@ GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 3.2.7, 3.2, 3, latest
-GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
+Tags: 3.2.8, 3.2, 3, latest
+GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
 Directory: 3.2
 
-Tags: 3.2.7-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
+Tags: 3.2.8-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
 Directory: 3.2/32bit
 
-Tags: 3.2.7-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 9d502df41786e2a374a3b0a96655fad4ed3a82b7
+Tags: 3.2.8-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
 Directory: 3.2/alpine
 
 Tags: 3.2.100-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.51.0, 0.51, 0, latest
-GitCommit: 17522f568af6ec96f182d4db9b47edb8f93cd831
+Tags: 0.52.0, 0.52, 0, latest
+GitCommit: 798ff0925df0c598ab57d3c441b2418cbd55040a

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
+GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
+GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: e32433a12099d96dc5a1b28a011b73af4f17cfff
+GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
+GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
+GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: b143db48ef460f4b456c2ca32b12147475a2094f
+GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
+GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
+GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 9c296b2ed4e76d6fd399974545a63d410ade0160
+GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
+GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
+GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: bae23407cd2c07756c8f88095a25129bf204efaf
+GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.48-jre7, 6.0-jre7, 6-jre7, 6.0.48, 6.0, 6
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+GitCommit: 30cca452bf25d5f7f6d164e66902a39afc4593ed
 Directory: 6/jre7
 
 Tags: 6.0.48-jre8, 6.0-jre8, 6-jre8
-GitCommit: e5ee9fb792276e4558733e22b3fb02af9de91ef5
+GitCommit: 30cca452bf25d5f7f6d164e66902a39afc4593ed
 Directory: 6/jre8
 
 Tags: 7.0.75-jre7, 7.0-jre7, 7-jre7, 7.0.75, 7.0, 7
-GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
+GitCommit: beafeb41b26e8cba4d78d213ec1a65baabecbc00
 Directory: 7/jre7
 
 Tags: 7.0.75-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.75-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre7-alpine
 
 Tags: 7.0.75-jre8, 7.0-jre8, 7-jre8
-GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
+GitCommit: beafeb41b26e8cba4d78d213ec1a65baabecbc00
 Directory: 7/jre8
 
 Tags: 7.0.75-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: 437ad1d98f2ca7667df856d13922b23a22b719d0
 Directory: 7/jre8-alpine
 
 Tags: 8.0.41-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.41, 8.0, 8, latest
-GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
+GitCommit: 9b435c815366378b65a78fa84d3bed5642fddaa6
 Directory: 8.0/jre7
 
 Tags: 8.0.41-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.41-alpine, 8.0-alpine, 8-alpine, alpine
@@ -37,7 +37,7 @@ GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.41-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
+GitCommit: 9b435c815366378b65a78fa84d3bed5642fddaa6
 Directory: 8.0/jre8
 
 Tags: 8.0.41-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.11-jre8, 8.5-jre8, 8.5.11, 8.5
-GitCommit: 023eb5126ff70b769f1f84b28c440fb6128bffe7
+GitCommit: 4d9eeecc2d0ed70ae63b48eb203a4bc4c76481ad
 Directory: 8.5/jre8
 
 Tags: 8.5.11-jre8-alpine, 8.5-jre8-alpine, 8.5.11-alpine, 8.5-alpine
@@ -53,7 +53,7 @@ GitCommit: 023eb5126ff70b769f1f84b28c440fb6128bffe7
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M17-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M17, 9.0.0, 9.0, 9
-GitCommit: 075a394e34f7329415e87ad5f0d77d46aac24876
+GitCommit: c5b4144188006445b32a9897f6ecd617afce7929
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M17-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M17-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine


### PR DESCRIPTION
- `golang`: update Git for Windows to 2.11.1 and use MinGit (docker-library/golang#147)
- `redis`: 3.2.8
- `rocket.chat`: 0.52.0
- `ruby`: bundler 1.14.4
- `tomcat`: OpenSSL 1.1.0d-2