### PR TITLE
Add an initial issue template to help guide users to the right place to file issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!--
+
+WAIT!  Before you file an issue here, please keep in mind that your issue is _probably_ more appropriately filed somewhere else.
+
+Specifically, if your issue is in regards to the documentation of an image, it should be filed at https://github.com/docker-library/docs/issues
+
+If your issue is in regards to a specific image, please see the "Issues" section of the relevant image's description on the Docker Hub for information about where to file issues for that image.  For example, issues with the "python" image should be filed at https://github.com/docker-library/python/issues, NOT here.
+
+-->


### PR DESCRIPTION
Hopefully this will help decrease the number of issues that are mistakenly filed on this repository for specific image issues.