### PR TITLE
Update Couchbase to 4.6.0

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,15 +1,15 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/4.5.1
-enterprise: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/4.5.1
-4.5.1: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/4.5.1
-enterprise-4.5.1: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/4.5.1
+latest: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/4.6.0
+enterprise: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/4.6.0
+4.6.0: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/4.6.0
+enterprise-4.6.0: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/4.6.0
 
-community: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 community/couchbase-server/4.5.0
-community-4.5.0: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 community/couchbase-server/4.5.0
+community: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 community/couchbase-server/4.5.0
+community-4.5.0: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 community/couchbase-server/4.5.0
 
-3.1.6: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/3.1.6
-enterprise-3.1.6: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 enterprise/couchbase-server/3.1.6
+3.1.6: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/3.1.6
+enterprise-3.1.6: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 enterprise/couchbase-server/3.1.6
 
-community-3.1.3: git://github.com/couchbase/docker@042e733f40487ee07c75413f10ce3c29b1d49181 community/couchbase-server/3.1.3
+community-3.1.3: git://github.com/couchbase/docker@8c3e58c1fd2572dee95c9b9dda0bdf5342bb8091 community/couchbase-server/3.1.3
 


### PR DESCRIPTION
Preparation for official Couchbase 4.6.0 launch on Feb. 16. If this could be pushed on the 15th or 16th that would be ideal; thanks!