### PR TITLE
Updated Oracle Linux official images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,10 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/docker-images.git
 GitFetch: refs/heads/OracleLinux-images
-GitCommit: 4cfe8d4ba9b909492ee0d4d26ec26f4b495578f3
+GitCommit: 91899be04766ddf7b2ad297e5159901889801ff8
+
+Tags: 7-slim
+Directory: OracleLinux/7-slim
 
 Tags: latest, 7, 7.3
 Directory: OracleLinux/7.3
@@ -14,6 +17,9 @@ Directory: OracleLinux/7.1
 
 Tags: 7.0
 Directory: OracleLinux/7.0
+
+Tags: 6-slim
+Directory: OracleLinux/6-slim
 
 Tags: 6, 6.8
 Directory: OracleLinux/6.8


### PR DESCRIPTION
Updated OL7 image for CVE-2017-3135.

We're also adding two new slim images that are much smaller builds of OL6 and OL7.

Signed-off-by: Avi Miller <avi.miller@oracle.com>