### PR TITLE
Update docker-library golang images to 1.8

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/e9c51096409712864189f9ed878a3f77c76ab101/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/445ba23ad32bf53dba66ce6309cab168c9307ce2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -31,58 +31,58 @@ GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
 Directory: 1.6/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.7.5, 1.7, 1, latest
+Tags: 1.7.5, 1.7
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7
 
-Tags: 1.7.5-onbuild, 1.7-onbuild, 1-onbuild, onbuild
+Tags: 1.7.5-onbuild, 1.7-onbuild
 GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
-Tags: 1.7.5-wheezy, 1.7-wheezy, 1-wheezy, wheezy
+Tags: 1.7.5-wheezy, 1.7-wheezy
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/wheezy
 
-Tags: 1.7.5-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.5-alpine, 1.7-alpine
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/alpine
 
-Tags: 1.7.5-alpine3.5, 1.7-alpine3.5, 1-alpine3.5, alpine3.5
+Tags: 1.7.5-alpine3.5, 1.7-alpine3.5
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/alpine3.5
 
-Tags: 1.7.5-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
+Tags: 1.7.5-windowsservercore, 1.7-windowsservercore
 GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.7.5-nanoserver, 1.7-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.7.5-nanoserver, 1.7-nanoserver
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8rc3, 1.8-rc, 1.8, rc
-GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
-Directory: 1.8-rc
+Tags: 1.8.0, 1.8, 1, latest
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8
 
-Tags: 1.8rc3-onbuild, 1.8-rc-onbuild, 1.8-onbuild, rc-onbuild
-GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
-Directory: 1.8-rc/onbuild
+Tags: 1.8.0-onbuild, 1.8-onbuild, 1-onbuild, onbuild
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/onbuild
 
-Tags: 1.8rc3-stretch, 1.8-rc-stretch, 1.8-stretch, rc-stretch
-GitCommit: 8ee098f95a9b99552a157b5909e6916c9c181cc9
-Directory: 1.8-rc/stretch
+Tags: 1.8.0-stretch, 1.8-stretch, 1-stretch, stretch
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/stretch
 
-Tags: 1.8rc3-alpine, 1.8-rc-alpine, 1.8-alpine, rc-alpine
-GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
-Directory: 1.8-rc/alpine
+Tags: 1.8.0-alpine, 1.8-alpine, 1-alpine, alpine
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/alpine
 
-Tags: 1.8rc3-windowsservercore, 1.8-rc-windowsservercore, 1.8-windowsservercore, rc-windowsservercore
-GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
-Directory: 1.8-rc/windows/windowsservercore
+Tags: 1.8.0-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8rc3-nanoserver, 1.8-rc-nanoserver, 1.8-nanoserver, rc-nanoserver
-GitCommit: f4a3691372cedcc546d7da35e30d961aec9ab04e
-Directory: 1.8-rc/windows/nanoserver
+Tags: 1.8.0-nanoserver, 1.8-nanoserver, 1-nanoserver, nanoserver
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
This also replaces the tags for 1 and latest (and related variants) with the 1.8 versions