### PR TITLE
Updated 6.8 and 6-slim images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/docker-images.git
 GitFetch: refs/heads/OracleLinux-images
-GitCommit: 91899be04766ddf7b2ad297e5159901889801ff8
+GitCommit: 59240b35264e017b366a6d60c7c29b9934d989dc
 
 Tags: 7-slim
 Directory: OracleLinux/7-slim


### PR DESCRIPTION
Further size reductions on our `6.8`, `6` and `6-slim` images. Reduction of 53MB for the `6.8` image and a reduction of 28MB for the `6-slim` image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>