### PR TITLE
version bump: otp-19.2.3

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -3,15 +3,15 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-Tags: 19.2.2, 19.2, 19, latest
-GitCommit: 1b03fdd83ec769e7962ec0dce01e25613a46dacf
+Tags: 19.2.3, 19.2, 19, latest
+GitCommit: 5962d4d7291b268eff8ff2513637eedabe9fe90f
 Directory: 19
 
-Tags: 19.2.2-slim, 19.2-slim, 19-slim, slim
-GitCommit: 1b03fdd83ec769e7962ec0dce01e25613a46dacf
+Tags: 19.2.3-slim, 19.2-slim, 19-slim, slim
+GitCommit: 5962d4d7291b268eff8ff2513637eedabe9fe90f
 Directory: 19/slim
 
-Tags: 19.2.2-onbuild, 19.2-onbuild, 19-onbuild, onbuild
+Tags: 19.2.3-onbuild, 19.2-onbuild, 19-onbuild, onbuild
 GitCommit: 1b03fdd83ec769e7962ec0dce01e25613a46dacf
 Directory: 19/onbuild
 


### PR DESCRIPTION
with c0b/docker-erlang-otp#37