### PR TITLE
remove unsupported 2.5 / 2.7; add 3.0x back.

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,16 +1,11 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.5.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
-2.5: git://github.com/arangodb/arangodb-docker@636cd874df38edd77a187c08e1803693b3d978d3 jessie/2.5.5
-
-
-2.7: git://github.com/arangodb/arangodb-docker@dbfcc5f3edb37f622a2acd221b58106547b05fae jessie/2.7.5
-2.7.5: git://github.com/arangodb/arangodb-docker@dbfcc5f3edb37f622a2acd221b58106547b05fae jessie/2.7.5
-
 2.8: git://github.com/arangodb/arangodb-docker@05366cb4c6a6aab8e1ff9ca74c81b09d9a57b5b5 jessie/2.8.11
 2.8.11: git://github.com/arangodb/arangodb-docker@05366cb4c6a6aab8e1ff9ca74c81b09d9a57b5b5 jessie/2.8.11
 
+3.0: git://github.com/arangodb/arangodb-docker@baaf2cdbbecf43b184ab45009ea01620760199b3 jessie/3.0.12
+3.0.12: git://github.com/arangodb/arangodb-docker@baaf2cdbbecf43b184ab45009ea01620760199b3 jessie/3.0.12
 
 3.1: git://github.com/arangodb/arangodb-docker@c1c353de96266d5b1497a40ce368a1a9a5022d87 jessie/3.1.11
 3.1.11: git://github.com/arangodb/arangodb-docker@c1c353de96266d5b1497a40ce368a1a9a5022d87 jessie/3.1.11


### PR DESCRIPTION
Fix the docker file.
 - remove officially unsupported 2.5 and 2.7 revisions
 - add back 3.0.x