### PR TITLE
Updating Oracle Linux images for OpenSSL CVEs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/docker-images.git
 GitFetch: refs/heads/OracleLinux-images
-GitCommit: 59240b35264e017b366a6d60c7c29b9934d989dc
+GitCommit: e5227c710ea2c92b0611127552134d757a3d02cc
 
 Tags: 7-slim
 Directory: OracleLinux/7-slim


### PR DESCRIPTION
Updating the Oracle Linux 6 and 7 (full/slim) images to address the following OpenSSL CVEs:

* CVE-2017-3731 - DoS via truncated packets with RC4-MD5 cipher
* CVE-2016-8610 - DoS of single-threaded servers via excessive alerts

Signed-off-by: Avi Miller <avi.miller@oracle.com>