### PR TITLE
Update for Node.js v7.6.0, v6.10.0 and v4.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,65 +1,65 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/90d5e3df903b830d039d3fe8f30e3a62395db37e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/0f8446512970e9330a95e417deaa0200dc9790cf/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.5.0, 7.5, 7, latest
-GitCommit: 90d5e3df903b830d039d3fe8f30e3a62395db37e
-Directory: 7.5
+Tags: 7.6.0, 7.6, 7, latest
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 7.6
 
-Tags: 7.5.0-alpine, 7.5-alpine, 7-alpine, alpine
-GitCommit: 90d5e3df903b830d039d3fe8f30e3a62395db37e
-Directory: 7.5/alpine
+Tags: 7.6.0-alpine, 7.6-alpine, 7-alpine, alpine
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 7.6/alpine
 
-Tags: 7.5.0-onbuild, 7.5-onbuild, 7-onbuild, onbuild
-GitCommit: 90d5e3df903b830d039d3fe8f30e3a62395db37e
-Directory: 7.5/onbuild
+Tags: 7.6.0-onbuild, 7.6-onbuild, 7-onbuild, onbuild
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 7.6/onbuild
 
-Tags: 7.5.0-slim, 7.5-slim, 7-slim, slim
-GitCommit: 90d5e3df903b830d039d3fe8f30e3a62395db37e
-Directory: 7.5/slim
+Tags: 7.6.0-slim, 7.6-slim, 7-slim, slim
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 7.6/slim
 
-Tags: 7.5.0-wheezy, 7.5-wheezy, 7-wheezy, wheezy
-GitCommit: 90d5e3df903b830d039d3fe8f30e3a62395db37e
-Directory: 7.5/wheezy
+Tags: 7.6.0-wheezy, 7.6-wheezy, 7-wheezy, wheezy
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 7.6/wheezy
 
-Tags: 6.9.5, 6.9, 6, boron
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 6.9
+Tags: 6.10.0, 6.10, 6, boron
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 6.10
 
-Tags: 6.9.5-alpine, 6.9-alpine, 6-alpine, boron-alpine
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 6.9/alpine
+Tags: 6.10.0-alpine, 6.10-alpine, 6-alpine, boron-alpine
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 6.10/alpine
 
-Tags: 6.9.5-onbuild, 6.9-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 6.9/onbuild
+Tags: 6.10.0-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
+GitCommit: db2660f326fdad12a21dd5e7351053a4d0691099
+Directory: 6.10/onbuild
 
-Tags: 6.9.5-slim, 6.9-slim, 6-slim, boron-slim
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 6.9/slim
+Tags: 6.10.0-slim, 6.10-slim, 6-slim, boron-slim
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 6.10/slim
 
-Tags: 6.9.5-wheezy, 6.9-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 6.9/wheezy
+Tags: 6.10.0-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 6.10/wheezy
 
-Tags: 4.7.3, 4.7, 4, argon
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 4.7
+Tags: 4.8.0, 4.8, 4, argon
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 4.8
 
-Tags: 4.7.3-alpine, 4.7-alpine, 4-alpine, argon-alpine
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 4.7/alpine
+Tags: 4.8.0-alpine, 4.8-alpine, 4-alpine, argon-alpine
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 4.8/alpine
 
-Tags: 4.7.3-onbuild, 4.7-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 4.7/onbuild
+Tags: 4.8.0-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 8345a12b6da2f0f124eb60cc248158a40b66d77f
+Directory: 4.8/onbuild
 
-Tags: 4.7.3-slim, 4.7-slim, 4-slim, argon-slim
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 4.7/slim
+Tags: 4.8.0-slim, 4.8-slim, 4-slim, argon-slim
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 4.8/slim
 
-Tags: 4.7.3-wheezy, 4.7-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 3b038b8a1ac8f65e3d368bedb9f979884342fdcb
-Directory: 4.7/wheezy
+Tags: 4.8.0-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+Directory: 4.8/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.6.0/
- https://nodejs.org/en/blog/release/v6.10.0/
- https://nodejs.org/en/blog/release/v4.8.0/

Also includes a new gpg fingerprint for Italo A. Casas:

- https://github.com/nodejs/docker-node/pull/336
- https://github.com/nodejs/node#release-team