### PR TITLE
Update cassandra, docker, ghost, memcached, ruby

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.16, 2.1
-GitCommit: 71d979a201b63d94ed904eef6218d50e2142845d
+Tags: 2.1.17, 2.1
+GitCommit: 3535be36e7b48b24b5abedebd345b5286bcffa60
 Directory: 2.1
 
-Tags: 2.2.8, 2.2, 2
-GitCommit: 71d979a201b63d94ed904eef6218d50e2142845d
+Tags: 2.2.9, 2.2, 2
+GitCommit: 3b54d76bf451717222e028b7db44044b03a3e620
 Directory: 2.2
 
-Tags: 3.0.10, 3.0
-GitCommit: 71d979a201b63d94ed904eef6218d50e2142845d
+Tags: 3.0.11, 3.0
+GitCommit: 6c3f791c239b24a25d9766edb6b4d22c71669cee
 Directory: 3.0
 
 Tags: 3.10, 3, latest

--- a/library/docker
+++ b/library/docker
@@ -1,8 +1,20 @@
-# this file is generated via https://github.com/docker-library/docker/blob/b202ec7e529f5426e2ad7e8c0a8b82cacd406573/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/21c954a70560f765490efc2f60e12e971fcafc77/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
+
+Tags: 17.03.0-ce-rc1, 17.03-rc, rc
+GitCommit: 06717e6f2add8226068bec54abb23e646dea90e0
+Directory: 17.03-rc
+
+Tags: 17.03.0-ce-rc1-dind, 17.03-rc-dind, rc-dind
+GitCommit: 06717e6f2add8226068bec54abb23e646dea90e0
+Directory: 17.03-rc/dind
+
+Tags: 17.03.0-ce-rc1-git, 17.03-rc-git, rc-git
+GitCommit: 06717e6f2add8226068bec54abb23e646dea90e0
+Directory: 17.03-rc/git
 
 Tags: 1.13.1, 1.13, 1, latest
 GitCommit: 50ec917e1b7601d655daee8893567e8cfd213248

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.4, 0.11, 0, latest
-GitCommit: 2abbd2be17b1f1418b2195ee60801585149d7b4a
+Tags: 0.11.5, 0.11, 0, latest
+GitCommit: 12006b77bf3f147a0aa81698d8531f0eff3d09c0

--- a/library/memcached
+++ b/library/memcached
@@ -5,9 +5,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.4.34, 1.4, 1, latest
-GitCommit: 53b91f1cfb308fe4946a79bd1d23ceaa3d18e250
+GitCommit: 66085edcbefc1d38e15c47366f614a4300b597f1
 Directory: debian
 
 Tags: 1.4.34-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 53b91f1cfb308fe4946a79bd1d23ceaa3d18e250
+GitCommit: 879da16d51831197ca5c6737bc76163d96c10077
 Directory: alpine

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
+GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
+GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: 1ab58f6415d01794d025ad245fb0f21521e1a159
+GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
+GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
+GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 0a9c4539b78e5265edf887b2a5537a1e81f6b5f7
+GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
+GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
+GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 17f666371fa5c88c48a38bc53c611f26c7455778
+GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
+GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
+GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: e294c37cc1c2e52e5e765b7dff7f6549eedd7a47
+GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `cassandra` bump versions `2.1.17`, `2.2.9`, `3.0.11`
- `docker` add `17.03-rc`
- `ghost` bump version `0.11.5`
- `memcached` Switch from "jessie" to "jessie-slim" (and fix multi-arch compatibility)
- `ruby` bundler `1.14.5`