### PR TITLE
Add "bashbrew list" output to "diff-pr.sh"

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -136,7 +136,7 @@ copy-tar() {
 mkdir temp
 git -C temp init --quiet
 
-bashbrew list "${images[@]}" > temp/_bashbrew-list || :
+bashbrew list "${images[@]}" | sort -V > temp/_bashbrew-list || :
 for image in "${images[@]}"; do
 	if script="$(bashbrew cat -f "$template" "$image")"; then
 		mkdir tar
@@ -151,7 +151,7 @@ git -C temp commit --quiet --allow-empty -m 'initial' || :
 git -C oi checkout --quiet pull
 
 git -C temp rm --quiet -rf . || :
-bashbrew list "${images[@]}" > temp/_bashbrew-list || :
+bashbrew list "${images[@]}" | sort -V > temp/_bashbrew-list || :
 script="$(bashbrew cat -f "$template" "${images[@]}")"
 mkdir tar
 ( eval "$script" | tar -xiC tar )

--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -136,6 +136,7 @@ copy-tar() {
 mkdir temp
 git -C temp init --quiet
 
+bashbrew list "${images[@]}" > temp/_bashbrew-list || :
 for image in "${images[@]}"; do
 	if script="$(bashbrew cat -f "$template" "$image")"; then
 		mkdir tar
@@ -150,6 +151,7 @@ git -C temp commit --quiet --allow-empty -m 'initial' || :
 git -C oi checkout --quiet pull
 
 git -C temp rm --quiet -rf . || :
+bashbrew list "${images[@]}" > temp/_bashbrew-list || :
 script="$(bashbrew cat -f "$template" "${images[@]}")"
 mkdir tar
 ( eval "$script" | tar -xiC tar )


### PR DESCRIPTION
I'm not sure if we should use something like `--build-order` here or simply stick to the order they spit out.

Here's an example of the added output from #2686:

```diff
diff --git a/_bashbrew-list b/_bashbrew-list
index e95699e..775a0ba 100644
--- a/_bashbrew-list
+++ b/_bashbrew-list
@@ -1,4 +1,13 @@
-xwiki:latest
-xwiki:mysql-tomcat
 xwiki:8
+xwiki:8.4
+xwiki:8.4.4
 xwiki:8-mysql-tomcat
+xwiki:mysql-tomcat
+xwiki:lts-mysql-tomcat
+xwiki:lts
+xwiki:latest
+xwiki:9
+xwiki:9.0
+xwiki:9-mysql-tomcat
+xwiki:stable-mysql-tomcat
+xwiki:stable
diff --git a/xwiki_8-mysql-tomcat/Dockerfile b/xwiki_latest/Dockerfile
similarity index 97%
rename from xwiki_8-mysql-tomcat/Dockerfile
rename to xwiki_latest/Dockerfile
index cc46e5a..c72d1cc 100644
--- a/xwiki_8-mysql-tomcat/Dockerfile
+++ b/xwiki_latest/Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && \
 # Configure the XWiki permanent directory
 ENV XWIKI_VERSION=8.4.4
...
```