### PR TITLE
Update mongo-express to version 0.38.0

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.35.0: git://github.com/mongo-express/mongo-express-docker@38f5663a1a783b8e94ac9a787c0642bc4d2dc60f
-0.35: git://github.com/mongo-express/mongo-express-docker@38f5663a1a783b8e94ac9a787c0642bc4d2dc60f
-latest: git://github.com/mongo-express/mongo-express-docker@38f5663a1a783b8e94ac9a787c0642bc4d2dc60f
+0.38.0: git://github.com/mongo-express/mongo-express-docker@500a1db15deef043a6937302a1407b25369c8b4a
+0.38: git://github.com/mongo-express/mongo-express-docker@500a1db15deef043a6937302a1407b25369c8b4a
+latest: git://github.com/mongo-express/mongo-express-docker@500a1db15deef043a6937302a1407b25369c8b4a


### PR DESCRIPTION
This mongo-express update includes:

- Fix content-disposition non-ascii header
- Docs for ME_CONFIG_SITE_GRIDFS_ENABLED env var
- Fixed issue where closing parentheses we're stringified wrongly
- Removed everything related to snyk
- Fixed loadDocumnet script that was no longer rendered in read-only
- Changed underscore to lodash
- Added support for / in collection names
- Updated unmaintained swig to maintained swig-templates
- Changed the way scripts are loaded into page
- Added initial tooling to support test for routes
- Added test for index of db, collection and document
- Fix router baseHref
- Changed only calculate routes once instead of every time