### PR TITLE
Update Node.js images to include yarn (v2)

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,11 +4,11 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.6.0, 7.6, 7, latest
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 7.6
 
 Tags: 7.6.0-alpine, 7.6-alpine, 7-alpine, alpine
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 7.6/alpine
 
 Tags: 7.6.0-onbuild, 7.6-onbuild, 7-onbuild, onbuild
@@ -16,19 +16,19 @@ GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
 Directory: 7.6/onbuild
 
 Tags: 7.6.0-slim, 7.6-slim, 7-slim, slim
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 7.6/slim
 
 Tags: 7.6.0-wheezy, 7.6-wheezy, 7-wheezy, wheezy
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 7.6/wheezy
 
 Tags: 6.10.0, 6.10, 6, boron
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 6.10
 
 Tags: 6.10.0-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 6.10/alpine
 
 Tags: 6.10.0-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
@@ -36,19 +36,19 @@ GitCommit: db2660f326fdad12a21dd5e7351053a4d0691099
 Directory: 6.10/onbuild
 
 Tags: 6.10.0-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 6.10/slim
 
 Tags: 6.10.0-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 6.10/wheezy
 
 Tags: 4.8.0, 4.8, 4, argon
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 4.8
 
 Tags: 4.8.0-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 4.8/alpine
 
 Tags: 4.8.0-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
@@ -56,10 +56,10 @@ GitCommit: 8345a12b6da2f0f124eb60cc248158a40b66d77f
 Directory: 4.8/onbuild
 
 Tags: 4.8.0-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 4.8/slim
 
 Tags: 4.8.0-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
+GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
This update adds the latest version of Yarn (0.21.3) to all the Node.js Docker images and variants:

- nodejs/docker-node#337
- nodejs/docker-node#342
- https://yarnpkg.com/

It also includes the improvements requested at https://github.com/docker-library/official-images/pull/2703#issuecomment-283201291 and supercedes #2703