### PR TITLE
Bump traefik to v1.2.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,11 +2,11 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.2.0-rc1, 1.2.0-rc1, morbier
-GitCommit: 134b33b66a8baf086557d9cca58b68f74e09e4b6
+Tags: v1.2.0-rc2, 1.2.0-rc2, morbier
+GitCommit: fa6fb13db40245897577a76e8bf598d361e19bb1
 
-Tags: v1.2.0-rc1-alpine, 1.2.0-rc1-alpine, morbier-alpine
-GitCommit: 134b33b66a8baf086557d9cca58b68f74e09e4b6
+Tags: v1.2.0-rc2-alpine, 1.2.0-rc2-alpine, morbier-alpine
+GitCommit: fa6fb13db40245897577a76e8bf598d361e19bb1
 Directory: alpine
 
 Tags: v1.1.2, 1.1.2, camembert, latest


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.2.0-rc2
/cc @vdemeester

Cheers