### PR TITLE
Update for Node.js v7.7.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,27 +1,27 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/0f8446512970e9330a95e417deaa0200dc9790cf/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/1d328d2d967bd3a8d9b0260566383775d1a4aecc/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.6.0, 7.6, 7, latest
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
-Directory: 7.6
+Tags: 7.7.0, 7.7, 7, latest
+GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Directory: 7.7
 
-Tags: 7.6.0-alpine, 7.6-alpine, 7-alpine, alpine
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
-Directory: 7.6/alpine
+Tags: 7.7.0-alpine, 7.7-alpine, 7-alpine, alpine
+GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Directory: 7.7/alpine
 
-Tags: 7.6.0-onbuild, 7.6-onbuild, 7-onbuild, onbuild
-GitCommit: 0f8446512970e9330a95e417deaa0200dc9790cf
-Directory: 7.6/onbuild
+Tags: 7.7.0-onbuild, 7.7-onbuild, 7-onbuild, onbuild
+GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Directory: 7.7/onbuild
 
-Tags: 7.6.0-slim, 7.6-slim, 7-slim, slim
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
-Directory: 7.6/slim
+Tags: 7.7.0-slim, 7.7-slim, 7-slim, slim
+GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Directory: 7.7/slim
 
-Tags: 7.6.0-wheezy, 7.6-wheezy, 7-wheezy, wheezy
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
-Directory: 7.6/wheezy
+Tags: 7.7.0-wheezy, 7.7-wheezy, 7-wheezy, wheezy
+GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Directory: 7.7/wheezy
 
 Tags: 6.10.0, 6.10, 6, boron
 GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.7.0/
- https://github.com/nodejs/docker-node/pull/343