### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -1,29 +1,41 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/a5a6b1294bd3a987d6410887ba895e5649dc163c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/4bc238b11f42dfb7bc26875cfea759f5709bb76d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.0-beta1-apache, 8.3-rc-apache, rc-apache, 8.3.0-beta1, 8.3-rc, rc
-GitCommit: f44562053cce67381e83f818d98e675ff74bfb4a
+Tags: 8.3.0-rc1-apache, 8.3-rc-apache, rc-apache, 8.3.0-rc1, 8.3-rc, rc
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 8.3-rc/apache
 
-Tags: 8.3.0-beta1-fpm, 8.3-rc-fpm, rc-fpm
-GitCommit: f44562053cce67381e83f818d98e675ff74bfb4a
+Tags: 8.3.0-rc1-fpm, 8.3-rc-fpm, rc-fpm
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 8.3-rc/fpm
 
+Tags: 8.3.0-rc1-fpm-alpine, 8.3-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Directory: 8.3-rc/fpm-alpine
+
 Tags: 8.2.6-apache, 8.2-apache, 8-apache, apache, 8.2.6, 8.2, 8, latest
-GitCommit: 1ad01e8c9b0b34d8525e277dc6b4a6aaaddf020f
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 8.2/apache
 
 Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: 1ad01e8c9b0b34d8525e277dc6b4a6aaaddf020f
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 8.2/fpm
 
+Tags: 8.2.6-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Directory: 8.2/fpm-alpine
+
 Tags: 7.54-apache, 7-apache, 7.54, 7
-GitCommit: aac79bfa92b93b484bd1d459adef02789ac2e011
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 7/apache
 
 Tags: 7.54-fpm, 7-fpm
-GitCommit: aac79bfa92b93b484bd1d459adef02789ac2e011
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
 Directory: 7/fpm
+
+Tags: 7.54-fpm-alpine, 7-fpm-alpine
+GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Directory: 7/fpm-alpine

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.2.1, 5.2, 5, latest
-GitCommit: 77a24ba41ba04771ebffb070e815338c68bd7f1c
+Tags: 5.2.2, 5.2, 5, latest
+GitCommit: d1765774a1effc5436f3d1f4ad6826dd9ed2186f
 Directory: 5
 
-Tags: 5.2.1-alpine, 5.2-alpine, 5-alpine, alpine
-GitCommit: 77a24ba41ba04771ebffb070e815338c68bd7f1c
+Tags: 5.2.2-alpine, 5.2-alpine, 5-alpine, alpine
+GitCommit: d1765774a1effc5436f3d1f4ad6826dd9ed2186f
 Directory: 5/alpine
 
 Tags: 2.4.4, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.5, 0.11, 0, latest
-GitCommit: 12006b77bf3f147a0aa81698d8531f0eff3d09c0
+Tags: 0.11.7, 0.11, 0, latest
+GitCommit: f57b040e28dca92eb3e1b072baa9922b12712b6c

--- a/library/golang
+++ b/library/golang
@@ -5,32 +5,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.6.4, 1.6
-GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
-Directory: 1.6
-
-Tags: 1.6.4-onbuild, 1.6-onbuild
-GitCommit: ce284e14cdee73fbaa8fb680011a812f272eae2e
-Directory: 1.6/onbuild
-
-Tags: 1.6.4-wheezy, 1.6-wheezy
-GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
-Directory: 1.6/wheezy
-
-Tags: 1.6.4-alpine, 1.6-alpine
-GitCommit: bfbd521de2942d10d96b14f99c491536490db018
-Directory: 1.6/alpine
-
-Tags: 1.6.4-windowsservercore, 1.6-windowsservercore
-GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
-Directory: 1.6/windows/windowsservercore
-Constraints: windowsservercore
-
-Tags: 1.6.4-nanoserver, 1.6-nanoserver
-GitCommit: fddc8c18282871b554cb0d74780767690bdda3ec
-Directory: 1.6/windows/nanoserver
-Constraints: nanoserver
-
 Tags: 1.7.5, 1.7
 GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
 Directory: 1.7

--- a/library/haproxy
+++ b/library/haproxy
@@ -28,10 +28,10 @@ Tags: 1.6.11-alpine, 1.6-alpine
 GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.6/alpine
 
-Tags: 1.7.2, 1.7, 1, latest
-GitCommit: 20816337017096e325c64627e58141e7c9628004
+Tags: 1.7.3, 1.7, 1, latest
+GitCommit: cdc1bafbfdc9195c843481808e301ee1af087148
 Directory: 1.7
 
-Tags: 1.7.2-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 20816337017096e325c64627e58141e7c9628004
+Tags: 1.7.3-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: cdc1bafbfdc9195c843481808e301ee1af087148
 Directory: 1.7/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.2.1, 5.2, 5, latest
-GitCommit: 672eff5126aa9f5ec73635d41a19032fade90083
+Tags: 5.2.2, 5.2, 5, latest
+GitCommit: beb960fe04ec8cf2b32b114ddbbf41cebc0271b0
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.2.1, 5.2, 5, latest
-GitCommit: 8b6fc0025e4201cca3a35b0bd0c9e564371f9d5f
+Tags: 5.2.2, 5.2, 5, latest
+GitCommit: 7c748e108c6a64d00e7b2dff4831ba6ffc85de2a
 Directory: 5
 
-Tags: 5.2.1-alpine, 5.2-alpine, 5-alpine, alpine
-GitCommit: b9d2c963d400d391b35c9e3f2cb644ddb923a9c4
+Tags: 5.2.2-alpine, 5.2-alpine, 5-alpine, alpine
+GitCommit: 7c748e108c6a64d00e7b2dff4831ba6ffc85de2a
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/piwik
+++ b/library/piwik
@@ -1,5 +1,5 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.0.1, 3.0, 3, latest
-GitCommit: b38670f41cce0b02b63ce6478ebbb0cbd3122eac
+Tags: 3.0.2, 3.0, 3, latest
+GitCommit: ddc78a24c43759a671d27054f20b15644a36af45


### PR DESCRIPTION
- `drupal`: 8.3.0-rc1, add `fpm-alpine` variants (docker-library/drupal#72)
- `elasticsearch`: 5.2.2
- `ghost`: 0.11.7
- `golang`: remove 1.6
- `haproxy`: 1.7.3
- `kibana`: 5.2.2
- `logstash`: 5.2.2
- `piwik`: 3.0.2