### PR TITLE
Node.js v7.7.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,24 +3,24 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.7.0, 7.7, 7, latest
-GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Tags: 7.7.1, 7.7, 7, latest
+GitCommit: 203044fdbf6ceaebd7db52137df102c01c5b6b0d
 Directory: 7.7
 
-Tags: 7.7.0-alpine, 7.7-alpine, 7-alpine, alpine
-GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Tags: 7.7.1-alpine, 7.7-alpine, 7-alpine, alpine
+GitCommit: 203044fdbf6ceaebd7db52137df102c01c5b6b0d
 Directory: 7.7/alpine
 
-Tags: 7.7.0-onbuild, 7.7-onbuild, 7-onbuild, onbuild
-GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Tags: 7.7.1-onbuild, 7.7-onbuild, 7-onbuild, onbuild
+GitCommit: 203044fdbf6ceaebd7db52137df102c01c5b6b0d
 Directory: 7.7/onbuild
 
-Tags: 7.7.0-slim, 7.7-slim, 7-slim, slim
-GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Tags: 7.7.1-slim, 7.7-slim, 7-slim, slim
+GitCommit: 203044fdbf6ceaebd7db52137df102c01c5b6b0d
 Directory: 7.7/slim
 
-Tags: 7.7.0-wheezy, 7.7-wheezy, 7-wheezy, wheezy
-GitCommit: 1d328d2d967bd3a8d9b0260566383775d1a4aecc
+Tags: 7.7.1-wheezy, 7.7-wheezy, 7-wheezy, wheezy
+GitCommit: 203044fdbf6ceaebd7db52137df102c01c5b6b0d
 Directory: 7.7/wheezy
 
 Tags: 6.10.0, 6.10, 6, boron


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.7.1/
- https://github.com/nodejs/docker-node/pull/347