### PR TITLE
alpine: 3.5.2 release + maintenance updates

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,9 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-3.1: git://github.com/gliderlabs/docker-alpine@6a7732123b1e22c836e7ff538828ecf9eb0ebbb3 versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@39157ab3587065a0e0928663dea293ae43110cd9 versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@62168e0f780d64f2124a7be94ed31991a31ae5ad versions/library-3.3
-3.4: git://github.com/gliderlabs/docker-alpine@71c9ce882016759bcc0d47f372d20a1b6ec93cd5 versions/library-3.4
-3.5: git://github.com/gliderlabs/docker-alpine@c584d0198d5dea1c5d942e1e1a7b2504ecdb4d30 versions/library-3.5
-latest: git://github.com/gliderlabs/docker-alpine@c584d0198d5dea1c5d942e1e1a7b2504ecdb4d30 versions/library-3.5
-edge: git://github.com/gliderlabs/docker-alpine@b14ddc0a4f7aed069027aa7943609a4e8e3001fc versions/library-edge
-
+3.1: git://github.com/gliderlabs/docker-alpine@cb0a5a01230693785e876a91b3484c4c05b2b06b versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@c60ae198ab8ac02a28725dfe990b1742c583b156 versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@401eef8812da24776468ff885a41afd2d7958882 versions/library-3.3
+3.4: git://github.com/gliderlabs/docker-alpine@47a904af6b2702a947fe3ce7d741f877c30c11d0 versions/library-3.4
+3.5: git://github.com/gliderlabs/docker-alpine@c7368b846ee805b286d9034a39e0bbf40bc079b3 versions/library-3.5
+latest: git://github.com/gliderlabs/docker-alpine@c7368b846ee805b286d9034a39e0bbf40bc079b3 versions/library-3.5
+edge: git://github.com/gliderlabs/docker-alpine@60d6d06885459a9fa7e5d51d986be89ce61d9c41 versions/library-edge


### PR DESCRIPTION
- update openssl in 3.[1-4] (CVE-2017-3732, CVE-2017-3731)
- update to 3.5.2 in 3.5-stable
- update busybox, libressl and zlib in edge