### PR TITLE
Add "ubuntu:rolling" as an alias for the "latest non-LTS release"

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -8,7 +8,7 @@ GitFetch: refs/heads/dist
 # see also https://wiki.ubuntu.com/Releases#Current
 
 # commits: (master..dist)
-#  - e1055db Update tarballs
+#  - 1a5cb40 Update tarballs
 #    - `ubuntu:precise`: 20170214
 #    - `ubuntu:trusty`: 20170214
 #    - `ubuntu:xenial`: 20170214
@@ -17,25 +17,25 @@ GitFetch: refs/heads/dist
 
 # 20170214
 Tags: 12.04.5, 12.04, precise-20170214, precise
-GitCommit: e1055dbe9145b36c0b2728d0ed0215c67627e2c0
+GitCommit: 1a5cb40f41ac4829d8c301ccd2cf3b7a13687a8b
 Directory: precise
 
 # 20170214
 Tags: 14.04.5, 14.04, trusty-20170214, trusty
-GitCommit: e1055dbe9145b36c0b2728d0ed0215c67627e2c0
+GitCommit: 1a5cb40f41ac4829d8c301ccd2cf3b7a13687a8b
 Directory: trusty
 
 # 20170214
 Tags: 16.04, xenial-20170214, xenial, latest
-GitCommit: e1055dbe9145b36c0b2728d0ed0215c67627e2c0
+GitCommit: 1a5cb40f41ac4829d8c301ccd2cf3b7a13687a8b
 Directory: xenial
 
 # 20170224
-Tags: 16.10, yakkety-20170224, yakkety
-GitCommit: e1055dbe9145b36c0b2728d0ed0215c67627e2c0
+Tags: 16.10, yakkety-20170224, yakkety, rolling
+GitCommit: 1a5cb40f41ac4829d8c301ccd2cf3b7a13687a8b
 Directory: yakkety
 
 # 20170224
 Tags: 17.04, zesty-20170224, zesty, devel
-GitCommit: e1055dbe9145b36c0b2728d0ed0215c67627e2c0
+GitCommit: 1a5cb40f41ac4829d8c301ccd2cf3b7a13687a8b
 Directory: zesty


### PR DESCRIPTION
Closes #2323 (thanks @OddBloke :heart:)

The commit references change, but the only _actual_ change is the addition of the new `ubuntu:rolling` tag which is an alias for `ubuntu:yakkety` right now.