### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/00d19129dcd4637a89309a5c6c10cf6a157b1a3b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/c3ce8229e967d1a243ffc8699ea1d2044647f523/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/julia
+++ b/library/julia
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.5.0, 0.5, 0, latest
-GitCommit: 0f29b23863e4ff1c99b13a30e845b66c7468f79b
+Tags: 0.5.1, 0.5, 0, latest
+GitCommit: 8de8734c2f3547332bc1e8688ba0eff58b3a1a50

--- a/library/openjdk
+++ b/library/openjdk
@@ -32,8 +32,8 @@ Tags: 8u121-jdk, 8u121, 8-jdk, 8, jdk, latest
 GitCommit: 445f8b8d18d7c61e2ae7fda76d8883b5d51ae0a5
 Directory: 8-jdk
 
-Tags: 8u111-jdk-alpine, 8u111-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
+Tags: 8u121-jdk-alpine, 8u121-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jdk/alpine
 
 Tags: 8u121-jdk-windowsservercore, 8u121-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
@@ -50,14 +50,14 @@ Tags: 8u121-jre, 8-jre, jre
 GitCommit: 445f8b8d18d7c61e2ae7fda76d8883b5d51ae0a5
 Directory: 8-jre
 
-Tags: 8u111-jre-alpine, 8-jre-alpine, jre-alpine
-GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
+Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine
+GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jre/alpine
 
-Tags: 9-b158-jdk, 9-b158, 9-jdk, 9
-GitCommit: 97ab55cab073e87658ec6f993538038bfc7a858d
+Tags: 9-b159-jdk, 9-b159, 9-jdk, 9
+GitCommit: d183725a5acda253132f21011fe903f3924e7e12
 Directory: 9-jdk
 
-Tags: 9-b158-jre, 9-jre
-GitCommit: 97ab55cab073e87658ec6f993538038bfc7a858d
+Tags: 9-b159-jre, 9-jre
+GitCommit: d183725a5acda253132f21011fe903f3924e7e12
 Directory: 9-jre

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
+GitCommit: daf4be52f413ad4121f9366f5e1b9a02f763f7b1
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
+GitCommit: daf4be52f413ad4121f9366f5e1b9a02f763f7b1
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: 448e0b809772b225d3fc2cbc3a6a2cc551e65400
+GitCommit: daf4be52f413ad4121f9366f5e1b9a02f763f7b1
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.6, 2.2
-GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
+GitCommit: fdfa234d2264af31a45af27c782844761dc4cbd0
 Directory: 2.2
 
 Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
+GitCommit: fdfa234d2264af31a45af27c782844761dc4cbd0
 Directory: 2.2/slim
 
 Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 60957cdfc0986eef4a6063e083d5ff27c901014a
+GitCommit: fdfa234d2264af31a45af27c782844761dc4cbd0
 Directory: 2.2/alpine
 
 Tags: 2.2.6-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.3, 2.3
-GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
+GitCommit: 0053e6ec1b9c5b86e5201def195993518590d22c
 Directory: 2.3
 
 Tags: 2.3.3-slim, 2.3-slim
-GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
+GitCommit: 0053e6ec1b9c5b86e5201def195993518590d22c
 Directory: 2.3/slim
 
 Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: aba4590582d91d49926558ac27b9f005c7488bc9
+GitCommit: 0053e6ec1b9c5b86e5201def195993518590d22c
 Directory: 2.3/alpine
 
 Tags: 2.3.3-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.0, 2.4, 2, latest
-GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
+GitCommit: 1c70fd4133287f2273a0cd890a21c91d8da98094
 Directory: 2.4
 
 Tags: 2.4.0-slim, 2.4-slim, 2-slim, slim
-GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
+GitCommit: 1c70fd4133287f2273a0cd890a21c91d8da98094
 Directory: 2.4/slim
 
 Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 2ad277a78dc56dff66b50ab7c17533f50f125008
+GitCommit: 1c70fd4133287f2273a0cd890a21c91d8da98094
 Directory: 2.4/alpine
 
 Tags: 2.4.0-onbuild, 2.4-onbuild, 2-onbuild, onbuild

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.2-apache, 4.7-apache, 4-apache, apache, 4.7.2, 4.7, 4, latest, 4.7.2-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.2-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-apache, 4.7-apache, 4-apache, apache, 4.7.3, 4.7, 4, latest, 4.7.3-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.3-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php5.6/apache
 
-Tags: 4.7.2-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.2-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.3-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php5.6/fpm
 
-Tags: 4.7.2-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.2-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.3-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.2-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.2-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.3-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.0/apache
 
-Tags: 4.7.2-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.0/fpm
 
-Tags: 4.7.2-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.2-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.2-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.3-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.1/apache
 
-Tags: 4.7.2-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.1/fpm
 
-Tags: 4.7.2-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: b807f1285869a220a5f72b935901603e5bde8822
+Tags: 4.7.3-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.1/fpm-alpine


### PR DESCRIPTION
- `docker`: minor `generate-stackbrew-library.sh` change
- `julia`: 0.5.1
- `openjdk`: update to Alpine 3.5 for Java 8 to get 8u121 (docker-library/openjdk#103)
- `ruby`: bundler 1.14.6
- `wordpress`: 4.7.3