### PR TITLE
Update docker-library images

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: 5159417968c6a08e2ed784498cba28f22a74b03e
 Directory: 9.6
 
 Tags: 9.6.2-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: dd88d2f02ad0f9852a7b33a8b542e14f5867b0c1
+GitCommit: 439c4976afbc9cb8c1fbc9c9783c84f62856a3c4
 Directory: 9.6/alpine
 
 Tags: 9.5.6, 9.5
@@ -17,7 +17,7 @@ GitCommit: a869eeccfb98c9653fca9f135f3bafa758c6f4f7
 Directory: 9.5
 
 Tags: 9.5.6-alpine, 9.5-alpine
-GitCommit: 738ec9015ca92fa79e541514f51b37a8d69e4979
+GitCommit: 439c4976afbc9cb8c1fbc9c9783c84f62856a3c4
 Directory: 9.5/alpine
 
 Tags: 9.4.11, 9.4
@@ -25,7 +25,7 @@ GitCommit: 1e7af691a3981ec1c86d23d585dcebd9154d1cd0
 Directory: 9.4
 
 Tags: 9.4.11-alpine, 9.4-alpine
-GitCommit: 5408eaec65c84374dd6a8f2f2e900197d50cf6c4
+GitCommit: 439c4976afbc9cb8c1fbc9c9783c84f62856a3c4
 Directory: 9.4/alpine
 
 Tags: 9.3.16, 9.3
@@ -33,7 +33,7 @@ GitCommit: 6870d3db740a321699ef49c8068c3d812b9681e1
 Directory: 9.3
 
 Tags: 9.3.16-alpine, 9.3-alpine
-GitCommit: a3b8f2bf53b603713ad84344e0cfc79587507d4b
+GitCommit: 439c4976afbc9cb8c1fbc9c9783c84f62856a3c4
 Directory: 9.3/alpine
 
 Tags: 9.2.20, 9.2
@@ -41,5 +41,5 @@ GitCommit: 8c03e6aed7046c4bacbc1b7c356edd81bd72c6d5
 Directory: 9.2
 
 Tags: 9.2.20-alpine, 9.2-alpine
-GitCommit: 86ef6fa873cdc310e9f23a127ae2865b1d8745ba
+GitCommit: 439c4976afbc9cb8c1fbc9c9783c84f62856a3c4
 Directory: 9.2/alpine


### PR DESCRIPTION
- `postgres`: add OSSP uuid to 9.2 and 9.3 Alpine images (docker-library/postgres#255)