### PR TITLE
Update Solr to 5.5.4, 6.4.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,26 +1,26 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.5.4: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
-5.5: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
-5: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
+5.5.4: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
+5.5: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
+5: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
 
-5.5.4-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
+5.5.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
 
-6.3.0: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3
-6.3: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3
+6.3.0: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3
+6.3: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3
 
-6.3.0-alpine: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3/alpine
-6.3-alpine: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3/alpine
+6.3.0-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3/alpine
+6.3-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3/alpine
 
-6.4.2: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
-6.4: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
-6: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
-latest: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
+6.4.2: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
+6.4: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
+6: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
+latest: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
 
-6.4.2-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
-6.4-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
+6.4.2-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
+6.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
+alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine

--- a/library/solr
+++ b/library/solr
@@ -1,26 +1,26 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.5.3: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5
-5.5: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5
-5: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5
+5.5.4: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
+5.5: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
+5: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5
 
-5.5.3-alpine: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 5.5/alpine
+5.5.4-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@54eefcbc49ce702c380a280df8add6a854206037 5.5/alpine
 
-6.3.0: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 6.3
-6.3: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 6.3
+6.3.0: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3
+6.3: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3
 
-6.3.0-alpine: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 6.3/alpine
-6.3-alpine: git://github.com/docker-solr/docker-solr@20e09a91045415c324bb6575bd63191624fa3875 6.3/alpine
+6.3.0-alpine: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3/alpine
+6.3-alpine: git://github.com/docker-solr/docker-solr@be05c8c5748e588d38cb0ed96770cf7ba9956589 6.3/alpine
 
-6.4.1: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4
-6.4: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4
-6: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4
-latest: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4
+6.4.2: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
+6.4: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
+6: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
+latest: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4
 
-6.4.1-alpine: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4/alpine
-6.4-alpine: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4/alpine
-alpine: git://github.com/docker-solr/docker-solr@8afee8bf17a7a3d1fdc453643abfdb5cf2e822d0 6.4/alpine
+6.4.2-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
+6.4-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine
+alpine: git://github.com/docker-solr/docker-solr@1315e4cf250e4d543312c7a36eac6235c50e3bc9 6.4/alpine


### PR DESCRIPTION
- Updated to Solr 6.4.2 (see announcement on http://mail-archives.apache.org/mod_mbox/www-announce/201703.mbox/%3CCAHPRk5EORQ9A4QHAuz_qBBpfU-NNL%3D0Pdao4o8VWmafoN-3zfA%40mail.gmail.com%3E, and changes https://lucene.apache.org/solr/6_4_2/changes/Changes.html. Note this includes a fix for a serious performance degradation)
- Updated to Solr 5.5.4 (see announcement on http://mail-archives.apache.org/mod_mbox/www-announce/201702.mbox/%3CCAPsWd%2BMy7eeWqNrNqPCNV%2BswKzXL%3DYf8WWvasfhK2-DsRDi0SQ%40mail.gmail.com%3E)
- improved error reporting for init-solr-home (https://github.com/docker-solr/docker-solr/issues/107)
- improved GPG verification (https://github.com/docker-solr/docker-solr/issues/106)