### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -7,13 +7,13 @@ GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
 Tags: 1.26.2-glibc, 1.26-glibc, 1-glibc, glibc
-GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
+GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
 Directory: glibc
 
 Tags: 1.26.2-musl, 1.26-musl, 1-musl, musl
-GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
+GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
 Directory: musl
 
 Tags: 1.26.2-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.2, 1.26, 1, latest
-GitCommit: dc7ac200409e8c5dc5c09ef26bfa82dbfec4605b
+GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
 Directory: uclibc

--- a/library/cassandra
+++ b/library/cassandra
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.17, 2.1
-GitCommit: 3535be36e7b48b24b5abedebd345b5286bcffa60
+GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 2.1
 
 Tags: 2.2.9, 2.2, 2
-GitCommit: 3b54d76bf451717222e028b7db44044b03a3e620
+GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 2.2
 
 Tags: 3.0.11, 3.0
-GitCommit: 6c3f791c239b24a25d9766edb6b4d22c71669cee
+GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 3.0
 
 Tags: 3.10, 3, latest
-GitCommit: 71d979a201b63d94ed904eef6218d50e2142845d
+GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 3.10

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.1.21, 10.1, 10, latest
 GitCommit: b558f64b736650b94df9a90e68ff9e3bc03d4bdb
 Directory: 10.1
 
-Tags: 10.0.29, 10.0
-GitCommit: b8a9bd6870bb327db7b238dc6efe909e5e7b399f
+Tags: 10.0.30, 10.0
+GitCommit: 76bf9d41fc187f83da5819601d6f964722759ebb
 Directory: 10.0
 
 Tags: 5.5.54, 5.5, 5


### PR DESCRIPTION
- `busybox`: switch `musl` variant builder to Alpine 3.5, switch `glibc` and `uclibc` builders to use `debian:jessie-slim`
- `cassandra`: include `cassandra-tools` (docker-library/cassandra#83)
- `mariadb`: 10.0.30