### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -12,8 +12,8 @@ Tags: 2.2.9, 2.2, 2
 GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 2.2
 
-Tags: 3.0.11, 3.0
-GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
+Tags: 3.0.12, 3.0
+GitCommit: 7ba44ab0fe6d8afdcad2ffe101303f13da20fff6
 Directory: 3.0
 
 Tags: 3.10, 3, latest

--- a/library/irssi
+++ b/library/irssi
@@ -4,10 +4,10 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.0.1, 1.0, 1, latest
-GitCommit: 02529da6afd7846e0024c9a8b72ab6a32b4cd402
+Tags: 1.0.2, 1.0, 1, latest
+GitCommit: f1d77f854e3eb49ba761723d608bfb6b3ddb867a
 Directory: debian
 
-Tags: 1.0.1-alpine, 1.0-alpine, 1-alpine, alpine
-GitCommit: 02529da6afd7846e0024c9a8b72ab6a32b4cd402
+Tags: 1.0.2-alpine, 1.0-alpine, 1-alpine, alpine
+GitCommit: f1d77f854e3eb49ba761723d608bfb6b3ddb867a
 Directory: alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,28 +1,28 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/c34d30fb49679a5bca90d2d3d37a6ce1dd6116e9/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/77da4fddf173fce45be73b74ba2471a9fb813239/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 10.0.3-apache, 10.0-apache, 10-apache, 10.0.3, 10.0, 10
-GitCommit: e8590ef1b7cd06aa3312cbdbfed951f4723e6ba3
+Tags: 10.0.4-apache, 10.0-apache, 10-apache, 10.0.4, 10.0, 10
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 10.0/apache
 
-Tags: 10.0.3-fpm, 10.0-fpm, 10-fpm
-GitCommit: e8590ef1b7cd06aa3312cbdbfed951f4723e6ba3
+Tags: 10.0.4-fpm, 10.0-fpm, 10-fpm
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 10.0/fpm
 
-Tags: 11.0.1-apache, 11.0-apache, 11-apache, apache, 11.0.1, 11.0, 11, latest
-GitCommit: e8590ef1b7cd06aa3312cbdbfed951f4723e6ba3
+Tags: 11.0.2-apache, 11.0-apache, 11-apache, 11.0.2, 11.0, 11
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 11.0/apache
 
-Tags: 11.0.1-fpm, 11.0-fpm, 11-fpm, fpm
-GitCommit: e8590ef1b7cd06aa3312cbdbfed951f4723e6ba3
+Tags: 11.0.2-fpm, 11.0-fpm, 11-fpm
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 11.0/fpm
 
-Tags: 9.0.56-apache, 9.0-apache, 9-apache, 9.0.56, 9.0, 9
-GitCommit: e0c8ce80b26d4755a9a2bfeb3c42c40c89d8c4f8
+Tags: 9.0.57-apache, 9.0-apache, 9-apache, 9.0.57, 9.0, 9
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 9.0/apache
 
-Tags: 9.0.56-fpm, 9.0-fpm, 9-fpm
-GitCommit: e0c8ce80b26d4755a9a2bfeb3c42c40c89d8c4f8
+Tags: 9.0.57-fpm, 9.0-fpm, 9-fpm
+GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 9.0/fpm


### PR DESCRIPTION
- `cassandra`: 3.0.12
- `irssi`: 1.0.2
- `nextcloud`: 9.0.57, 10.0.4 and 11.0.2 (nextcloud/docker#41)