### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,28 +4,28 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.0-rc1-apache, 8.3-rc-apache, rc-apache, 8.3.0-rc1, 8.3-rc, rc
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.3.0-rc2-apache, 8.3-rc-apache, rc-apache, 8.3.0-rc2, 8.3-rc, rc
+GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
 Directory: 8.3-rc/apache
 
-Tags: 8.3.0-rc1-fpm, 8.3-rc-fpm, rc-fpm
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.3.0-rc2-fpm, 8.3-rc-fpm, rc-fpm
+GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
 Directory: 8.3-rc/fpm
 
-Tags: 8.3.0-rc1-fpm-alpine, 8.3-rc-fpm-alpine, rc-fpm-alpine
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.3.0-rc2-fpm-alpine, 8.3-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
 Directory: 8.3-rc/fpm-alpine
 
-Tags: 8.2.6-apache, 8.2-apache, 8-apache, apache, 8.2.6, 8.2, 8, latest
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.2.7-apache, 8.2-apache, 8-apache, apache, 8.2.7, 8.2, 8, latest
+GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
 Directory: 8.2/apache
 
-Tags: 8.2.6-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.2.7-fpm, 8.2-fpm, 8-fpm, fpm
+GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
 Directory: 8.2/fpm
 
-Tags: 8.2.6-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: e8e2309427218cb2e250a3af013e8efe54703404
+Tags: 8.2.7-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
 Directory: 8.2/fpm-alpine
 
 Tags: 7.54-apache, 7-apache, 7.54, 7

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.1.21, 10.1, 10, latest
-GitCommit: b558f64b736650b94df9a90e68ff9e3bc03d4bdb
+Tags: 10.1.22, 10.1, 10, latest
+GitCommit: 58422728079b38cfd883d11fa1ec0252fa6779fe
 Directory: 10.1
 
 Tags: 10.0.30, 10.0

--- a/library/memcached
+++ b/library/memcached
@@ -5,9 +5,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.4.35, 1.4, 1, latest
-GitCommit: c7e9192a40c261a9d8743eafa348fc6af1b454f8
+GitCommit: 0c32d28898ba19637ab990b3c092b9e178dfade0
 Directory: debian
 
 Tags: 1.4.35-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: c7e9192a40c261a9d8743eafa348fc6af1b454f8
+GitCommit: 0c32d28898ba19637ab990b3c092b9e178dfade0
 Directory: alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -4,25 +4,25 @@ Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 10.0.4-apache, 10.0-apache, 10-apache, 10.0.4, 10.0, 10
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
 Directory: 10.0/apache
 
 Tags: 10.0.4-fpm, 10.0-fpm, 10-fpm
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
 Directory: 10.0/fpm
 
-Tags: 11.0.2-apache, 11.0-apache, 11-apache, 11.0.2, 11.0, 11
+Tags: 11.0.2-apache, 11.0-apache, 11-apache, apache, 11.0.2, 11.0, 11, latest
 GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 11.0/apache
 
-Tags: 11.0.2-fpm, 11.0-fpm, 11-fpm
+Tags: 11.0.2-fpm, 11.0-fpm, 11-fpm, fpm
 GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
 Directory: 11.0/fpm
 
 Tags: 9.0.57-apache, 9.0-apache, 9-apache, 9.0.57, 9.0, 9
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
 Directory: 9.0/apache
 
 Tags: 9.0.57-fpm, 9.0-fpm, 9-fpm
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
 Directory: 9.0/fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.6, 3.6, 3, latest
-GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
+Tags: 3.6.7, 3.6, 3, latest
+GitCommit: 9646c8c3908387ff91e027566204ef6421a31f2d
 Directory: debian
 
-Tags: 3.6.6-management, 3.6-management, 3-management, management
+Tags: 3.6.7-management, 3.6-management, 3-management, management
 GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
 Directory: debian/management
 
-Tags: 3.6.6-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 370d42f7ff049b8194637668d972216026c3d144
+Tags: 3.6.7-alpine, 3.6-alpine, 3-alpine, alpine
+GitCommit: e8b2c67785ed0708fee28fedbccb6d84abf3b293
 Directory: alpine
 
-Tags: 3.6.6-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.6.7-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
 GitCommit: 74a9d28d4882360eab74a1b9d78ec67143cef345
 Directory: alpine/management

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,18 +44,18 @@ Tags: 8.0.41-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
 GitCommit: e4ffae4e6e76e979ad524970f80984ee4cff88d7
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.11-jre8, 8.5-jre8, 8.5.11, 8.5
-GitCommit: e06eaa32013932a95835399c0ae4a497134db0a5
+Tags: 8.5.12-jre8, 8.5-jre8, 8.5.12, 8.5
+GitCommit: db35ce4f9b3ea68419f5c0a908cbf83343bbc0ca
 Directory: 8.5/jre8
 
-Tags: 8.5.11-jre8-alpine, 8.5-jre8-alpine, 8.5.11-alpine, 8.5-alpine
-GitCommit: 023eb5126ff70b769f1f84b28c440fb6128bffe7
+Tags: 8.5.12-jre8-alpine, 8.5-jre8-alpine, 8.5.12-alpine, 8.5-alpine
+GitCommit: 89b879193cbf8eff9792d847f2bdc285647ded15
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M17-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M17, 9.0.0, 9.0, 9
-GitCommit: d759792f71eb5889c1e73c01d47a2e1b2a6bae7b
+Tags: 9.0.0.M18-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M18, 9.0.0, 9.0, 9
+GitCommit: 8b361a27d3ea746682b8dd93327d6b5e376b8dee
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M17-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M17-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 075a394e34f7329415e87ad5f0d77d46aac24876
+Tags: 9.0.0.M18-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M18-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: a2fb7998939d5dcd40c1b01382b0b62a47d06c54
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `drupal`: 8.2.7, 8.3.0-rc2
- `mariadb`: 10.1.22
- `memcached`: use `https` (docker-library/memcached#17)
- `nextcloud`: PHP version back to 5.6 for 9 and 10
- `rabbitmq`: 3.6.7
- `tomcat`: 8.5.12, 9.0.0.M18