### PR TITLE
openSUSE: update images

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -7,16 +7,16 @@ Constraints: !aufs
 
 Tags: 42.2, leap, latest
 GitFetch: refs/heads/openSUSE-42.2
-GitCommit: a8957648fda4fe9628021c45d3d9937641d74d77
+GitCommit: bae99d3adc6eb7ce723648ead93c64516b8813a3
 
 Tags: 42.1
 GitFetch: refs/heads/openSUSE-42.1
-GitCommit: 2395f4feda48485ee61d0d3582dd875a6400831e
+GitCommit: b979c73ab7c69db3e92cbda2cb3d11511d55c78f
 
 Tags: 13.2, harlequin
 GitFetch: refs/heads/openSUSE-13.2
-GitCommit: 4d42cf8daf415e9e9c732ffa7532857a67f3ab5f
+GitCommit: 1fe6144ea730537817480079ff4cbbdcc5de8cce
 
 Tags: tumbleweed
 GitFetch: refs/heads/openSUSE-Tumbleweed
-GitCommit: 888608e52b0b3fe54dcafb6e82e78235bb252fb9
+GitCommit: 4f6938c5ab5cd6ba01e6155d4e4240cd09b25b41


### PR DESCRIPTION
The updated images contain fixes for various bugs.

Signed-off-by: Thomas Hipp <thipp@suse.de>