### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.14, 3.0
-GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
+GitCommit: 27f2722bb2ebd26354321adc8c3f19f7958529e1
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.12, 3.2
-GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
+GitCommit: 27f2722bb2ebd26354321adc8c3f19f7958529e1
 Directory: 3.2
 
 Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: 4a81205a13fefc418355248f750551e4f7c62361
+GitCommit: 27f2722bb2ebd26354321adc8c3f19f7958529e1
 Directory: 3.4
 
 Tags: 3.4.2-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore

--- a/library/pypy
+++ b/library/pypy
@@ -16,14 +16,14 @@ Tags: 2-5.7.0-onbuild, 2-5.7-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-5.5.0-alpha, 3-5.5.0, 3-5.5, 3-5, 3, latest
-GitCommit: d280acb013c2248452caf98117334eab9da5a8f6
+Tags: 3-5.7.0, 3-5.7, 3-5, 3, latest
+GitCommit: efd06021f245f79c905bf0db5e24031ca62a4dbe
 Directory: 3
 
-Tags: 3-5.5.0-alpha-slim, 3-5.5.0-slim, 3-5.5-slim, 3-5-slim, 3-slim, slim
-GitCommit: 95f6702ded19c44f5dc872ff5ea0374138804829
+Tags: 3-5.7.0-slim, 3-5.7-slim, 3-5-slim, 3-slim, slim
+GitCommit: efd06021f245f79c905bf0db5e24031ca62a4dbe
 Directory: 3/slim
 
-Tags: 3-5.5.0-alpha-onbuild, 3-5.5.0-onbuild, 3-5.5-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Tags: 3-5.7.0-onbuild, 3-5.7-onbuild, 3-5-onbuild, 3-onbuild, onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild


### PR DESCRIPTION
- `mongo`: add `docker-entrypoint-initdb.d` behavior with (optional) automated "root" user creation (docker-library/mongo#145)
- `pypy`: pypy3-5.7.0