### PR TITLE
Update registry for v2.6.1-rc.2

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -7,5 +7,6 @@
 2: git://github.com/docker/distribution-library-image@4339e1083299550aeb5915e0d5a5238d159872da
 2.6: git://github.com/docker/distribution-library-image@4339e1083299550aeb5915e0d5a5238d159872da
 2.6.0: git://github.com/docker/distribution-library-image@4339e1083299550aeb5915e0d5a5238d159872da
+2.6.1-rc.2: git://github.com/docker/distribution-library-image@125d5f1ef4f3d60f5a19cf9dc867be80e1b3ef00
 latest: git://github.com/docker/distribution-library-image@4339e1083299550aeb5915e0d5a5238d159872da
 


### PR DESCRIPTION
Second release candidate for registry patch release (rc1 was updated to rc2 before updating image).

See https://github.com/docker/distribution/releases/tag/v2.6.1-rc.2

ping @dmp42 @aaronlehmann @marcusmartins 