### PR TITLE
Update for Node.js v7.7.4, v6.10.1 and v4.8.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,63 +3,63 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.7.3, 7.7, 7, latest
-GitCommit: 66084ef79197a4fd1198568fb41bd547ee62b8ae
+Tags: 7.7.4, 7.7, 7, latest
+GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
 Directory: 7.7
 
-Tags: 7.7.3-alpine, 7.7-alpine, 7-alpine, alpine
-GitCommit: 66084ef79197a4fd1198568fb41bd547ee62b8ae
+Tags: 7.7.4-alpine, 7.7-alpine, 7-alpine, alpine
+GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
 Directory: 7.7/alpine
 
-Tags: 7.7.3-onbuild, 7.7-onbuild, 7-onbuild, onbuild
-GitCommit: 66084ef79197a4fd1198568fb41bd547ee62b8ae
+Tags: 7.7.4-onbuild, 7.7-onbuild, 7-onbuild, onbuild
+GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
 Directory: 7.7/onbuild
 
-Tags: 7.7.3-slim, 7.7-slim, 7-slim, slim
-GitCommit: 66084ef79197a4fd1198568fb41bd547ee62b8ae
+Tags: 7.7.4-slim, 7.7-slim, 7-slim, slim
+GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
 Directory: 7.7/slim
 
-Tags: 7.7.3-wheezy, 7.7-wheezy, 7-wheezy, wheezy
-GitCommit: 66084ef79197a4fd1198568fb41bd547ee62b8ae
+Tags: 7.7.4-wheezy, 7.7-wheezy, 7-wheezy, wheezy
+GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
 Directory: 7.7/wheezy
 
-Tags: 6.10.0, 6.10, 6, boron
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 6.10.1, 6.10, 6, boron
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10
 
-Tags: 6.10.0-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 6.10.1-alpine, 6.10-alpine, 6-alpine, boron-alpine
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10/alpine
 
-Tags: 6.10.0-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
-GitCommit: db2660f326fdad12a21dd5e7351053a4d0691099
+Tags: 6.10.1-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10/onbuild
 
-Tags: 6.10.0-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 6.10.1-slim, 6.10-slim, 6-slim, boron-slim
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10/slim
 
-Tags: 6.10.0-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 6.10.1-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10/wheezy
 
-Tags: 4.8.0, 4.8, 4, argon
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 4.8.1, 4.8, 4, argon
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 4.8
 
-Tags: 4.8.0-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 4.8.1-alpine, 4.8-alpine, 4-alpine, argon-alpine
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 4.8/alpine
 
-Tags: 4.8.0-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 8345a12b6da2f0f124eb60cc248158a40b66d77f
+Tags: 4.8.1-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 4.8/onbuild
 
-Tags: 4.8.0-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 4.8.1-slim, 4.8-slim, 4-slim, argon-slim
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 4.8/slim
 
-Tags: 4.8.0-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: debf4ea17cee8c078df632e975ea69f1969094c0
+Tags: 4.8.1-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v4.8.1/
- https://nodejs.org/en/blog/release/v6.10.1/
- https://nodejs.org/en/blog/release/v7.7.4/
- https://github.com/nodejs/docker-node/pull/361
- https://github.com/nodejs/docker-node/pull/360