### PR TITLE
Update to Adminer 4.3.0

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -1,10 +1,10 @@
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
-Tags: 4.2.5-standalone, 4.2-standalone, 4-standalone, standalone, 4.2.5, 4.2, 4, latest
-GitCommit: 66fd66f352b5447d154bfed125d10b0c9ea61c2b
-Directory: 4.2
+Tags: 4.3.0-standalone, 4.3-standalone, 4-standalone, standalone, 4.3.0, 4.3, 4, latest
+GitCommit: 583a3425bf560b744f0ac16be398b2b589474c8b
+Directory: 4.3
 
-Tags: 4.2.5-fastcgi, 4.2-fastcgi, 4-fastcgi, fastcgi
-GitCommit: 66fd66f352b5447d154bfed125d10b0c9ea61c2b
-Directory: 4.2/fastcgi
+Tags: 4.3.0-fastcgi, 4.3-fastcgi, 4-fastcgi, fastcgi
+GitCommit: a07553cc164c5fd9533cda44568a58dfad0fa864
+Directory: 4.3/fastcgi


### PR DESCRIPTION
This updates Adminer to the new upstream release 4.3.0 and fixes a stop issue with the standalone version of this image.