### PR TITLE
Update Solr to 6.5.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -24,3 +24,9 @@ latest: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd08373
 6.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
 6-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
 alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
+
+6.5.0: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5
+6.5: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5
+
+6.5.0-alpine: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5/alpine
+6.5-alpine: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5/alpine


### PR DESCRIPTION
Update Solr to 6.5.0 (see announcement on https://github.com/docker-library/official-images/compare/master...docker-solr:master?expand=1 and changes on https://lucene.apache.org/solr/6_5_0/changes/Changes.html