### PR TITLE
Add new version (7.4.3) of Bonita BPM

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -1,7 +1,8 @@
 # maintainer: Jérémy Jacquier-Roux <jeremy.jacquier-roux@bonitasoft.org> (@JeremJR)
 # maintainer: Guillaume Rosinosky <guillaume.rosinosky@bonitasoft.org> (@guillaumerosinosky)
 # maintainer: Truc Nguyen <truc.nguyen@bonitasoft.org> (@tnguyen1)
+# maintainer: Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur)
 
 7.3.3: git://github.com/Bonitasoft-Community/docker_bonita@19d78ec0f212891e97814b2db30891b9b280f7e5 7.3
-7.4.2: git://github.com/Bonitasoft-Community/docker_bonita@3cba78412d44ab6719dcd3951db11feaa76a8dfc 7.4
-latest: git://github.com/Bonitasoft-Community/docker_bonita@3cba78412d44ab6719dcd3951db11feaa76a8dfc 7.4
+7.4.3: git://github.com/Bonitasoft-Community/docker_bonita@5e4d4c6d86a90b2f7639215e4098097200a8751a 7.4
+latest: git://github.com/Bonitasoft-Community/docker_bonita@5e4d4c6d86a90b2f7639215e4098097200a8751a 7.4


### PR DESCRIPTION
* update version to 7.4.3
* add build arguments to Dockerfile to allow:
  * override bonita version (may include snapshot versions for internal use)
  * override tomcat version (in case of upgrade due to security fix)
  * override download URL (e.g. private repo)
  * override expected sha256 (for previous reasons)

keep same behaviour if no extra arg arg provided

to override any added argument, add --build-arg key=value while running docker buil command

this is a required step to build Docker images based on snapshot build and located on exotic server
