### PR TITLE
Adding Oracle Linux 6.9 and updating the 6-slim image accordingly.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/docker-images.git
 GitFetch: refs/heads/OracleLinux-images
-GitCommit: e5227c710ea2c92b0611127552134d757a3d02cc
+GitCommit: eedf4cd96b9904c529c405dfbd4fd0eb4d8ffd89
 
 Tags: 7-slim
 Directory: OracleLinux/7-slim
@@ -21,7 +21,10 @@ Directory: OracleLinux/7.0
 Tags: 6-slim
 Directory: OracleLinux/6-slim
 
-Tags: 6, 6.8
+Tags: 6, 6.9
+Directory: OracleLinux/6.9
+
+Tags: 6.8
 Directory: OracleLinux/6.8
 
 Tags: 6.7


### PR DESCRIPTION
This also changed the `6` tag to point to `6.9`.

Signed-off-by: Avi Miller <avi.miller@oracle.com>