### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/c3ce8229e967d1a243ffc8699ea1d2044647f523/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/1d6dade8477cf2c7911f82980a6d8d12893bf3e3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,15 +16,15 @@ Tags: 17.04.0-ce-rc1-git, 17.04.0-ce-git, 17.04.0-git, 17.04-rc-git, rc-git
 GitCommit: e9c09260bfaea5199c6c053a83fc46564aa14990
 Directory: 17.04-rc/git
 
-Tags: 17.03.0-ce, 17.03.0, 17.03, 17, latest
-GitCommit: bf822e2b9b4f755156b825444562c9865f22557f
+Tags: 17.03.1-ce, 17.03.1, 17.03, 17, latest, stable
+GitCommit: 91d454d113abfb2328c88bbd48b81e495605e809
 Directory: 17.03
 
-Tags: 17.03.0-ce-dind, 17.03.0-dind, 17.03-dind, 17-dind, dind
+Tags: 17.03.1-ce-dind, 17.03.1-dind, 17.03-dind, 17-dind, dind, stable-dind
 GitCommit: bf822e2b9b4f755156b825444562c9865f22557f
 Directory: 17.03/dind
 
-Tags: 17.03.0-ce-git, 17.03.0-git, 17.03-git, 17-git, git
+Tags: 17.03.1-ce-git, 17.03.1-git, 17.03-git, 17-git, git, stable-git
 GitCommit: bf822e2b9b4f755156b825444562c9865f22557f
 Directory: 17.03/git
 

--- a/library/haproxy
+++ b/library/haproxy
@@ -28,10 +28,10 @@ Tags: 1.6.11-alpine, 1.6-alpine
 GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.6/alpine
 
-Tags: 1.7.3, 1.7, 1, latest
-GitCommit: cdc1bafbfdc9195c843481808e301ee1af087148
+Tags: 1.7.4, 1.7, 1, latest
+GitCommit: 059eb2c6a8ee5bf74f90cafd9d1736fa3ebf5aac
 Directory: 1.7
 
-Tags: 1.7.3-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: cdc1bafbfdc9195c843481808e301ee1af087148
+Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: 059eb2c6a8ee5bf74f90cafd9d1736fa3ebf5aac
 Directory: 1.7/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.2.2, 5.2, 5, latest
-GitCommit: beb960fe04ec8cf2b32b114ddbbf41cebc0271b0
+Tags: 5.3.0, 5.3, 5, latest
+GitCommit: d73d06c827383cad1cedc2a3236390f47fab63cd
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.2.2, 5.2, 5, latest
-GitCommit: 7c748e108c6a64d00e7b2dff4831ba6ffc85de2a
+Tags: 5.3.0, 5.3, 5, latest
+GitCommit: bad127e3f5912e5fdbff825e4ac832b725bd0c8d
 Directory: 5
 
-Tags: 5.2.2-alpine, 5.2-alpine, 5-alpine, alpine
-GitCommit: 7c748e108c6a64d00e7b2dff4831ba6ffc85de2a
+Tags: 5.3.0-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: bad127e3f5912e5fdbff825e4ac832b725bd0c8d
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: 1047c0e9975a32102595bc824a2655dee22e595a
+GitCommit: 5ea97c509a67761e32ee4d3ca1c184fcc500481c
 Directory: 3.4
 
 Tags: 3.4.2-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore

--- a/library/mongo
+++ b/library/mongo
@@ -22,11 +22,11 @@ GitCommit: 5c0e43ac8eba7c2fb8cc3de9542f48b31c48da14
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.2, 3.4, 3, latest
-GitCommit: 5ea97c509a67761e32ee4d3ca1c184fcc500481c
+Tags: 3.4.3, 3.4, 3, latest
+GitCommit: 2754d33460e0bfe196dccdccf9a8ff2b43816d00
 Directory: 3.4
 
-Tags: 3.4.2-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 310529fb5cb2ba79e9b28e94af76740a8edbd8a7
+Tags: 3.4.3-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 2754d33460e0bfe196dccdccf9a8ff2b43816d00
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.0, 8.0, 8
-GitCommit: eeb0c33dfcad3db46a0dfb24c352d2a1601c7667
+GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
 Directory: 8.0
 
 Tags: 5.7.17, 5.7, 5, latest
-GitCommit: eeb0c33dfcad3db46a0dfb24c352d2a1601c7667
+GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
 Directory: 5.7
 
 Tags: 5.6.35, 5.6
-GitCommit: b4b7c8eea0690d0406a5ffc2d3404c8c42457a2d
+GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
 Directory: 5.6
 
 Tags: 5.5.54, 5.5
-GitCommit: 56e06bbed26b0e1893493c0dfd168d843c87e766
+GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -37,12 +37,12 @@ GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jdk/alpine
 
 Tags: 8u121-jdk-windowsservercore, 8u121-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
-GitCommit: fbf3a8f396844832bd11a89d6299066a4669383d
+GitCommit: 4815a7dc43f0fb212c40f357624fb4ec943992bf
 Directory: 8-jdk/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 8u121-jdk-nanoserver, 8u121-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
-GitCommit: fbf3a8f396844832bd11a89d6299066a4669383d
+GitCommit: 4815a7dc43f0fb212c40f357624fb4ec943992bf
 Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 

--- a/library/percona
+++ b/library/percona
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.17, 5.7, 5, latest
-GitCommit: 2ae90072239e8fd56bb9dbff13b3f3a2b0f82b83
+GitCommit: ca8b1f78388a0d397a5b95f42597671637f839d7
 Directory: 5.7
 
 Tags: 5.6.35, 5.6
-GitCommit: ab9ff984082a30195b16bb4d5f635ba1b248fecb
+GitCommit: 14bca28392a7571d5288affb108acd4fc794f104
 Directory: 5.6
 
 Tags: 5.5.54, 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.8, 3.6, 3, latest
-GitCommit: 59ecc28d6c3de1aef51cc8a4e869093417dcd4f9
+GitCommit: 0c145281638dcb6e8de8ff37d08168175b5f3665
 Directory: debian
 
 Tags: 3.6.8-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
 Directory: debian/management
 
 Tags: 3.6.8-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 07a16a2856ee8ae9dc50e0ad264e175bf1178dc1
+GitCommit: 0c145281638dcb6e8de8ff37d08168175b5f3665
 Directory: alpine
 
 Tags: 3.6.8-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.8, 3.6, 3, latest
-GitCommit: 0c145281638dcb6e8de8ff37d08168175b5f3665
+Tags: 3.6.9, 3.6, 3, latest
+GitCommit: 6c224be56c42502430716e5d43a1a1726456809a
 Directory: debian
 
-Tags: 3.6.8-management, 3.6-management, 3-management, management
+Tags: 3.6.9-management, 3.6-management, 3-management, management
 GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
 Directory: debian/management
 
-Tags: 3.6.8-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 0c145281638dcb6e8de8ff37d08168175b5f3665
+Tags: 3.6.9-alpine, 3.6-alpine, 3-alpine, alpine
+GitCommit: 945697283f22bf3b21166a8b494447faf67301f6
 Directory: alpine
 
-Tags: 3.6.8-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.6.9-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
 GitCommit: 74a9d28d4882360eab74a1b9d78ec67143cef345
 Directory: alpine/management

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.54.0, 0.54, 0, latest
-GitCommit: 9af840f1f089223168ac7983ddf736ae487cecc8
+Tags: 0.54.2, 0.54, 0, latest
+GitCommit: b3edd574f8bceb7504be78074f561fd6674b96f8

--- a/library/ruby
+++ b/library/ruby
@@ -20,35 +20,35 @@ Tags: 2.1.10-onbuild, 2.1-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
-Tags: 2.2.6, 2.2
-GitCommit: 1f59d1d363dd65945a1feae08da2518ea934c334
+Tags: 2.2.7, 2.2
+GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
 Directory: 2.2
 
-Tags: 2.2.6-slim, 2.2-slim
-GitCommit: 1f59d1d363dd65945a1feae08da2518ea934c334
+Tags: 2.2.7-slim, 2.2-slim
+GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
 Directory: 2.2/slim
 
-Tags: 2.2.6-alpine, 2.2-alpine
-GitCommit: 1f59d1d363dd65945a1feae08da2518ea934c334
+Tags: 2.2.7-alpine, 2.2-alpine
+GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
 Directory: 2.2/alpine
 
-Tags: 2.2.6-onbuild, 2.2-onbuild
+Tags: 2.2.7-onbuild, 2.2-onbuild
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
-Tags: 2.3.3, 2.3
-GitCommit: 7a3e1295bbc840c350fc37d406692301b27f4e86
+Tags: 2.3.4, 2.3
+GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
 Directory: 2.3
 
-Tags: 2.3.3-slim, 2.3-slim
-GitCommit: 7a3e1295bbc840c350fc37d406692301b27f4e86
+Tags: 2.3.4-slim, 2.3-slim
+GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
 Directory: 2.3/slim
 
-Tags: 2.3.3-alpine, 2.3-alpine
-GitCommit: 7a3e1295bbc840c350fc37d406692301b27f4e86
+Tags: 2.3.4-alpine, 2.3-alpine
+GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
 Directory: 2.3/alpine
 
-Tags: 2.3.3-onbuild, 2.3-onbuild
+Tags: 2.3.4-onbuild, 2.3-onbuild
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 


### PR DESCRIPTION
- `docker`: 17.03.1-ce
- `haproxy`: 1.7.4
- `kibana`: 5.3.0
- `logstash`: 5.3.0
- `mongo`: simplify entrypoint for 3.4 (docker-library/mongo#156)
- `mysql`: fetch `--socket` during initdb (docker-library/mysql#266)
- `percona`: `5.7.17-12-1.jessie`, `5.6.35-81.0-1.jessie`, `5.5.54-rel38.7-1.jessie`
- `rabbitmq`: `RABBITMQ_DEFAULT_USER_FILE` & `RABBITMQ_DEFAULT_PASS_FILE` support esp. for Docker secrets (docker-library/rabbitmq#143)
- `rocket.chat`: 0.54.2