### PR TITLE
Updating Oracle Linux 6 images to resolve CVE-2017-2628

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/docker-images.git
 GitFetch: refs/heads/OracleLinux-images
-GitCommit: eedf4cd96b9904c529c405dfbd4fd0eb4d8ffd89
+GitCommit: c5c31e27b7b8c22f53414cf1f567bc6b48c973d5
 
 Tags: 7-slim
 Directory: OracleLinux/7-slim


### PR DESCRIPTION
Description of changes:

[7.19.7-53]
- treat Negotiate authentication as connection-oriented (CVE-2017-2628)

https://oss.oracle.com/pipermail/el-errata/2017-March/006813.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>