### PR TITLE
Update for Node.js v7.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/1d328d2d967bd3a8d9b0260566383775d1a4aecc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/189588b1b52f80f8b3cec7f432ac60c0e884116e/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.7.4, 7.7, 7, latest
-GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
-Directory: 7.7
+Tags: 7.8.0, 7.8, 7, latest
+GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+Directory: 7.8
 
-Tags: 7.7.4-alpine, 7.7-alpine, 7-alpine, alpine
-GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
-Directory: 7.7/alpine
+Tags: 7.8.0-alpine, 7.8-alpine, 7-alpine, alpine
+GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+Directory: 7.8/alpine
 
-Tags: 7.7.4-onbuild, 7.7-onbuild, 7-onbuild, onbuild
-GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
-Directory: 7.7/onbuild
+Tags: 7.8.0-onbuild, 7.8-onbuild, 7-onbuild, onbuild
+GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+Directory: 7.8/onbuild
 
-Tags: 7.7.4-slim, 7.7-slim, 7-slim, slim
-GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
-Directory: 7.7/slim
+Tags: 7.8.0-slim, 7.8-slim, 7-slim, slim
+GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+Directory: 7.8/slim
 
-Tags: 7.7.4-wheezy, 7.7-wheezy, 7-wheezy, wheezy
-GitCommit: 6f9f865df604e72ad2cabe2d78ab12c8f61640cb
-Directory: 7.7/wheezy
+Tags: 7.8.0-wheezy, 7.8-wheezy, 7-wheezy, wheezy
+GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+Directory: 7.8/wheezy
 
 Tags: 6.10.1, 6.10, 6, boron
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
 Directory: 6.10
 
 Tags: 6.10.1-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
 Directory: 6.10/alpine
 
 Tags: 6.10.1-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
@@ -44,11 +44,11 @@ GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
 Directory: 6.10/wheezy
 
 Tags: 4.8.1, 4.8, 4, argon
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
 Directory: 4.8
 
 Tags: 4.8.1-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
 Directory: 4.8/alpine
 
 Tags: 4.8.1-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.8.0/
- https://github.com/nodejs/docker-node/pull/371

Also updates the Alpine variant with new group and user:

- https://github.com/nodejs/docker-node/pull/370