### PR TITLE
Update mongo-basics test to use a seccomp profile to get numactl access

### DIFF
--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -18,8 +18,8 @@ EOF
 
 # need set_mempolicy syscall to be able to do numactl for mongodb
 # if "set_mempolicy" is not in the always allowed list, add it
-extraSeccomp="$(echo "$seccomp" | docker run -i --rm $jqImage --tab '
-.syscalls[] |= if (
+extraSeccomp="$(echo "$seccomp" | docker run -i --rm "$jqImage" --tab '
+	.syscalls[] |= if (
 		.action == "SCMP_ACT_ALLOW"
 		and .args == []
 		and .comment == ""
@@ -42,7 +42,7 @@ cid="$(docker run -d --security-opt seccomp=<(echo "$extraSeccomp") --name "$cna
 trap "docker rm -vf $cid > /dev/null" EXIT
 
 mongo() {
-	docker run --rm -i --security-opt seccomp=<(echo "$extraSeccomp") --link "$cname":mongo --entrypoint mongo "$image" --host mongo "$@"
+	docker run --rm -i --security-opt seccomp=<(echo "$extraSeccomp") --link "$cname":mongo "$image" mongo --host mongo "$@"
 }
 
 mongo_eval() {

--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -3,12 +3,46 @@ set -e
 
 image="$1"
 
+# get docker default seccomp profile
+seccomp="$(wget -q -O - 'https://raw.githubusercontent.com/docker/docker/v17.03.1-ce/profiles/seccomp/default.json')"
+
+# make container with jq since it is not guaranteed on the host
+jqImage='librarytest/mongo-basics-jq:alpine'
+docker build -t "$jqImage" - > /dev/null <<'EOF'
+FROM alpine:3.5
+
+RUN apk add --no-cache jq
+
+ENTRYPOINT ["jq"]
+EOF
+
+# need set_mempolicy syscall to be able to do numactl for mongodb
+# if "set_mempolicy" is not in the always allowed list, add it
+extraSeccomp="$(echo "$seccomp" | docker run -i --rm $jqImage --tab '
+.syscalls[] |= if (
+		.action == "SCMP_ACT_ALLOW"
+		and .args == []
+		and .comment == ""
+		and .includes == {}
+		and .excludes == {}
+	) then (
+		if ( .names | index("set_mempolicy") ) > 0 then
+			.
+		else (
+			.names |= . + ["set_mempolicy"]
+		) end
+	)
+	else
+		.
+	end
+')"
+
 cname="mongo-container-$RANDOM-$RANDOM"
-cid="$(docker run -d --name "$cname" "$image")"
+cid="$(docker run -d --security-opt seccomp=<(echo "$extraSeccomp") --name "$cname" "$image")"
 trap "docker rm -vf $cid > /dev/null" EXIT
 
 mongo() {
-	docker run --rm -i --link "$cname":mongo --entrypoint mongo "$image" --host mongo "$@"
+	docker run --rm -i --security-opt seccomp=<(echo "$extraSeccomp") --link "$cname":mongo --entrypoint mongo "$image" --host mongo "$@"
 }
 
 mongo_eval() {


### PR DESCRIPTION
Uses Docker's default seccomp profile and adds `set_mempolicy` to the always allowed section.

Doesn't guarantee that the mongo test will always use numa, but it should now be available if the host is numa enabled.