### PR TITLE
Update docker-library images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -28,10 +28,10 @@ Tags: 1.6.11-alpine, 1.6-alpine
 GitCommit: 20816337017096e325c64627e58141e7c9628004
 Directory: 1.6/alpine
 
-Tags: 1.7.4, 1.7, 1, latest
-GitCommit: 059eb2c6a8ee5bf74f90cafd9d1736fa3ebf5aac
+Tags: 1.7.5, 1.7, 1, latest
+GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
 Directory: 1.7
 
-Tags: 1.7.4-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 059eb2c6a8ee5bf74f90cafd9d1736fa3ebf5aac
+Tags: 1.7.5-alpine, 1.7-alpine, 1-alpine, alpine
+GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
 Directory: 1.7/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.12, 3.2
-GitCommit: 5fa47142887600edcd437e7689f40342b3572e71
+GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
 Directory: 3.2
 
 Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
@@ -23,10 +23,19 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.3, 3.4, 3, latest
-GitCommit: 812b8fb401a929c312c7222a26b707a6415450c6
+GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
 Directory: 3.4
 
 Tags: 3.4.3-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
 GitCommit: 2754d33460e0bfe196dccdccf9a8ff2b43816d00
 Directory: 3.4/windows/windowsservercore
+Constraints: windowsservercore
+
+Tags: 3.5.5, 3.5, unstable
+GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
+Directory: 3.5
+
+Tags: 3.5.5-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
+Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/pypy
+++ b/library/pypy
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.7.0, 2-5.7, 2-5, 2
-GitCommit: ca2e765c5093389cf9b805fc959d43645a502a77
+Tags: 2-5.7.1, 2-5.7, 2-5, 2
+GitCommit: 92891392566f11de4b80fafe1b2383490350be47
 Directory: 2
 
-Tags: 2-5.7.0-slim, 2-5.7-slim, 2-5-slim, 2-slim
-GitCommit: ca2e765c5093389cf9b805fc959d43645a502a77
+Tags: 2-5.7.1-slim, 2-5.7-slim, 2-5-slim, 2-slim
+GitCommit: 92891392566f11de4b80fafe1b2383490350be47
 Directory: 2/slim
 
-Tags: 2-5.7.0-onbuild, 2-5.7-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.7.1-onbuild, 2-5.7-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-5.7.0, 3-5.7, 3-5, 3, latest
-GitCommit: efd06021f245f79c905bf0db5e24031ca62a4dbe
+Tags: 3-5.7.1, 3-5.7, 3-5, 3, latest
+GitCommit: 92891392566f11de4b80fafe1b2383490350be47
 Directory: 3
 
-Tags: 3-5.7.0-slim, 3-5.7-slim, 3-5-slim, 3-slim, slim
-GitCommit: efd06021f245f79c905bf0db5e24031ca62a4dbe
+Tags: 3-5.7.1-slim, 3-5.7-slim, 3-5-slim, 3-slim, slim
+GitCommit: 92891392566f11de4b80fafe1b2383490350be47
 Directory: 3/slim
 
-Tags: 3-5.7.0-onbuild, 3-5.7-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Tags: 3-5.7.1-onbuild, 3-5.7-onbuild, 3-5-onbuild, 3-onbuild, onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild

--- a/library/tomcat
+++ b/library/tomcat
@@ -12,36 +12,36 @@ Tags: 6.0.51-jre8, 6.0-jre8, 6-jre8
 GitCommit: 4b5335ec27aee302823bea2e30dcf7b3118e61f2
 Directory: 6/jre8
 
-Tags: 7.0.76-jre7, 7.0-jre7, 7-jre7, 7.0.76, 7.0, 7
-GitCommit: 51f9cbc7c310671209ce69e128738a74593de870
+Tags: 7.0.77-jre7, 7.0-jre7, 7-jre7, 7.0.77, 7.0, 7
+GitCommit: 6f4b7544afb91088a666ef620e8ad5e989ed9abb
 Directory: 7/jre7
 
-Tags: 7.0.76-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.76-alpine, 7.0-alpine, 7-alpine
-GitCommit: 4b8ed1747ba0a6e5c9f859e518cecced13335d82
+Tags: 7.0.77-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.77-alpine, 7.0-alpine, 7-alpine
+GitCommit: 7a16673434d629938f064b5aed86df44ee49b53a
 Directory: 7/jre7-alpine
 
-Tags: 7.0.76-jre8, 7.0-jre8, 7-jre8
-GitCommit: 51f9cbc7c310671209ce69e128738a74593de870
+Tags: 7.0.77-jre8, 7.0-jre8, 7-jre8
+GitCommit: 6f4b7544afb91088a666ef620e8ad5e989ed9abb
 Directory: 7/jre8
 
-Tags: 7.0.76-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: 4b8ed1747ba0a6e5c9f859e518cecced13335d82
+Tags: 7.0.77-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: 7a16673434d629938f064b5aed86df44ee49b53a
 Directory: 7/jre8-alpine
 
-Tags: 8.0.42-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.42, 8.0, 8, latest
-GitCommit: 3bbd4ed7a59680ae1d6dc3f123897f07e0625989
+Tags: 8.0.43-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.43, 8.0, 8, latest
+GitCommit: 6be7d97a528019fd7cedb0f3ef0dca674713512b
 Directory: 8.0/jre7
 
-Tags: 8.0.42-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.42-alpine, 8.0-alpine, 8-alpine, alpine
-GitCommit: 4f193f544a7deb2dc95a33f8ea447c235c7d180a
+Tags: 8.0.43-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.43-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: 27c1f03b80a8d98c7355e57dbd2c35ae0ff73b27
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.42-jre8, 8.0-jre8, 8-jre8, jre8
-GitCommit: 3bbd4ed7a59680ae1d6dc3f123897f07e0625989
+Tags: 8.0.43-jre8, 8.0-jre8, 8-jre8, jre8
+GitCommit: 6be7d97a528019fd7cedb0f3ef0dca674713512b
 Directory: 8.0/jre8
 
-Tags: 8.0.42-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
-GitCommit: 4f193f544a7deb2dc95a33f8ea447c235c7d180a
+Tags: 8.0.43-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+GitCommit: 27c1f03b80a8d98c7355e57dbd2c35ae0ff73b27
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.13-jre8, 8.5-jre8, 8.5.13, 8.5


### PR DESCRIPTION
- `haproxy`: 1.7.5
- `mongo`: add 3.5/unstable (docker-library/mongo#163)
- `pypy`: 5.7.1
- `tomcat`: 8.0.43, 7.0.77