### PR TITLE
Update for Node.js v4.8.2 and v6.10.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -23,43 +23,43 @@ Tags: 7.8.0-wheezy, 7.8-wheezy, 7-wheezy, wheezy
 GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
 Directory: 7.8/wheezy
 
-Tags: 6.10.1, 6.10, 6, boron
-GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
+Tags: 6.10.2, 6.10, 6, boron
+GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10
 
-Tags: 6.10.1-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
+Tags: 6.10.2-alpine, 6.10-alpine, 6-alpine, boron-alpine
+GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10/alpine
 
-Tags: 6.10.1-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 6.10.2-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
+GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10/onbuild
 
-Tags: 6.10.1-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 6.10.2-slim, 6.10-slim, 6-slim, boron-slim
+GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10/slim
 
-Tags: 6.10.1-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 6.10.2-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10/wheezy
 
-Tags: 4.8.1, 4.8, 4, argon
-GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
+Tags: 4.8.2, 4.8, 4, argon
+GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8
 
-Tags: 4.8.1-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: a5141d841167d109bcad542c9fb636607dabc8b1
+Tags: 4.8.2-alpine, 4.8-alpine, 4-alpine, argon-alpine
+GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8/alpine
 
-Tags: 4.8.1-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 4.8.2-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8/onbuild
 
-Tags: 4.8.1-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 4.8.2-slim, 4.8-slim, 4-slim, argon-slim
+GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8/slim
 
-Tags: 4.8.1-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 14681db8e89c0493e8af20657883fa21488a7766
+Tags: 4.8.2-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v4.8.2/
- https://nodejs.org/en/blog/release/v6.10.2/
- https://github.com/nodejs/docker-node/pull/373