### PR TITLE
Update elasticsearch, haproxy, rabbitmq

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.2.2, 5.2, 5, latest
-GitCommit: d1765774a1effc5436f3d1f4ad6826dd9ed2186f
+Tags: 5.3.0, 5.3, 5, latest
+GitCommit: 391a5a9ba2836175f68c9c2d3655825300e4585e
 Directory: 5
 
-Tags: 5.2.2-alpine, 5.2-alpine, 5-alpine, alpine
-GitCommit: d1765774a1effc5436f3d1f4ad6826dd9ed2186f
+Tags: 5.3.0-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: fe76ec27a3f75b672914eb84bb4967718614ca13
 Directory: 5/alpine
 
 Tags: 2.4.4, 2.4, 2
@@ -17,7 +17,7 @@ GitCommit: 8f00ad520c1c33b879a715700905d3c25c526331
 Directory: 2.4
 
 Tags: 2.4.4-alpine, 2.4-alpine, 2-alpine
-GitCommit: 8f00ad520c1c33b879a715700905d3c25c526331
+GitCommit: 5727443ead111be19b55bfe5412dae5133cab8b1
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1
@@ -25,5 +25,5 @@ GitCommit: ffd7a19f1e68329cc310f145c232e83abec09067
 Directory: 1.7
 
 Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine
-GitCommit: 1107caed5c403a63d99c1b1ae1f7002d387c7e85
+GitCommit: 5727443ead111be19b55bfe5412dae5133cab8b1
 Directory: 1.7/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -20,12 +20,12 @@ Tags: 1.5.19-alpine, 1.5-alpine
 GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
-Tags: 1.6.11, 1.6
-GitCommit: 20816337017096e325c64627e58141e7c9628004
+Tags: 1.6.12, 1.6
+GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
 Directory: 1.6
 
-Tags: 1.6.11-alpine, 1.6-alpine
-GitCommit: 20816337017096e325c64627e58141e7c9628004
+Tags: 1.6.12-alpine, 1.6-alpine
+GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
 Directory: 1.6/alpine
 
 Tags: 1.7.5, 1.7, 1, latest

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.9, 3.6, 3, latest
-GitCommit: 6c224be56c42502430716e5d43a1a1726456809a
+GitCommit: 84eccd5c9be6609d30f6f02f924db505daaef172
 Directory: debian
 
 Tags: 3.6.9-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 366975d8089b28fb2a58054835f80e1a74328d05
 Directory: debian/management
 
 Tags: 3.6.9-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 945697283f22bf3b21166a8b494447faf67301f6
+GitCommit: 84eccd5c9be6609d30f6f02f924db505daaef172
 Directory: alpine
 
 Tags: 3.6.9-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
- `elasticsearch` bump `5.3.0`
- `haproxy` bump `1.6.12`
- `rabbitmq` `RABBITMQ_SSL_DEPTH` env