### PR TITLE
Bump docker version in Dockerfile to use supported release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.10-git
+FROM docker:stable-git
 
 RUN apk add --no-cache \
 # bash for running scripts


### PR DESCRIPTION
https://github.com/docker-library/docker/pull/48 reminded me that `1.13` was going away and then I saw this was on `1.10`.  This should help us see any new docker-related issues when building images.