### PR TITLE
Amazon Linux: add 2017.03.0.20170401

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -3,10 +3,18 @@ Maintainers: Amazon Linux Team <amazon-linux-ami@amazon.com> (@aws),
              Praveen K Paladugu (@praveen-pk)
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
 
-Tags: 2016.09.1.20161221, 2016.09, latest
+Tags: 2017.03.0.20170401, 2017.03, latest
+GitFetch: refs/heads/2017.03
+GitCommit: 0b9e43b1675ad911037317052c30074fc962ece0
+
+Tags: 2017.03.0.20170401-with-sources, 2017.03-with-sources, with-sources
+GitFetch: refs/heads/2017.03-with-sources
+GitCommit: 9a0f82efd72c4ce7a00ae0d1145798e833e3fc6c
+
+Tags: 2016.09.1.20161221, 2016.09
 GitFetch: refs/heads/2016.09
 GitCommit: e1b56e68ebd2b274c64e0a0a18ae0a9a8122822d
 
-Tags: 2016.09.1.20161221-with-sources, 2016.09-with-sources, with-sources
+Tags: 2016.09.1.20161221-with-sources, 2016.09-with-sources
 GitFetch: refs/heads/2016.09-with-sources
 GitCommit: 2de60e8c98421694c293639659a88ed81ce29298


### PR DESCRIPTION
GUESS WHAT :confetti_ball: 

```
$ sudo docker images
REPOSITORY          TAG                  IMAGE ID            CREATED             SIZE
amazonlinux         2016.09.1.20170404   d2fc5bf73930        32 minutes ago      162 MB
amazonlinux         2016.09.1.20161221   8ae6f52035b5        3 months ago        292 MB
```

~~This is the last planned update to the 2016.09 image as 2017.03 is now available.~~