### PR TITLE
Node.js image: Update for yarn v0.22.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,11 +4,11 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.8.0, 7.8, 7, latest
-GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 7.8
 
 Tags: 7.8.0-alpine, 7.8-alpine, 7-alpine, alpine
-GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 7.8/alpine
 
 Tags: 7.8.0-onbuild, 7.8-onbuild, 7-onbuild, onbuild
@@ -16,19 +16,19 @@ GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
 Directory: 7.8/onbuild
 
 Tags: 7.8.0-slim, 7.8-slim, 7-slim, slim
-GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 7.8/slim
 
 Tags: 7.8.0-wheezy, 7.8-wheezy, 7-wheezy, wheezy
-GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 7.8/wheezy
 
 Tags: 6.10.2, 6.10, 6, boron
-GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 6.10
 
 Tags: 6.10.2-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 6.10/alpine
 
 Tags: 6.10.2-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
@@ -36,19 +36,19 @@ GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
 Directory: 6.10/onbuild
 
 Tags: 6.10.2-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 6.10/slim
 
 Tags: 6.10.2-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 6.10/wheezy
 
 Tags: 4.8.2, 4.8, 4, argon
-GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 4.8
 
 Tags: 4.8.2-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 4.8/alpine
 
 Tags: 4.8.2-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
@@ -56,10 +56,10 @@ GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
 Directory: 4.8/onbuild
 
 Tags: 4.8.2-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 4.8/slim
 
 Tags: 4.8.2-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
+GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
This also includes an improvement to how pgp keys are fetched which
should prevent the occasional build errors we see in travis-ci.

See:
- https://github.com/nodejs/docker-node/pull/376
- https://github.com/nodejs/docker-node/pull/375