### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -1,32 +1,20 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/4bc238b11f42dfb7bc26875cfea759f5709bb76d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/bd0f1c85b015a1cefe7ebaeba5b1061fd8ac6555/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.0-rc2-apache, 8.3-rc-apache, rc-apache, 8.3.0-rc2, 8.3-rc, rc
-GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
-Directory: 8.3-rc/apache
+Tags: 8.3.0-apache, 8.3-apache, 8-apache, apache, 8.3.0, 8.3, 8, latest
+GitCommit: 05987d0765ae376565194b49ec37f3f1d0bd9ab0
+Directory: 8.3/apache
 
-Tags: 8.3.0-rc2-fpm, 8.3-rc-fpm, rc-fpm
-GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
-Directory: 8.3-rc/fpm
+Tags: 8.3.0-fpm, 8.3-fpm, 8-fpm, fpm
+GitCommit: 05987d0765ae376565194b49ec37f3f1d0bd9ab0
+Directory: 8.3/fpm
 
-Tags: 8.3.0-rc2-fpm-alpine, 8.3-rc-fpm-alpine, rc-fpm-alpine
-GitCommit: 407abbdffe21637509688ec29cd761e0b56b6812
-Directory: 8.3-rc/fpm-alpine
-
-Tags: 8.2.7-apache, 8.2-apache, 8-apache, apache, 8.2.7, 8.2, 8, latest
-GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
-Directory: 8.2/apache
-
-Tags: 8.2.7-fpm, 8.2-fpm, 8-fpm, fpm
-GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
-Directory: 8.2/fpm
-
-Tags: 8.2.7-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: 67dab10dcf957e66d8d257c069e40b255a5f2a7c
-Directory: 8.2/fpm-alpine
+Tags: 8.3.0-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: f0e99d1b1a85b0c8ad0fddc1bb7c9a5ea53a61dc
+Directory: 8.3/fpm-alpine
 
 Tags: 7.54-apache, 7-apache, 7.54, 7
 GitCommit: e8e2309427218cb2e250a3af013e8efe54703404

--- a/library/ghost
+++ b/library/ghost
@@ -1,8 +1,13 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/8652c806a1af1beef0f9c4ec146262e50f6a4875/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/7251ebfe67deb5452377435b0645a10fe81399b5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 0.11.7, 0.11, 0, latest
-GitCommit: f57b040e28dca92eb3e1b072baa9922b12712b6c
+GitCommit: 7251ebfe67deb5452377435b0645a10fe81399b5
+Directory: debian
+
+Tags: 0.11.7-alpine, 0.11-alpine, 0-alpine, alpine
+GitCommit: 7251ebfe67deb5452377435b0645a10fe81399b5
+Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.14, 3.0
-GitCommit: 5fa47142887600edcd437e7689f40342b3572e71
+GitCommit: 1df3c6081a80100589b9b1185a79ccceee9f9912
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.12, 3.2
-GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
+GitCommit: 1df3c6081a80100589b9b1185a79ccceee9f9912
 Directory: 3.2
 
 Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.3, 3.4, 3, latest
-GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
+GitCommit: 1df3c6081a80100589b9b1185a79ccceee9f9912
 Directory: 3.4
 
 Tags: 3.4.3-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
@@ -32,7 +32,7 @@ Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.5.5, 3.5, unstable
-GitCommit: 17f05e95936bc3ec911446ffe4c2f5889363083d
+GitCommit: 1df3c6081a80100589b9b1185a79ccceee9f9912
 Directory: 3.5
 
 Tags: 3.5.5-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.2, 9.6, 9, latest
-GitCommit: 913bc48bfdccab58c6c15f11841da5146e7bf968
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.6
 
 Tags: 9.6.2-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 123aedc09bc067740fb28921c500ded83c018bd4
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.6/alpine
 
 Tags: 9.5.6, 9.5
-GitCommit: 913bc48bfdccab58c6c15f11841da5146e7bf968
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.5
 
 Tags: 9.5.6-alpine, 9.5-alpine
-GitCommit: 123aedc09bc067740fb28921c500ded83c018bd4
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.5/alpine
 
 Tags: 9.4.11, 9.4
-GitCommit: 913bc48bfdccab58c6c15f11841da5146e7bf968
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.4
 
 Tags: 9.4.11-alpine, 9.4-alpine
-GitCommit: 123aedc09bc067740fb28921c500ded83c018bd4
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.4/alpine
 
 Tags: 9.3.16, 9.3
-GitCommit: 913bc48bfdccab58c6c15f11841da5146e7bf968
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.3
 
 Tags: 9.3.16-alpine, 9.3-alpine
-GitCommit: 123aedc09bc067740fb28921c500ded83c018bd4
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.3/alpine
 
 Tags: 9.2.20, 9.2
-GitCommit: 913bc48bfdccab58c6c15f11841da5146e7bf968
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.2
 
 Tags: 9.2.20-alpine, 9.2-alpine
-GitCommit: 123aedc09bc067740fb28921c500ded83c018bd4
+GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.2/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.9, 3.6, 3, latest
-GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
+GitCommit: d2bd71d329cacc3f010e665fbfd54f3ceaec1071
 Directory: 3.6/debian
 
 Tags: 3.6.9-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.9-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
+GitCommit: d2bd71d329cacc3f010e665fbfd54f3ceaec1071
 Directory: 3.6/alpine
 
 Tags: 3.6.9-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.54.2, 0.54, 0, latest
-GitCommit: b3edd574f8bceb7504be78074f561fd6674b96f8
+Tags: 0.55.0-rc.1, 0.55.0-rc, 0.55, latest
+GitCommit: b82656047fd1d91e4124c5626e970d86b6dfc36b

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/637afb53dc03b4af19149a0880e796346f97c137/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/e6af22dc6f8553e62acc0c29d6e4e86b2287daf7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -39,3 +39,17 @@ Directory: php7.1/fpm
 Tags: 4.7.3-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
 Directory: php7.1/fpm-alpine
+
+# Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
+
+Tags: cli-1.1.0, cli-1.1, cli-1, cli, cli-1.1.0-php5.6, cli-1.1-php5.6, cli-1-php5.6, cli-php5.6
+GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+Directory: php5.6/cli
+
+Tags: cli-1.1.0-php7.0, cli-1.1-php7.0, cli-1-php7.0, cli-php7.0
+GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+Directory: php7.0/cli
+
+Tags: cli-1.1.0-php7.1, cli-1.1-php7.1, cli-1-php7.1, cli-php7.1
+GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+Directory: php7.1/cli


### PR DESCRIPTION
- `drupal`: 8.3.0 (docker-library/drupal#78), remove 8.2 (docker-library/drupal#80)
- `ghost`: add `alpine` variant (docker-library/ghost#55)
- `mongo`: more edge cases (docker-library/mongo#167, docker-library/mongo#169)
- `postgres`: adjust append (docker-library/postgres#270)
- `rabbitmq`: add `vm_memory_high_watermark` support based on cgroup limits (docker-library/rabbitmq#105)
- `rocket.chat`: 0.55.0-rc.1
- `wordpress`: add `wp-cli` variant (docker-library/wordpress#198)