### PR TITLE
Update docker-library images

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -28,7 +28,7 @@ Tags: 7.0.77-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 GitCommit: 7a16673434d629938f064b5aed86df44ee49b53a
 Directory: 7/jre8-alpine
 
-Tags: 8.0.43-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.43, 8.0, 8, latest
+Tags: 8.0.43-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.43, 8.0, 8
 GitCommit: 6be7d97a528019fd7cedb0f3ef0dca674713512b
 Directory: 8.0/jre7
 
@@ -52,7 +52,7 @@ Tags: 8.5.13-jre8-alpine, 8.5-jre8-alpine, 8.5.13-alpine, 8.5-alpine
 GitCommit: e06e384de299e232670c398deb8b87cec1893eaf
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M19-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M19, 9.0.0, 9.0, 9
+Tags: 9.0.0.M19-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M19, 9.0.0, 9.0, 9, latest
 GitCommit: f3006804326b1fed9a20158ccb8007d5da80e31a
 Directory: 9.0/jre8
 


### PR DESCRIPTION
moved 'latest' tag to 9.0 non-alpine version