### PR TITLE
[nats-streaming] Release v0.4.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,6 +1,6 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 
-Tags: 0.3.8, latest
+Tags: 0.4.0, latest
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 8c51cccfe250cb144becd082e3ccdf531a31b30a
+GitCommit: 048c972a51fdacfe406cc254cfde35b8bcc0e1aa
 


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.4.0)