### PR TITLE
Update Mono to latest 4.8 release

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -105,13 +105,17 @@
 4.6.2.7-onbuild: git://github.com/mono/docker@a41b568af8e26dac60a11432b5bb1c910d44f44a 4.6.2.7/onbuild
 
 4.8.0.495: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495
-4.8.0: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495
-4.8: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495
-4: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495
-latest: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495
 
 4.8.0.495-onbuild: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495/onbuild
-4.8.0-onbuild: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495/onbuild
-4.8-onbuild: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495/onbuild
-4-onbuild: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495/onbuild
-onbuild: git://github.com/mono/docker@0dcec42351bdb86248361a5eff6cafbc99a538ce 4.8.0.495/onbuild
+
+4.8.0.524: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524
+4.8.0: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524
+4.8: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524
+4: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524
+latest: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524
+
+4.8.0.524-onbuild: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524/onbuild
+4.8.0-onbuild: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524/onbuild
+4.8-onbuild: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524/onbuild
+4-onbuild: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524/onbuild
+onbuild: git://github.com/mono/docker@13dbbc26567ac279f344c5be0491a95ba16e9604 4.8.0.524/onbuild


### PR DESCRIPTION
@tianon FYI we'll likely cleanup the old packages with the upcoming Mono 5.0 release :)