### PR TITLE
Update docker-library images

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.0, 8.0, 8
-GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
+Tags: 8.0.1, 8.0, 8
+GitCommit: 7a850980c4b0d5fb5553986d280ebfb43230a6bb
 Directory: 8.0
 
-Tags: 5.7.17, 5.7, 5, latest
-GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
+Tags: 5.7.18, 5.7, 5, latest
+GitCommit: 6b1dc54320b03b83a89068f49cc796fea0ff6bb4
 Directory: 5.7
 
-Tags: 5.6.35, 5.6
-GitCommit: f42fa91856b557940a4ddd86d70cc2518cab818b
+Tags: 5.6.36, 5.6
+GitCommit: 2bbab7b691b582e2df99dbd16525608adbff016e
 Directory: 5.6
 
 Tags: 5.5.55, 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.9, 3.6, 3, latest
-GitCommit: d2bd71d329cacc3f010e665fbfd54f3ceaec1071
+GitCommit: 1509b142f0b858bb9d8521397f34229cd3027c1e
 Directory: 3.6/debian
 
 Tags: 3.6.9-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.9-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: d2bd71d329cacc3f010e665fbfd54f3ceaec1071
+GitCommit: 1509b142f0b858bb9d8521397f34229cd3027c1e
 Directory: 3.6/alpine
 
 Tags: 3.6.9-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.55.0-rc.1, 0.55.0-rc, 0.55, latest
-GitCommit: b82656047fd1d91e4124c5626e970d86b6dfc36b
+Tags: 0.54.2, 0.54, 0, latest
+GitCommit: a721d599218803d2acb27f92b11d2cdcf0a226d5

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/5f1abae99c0b1ebbd4f020bc4b5696619d948cfd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/d70d05cfa398310f7a02c7bca5db2eb4ad5ef417/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -28,27 +28,27 @@ Tags: 7.0.77-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 GitCommit: 7a16673434d629938f064b5aed86df44ee49b53a
 Directory: 7/jre8-alpine
 
-Tags: 8.0.43-jre7, 8.0-jre7, 8-jre7, jre7, 8.0.43, 8.0, 8, latest
+Tags: 8.0.43-jre7, 8.0-jre7, 8.0.43, 8.0
 GitCommit: 6be7d97a528019fd7cedb0f3ef0dca674713512b
 Directory: 8.0/jre7
 
-Tags: 8.0.43-jre7-alpine, 8.0-jre7-alpine, 8-jre7-alpine, jre7-alpine, 8.0.43-alpine, 8.0-alpine, 8-alpine, alpine
+Tags: 8.0.43-jre7-alpine, 8.0-jre7-alpine, 8.0.43-alpine, 8.0-alpine
 GitCommit: 27c1f03b80a8d98c7355e57dbd2c35ae0ff73b27
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.43-jre8, 8.0-jre8, 8-jre8, jre8
+Tags: 8.0.43-jre8, 8.0-jre8
 GitCommit: 6be7d97a528019fd7cedb0f3ef0dca674713512b
 Directory: 8.0/jre8
 
-Tags: 8.0.43-jre8-alpine, 8.0-jre8-alpine, 8-jre8-alpine, jre8-alpine
+Tags: 8.0.43-jre8-alpine, 8.0-jre8-alpine
 GitCommit: 27c1f03b80a8d98c7355e57dbd2c35ae0ff73b27
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.13-jre8, 8.5-jre8, 8.5.13, 8.5
+Tags: 8.5.13-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.13, 8.5, 8, latest
 GitCommit: 64166c6cb450e6701d7b493d1d296c6c1c972a1e
 Directory: 8.5/jre8
 
-Tags: 8.5.13-jre8-alpine, 8.5-jre8-alpine, 8.5.13-alpine, 8.5-alpine
+Tags: 8.5.13-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.13-alpine, 8.5-alpine, 8-alpine, alpine
 GitCommit: e06e384de299e232670c398deb8b87cec1893eaf
 Directory: 8.5/jre8-alpine
 


### PR DESCRIPTION
- `mysql`: 5.7.18, 5.6.36, 5.5.55, 8.0.1
- `rabbitmq`: adjust `vm_memory_high_watermark` handling to fix several edge cases (docker-library/rabbitmq#149)
- `rocket.chat`: revert to 0.54.2, skipping RCs for the official image (RocketChat/Docker.Official.Image#31)
- `tomcat`: update `8` and `latest` to be `8.5` (docker-library/tomcat#67)