### PR TITLE
Update for Node.js v7.9.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,27 +1,27 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/189588b1b52f80f8b3cec7f432ac60c0e884116e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.8.0, 7.8, 7, latest
-GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
-Directory: 7.8
+Tags: 7.9.0, 7.9, 7, latest
+GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
+Directory: 7.9
 
-Tags: 7.8.0-alpine, 7.8-alpine, 7-alpine, alpine
-GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
-Directory: 7.8/alpine
+Tags: 7.9.0-alpine, 7.9-alpine, 7-alpine, alpine
+GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
+Directory: 7.9/alpine
 
-Tags: 7.8.0-onbuild, 7.8-onbuild, 7-onbuild, onbuild
-GitCommit: 189588b1b52f80f8b3cec7f432ac60c0e884116e
-Directory: 7.8/onbuild
+Tags: 7.9.0-onbuild, 7.9-onbuild, 7-onbuild, onbuild
+GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
+Directory: 7.9/onbuild
 
-Tags: 7.8.0-slim, 7.8-slim, 7-slim, slim
-GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
-Directory: 7.8/slim
+Tags: 7.9.0-slim, 7.9-slim, 7-slim, slim
+GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
+Directory: 7.9/slim
 
-Tags: 7.8.0-wheezy, 7.8-wheezy, 7-wheezy, wheezy
-GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f
-Directory: 7.8/wheezy
+Tags: 7.9.0-wheezy, 7.9-wheezy, 7-wheezy, wheezy
+GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
+Directory: 7.9/wheezy
 
 Tags: 6.10.2, 6.10, 6, boron
 GitCommit: 4fa0c90f383880b8c03f6e2c07e8d46a0ae9075f


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v7.9.0/
- https://github.com/nodejs/docker-node/pull/377