### PR TITLE
Update to Adminer 4.3.1

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -1,10 +1,10 @@
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
-Tags: 4.3.0-standalone, 4.3-standalone, 4-standalone, standalone, 4.3.0, 4.3, 4, latest
-GitCommit: 583a3425bf560b744f0ac16be398b2b589474c8b
+Tags: 4.3.1-standalone, 4.3-standalone, 4-standalone, standalone, 4.3.1, 4.3, 4, latest
+GitCommit: e1aaa5a4a298198d739d794d239f97edcae0c1b8
 Directory: 4.3
 
-Tags: 4.3.0-fastcgi, 4.3-fastcgi, 4-fastcgi, fastcgi
-GitCommit: a07553cc164c5fd9533cda44568a58dfad0fa864
+Tags: 4.3.1-fastcgi, 4.3-fastcgi, 4-fastcgi, fastcgi
+GitCommit: e1aaa5a4a298198d739d794d239f97edcae0c1b8
 Directory: 4.3/fastcgi


### PR DESCRIPTION
This updates Adminer to version 4.3.1 and adds support for:

- Different Adminer designs (TimWolla/docker-adminer#4)
- Adminer plugins (TimWolla/docker-adminer#5)

Docs PR: docker-library/docs#882