### PR TITLE
remove centos5 container references, reorder c6 containers

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -11,10 +11,6 @@ Tags: centos6, 6
 GitFetch: refs/heads/CentOS-6
 GitCommit: 5048dc2d18390e22bc9c95fe7526f7f63490b7b6
 
-Tags: centos5, 5
-GitFetch: refs/heads/CentOS-5
-GitCommit: 4bf8330498e1c10cf365aff31d2a8a5c3254c2cf
-
 Tags: centos7.3.1611, 7.3.1611
 GitFetch: refs/heads/CentOS-7.3.1611
 GitCommit: 5bbaef9f60ab9e3eeb61acec631c2d91f8714fff
@@ -31,13 +27,13 @@ Tags: centos7.0.1406, 7.0.1406
 GitFetch: refs/heads/CentOS-7.0.1406
 GitCommit: f1d1e0bd83baef08e257da50e6fb446e4dd1b90c
 
-Tags: centos6.8, 6.8
-GitFetch: refs/heads/CentOS-6.8
-GitCommit: f32666d2af356ed6835942ed753a4970e18bca94
-
 Tags: centos6.9, 6.9
 GitFetch: refs/heads/CentOS-6.9
 GitCommit: 4f329fe087b0152df26344cecee9ba30b03b1a7b
+
+Tags: centos6.8, 6.8
+GitFetch: refs/heads/CentOS-6.8
+GitCommit: f32666d2af356ed6835942ed753a4970e18bca94
 
 Tags: centos6.7, 6.7
 GitFetch: refs/heads/CentOS-6.7
@@ -46,7 +42,3 @@ GitCommit: d0b72df83f49da844f88aabebe3826372f675370
 Tags: centos6.6, 6.6
 GitFetch: refs/heads/CentOS-6.6
 GitCommit: 8911843d9a6cc71aadd81e491f94618aded94f30
-
-Tags: centos5.11, 5.11
-GitFetch: refs/heads/CentOS-5.11
-GitCommit: 2d0554464ae19f4fd70d1b540c8968dbe872797b


### PR DESCRIPTION
My understanding is that this will leave the c5 containers available, but won't advertise them. is that correct?