### PR TITLE
Updated stable nginx to 1.12.0.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -11,10 +11,18 @@ Tags: 1.11.13-alpine, mainline-alpine, 1-alpine, 1.11-alpine, alpine
 GitCommit: 0c7611139f2ce7c5a6b1febbfd5b436c8c7d2d53
 Directory: mainline/alpine
 
-Tags: 1.10.3, stable, 1.10
-GitCommit: 014e624239987a0a46bee5b44088a8c5150bf0bb
-Directory: stable/jessie
+Tags: 1.12.0, stable, 1.12
+GitCommit: 4d1f7f8ec281117d1d79bed4c6bc28b86039ca84
+Directory: stable/stretch
 
-Tags: 1.10.3-alpine, stable-alpine, 1.10-alpine
-GitCommit: 014e624239987a0a46bee5b44088a8c5150bf0bb
+Tags: 1.12.0-perl, stable-perl, 1.12-perl
+GitCommit: 4d1f7f8ec281117d1d79bed4c6bc28b86039ca84
+Directory: stable/stretch-perl
+
+Tags: 1.12.0-alpine, stable-alpine, 1.12-alpine
+GitCommit: 4d1f7f8ec281117d1d79bed4c6bc28b86039ca84
 Directory: stable/alpine
+
+Tags: 1.12.0-alpine-perl, stable-alpine-perl, 1.12-alpine-perl
+GitCommit: 4d1f7f8ec281117d1d79bed4c6bc28b86039ca84
+Directory: stable/alpine-perl


### PR DESCRIPTION
This also adds a new -perl tag introduced to move requested but not
often used perl module to a separate image.