### PR TITLE
Update the cassandra-basics test to use an explicitly smaller max heap size

### DIFF
--- a/test/tests/cassandra-basics/run.sh
+++ b/test/tests/cassandra-basics/run.sh
@@ -14,6 +14,8 @@ clientImage="$image"
 # Create an instance of the container-under-test
 cid="$(
 	docker run -d \
+		-e MAX_HEAP_SIZE='128m' \
+		-e HEAP_NEWSIZE='32m' \
 		-e JVM_OPTS='
 			-Dcom.sun.management.jmxremote.port=7199
 			-Dcom.sun.management.jmxremote.ssl=false


### PR DESCRIPTION
This should help with the Jenkins tests failing (using an explicitly small value rather than letting the script auto-detect our total RAM size and try to eat as much as possible).