### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -12,8 +12,8 @@ Tags: 2.2.9, 2.2, 2
 GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
 Directory: 2.2
 
-Tags: 3.0.12, 3.0
-GitCommit: 7ba44ab0fe6d8afdcad2ffe101303f13da20fff6
+Tags: 3.0.13, 3.0
+GitCommit: e80c6550afd16ead245ec73b16862984480a7cf9
 Directory: 3.0
 
 Tags: 3.10, 3, latest

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.3.0, 5.3, 5, latest
-GitCommit: 391a5a9ba2836175f68c9c2d3655825300e4585e
+Tags: 5.3.1, 5.3, 5, latest
+GitCommit: 35d99e915d909688807c507a59a2c06039ac92b2
 Directory: 5
 
-Tags: 5.3.0-alpine, 5.3-alpine, 5-alpine, alpine
-GitCommit: fe76ec27a3f75b672914eb84bb4967718614ca13
+Tags: 5.3.1-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: 35d99e915d909688807c507a59a2c06039ac92b2
 Directory: 5/alpine
 
 Tags: 2.4.4, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.7, 0.11, 0, latest
-GitCommit: 7251ebfe67deb5452377435b0645a10fe81399b5
+Tags: 0.11.8, 0.11, 0, latest
+GitCommit: 1e9307eb3642dd5fb2b8e9c25a15fa524ad0e219
 Directory: debian
 
-Tags: 0.11.7-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: 7251ebfe67deb5452377435b0645a10fe81399b5
+Tags: 0.11.8-alpine, 0.11-alpine, 0-alpine, alpine
+GitCommit: 1e9307eb3642dd5fb2b8e9c25a15fa524ad0e219
 Directory: alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.3.0, 5.3, 5, latest
-GitCommit: d73d06c827383cad1cedc2a3236390f47fab63cd
+Tags: 5.3.1, 5.3, 5, latest
+GitCommit: 17280c315c2865d0e6bb6dfacd0ed7eead881ca7
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.3.0, 5.3, 5, latest
-GitCommit: bad127e3f5912e5fdbff825e4ac832b725bd0c8d
+Tags: 5.3.1, 5.3, 5, latest
+GitCommit: 5823b0a117cb5c4a50c6a5890f73b0ec878f4bcc
 Directory: 5
 
-Tags: 5.3.0-alpine, 5.3-alpine, 5-alpine, alpine
-GitCommit: bad127e3f5912e5fdbff825e4ac832b725bd0c8d
+Tags: 5.3.1-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: 5823b0a117cb5c4a50c6a5890f73b0ec878f4bcc
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -22,12 +22,12 @@ GitCommit: 5c0e43ac8eba7c2fb8cc3de9542f48b31c48da14
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.3, 3.4, 3, latest
-GitCommit: 9914fd4e7967c32ad79710b08e4a21f4f68239f9
+Tags: 3.4.4, 3.4, 3, latest
+GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
 Directory: 3.4
 
-Tags: 3.4.3-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 2754d33460e0bfe196dccdccf9a8ff2b43816d00
+Tags: 3.4.4-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,26 +3,26 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 10.0.4-apache, 10.0-apache, 10-apache, 10.0.4, 10.0, 10
-GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
+Tags: 10.0.5-apache, 10.0-apache, 10-apache, 10.0.5, 10.0, 10
+GitCommit: 2bb94165af875755fa775a2ce08c2306f7ee6374
 Directory: 10.0/apache
 
-Tags: 10.0.4-fpm, 10.0-fpm, 10-fpm
-GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
+Tags: 10.0.5-fpm, 10.0-fpm, 10-fpm
+GitCommit: 2bb94165af875755fa775a2ce08c2306f7ee6374
 Directory: 10.0/fpm
 
-Tags: 11.0.2-apache, 11.0-apache, 11-apache, apache, 11.0.2, 11.0, 11, latest
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+Tags: 11.0.3-apache, 11.0-apache, 11-apache, apache, 11.0.3, 11.0, 11, latest
+GitCommit: 6c9dd8442493c82f03cbcde8def0b7231b8fdb48
 Directory: 11.0/apache
 
-Tags: 11.0.2-fpm, 11.0-fpm, 11-fpm, fpm
-GitCommit: 843d309ee62b9d2704e6141d2103f9ded97e35b6
+Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm, fpm
+GitCommit: 6c9dd8442493c82f03cbcde8def0b7231b8fdb48
 Directory: 11.0/fpm
 
-Tags: 9.0.57-apache, 9.0-apache, 9-apache, 9.0.57, 9.0, 9
-GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
+Tags: 9.0.58-apache, 9.0-apache, 9-apache, 9.0.58, 9.0, 9
+GitCommit: c178ab0a8aaf1442149eee91d9e9eea8a4375ce9
 Directory: 9.0/apache
 
-Tags: 9.0.57-fpm, 9.0-fpm, 9-fpm
-GitCommit: 534665db850902068eca461cf1e67c2309e8ebaa
+Tags: 9.0.58-fpm, 9.0-fpm, 9-fpm
+GitCommit: c178ab0a8aaf1442149eee91d9e9eea8a4375ce9
 Directory: 9.0/fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -36,13 +36,13 @@ Tags: 8u121-jdk-alpine, 8u121-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jdk/alpine
 
-Tags: 8u121-jdk-windowsservercore, 8u121-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
-GitCommit: 4815a7dc43f0fb212c40f357624fb4ec943992bf
+Tags: 8u131-jdk-windowsservercore, 8u131-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+GitCommit: 9745c87a15896ec558429a826e23926e721e4846
 Directory: 8-jdk/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 8u121-jdk-nanoserver, 8u121-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
-GitCommit: 4815a7dc43f0fb212c40f357624fb4ec943992bf
+Tags: 8u131-jdk-nanoserver, 8u131-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
+GitCommit: 9745c87a15896ec558429a826e23926e721e4846
 Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 

--- a/library/owncloud
+++ b/library/owncloud
@@ -20,26 +20,26 @@ Tags: 8.1.12-fpm, 8.1-fpm
 GitCommit: 2e581bdb03a2961e5dad7764f59ff363da94e6fb
 Directory: 8.1/fpm
 
-Tags: 8.2.10-apache, 8.2-apache, 8-apache, 8.2.10, 8.2, 8
-GitCommit: d7fbed06a3ff66601d5940cf865d920672a9fadf
+Tags: 8.2.11-apache, 8.2-apache, 8-apache, 8.2.11, 8.2, 8
+GitCommit: 3182c1fc072fb43c165d65de7bee16aa2374efd7
 Directory: 8.2/apache
 
-Tags: 8.2.10-fpm, 8.2-fpm, 8-fpm
-GitCommit: d7fbed06a3ff66601d5940cf865d920672a9fadf
+Tags: 8.2.11-fpm, 8.2-fpm, 8-fpm
+GitCommit: 3182c1fc072fb43c165d65de7bee16aa2374efd7
 Directory: 8.2/fpm
 
-Tags: 9.0.8-apache, 9.0-apache, 9.0.8, 9.0
-GitCommit: d68839fc9d471e9776d1f51f273303e863db9e2b
+Tags: 9.0.9-apache, 9.0-apache, 9.0.9, 9.0
+GitCommit: f6016dc858a63c398df0e6797e5b45ca0eaca336
 Directory: 9.0/apache
 
-Tags: 9.0.8-fpm, 9.0-fpm
-GitCommit: d68839fc9d471e9776d1f51f273303e863db9e2b
+Tags: 9.0.9-fpm, 9.0-fpm
+GitCommit: f6016dc858a63c398df0e6797e5b45ca0eaca336
 Directory: 9.0/fpm
 
-Tags: 9.1.4-apache, 9.1-apache, 9-apache, apache, 9.1.4, 9.1, 9, latest
-GitCommit: 61f63930e743211540df45e0c32165ec043dd6f5
+Tags: 9.1.5-apache, 9.1-apache, 9-apache, apache, 9.1.5, 9.1, 9, latest
+GitCommit: 167aa3b02320358a8cc3cdbbbc3ffb4643d6e369
 Directory: 9.1/apache
 
-Tags: 9.1.4-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 61f63930e743211540df45e0c32165ec043dd6f5
+Tags: 9.1.5-fpm, 9.1-fpm, 9-fpm, fpm
+GitCommit: 167aa3b02320358a8cc3cdbbbc3ffb4643d6e369
 Directory: 9.1/fpm

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.54.2, 0.54, 0, latest
-GitCommit: a721d599218803d2acb27f92b11d2cdcf0a226d5
+Tags: 0.55.1, 0.55, 0, latest
+GitCommit: 28124b975c164219a110080d9f1af943332fb748

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,18 +44,18 @@ Tags: 8.0.43-jre8-alpine, 8.0-jre8-alpine
 GitCommit: 27c1f03b80a8d98c7355e57dbd2c35ae0ff73b27
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.13-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.13, 8.5, 8, latest
-GitCommit: 64166c6cb450e6701d7b493d1d296c6c1c972a1e
+Tags: 8.5.14-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.14, 8.5, 8, latest
+GitCommit: 1c81097952f3ba0f4c84f7b7160ccdac34c3b4cf
 Directory: 8.5/jre8
 
-Tags: 8.5.13-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.13-alpine, 8.5-alpine, 8-alpine, alpine
-GitCommit: e06e384de299e232670c398deb8b87cec1893eaf
+Tags: 8.5.14-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.14-alpine, 8.5-alpine, 8-alpine, alpine
+GitCommit: 1cf5b22547122751cc7e1149483dfa662639a450
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M19-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M19, 9.0.0, 9.0, 9
-GitCommit: f3006804326b1fed9a20158ccb8007d5da80e31a
+Tags: 9.0.0.M20-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M20, 9.0.0, 9.0, 9
+GitCommit: 7457d9c11ffdb055cb9084c498c2d47118561814
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M19-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M19-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 07b235d59c6a87e8c8ca14918105de993797435a
+Tags: 9.0.0.M20-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M20-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+GitCommit: 62da5129632732dc85024a52a55465a86ecb3d03
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,40 +4,40 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.3-apache, 4.7-apache, 4-apache, apache, 4.7.3, 4.7, 4, latest, 4.7.3-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.3-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-apache, 4.7-apache, 4-apache, apache, 4.7.4, 4.7, 4, latest, 4.7.4-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.4-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php5.6/apache
 
-Tags: 4.7.3-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.3-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.4-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php5.6/fpm
 
-Tags: 4.7.3-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.3-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.4-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.3-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.3-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.4-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.0/apache
 
-Tags: 4.7.3-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.0/fpm
 
-Tags: 4.7.3-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.3-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.3-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.4-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.1/apache
 
-Tags: 4.7.3-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.1/fpm
 
-Tags: 4.7.3-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: 3a1ca61731e6070764d5b7235e3b6617798b8af8
+Tags: 4.7.4-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `cassandra`: 3.0.13
- `elasticsearch`: 5.3.1
- `ghost`: 0.11.8
- `kibana`: 5.3.1
- `logstash`: 5.3.1
- `mongo`: 3.4.4
- `nextcloud`: 10.0.5, 11.0.3, 9.0.58
- `openjdk`: windows ojdkbuild 1.8.0.131-1
- `owncloud`: 8.2.11, 9.0.9, 9.1.5
- `rocket.chat`: 0.55.1
- `tomcat`: 8.5.14, 9.0.0.M20
- `wordpress`: 4.7.4