### PR TITLE
Release Nuxeo 9.1 and image enhancement

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,9 +1,12 @@
 Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
              Arnaud Kervern <akervern@nuxeo.com> (@akervern)
 GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: 537f17593e1c3348f3163ae6986b603168e59fc5
+GitCommit: 6e58c4a613adb80e7deb8d5c834929a4f7e401a7
 
-Tags: latest, LTS, LTS-2016, 8, 8.10, FT
+Tags: latest, 9, 9.1, FT
+Directory: 9.1
+
+Tags: latest, LTS, LTS-2016, 8, 8.10
 Directory: 8.10
 
 Tags: 8.3

--- a/library/nuxeo
+++ b/library/nuxeo
@@ -6,7 +6,7 @@ GitCommit: 6e58c4a613adb80e7deb8d5c834929a4f7e401a7
 Tags: latest, 9, 9.1, FT
 Directory: 9.1
 
-Tags: latest, LTS, LTS-2016, 8, 8.10
+Tags: LTS, LTS-2016, 8, 8.10
 Directory: 8.10
 
 Tags: 8.3


### PR DESCRIPTION
This PR is to release the 9.1 docker image and also embeds some enhancements in the way the image is built and can be used. 

About all the enhancements, you can have a look at the epic https://jira.nuxeo.com/browse/NXP-21879.

Some of them are only available for 9.1 since we included a new mechanism to simplify handling of environment variables (see https://jira.nuxeo.com/browse/NXP-21533), that's why the image build has slightly changed (basically less shell in the entrypoint).