### PR TITLE
Add Apache Flink

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,0 +1,37 @@
+# this file is generated via https://github.com/docker-flink/docker-flink/blob/e7395d7c3807ef35b72d8ae99a8723e0c12020f9/generate-stackbrew-library.sh
+
+Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
+             Ismaël Mejía <iemejia@gmail.com> (@iemejia)
+GitRepo: https://github.com/docker-flink/docker-flink.git
+
+Tags: 1.2.1-hadoop2-scala_2.10
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop2-scala_2.10-debian
+
+Tags: 1.2.1-hadoop2-scala_2.11, 1.2.1-hadoop2, 1.2-hadoop2, hadoop2
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop2-scala_2.11-debian
+
+Tags: 1.2.1-hadoop24-scala_2.10
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop24-scala_2.10-debian
+
+Tags: 1.2.1-hadoop24-scala_2.11, 1.2.1-hadoop24, 1.2-hadoop24, hadoop24
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop24-scala_2.11-debian
+
+Tags: 1.2.1-hadoop26-scala_2.10
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop26-scala_2.10-debian
+
+Tags: 1.2.1-hadoop26-scala_2.11, 1.2.1-hadoop26, 1.2-hadoop26, hadoop26
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop26-scala_2.11-debian
+
+Tags: 1.2.1-hadoop27-scala_2.10, 1.2.1-scala_2.10, 1.2-scala_2.10, scala_2.10
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop27-scala_2.10-debian
+
+Tags: 1.2.1-hadoop27-scala_2.11, 1.2.1-scala_2.11, 1.2-scala_2.11, scala_2.11, 1.2.1-hadoop27, 1.2-hadoop27, hadoop27, 1.2.1, 1.2, latest
+GitCommit: 263dcb48ce49fcc129bbf09f331360549d573db5
+Directory: 1.2/hadoop27-scala_2.11-debian


### PR DESCRIPTION
Associated docs PR: https://github.com/docker-library/docs/issues/893

See discussion on https://github.com/docker-library/docs/issues/850

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - http://mail-archives.apache.org/mod_mbox/flink-dev/201704.mbox/%3CCAJcjjQxAcoSLLze3ZJfEw2cuV5Vj084644d2PEC1FUL5QcUsdg%40mail.gmail.com%3E
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/issues/893
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
