### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.05.0-ce-rc1, 17.05.0-ce, 17.05.0, 17.05-rc, rc
-GitCommit: 56215ac49d9947e317154fad823410df1201089b
+GitCommit: 47d5d4ead8a95871d011b005394c9f2f7af68dab
 Directory: 17.05-rc
 
 Tags: 17.05.0-ce-rc1-dind, 17.05.0-ce-dind, 17.05.0-dind, 17.05-rc-dind, rc-dind
@@ -17,7 +17,7 @@ GitCommit: 56215ac49d9947e317154fad823410df1201089b
 Directory: 17.05-rc/git
 
 Tags: 17.04.0-ce, 17.04.0, 17.04, 17, latest, edge
-GitCommit: 587b66d54a69996fc765c9671eb9bc8740172f2d
+GitCommit: 47d5d4ead8a95871d011b005394c9f2f7af68dab
 Directory: 17.04
 
 Tags: 17.04.0-ce-dind, 17.04.0-dind, 17.04-dind, 17-dind, dind, edge-dind
@@ -29,7 +29,7 @@ GitCommit: 587b66d54a69996fc765c9671eb9bc8740172f2d
 Directory: 17.04/git
 
 Tags: 17.03.1-ce, 17.03.1, 17.03, stable
-GitCommit: 91d454d113abfb2328c88bbd48b81e495605e809
+GitCommit: 47d5d4ead8a95871d011b005394c9f2f7af68dab
 Directory: 17.03
 
 Tags: 17.03.1-ce-dind, 17.03.1-dind, 17.03-dind, stable-dind

--- a/library/golang
+++ b/library/golang
@@ -6,7 +6,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 
 Tags: 1.7.5, 1.7
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7
 
 Tags: 1.7.5-onbuild, 1.7-onbuild
@@ -14,29 +14,29 @@ GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
 Directory: 1.7/onbuild
 
 Tags: 1.7.5-wheezy, 1.7-wheezy
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/wheezy
 
 Tags: 1.7.5-alpine, 1.7-alpine
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/alpine
 
 Tags: 1.7.5-alpine3.5, 1.7-alpine3.5
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/alpine3.5
 
 Tags: 1.7.5-windowsservercore, 1.7-windowsservercore
-GitCommit: 3bccc597c14b6274d7855d968f881ac6407b0a61
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 1.7.5-nanoserver, 1.7-nanoserver
-GitCommit: 349270dbc128e396888cb2423ffc85d2c3039a27
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 1.8.1, 1.8, 1, latest
-GitCommit: 7e9aedf483dc0a035747f37af37ed260f2a6cf57
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8
 
 Tags: 1.8.1-onbuild, 1.8-onbuild, 1-onbuild, onbuild
@@ -44,19 +44,19 @@ GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
 Tags: 1.8.1-stretch, 1.8-stretch, 1-stretch, stretch
-GitCommit: 7e9aedf483dc0a035747f37af37ed260f2a6cf57
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8/stretch
 
 Tags: 1.8.1-alpine, 1.8-alpine, 1-alpine, alpine
-GitCommit: 7e9aedf483dc0a035747f37af37ed260f2a6cf57
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8/alpine
 
 Tags: 1.8.1-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 7e9aedf483dc0a035747f37af37ed260f2a6cf57
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 1.8.1-nanoserver, 1.8-nanoserver, 1-nanoserver, nanoserver
-GitCommit: 7e9aedf483dc0a035747f37af37ed260f2a6cf57
+GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -4,25 +4,25 @@ Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 10.0.5-apache, 10.0-apache, 10-apache, 10.0.5, 10.0, 10
-GitCommit: 2bb94165af875755fa775a2ce08c2306f7ee6374
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 10.0/apache
 
 Tags: 10.0.5-fpm, 10.0-fpm, 10-fpm
-GitCommit: 2bb94165af875755fa775a2ce08c2306f7ee6374
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 10.0/fpm
 
 Tags: 11.0.3-apache, 11.0-apache, 11-apache, apache, 11.0.3, 11.0, 11, latest
-GitCommit: 6c9dd8442493c82f03cbcde8def0b7231b8fdb48
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 11.0/apache
 
 Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm, fpm
-GitCommit: 6c9dd8442493c82f03cbcde8def0b7231b8fdb48
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 11.0/fpm
 
 Tags: 9.0.58-apache, 9.0-apache, 9-apache, 9.0.58, 9.0, 9
-GitCommit: c178ab0a8aaf1442149eee91d9e9eea8a4375ce9
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 9.0/apache
 
 Tags: 9.0.58-fpm, 9.0-fpm, 9-fpm
-GitCommit: c178ab0a8aaf1442149eee91d9e9eea8a4375ce9
+GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
 Directory: 9.0/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.6
 
 Tags: 9.6.2-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
+GitCommit: ee20f10a40f8893d5f67d593ddd44ba05d0c9df9
 Directory: 9.6/alpine
 
 Tags: 9.5.6, 9.5
@@ -17,7 +17,7 @@ GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.5
 
 Tags: 9.5.6-alpine, 9.5-alpine
-GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
+GitCommit: ee20f10a40f8893d5f67d593ddd44ba05d0c9df9
 Directory: 9.5/alpine
 
 Tags: 9.4.11, 9.4
@@ -25,7 +25,7 @@ GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.4
 
 Tags: 9.4.11-alpine, 9.4-alpine
-GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
+GitCommit: ee20f10a40f8893d5f67d593ddd44ba05d0c9df9
 Directory: 9.4/alpine
 
 Tags: 9.3.16, 9.3
@@ -33,7 +33,7 @@ GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.3
 
 Tags: 9.3.16-alpine, 9.3-alpine
-GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
+GitCommit: ee20f10a40f8893d5f67d593ddd44ba05d0c9df9
 Directory: 9.3/alpine
 
 Tags: 9.2.20, 9.2
@@ -41,5 +41,5 @@ GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
 Directory: 9.2
 
 Tags: 9.2.20-alpine, 9.2-alpine
-GitCommit: 3d4e5e9f64124b72aa80f80e2635aff0545988c6
+GitCommit: ee20f10a40f8893d5f67d593ddd44ba05d0c9df9
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.13, 2.7, 2
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
 Directory: 2.7
 
 Tags: 2.7.13-slim, 2.7-slim, 2-slim
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
+GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
 Directory: 2.7/alpine
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
 Directory: 2.7/wheezy
 
 Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
@@ -30,19 +30,19 @@ Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: ad4706ad7d23ef13472d2ee340aa43f3b9573e3d
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -50,19 +50,19 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.6, 3.4
-GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.4
 
 Tags: 3.4.6-slim, 3.4-slim
-GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.4/slim
 
 Tags: 3.4.6-alpine, 3.4-alpine
-GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.4/alpine
 
 Tags: 3.4.6-wheezy, 3.4-wheezy
-GitCommit: 1f7a601534dcc6377dcdef10bd3387f5c669c569
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.4/wheezy
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
@@ -70,15 +70,15 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.3, 3.5
-GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.5
 
 Tags: 3.5.3-slim, 3.5-slim
-GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.5/slim
 
 Tags: 3.5.3-alpine, 3.5-alpine
-GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.5/alpine
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
@@ -86,20 +86,20 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
 Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
-GitCommit: 9f67896dbaf1b86f2446b0ab981aa20f4d336132
+GitCommit: 60d03bd670bb9956b9c62a1004640e88669c301c
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.1, 3.6, 3, latest
-GitCommit: 32e920eb13714a9aeff2e016fb467901222d17b5
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.6
 
 Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
-GitCommit: 32e920eb13714a9aeff2e016fb467901222d17b5
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.6/slim
 
 Tags: 3.6.1-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 32e920eb13714a9aeff2e016fb467901222d17b5
+GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
 Directory: 3.6/alpine
 
 Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -107,6 +107,6 @@ GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/onbuild
 
 Tags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 32e920eb13714a9aeff2e016fb467901222d17b5
+GitCommit: 60d03bd670bb9956b9c62a1004640e88669c301c
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
- `docker`: experimental multiarch (docker-library/docker#52)
- `golang`: experimental multiarch (docker-library/golang#158)
- `nextcloud`: 10.0.5, 11.0.3, 9.0.58, update via container updates (nextcloud/docker#65)
- `postgres`: ensure `postgres` user's HOME has decent permissions (docker-library/postgres#277)
- `python`: fix `pip` install to also install `setuptools` and `wheel` (docker-library/python#186, docker-library/python#187)