### PR TITLE
Add LogicalDOC

### DIFF
--- a/library/logicaldoc
+++ b/library/logicaldoc
@@ -1,6 +1,6 @@
 Maintainers: Marco Meschieri <m.meschieri@logicaldoc.com> (@car031),
              Alessandro Gasparini <a.gasparini@logicaldoc.com> (@gasparez15)
-GitRepo: https://github.com/logicaldo/docker-logicaldoc.git
+GitRepo: https://github.com/logicaldoc/docker-logicaldoc.git
 
 Tags: latest, 7.6.4 
 GitCommit: 4a5e6ab215c45ddbde88c296b5093af6333a5364 

--- a/library/logicaldoc
+++ b/library/logicaldoc
@@ -1,0 +1,6 @@
+Maintainers: Marco Meschieri <m.meschieri@logicaldoc.com> (@car031),
+             Alessandro Gasparini <a.gasparini@logicaldoc.com> (@gasparez15)
+GitRepo: https://github.com/logicaldo/docker-logicaldoc.git
+
+Tags: latest, 7.6.4 
+GitCommit: 4a5e6ab215c45ddbde88c296b5093af6333a5364 


### PR DESCRIPTION
We wish to add our Official image for LogicalDOC
Our git repository is logicaldoc/docker-logicaldoc

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/logicaldoc
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/896
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
