### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -18,11 +18,11 @@ GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.7/wheezy
 
 Tags: 1.7.5-alpine, 1.7-alpine
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: d8ff0dd77a4910759d7f6b11e2ec0169337e14d1
 Directory: 1.7/alpine
 
 Tags: 1.7.5-alpine3.5, 1.7-alpine3.5
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: d8ff0dd77a4910759d7f6b11e2ec0169337e14d1
 Directory: 1.7/alpine3.5
 
 Tags: 1.7.5-windowsservercore, 1.7-windowsservercore
@@ -48,7 +48,7 @@ GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
 Directory: 1.8/stretch
 
 Tags: 1.8.1-alpine, 1.8-alpine, 1-alpine, alpine
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: d8ff0dd77a4910759d7f6b11e2ec0169337e14d1
 Directory: 1.8/alpine
 
 Tags: 1.8.1-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/77da4fddf173fce45be73b74ba2471a9fb813239/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/20694c47e7f2f7ab8946767b1dfcc7ff5e582534/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git

--- a/library/openjdk
+++ b/library/openjdk
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/openjdk.git
 
 Tags: 6b38-jdk, 6b38, 6-jdk, 6
-GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 6-jdk
 
 Tags: 6b38-jre, 6-jre
-GitCommit: 89851f0abc3a83cfad5248102f379d6a0bd3951a
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 6-jre
 
 Tags: 7u121-jdk, 7u121, 7-jdk, 7
-GitCommit: e3386b5a2b4004da498e145cf840561d50acd7fb
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 7-jdk
 
 Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jdk/alpine
 
 Tags: 7u121-jre, 7-jre
-GitCommit: e3386b5a2b4004da498e145cf840561d50acd7fb
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 7-jre
 
 Tags: 7u121-jre-alpine, 7-jre-alpine
@@ -29,7 +29,7 @@ GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jre/alpine
 
 Tags: 8u121-jdk, 8u121, 8-jdk, 8, jdk, latest
-GitCommit: 445f8b8d18d7c61e2ae7fda76d8883b5d51ae0a5
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 8-jdk
 
 Tags: 8u121-jdk-alpine, 8u121-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
@@ -47,7 +47,7 @@ Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 8u121-jre, 8-jre, jre
-GitCommit: 445f8b8d18d7c61e2ae7fda76d8883b5d51ae0a5
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 8-jre
 
 Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine
@@ -55,9 +55,9 @@ GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jre/alpine
 
 Tags: 9-b161-jdk, 9-b161, 9-jdk, 9
-GitCommit: 50c491c7c2378182866d89e857eb1f0c77985507
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 9-jdk
 
 Tags: 9-b161-jre, 9-jre
-GitCommit: 50c491c7c2378182866d89e857eb1f0c77985507
+GitCommit: 882461ade8207de7647d083009200de85eb978bc
 Directory: 9-jre


### PR DESCRIPTION
- `golang`: minor cross-building fix (docker-library/golang#159)
- `nextcloud`: no changes (comment change only)
- `openjdk`: `update-alternatives` so `/usr/bin/java` stays the right version (docker-library/openjdk#111)