### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,15 +4,15 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.05.0-ce-rc1, 17.05.0-ce, 17.05.0, 17.05-rc, rc
-GitCommit: 47d5d4ead8a95871d011b005394c9f2f7af68dab
+Tags: 17.05.0-ce-rc2, 17.05.0-ce, 17.05.0, 17.05-rc, rc
+GitCommit: 73485ebaa25a2212572838ccad4cea9728a438ca
 Directory: 17.05-rc
 
-Tags: 17.05.0-ce-rc1-dind, 17.05.0-ce-dind, 17.05.0-dind, 17.05-rc-dind, rc-dind
+Tags: 17.05.0-ce-rc2-dind, 17.05.0-ce-dind, 17.05.0-dind, 17.05-rc-dind, rc-dind
 GitCommit: 56215ac49d9947e317154fad823410df1201089b
 Directory: 17.05-rc/dind
 
-Tags: 17.05.0-ce-rc1-git, 17.05.0-ce-git, 17.05.0-git, 17.05-rc-git, rc-git
+Tags: 17.05.0-ce-rc2-git, 17.05.0-ce-git, 17.05.0-git, 17.05-rc-git, rc-git
 GitCommit: 56215ac49d9947e317154fad823410df1201089b
 Directory: 17.05-rc/git
 

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.3.1, 5.3, 5, latest
-GitCommit: 35d99e915d909688807c507a59a2c06039ac92b2
+Tags: 5.3.2, 5.3, 5, latest
+GitCommit: 936f86660d169f41457c235d7282e446b0174654
 Directory: 5
 
-Tags: 5.3.1-alpine, 5.3-alpine, 5-alpine, alpine
-GitCommit: 35d99e915d909688807c507a59a2c06039ac92b2
+Tags: 5.3.2-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: 936f86660d169f41457c235d7282e446b0174654
 Directory: 5/alpine
 
-Tags: 2.4.4, 2.4, 2
-GitCommit: 8f00ad520c1c33b879a715700905d3c25c526331
+Tags: 2.4.5, 2.4, 2
+GitCommit: ee9ba02f90f6b34ca33c20140ecff2b6db7c0c90
 Directory: 2.4
 
-Tags: 2.4.4-alpine, 2.4-alpine, 2-alpine
-GitCommit: 5727443ead111be19b55bfe5412dae5133cab8b1
+Tags: 2.4.5-alpine, 2.4-alpine, 2-alpine
+GitCommit: ee9ba02f90f6b34ca33c20140ecff2b6db7c0c90
 Directory: 2.4/alpine
 
 Tags: 1.7.6, 1.7, 1

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.3.1, 5.3, 5, latest
-GitCommit: 17280c315c2865d0e6bb6dfacd0ed7eead881ca7
+Tags: 5.3.2, 5.3, 5, latest
+GitCommit: d919877a1420ac42a95a398bbf035deeb0b171f4
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.3.1, 5.3, 5, latest
-GitCommit: 5823b0a117cb5c4a50c6a5890f73b0ec878f4bcc
+Tags: 5.3.2, 5.3, 5, latest
+GitCommit: 1c6b5eb0f0764f1272454236845d10ddfb5e7392
 Directory: 5
 
-Tags: 5.3.1-alpine, 5.3-alpine, 5-alpine, alpine
-GitCommit: 5823b0a117cb5c4a50c6a5890f73b0ec878f4bcc
+Tags: 5.3.2-alpine, 5.3-alpine, 5-alpine, alpine
+GitCommit: 1c6b5eb0f0764f1272454236845d10ddfb5e7392
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.14, 3.0
-GitCommit: 9914fd4e7967c32ad79710b08e4a21f4f68239f9
+GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
 Directory: 3.0
 
 Tags: 3.0.14-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.12, 3.2
-GitCommit: 9914fd4e7967c32ad79710b08e4a21f4f68239f9
+GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
 Directory: 3.2
 
 Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.4, 3.4, 3, latest
-GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
+GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
 Directory: 3.4
 
 Tags: 3.4.4-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
@@ -32,7 +32,7 @@ Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.5.6, 3.5, unstable
-GitCommit: 52ed5feba01538e24831b06ab8e9ad3019fb5036
+GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
 Directory: 3.5
 
 Tags: 3.5.6-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.1, 8.0, 8
-GitCommit: 7a850980c4b0d5fb5553986d280ebfb43230a6bb
+GitCommit: dc60c4b80f3eb5b7ef8b9ae09f16f6fab7a2fbf5
 Directory: 8.0
 
 Tags: 5.7.18, 5.7, 5, latest


### PR DESCRIPTION
- `docker`: 17.05.0-ce-rc2
- `elasticsearch`: 2.4.5, 5.3.2
- `kibana`: 5.3.2
- `logstash`: 5.3.2
- `mongo`: include `ca-certificates` in the image (docker-library/mongo#175)
- `mysql`: use new (slimmer) `-core` packages for 8.0 (docker-library/mysql#282)
- ~~`python`: setuptools 35.0.2~~ (see https://github.com/docker-library/python/pull/194)