### PR TITLE
Remove Ubuntu 12.04 (Precise Pangolin); End of Life today

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -9,16 +9,10 @@ GitFetch: refs/heads/dist
 
 # commits: (master..dist)
 #  - 8ec739c Update tarballs
-#    - `ubuntu:precise`: 20170331
 #    - `ubuntu:trusty`: 20170330
 #    - `ubuntu:xenial`: 20170417.1
 #    - `ubuntu:yakkety`: 20170327
 #    - `ubuntu:zesty`: 20170411
-
-# 20170331
-Tags: 12.04.5, 12.04, precise-20170331, precise
-GitCommit: 8ec739cf49ac7fb7517d9ba97b04216dc8d8459b
-Directory: precise
 
 # 20170330
 Tags: 14.04.5, 14.04, trusty-20170330, trusty


### PR DESCRIPTION
See https://lists.ubuntu.com/archives/ubuntu-security-announce/2017-April/003833.html for more details.