### PR TITLE
Update Solr to 6.5.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -17,16 +17,12 @@
 
 6.4.2: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
 6.4: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
-6: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
-latest: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
 
 6.4.2-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
 6.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
 
-6.5.0: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5
-6.5: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5
+6.5.1: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5
+6.5: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5
 
-6.5.0-alpine: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5/alpine
-6.5-alpine: git://github.com/docker-solr/docker-solr@1738f9a3cbad82e46c5ccebfb44707da13d05479 6.5/alpine
+6.5.1-alpine: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5/alpine
+6.5-alpine: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5/alpine


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/www-announce/201704.mbox/raw/%3CCAKUpjcQiYLZ1a%2BZM%3DoHUxJywLj9vNub8q9b_iLrvmkidiDV2xg%40mail.gmail.com%3E
Changes: https://lucene.apache.org/solr/6_5_1/changes/Changes.html