### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -13,12 +13,12 @@ GitCommit: a51b641c84e1a8d543b6a234a090f8263188139a
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.12, 3.2
-GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
+Tags: 3.2.13, 3.2
+GitCommit: 1bf5765ba4a8a46a70f5b2b634ef2070b4b89455
 Directory: 3.2
 
-Tags: 3.2.12-windowsservercore, 3.2-windowsservercore
-GitCommit: 5c0e43ac8eba7c2fb8cc3de9542f48b31c48da14
+Tags: 3.2.13-windowsservercore, 3.2-windowsservercore
+GitCommit: 1bf5765ba4a8a46a70f5b2b634ef2070b4b89455
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/python
+++ b/library/python
@@ -5,19 +5,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.13, 2.7, 2
-GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7
 
 Tags: 2.7.13-slim, 2.7-slim, 2-slim
-GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7/alpine
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: 05db1fffa8c302b1f94cf39a9d446be285e39668
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7/wheezy
 
 Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
@@ -25,24 +25,24 @@ GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 2.7.13-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -50,19 +50,19 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.6, 3.4
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.4
 
 Tags: 3.4.6-slim, 3.4-slim
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.4/slim
 
 Tags: 3.4.6-alpine, 3.4-alpine
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.4/alpine
 
 Tags: 3.4.6-wheezy, 3.4-wheezy
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.4/wheezy
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
@@ -70,15 +70,15 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.3, 3.5
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5
 
 Tags: 3.5.3-slim, 3.5-slim
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5/slim
 
 Tags: 3.5.3-alpine, 3.5-alpine
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5/alpine
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
@@ -86,20 +86,20 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
 Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
-GitCommit: 60d03bd670bb9956b9c62a1004640e88669c301c
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.1, 3.6, 3, latest
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6
 
 Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/slim
 
 Tags: 3.6.1-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: dc016eb55d86dd6e23ec5ee2a537ee60ab11c795
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/alpine
 
 Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -107,6 +107,6 @@ GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/onbuild
 
 Tags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
-GitCommit: 60d03bd670bb9956b9c62a1004640e88669c301c
+GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: d2e8fbec715d6adab99835cb4c7fd5acb7149a51
+GitCommit: 1b6455cc7246264f27232fe971253d083ad0aedb
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: d2e8fbec715d6adab99835cb4c7fd5acb7149a51
+GitCommit: 1b6455cc7246264f27232fe971253d083ad0aedb
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: d2e8fbec715d6adab99835cb4c7fd5acb7149a51
+GitCommit: 1b6455cc7246264f27232fe971253d083ad0aedb
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.7, 2.2
-GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
+GitCommit: f71f396078ea28a60d0b4cb805ef6d3d86419989
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
-GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
+GitCommit: f71f396078ea28a60d0b4cb805ef6d3d86419989
 Directory: 2.2/slim
 
 Tags: 2.2.7-alpine, 2.2-alpine
-GitCommit: 8e83e621cc71c4f55b7f1d62e47ec9b56258c740
+GitCommit: f71f396078ea28a60d0b4cb805ef6d3d86419989
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
-GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
+GitCommit: f47162319baa20972289786bea2e7498d04a8e82
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
-GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
+GitCommit: f47162319baa20972289786bea2e7498d04a8e82
 Directory: 2.3/slim
 
 Tags: 2.3.4-alpine, 2.3-alpine
-GitCommit: 1f028a535fe8e97b86f99899afd08b1b1df1406c
+GitCommit: f47162319baa20972289786bea2e7498d04a8e82
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
-GitCommit: e98bec810e6f1bd88ad0106f2e3b3f3291f5f5bb
+GitCommit: fbb4b1683e3689efcf1bf3899125f9f6ec1ba84b
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
-GitCommit: e98bec810e6f1bd88ad0106f2e3b3f3291f5f5bb
+GitCommit: fbb4b1683e3689efcf1bf3899125f9f6ec1ba84b
 Directory: 2.4/slim
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: e98bec810e6f1bd88ad0106f2e3b3f3291f5f5bb
+GitCommit: fbb4b1683e3689efcf1bf3899125f9f6ec1ba84b
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `mongo`: 3.2.13
- `python`: unconditionally invoke `get-pip.py` to install `pip` more consistently (docker-library/python#194)
- `ruby`: rubygems 2.6.12