### PR TITLE
Add CentOS variant and new template system

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,7 +1,7 @@
-# this file is generated via https://github.com/nuxeo/docker-nuxeo/blob/9ab02e276b899ac1982a3ec739f1fde240146c02/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nuxeo/docker-nuxeo/blob/c737024a9d2c0425ba924cb1f6436adfc7a039e7/generate-stackbrew-library.sh
 
-Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
-             Arnaud Kervern <akervern@nuxeo.com> (@akervern)
+Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@damienmetzler),
+             Arnaud Kervern <akervern@nuxeo.com> (@arnaudke)
 GitRepo: https://github.com/nuxeo/docker-nuxeo.git
 
 Tags: 6.0, 6, LTS-2014
@@ -16,22 +16,6 @@ Tags: 8.10, 8, LTS-2016, LTS
 GitCommit: bbe7c0d45e6608bbd50283bf753be4c501daec52
 Directory: 8.10
 
-Tags: 9.1, 9, FT, ubuntu
+Tags: 9.1, 9, FT, latest
 GitCommit: bbe7c0d45e6608bbd50283bf753be4c501daec52
 Directory: 9.1
-
-Tags: 6.0-centos, 6-centos, LTS-2014-centos
-GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
-Directory: 6.0/centos
-
-Tags: 7.10-centos, 7-centos, LTS-2015-centos
-GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
-Directory: 7.10/centos
-
-Tags: 8.10-centos, 8-centos, LTS-2016-centos, LTS-centos
-GitCommit: ccf86bdc2dbfd9dae0ba30ecc4a0bf4ef2f4e904
-Directory: 8.10/centos
-
-Tags: 9.1-centos, 9-centos, FT-centos, centos
-GitCommit: 1eabda369934f9c0d73b39c9020f5df2288e5561
-Directory: 9.1/centos

--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,22 +1,37 @@
+# this file is generated via https://github.com/nuxeo/docker-nuxeo/blob/9ab02e276b899ac1982a3ec739f1fde240146c02/generate-stackbrew-library.sh
+
 Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
              Arnaud Kervern <akervern@nuxeo.com> (@akervern)
 GitRepo: https://github.com/nuxeo/docker-nuxeo.git
-GitCommit: 12c5d2e01e3a3a492a57ab46e1f8795c9e68cbc3
 
-Tags: latest, 9, 9.1, FT
-Directory: 9.1
+Tags: 6.0, 6, LTS-2014
+GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
+Directory: 6.0
 
-Tags: LTS, LTS-2016, 8, 8.10
-Directory: 8.10
-
-Tags: 8.3
-Directory: 8.3
-
-Tags: 8.2
-Directory: 8.2
-
-Tags: LTS-2015, 7, 7.10
+Tags: 7.10, 7, LTS-2015
+GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
 Directory: 7.10
 
-Tags: LTS-2014, 6, 6.0
-Directory: 6.0
+Tags: 8.10, 8, LTS-2016, LTS
+GitCommit: ccf86bdc2dbfd9dae0ba30ecc4a0bf4ef2f4e904
+Directory: 8.10
+
+Tags: 9.1, 9, FT, ubuntu
+GitCommit: 1eabda369934f9c0d73b39c9020f5df2288e5561
+Directory: 9.1
+
+Tags: 6.0-centos, 6-centos, LTS-2014-centos
+GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
+Directory: 6.0/centos
+
+Tags: 7.10-centos, 7-centos, LTS-2015-centos
+GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
+Directory: 7.10/centos
+
+Tags: 8.10-centos, 8-centos, LTS-2016-centos, LTS-centos
+GitCommit: ccf86bdc2dbfd9dae0ba30ecc4a0bf4ef2f4e904
+Directory: 8.10/centos
+
+Tags: 9.1-centos, 9-centos, FT-centos, centos
+GitCommit: 1eabda369934f9c0d73b39c9020f5df2288e5561
+Directory: 9.1/centos

--- a/library/nuxeo
+++ b/library/nuxeo
@@ -13,11 +13,11 @@ GitCommit: 4da3ff891d3d6911304cbbe0895333ae4c84ffa7
 Directory: 7.10
 
 Tags: 8.10, 8, LTS-2016, LTS
-GitCommit: ccf86bdc2dbfd9dae0ba30ecc4a0bf4ef2f4e904
+GitCommit: bbe7c0d45e6608bbd50283bf753be4c501daec52
 Directory: 8.10
 
 Tags: 9.1, 9, FT, ubuntu
-GitCommit: 1eabda369934f9c0d73b39c9020f5df2288e5561
+GitCommit: bbe7c0d45e6608bbd50283bf753be4c501daec52
 Directory: 9.1
 
 Tags: 6.0-centos, 6-centos, LTS-2014-centos


### PR DESCRIPTION
This just adds a CentOS variant. For that we also introduce a new templating system that allows us to generate more easily the Dockerfiles etc... plus a `generate-stackbrew` script.

Complete story of development can be found here : https://github.com/nuxeo/docker-nuxeo/pull/10

No rush to merge, I did that in parallel of our 9.1 release, so PR happens after it. 