### PR TITLE
Updates for Node.js v7.10.0, v6.10.3 and v4.8.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/e866277fa5a05cc0fafb14ffc406343b9c7ef9f7/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.10.0, 7.10
+Tags: 7.10.0, 7.10, 7, latest
 GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
 Directory: 7.10
 
-Tags: 7.10.0-alpine, 7.10-alpine
+Tags: 7.10.0-alpine, 7.10-alpine, 7-alpine, alpine
 GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
 Directory: 7.10/alpine
 
-Tags: 7.10.0-onbuild, 7.10-onbuild
+Tags: 7.10.0-onbuild, 7.10-onbuild, 7-onbuild, onbuild
 GitCommit: 2e7fd977fb10088c82c559926580b60a47f40732
 Directory: 7.10/onbuild
 
-Tags: 7.10.0-slim, 7.10-slim
+Tags: 7.10.0-slim, 7.10-slim, 7-slim, slim
 GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
 Directory: 7.10/slim
 
-Tags: 7.10.0-wheezy, 7.10-wheezy
+Tags: 7.10.0-wheezy, 7.10-wheezy, 7-wheezy, wheezy
 GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
 Directory: 7.10/wheezy
 

--- a/library/node
+++ b/library/node
@@ -4,11 +4,11 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 7.9.0, 7.9, 7, latest
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+GitCommit: b328087a2e63a327ab421a754559fb61864d4345
 Directory: 7.9
 
 Tags: 7.9.0-alpine, 7.9-alpine, 7-alpine, alpine
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+GitCommit: b328087a2e63a327ab421a754559fb61864d4345
 Directory: 7.9/alpine
 
 Tags: 7.9.0-onbuild, 7.9-onbuild, 7-onbuild, onbuild
@@ -16,50 +16,50 @@ GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
 Directory: 7.9/onbuild
 
 Tags: 7.9.0-slim, 7.9-slim, 7-slim, slim
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+GitCommit: b328087a2e63a327ab421a754559fb61864d4345
 Directory: 7.9/slim
 
 Tags: 7.9.0-wheezy, 7.9-wheezy, 7-wheezy, wheezy
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+GitCommit: b328087a2e63a327ab421a754559fb61864d4345
 Directory: 7.9/wheezy
 
-Tags: 6.10.2, 6.10, 6, boron
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 6.10.3, 6.10, 6, boron
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 6.10
 
-Tags: 6.10.2-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 6.10.3-alpine, 6.10-alpine, 6-alpine, boron-alpine
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 6.10/alpine
 
-Tags: 6.10.2-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
-GitCommit: 140ada855e777f9aa3156a2169817b2778f707be
+Tags: 6.10.3-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
+GitCommit: ffecb0e9ca258d6b20ff60b30956bd33f7357142
 Directory: 6.10/onbuild
 
-Tags: 6.10.2-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 6.10.3-slim, 6.10-slim, 6-slim, boron-slim
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 6.10/slim
 
-Tags: 6.10.2-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 6.10.3-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 6.10/wheezy
 
-Tags: 4.8.2, 4.8, 4, argon
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 4.8.3, 4.8, 4, argon
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 4.8
 
-Tags: 4.8.2-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 4.8.3-alpine, 4.8-alpine, 4-alpine, argon-alpine
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 4.8/alpine
 
-Tags: 4.8.2-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 9bc214cd9f0cc1a84d74f03665aa87e37535cd14
+Tags: 4.8.3-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 974c2a3c3cc488c3491a7ffd85e90c079d0d78e1
 Directory: 4.8/onbuild
 
-Tags: 4.8.2-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 4.8.3-slim, 4.8-slim, 4-slim, argon-slim
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 4.8/slim
 
-Tags: 4.8.2-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: e1103db1e7330f620ec4b5961b93936da11becdf
+Tags: 4.8.3-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4
 Directory: 4.8/wheezy
 

--- a/library/node
+++ b/library/node
@@ -3,25 +3,25 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.9.0, 7.9, 7, latest
-GitCommit: b328087a2e63a327ab421a754559fb61864d4345
-Directory: 7.9
+Tags: 7.10.0, 7.10
+GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
+Directory: 7.10
 
-Tags: 7.9.0-alpine, 7.9-alpine, 7-alpine, alpine
-GitCommit: b328087a2e63a327ab421a754559fb61864d4345
-Directory: 7.9/alpine
+Tags: 7.10.0-alpine, 7.10-alpine
+GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
+Directory: 7.10/alpine
 
-Tags: 7.9.0-onbuild, 7.9-onbuild, 7-onbuild, onbuild
-GitCommit: a82c9dcd3f85ff8055f56c53e6d8f31c5ae28ed7
-Directory: 7.9/onbuild
+Tags: 7.10.0-onbuild, 7.10-onbuild
+GitCommit: 2e7fd977fb10088c82c559926580b60a47f40732
+Directory: 7.10/onbuild
 
-Tags: 7.9.0-slim, 7.9-slim, 7-slim, slim
-GitCommit: b328087a2e63a327ab421a754559fb61864d4345
-Directory: 7.9/slim
+Tags: 7.10.0-slim, 7.10-slim
+GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
+Directory: 7.10/slim
 
-Tags: 7.9.0-wheezy, 7.9-wheezy, 7-wheezy, wheezy
-GitCommit: b328087a2e63a327ab421a754559fb61864d4345
-Directory: 7.9/wheezy
+Tags: 7.10.0-wheezy, 7.10-wheezy
+GitCommit: 97fa0404116a7b6f926cd4c947199fbaea6d4e67
+Directory: 7.10/wheezy
 
 Tags: 6.10.3, 6.10, 6, boron
 GitCommit: 68ec46d47edc70337e602dd98cb6606c434783d4


### PR DESCRIPTION
Related: https://github.com/nodejs/docker-node/pull/389
Related: https://github.com/nodejs/docker-node/pull/390
Related: https://github.com/nodejs/docker-node/pull/391
Related: https://github.com/nodejs/docker-node/pull/392