### PR TITLE
Bumping to fsharp 4.1.18

### DIFF
--- a/library/fsharp
+++ b/library/fsharp
@@ -7,7 +7,7 @@ GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.1.18/mono
 
 Tags: core
-GitCommit: a28196740e38035beea04c41d5862136413281e3
+GitCommit: bf7c49e91af9f2c086de71ca9e9dd9d210e9c9da
 Directory: 4.1.18/core
 
 Tags: 4.1.0.1

--- a/library/fsharp
+++ b/library/fsharp
@@ -6,10 +6,6 @@ Tags: latest, 4, 4.1, 4.1.18
 GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.1.18/mono
 
-Tags: core
-GitCommit: bf7c49e91af9f2c086de71ca9e9dd9d210e9c9da
-Directory: 4.1.18/core
-
 Tags: 4.1.0.1
 GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.1.0.1/mono

--- a/library/fsharp
+++ b/library/fsharp
@@ -11,13 +11,13 @@ GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.1.18/core
 
 Tags: 4.1.0.1
-GitCommit: 289a5e0066c69255c055dd5ee22f2e583d37fab4
+GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.1.0.1/mono
 
 Tags: 4.0, 4.0.1, 4.0.1.1
-GitCommit: 289a5e0066c69255c055dd5ee22f2e583d37fab4
+GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.0.1.1
 
 Tags: 4.0.0.4
-GitCommit: 289a5e0066c69255c055dd5ee22f2e583d37fab4
+GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.0.0.4

--- a/library/fsharp
+++ b/library/fsharp
@@ -1,4 +1,4 @@
-Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
+Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 

--- a/library/fsharp
+++ b/library/fsharp
@@ -1,9 +1,18 @@
-Maintainers: Henrik Feldt <henrik@haf.se> (@haf)
+Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
+             Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 
-Tags: latest, 4, 4.1, 4.1.0.1
+Tags: latest, 4, 4.1, 4.1.18
+GitCommit: a28196740e38035beea04c41d5862136413281e3
+Directory: 4.1.18/mono
+
+Tags: core
+GitCommit: a28196740e38035beea04c41d5862136413281e3
+Directory: 4.1.18/core
+
+Tags: 4.1.0.1
 GitCommit: 289a5e0066c69255c055dd5ee22f2e583d37fab4
-Directory: 4.1.0.1
+Directory: 4.1.0.1/mono
 
 Tags: 4.0, 4.0.1, 4.0.1.1
 GitCommit: 289a5e0066c69255c055dd5ee22f2e583d37fab4


### PR DESCRIPTION
Updating mono based image with 4.1.18
Added .NET Core image with `core` tag
Update to maintainers