### PR TITLE
Bump traefik to v1.3.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,16 +2,16 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
+Tags: v1.3.0-rc1, 1.3.0-rc1, v1.3, 1.3, raclette
+GitCommit: 2e3f79a93cd9fd5199abe02de54dd37726843bf4
+
+Tags: v1.3.0-rc1-alpine, 1.3.0-rc1-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 2e3f79a93cd9fd5199abe02de54dd37726843bf4
+Directory: alpine
+
 Tags: v1.2.3, 1.2.3, v1.2, 1.2, morbier, latest
 GitCommit: 50d631ddf197da6228172cb86ab6098d875a6ea0
 
 Tags: v1.2.3-alpine, 1.2.3-alpine, v1.2-alpine, 1.2-alpine, morbier-alpine
 GitCommit: 50d631ddf197da6228172cb86ab6098d875a6ea0
-Directory: alpine
-
-Tags: v1.1.2, 1.1.2, v1.1, 1.1, camembert
-GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
-
-Tags: v1.1.2-alpine, 1.1.2-alpine, v1.1-alpine, 1.1-alpine, camembert-alpine
-GitCommit: 3645f9dfbd417ee8dad608257c7aeec3a407711f
 Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.3.0-rc1
/cc @vdemeester @ldez @atbore-phx 

Cheers