### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,18 +16,6 @@ Tags: jessie, latest
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: jessie
 
-Tags: precise-curl
-GitCommit: af914a5bde2a749884177393c8140384048dc5f9
-Directory: precise/curl
-
-Tags: precise-scm
-GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
-Directory: precise/scm
-
-Tags: precise
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
-Directory: precise
-
 Tags: sid-curl
 GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
 Directory: sid/curl

--- a/library/openjdk
+++ b/library/openjdk
@@ -54,10 +54,10 @@ Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jre/alpine
 
-Tags: 9-b161-jdk, 9-b161, 9-jdk, 9
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 9-b168-jdk, 9-b168, 9-jdk, 9
+GitCommit: cf54b49f29ea633bd7d0fdbcaa1b052ea9ad18e9
 Directory: 9-jdk
 
-Tags: 9-b161-jre, 9-jre
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 9-b168-jre, 9-jre
+GitCommit: cf54b49f29ea633bd7d0fdbcaa1b052ea9ad18e9
 Directory: 9-jre


### PR DESCRIPTION
- `buildpack-deps`: remove EOL precise variants
- `openjdk`: debian `9~b168-1`