### PR TITLE
Bump alpine builds for 3.4 apk-tools fix and new default CMD

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,9 +1,9 @@
 # maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 
-3.1: git://github.com/gliderlabs/docker-alpine@cb0a5a01230693785e876a91b3484c4c05b2b06b versions/library-3.1
-3.2: git://github.com/gliderlabs/docker-alpine@c60ae198ab8ac02a28725dfe990b1742c583b156 versions/library-3.2
-3.3: git://github.com/gliderlabs/docker-alpine@401eef8812da24776468ff885a41afd2d7958882 versions/library-3.3
-3.4: git://github.com/gliderlabs/docker-alpine@47a904af6b2702a947fe3ce7d741f877c30c11d0 versions/library-3.4
-3.5: git://github.com/gliderlabs/docker-alpine@c7368b846ee805b286d9034a39e0bbf40bc079b3 versions/library-3.5
-latest: git://github.com/gliderlabs/docker-alpine@c7368b846ee805b286d9034a39e0bbf40bc079b3 versions/library-3.5
-edge: git://github.com/gliderlabs/docker-alpine@60d6d06885459a9fa7e5d51d986be89ce61d9c41 versions/library-edge
+3.1: git://github.com/gliderlabs/docker-alpine@3d0e79188adb609440a3b2c8516d7bd0b9db9107 versions/library-3.1
+3.2: git://github.com/gliderlabs/docker-alpine@ef2b09086c8b3f9f673c5100470462a28efe9038 versions/library-3.2
+3.3: git://github.com/gliderlabs/docker-alpine@84063540fc7568984d0c1f819107fd02081696c7 versions/library-3.3
+3.4: git://github.com/gliderlabs/docker-alpine@fb9930f2c3179e629f5cff887742f31bbb7d8d46 versions/library-3.4
+3.5: git://github.com/gliderlabs/docker-alpine@cb5e568b84f4a48bb1245c602bae3de38a67bd55 versions/library-3.5
+latest: git://github.com/gliderlabs/docker-alpine@cb5e568b84f4a48bb1245c602bae3de38a67bd55 versions/library-3.5
+edge: git://github.com/gliderlabs/docker-alpine@fa6353d492aefa36c4a2e1c6130b891c85047e75 versions/library-edge


### PR DESCRIPTION
These are bumped builds for:

* New default CMD.
* apk-tools 2.6.8 in 3.4 (security fix).
* tars built as xz.

Changes since last builds: https://github.com/gliderlabs/docker-alpine/compare/13e065eb5cacd5d6b7c4a2e98278a950bc752067...release.

Ping @ncopa.