### PR TITLE
Update busybox tarballs (newer buildroot, newer libcs, add libpthread in glibc, https, fixed GPG)

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -7,13 +7,13 @@ GitRepo: https://github.com/docker-library/busybox.git
 GitFetch: refs/heads/dist
 
 Tags: 1.26.2-glibc, 1.26-glibc, 1-glibc, glibc
-GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
+GitCommit: de3cbcb2cd371e55119e460c03bf73b8abbbd064
 Directory: glibc
 
 Tags: 1.26.2-musl, 1.26-musl, 1-musl, musl
-GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
+GitCommit: de3cbcb2cd371e55119e460c03bf73b8abbbd064
 Directory: musl
 
 Tags: 1.26.2-uclibc, 1.26-uclibc, 1-uclibc, uclibc, 1.26.2, 1.26, 1, latest
-GitCommit: b18bec4367d42f4b4749379911f29346f1068cde
+GitCommit: de3cbcb2cd371e55119e460c03bf73b8abbbd064
 Directory: uclibc


### PR DESCRIPTION
(This is the update to https://github.com/docker-library/official-images/pull/2953)