### PR TITLE
Upgrades elixir to 1.4.4

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,14 +1,14 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/36ed572a13d5bba010834574c72efbd44f000288/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-elixir/blob/e5578add88b8498cdb6c5fc8f6dd2e971f1a8cca/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.4.2, 1.4, latest
-GitCommit: 36ed572a13d5bba010834574c72efbd44f000288
+Tags: 1.4.4, 1.4, latest
+GitCommit: e5578add88b8498cdb6c5fc8f6dd2e971f1a8cca
 Directory: 1.4
 
-Tags: 1.4.2-slim, 1.4-slim, slim
-GitCommit: 36ed572a13d5bba010834574c72efbd44f000288
+Tags: 1.4.4-slim, 1.4-slim, slim
+GitCommit: e5578add88b8498cdb6c5fc8f6dd2e971f1a8cca
 Directory: 1.4/slim
 
 Tags: 1.3.4, 1.3


### PR DESCRIPTION
Version 1.4.3 was skipped since it contains a regression.

Refs c0b/docker-elixir#26