### PR TITLE
Bump traefik to v1.3.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -2,11 +2,11 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.0-rc1, 1.3.0-rc1, v1.3, 1.3, raclette
-GitCommit: 2e3f79a93cd9fd5199abe02de54dd37726843bf4
+Tags: v1.3.0-rc2, 1.3.0-rc2, v1.3, 1.3, raclette
+GitCommit: 9be98ef312ed6bdeb57fd3708be355978393041c
 
-Tags: v1.3.0-rc1-alpine, 1.3.0-rc1-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 2e3f79a93cd9fd5199abe02de54dd37726843bf4
+Tags: v1.3.0-rc2-alpine, 1.3.0-rc2-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 9be98ef312ed6bdeb57fd3708be355978393041c
 Directory: alpine
 
 Tags: v1.2.3, 1.2.3, v1.2, 1.2, morbier, latest


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.3.0-rc2
/cc @vdemeester @ldez @timoreimann

Cheers