### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -28,8 +28,8 @@ Tags: 7u121-jre-alpine, 7-jre-alpine
 GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jre/alpine
 
-Tags: 8u121-jdk, 8u121, 8-jdk, 8, jdk, latest
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 8u131-jdk, 8u131, 8-jdk, 8, jdk, latest
+GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jdk
 
 Tags: 8u121-jdk-alpine, 8u121-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
@@ -46,8 +46,8 @@ GitCommit: 9745c87a15896ec558429a826e23926e721e4846
 Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 8u121-jre, 8-jre, jre
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 8u131-jre, 8-jre, jre
+GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jre
 
 Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.55.1, 0.55, 0, latest
-GitCommit: 28124b975c164219a110080d9f1af943332fb748
+Tags: 0.56.0, 0.56, 0, latest
+GitCommit: f65fa9bf451f0e11e651ddd5b9399b8aacbc035c


### PR DESCRIPTION
- `openjdk`: debian `8u131-b11-1~bpo8+1`
- `rocket.chat`: 0.56.0