### PR TITLE
telegraf 1.3.0 and smaller chronograf image

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -2,10 +2,10 @@ Maintainers: Jonathan A. Sternberg <jonathan@influxdb.com> (@jsternberg)
 
 Tags: 1.3, 1.3.0, latest
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: c2f56dd3818aaf015ed205f769f40770d9c7441c
+GitCommit: 7be94386cd401e0706ad259c1189f75925e76272
 Directory: chronograf/1.3
 
 Tags: 1.3-alpine, 1.3.0-alpine, alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: c2f56dd3818aaf015ed205f769f40770d9c7441c
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: chronograf/1.3/alpine

--- a/library/influxdb
+++ b/library/influxdb
@@ -2,20 +2,20 @@ Maintainers: Jonathan A. Sternberg <jonathan@influxdb.com> (@jsternberg)
 
 Tags: 1.1, 1.1.5
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: ab9f2373d6ea1d5a530be529225c5bb1c18d37ee
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: influxdb/1.1
 
 Tags: 1.1-alpine, 1.1.5-alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: ab9f2373d6ea1d5a530be529225c5bb1c18d37ee
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: influxdb/1.1/alpine
 
 Tags: 1.2, 1.2.4, latest
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: a90cd8cfb38357456914aabe63ce9cd8d216c464
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: influxdb/1.2
 
 Tags: 1.2-alpine, 1.2.4-alpine, alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: a90cd8cfb38357456914aabe63ce9cd8d216c464
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: influxdb/1.2/alpine

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -2,20 +2,20 @@ Maintainers: Jonathan A. Sternberg <jonathan@influxdb.com> (@jsternberg)
 
 Tags: 1.1, 1.1.1
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: kapacitor/1.1
 
 Tags: 1.1-alpine, 1.1.1-alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: kapacitor/1.1/alpine
 
 Tags: 1.2, 1.2.1, latest
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 691c4a7fe190427448d5c92abc9ea5c5be6b4e63
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: kapacitor/1.2
 
 Tags: 1.2-alpine, 1.2.1-alpine, alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 691c4a7fe190427448d5c92abc9ea5c5be6b4e63
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: kapacitor/1.2/alpine

--- a/library/telegraf
+++ b/library/telegraf
@@ -1,21 +1,21 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdb.com> (@jsternberg)
 
-Tags: 1.1, 1.1.2
+Tags: 1.2, 1.2.1
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
-Directory: telegraf/1.1
-
-Tags: 1.1-alpine, 1.1.2-alpine
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
-Directory: telegraf/1.1/alpine
-
-Tags: 1.2, 1.2.1, latest
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: telegraf/1.2
 
-Tags: 1.2-alpine, 1.2.1-alpine, alpine
+Tags: 1.2-alpine, 1.2.1-alpine
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: d3babf9a87cb217d99aeabcea369c917b81121e1
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
 Directory: telegraf/1.2/alpine
+
+Tags: 1.3, 1.3.0, latest
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
+Directory: telegraf/1.3
+
+Tags: 1.3-alpine, 1.3.0-alpine, alpine
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: 3a8019600cefcb4ffc85c3e3a155980d2dc3f5ff
+Directory: telegraf/1.3/alpine


### PR DESCRIPTION
Update chronograf, influxdb, kapacitor, and telegraf so they check
multiple gpg servers for a key rather than failing if the keyserver
fails. This should make the builds more reliable.