### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.8, 0.11, 0, latest
-GitCommit: 1e9307eb3642dd5fb2b8e9c25a15fa524ad0e219
+Tags: 0.11.9, 0.11, 0, latest
+GitCommit: 8435a22109f8d1556c3e824b1ca3cfadd2454f37
 Directory: debian
 
-Tags: 0.11.8-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: 1e9307eb3642dd5fb2b8e9c25a15fa524ad0e219
+Tags: 0.11.9-alpine, 0.11-alpine, 0-alpine, alpine
+GitCommit: 8435a22109f8d1556c3e824b1ca3cfadd2454f37
 Directory: alpine

--- a/library/piwik
+++ b/library/piwik
@@ -2,10 +2,10 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.0.3-apache, 3.0-apache, 3-apache, apache, 3.0.3, 3.0, 3, latest
-GitCommit: b00cca0f4bce10167cda80c6ca640ffc771812df
+Tags: 3.0.4-apache, 3.0-apache, 3-apache, apache, 3.0.4, 3.0, 3, latest
+GitCommit: 4d9eadce21a4900442b16a3ef4c8ab7582cc7c83
 Directory: apache
 
-Tags: 3.0.3-fpm, 3.0-fpm, 3-fpm, fpm
-GitCommit: b00cca0f4bce10167cda80c6ca640ffc771812df
+Tags: 3.0.4-fpm, 3.0-fpm, 3-fpm, fpm
+GitCommit: 4d9eadce21a4900442b16a3ef4c8ab7582cc7c83
 Directory: fpm

--- a/library/tomcat
+++ b/library/tomcat
@@ -12,36 +12,36 @@ Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
 GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
 Directory: 6/jre8
 
-Tags: 7.0.77-jre7, 7.0-jre7, 7-jre7, 7.0.77, 7.0, 7
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 7.0.78-jre7, 7.0-jre7, 7-jre7, 7.0.78, 7.0, 7
+GitCommit: 9355db128c52e0463e37d2fbd267c0ea33ed0b19
 Directory: 7/jre7
 
-Tags: 7.0.77-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.77-alpine, 7.0-alpine, 7-alpine
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 7.0.78-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.78-alpine, 7.0-alpine, 7-alpine
+GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
 Directory: 7/jre7-alpine
 
-Tags: 7.0.77-jre8, 7.0-jre8, 7-jre8
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 7.0.78-jre8, 7.0-jre8, 7-jre8
+GitCommit: 9355db128c52e0463e37d2fbd267c0ea33ed0b19
 Directory: 7/jre8
 
-Tags: 7.0.77-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 7.0.78-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
 Directory: 7/jre8-alpine
 
-Tags: 8.0.43-jre7, 8.0-jre7, 8.0.43, 8.0
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 8.0.44-jre7, 8.0-jre7, 8.0.44, 8.0
+GitCommit: eba2c31453300691978be256d5416821a788850d
 Directory: 8.0/jre7
 
-Tags: 8.0.43-jre7-alpine, 8.0-jre7-alpine, 8.0.43-alpine, 8.0-alpine
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 8.0.44-jre7-alpine, 8.0-jre7-alpine, 8.0.44-alpine, 8.0-alpine
+GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.43-jre8, 8.0-jre8
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 8.0.44-jre8, 8.0-jre8
+GitCommit: eba2c31453300691978be256d5416821a788850d
 Directory: 8.0/jre8
 
-Tags: 8.0.43-jre8-alpine, 8.0-jre8-alpine
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+Tags: 8.0.44-jre8-alpine, 8.0-jre8-alpine
+GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.15-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.15, 8.5, 8, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,40 +4,40 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.4-apache, 4.7-apache, 4-apache, apache, 4.7.4, 4.7, 4, latest, 4.7.4-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.4-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-apache, 4.7-apache, 4-apache, apache, 4.7.5, 4.7, 4, latest, 4.7.5-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.5-php5.6, 4.7-php5.6, 4-php5.6, php5.6
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php5.6/apache
 
-Tags: 4.7.4-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.4-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.5-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php5.6/fpm
 
-Tags: 4.7.4-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.4-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.5-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.4-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.4-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.5-php7.0, 4.7-php7.0, 4-php7.0, php7.0
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.0/apache
 
-Tags: 4.7.4-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.0/fpm
 
-Tags: 4.7.4-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.4-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.4-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.5-php7.1, 4.7-php7.1, 4-php7.1, php7.1
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.1/apache
 
-Tags: 4.7.4-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.1/fpm
 
-Tags: 4.7.4-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: 716fe2fabb0be1bcd46626fad83d8c345946d343
+Tags: 4.7.5-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost`: 0.11.9
- `piwik`: 3.0.4
- `tomcat`: 8.0.44, 7.0.78
- `wordpress`: 4.7.5