### PR TITLE
Bump Vault to 0.7.2

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -3,4 +3,5 @@
 0.6.4: git://github.com/hashicorp/docker-vault@c087a27b5ec93445e89dc46f25af973f114f1399 0.6.4
 0.6.5: git://github.com/hashicorp/docker-vault@c087a27b5ec93445e89dc46f25af973f114f1399 0.6.5
 0.7.0: git://github.com/hashicorp/docker-vault@e0a91ac0bc931fca599d14c0593cc8e28c56a30d 0.7.0
-latest: git://github.com/hashicorp/docker-vault@e0a91ac0bc931fca599d14c0593cc8e28c56a30d 0.7.0
+0.7.2: git://github.com/hashicorp/docker-vault@9a0b4b5039b66f4a9591b8be6ff79c15c112f882 0.7.2
+latest: git://github.com/hashicorp/docker-vault@9a0b4b5039b66f4a9591b8be6ff79c15c112f882 0.7.2


### PR DESCRIPTION
Skipping over `0.7.1` since it was quickly superseded by a bugfix release of `0.7.2`.