### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,6 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
+Tags: 10.3.0, 10.3
+GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
+Directory: 10.3
+
+Tags: 10.2.5, 10.2
+GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
+Directory: 10.2
+
 Tags: 10.1.23, 10.1, 10, latest
 GitCommit: 352f47fdb034a359e27ef6223f252a9e75e2f596
 Directory: 10.1

--- a/library/redis
+++ b/library/redis
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 3.0.7, 3.0
-GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.0
 
 Tags: 3.0.7-32bit, 3.0-32bit
-GitCommit: 6cb8a8015f126e2a7251c5d011b86b657e9febd6
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.0/32bit
 
 Tags: 3.0.7-alpine, 3.0-alpine
-GitCommit: 9db6cc1645465f134d03584dbbbd962ce822479a
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.0/alpine
 
 Tags: 3.0.504-windowsservercore, 3.0-windowsservercore
@@ -26,16 +26,16 @@ GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 3.2.8, 3.2, 3, latest
-GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
+Tags: 3.2.9, 3.2, 3, latest
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.2
 
-Tags: 3.2.8-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
+Tags: 3.2.9-32bit, 3.2-32bit, 3-32bit, 32bit
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.2/32bit
 
-Tags: 3.2.8-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 3f926a47370a19fc88d57d0245823758cbf19b2d
+Tags: 3.2.9-alpine, 3.2-alpine, 3-alpine, alpine
+GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
 Directory: 3.2/alpine
 
 Tags: 3.2.100-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore


### PR DESCRIPTION
- `mariadb`: add 10.2 and 10.3
- `redis`: 3.2.9

fixes https://github.com/docker-library/mariadb/issues/110