### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.05.0-ce, 17.05.0, 17.05, 17, latest, edge
-GitCommit: ce78a19aac321bbe50d060426b5b633cb5f74825
+GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
 Directory: 17.05
 
 Tags: 17.05.0-ce-dind, 17.05.0-dind, 17.05-dind, 17-dind, dind, edge-dind
-GitCommit: ce78a19aac321bbe50d060426b5b633cb5f74825
+GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
 Directory: 17.05/dind
 
 Tags: 17.05.0-ce-git, 17.05.0-git, 17.05-git, 17-git, git, edge-git
@@ -17,11 +17,11 @@ GitCommit: ce78a19aac321bbe50d060426b5b633cb5f74825
 Directory: 17.05/git
 
 Tags: 17.03.1-ce, 17.03.1, 17.03, stable
-GitCommit: 47d5d4ead8a95871d011b005394c9f2f7af68dab
+GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
 Directory: 17.03
 
 Tags: 17.03.1-ce-dind, 17.03.1-dind, 17.03-dind, stable-dind
-GitCommit: bf822e2b9b4f755156b825444562c9865f22557f
+GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
 Directory: 17.03/dind
 
 Tags: 17.03.1-ce-git, 17.03.1-git, 17.03-git, stable-git

--- a/library/golang
+++ b/library/golang
@@ -36,7 +36,7 @@ Directory: 1.7/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 1.8.1, 1.8, 1, latest
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: a3b3abe48e2abec29bfea558b0916c8c682f88b0
 Directory: 1.8
 
 Tags: 1.8.1-onbuild, 1.8-onbuild, 1-onbuild, onbuild
@@ -44,19 +44,19 @@ GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
 Tags: 1.8.1-stretch, 1.8-stretch, 1-stretch, stretch
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: a3b3abe48e2abec29bfea558b0916c8c682f88b0
 Directory: 1.8/stretch
 
 Tags: 1.8.1-alpine, 1.8-alpine, 1-alpine, alpine
-GitCommit: d8ff0dd77a4910759d7f6b11e2ec0169337e14d1
+GitCommit: a3b3abe48e2abec29bfea558b0916c8c682f88b0
 Directory: 1.8/alpine
 
 Tags: 1.8.1-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: a3b3abe48e2abec29bfea558b0916c8c682f88b0
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 1.8.1-nanoserver, 1.8-nanoserver, 1-nanoserver, nanoserver
-GitCommit: 07253735ad448adf751e4f9ba4c71acdb735367f
+GitCommit: a3b3abe48e2abec29bfea558b0916c8c682f88b0
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
- `docker`: switch from get.docker.com to download.docker.com (https://github.com/docker-library/docker/pull/54)
- `golang`: address a bit of a snafu with `release-branch.go1.8` around the upcoming 1.8.2 release (https://github.com/docker-library/golang/commit/a3b3abe48e2abec29bfea558b0916c8c682f88b0)