### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -12,16 +12,16 @@ Tags: 6b38-jre, 6-jre
 GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
 Directory: 6-jre
 
-Tags: 7u121-jdk, 7u121, 7-jdk, 7
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 7u131-jdk, 7u131, 7-jdk, 7
+GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jdk
 
 Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
 GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
 Directory: 7-jdk/alpine
 
-Tags: 7u121-jre, 7-jre
-GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
+Tags: 7u131-jre, 7-jre
+GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jre
 
 Tags: 7u121-jre-alpine, 7-jre-alpine
@@ -54,10 +54,10 @@ Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine
 GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
 Directory: 8-jre/alpine
 
-Tags: 9-b169-jdk, 9-b169, 9-jdk, 9
-GitCommit: b93e629663f80ca4214097b5a3c248d9a866779b
+Tags: 9-b170-jdk, 9-b170, 9-jdk, 9
+GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jdk
 
-Tags: 9-b169-jre, 9-jre
-GitCommit: b93e629663f80ca4214097b5a3c248d9a866779b
+Tags: 9-b170-jre, 9-jre
+GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jre

--- a/library/postgres
+++ b/library/postgres
@@ -5,41 +5,41 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.3, 9.6, 9, latest
-GitCommit: e7222bf98572eec2a7b8875c13825015a163091c
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.6
 
 Tags: 9.6.3-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: a554d043a3b77937120d325b30fefaad2e3be12d
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.6/alpine
 
 Tags: 9.5.7, 9.5
-GitCommit: f59e5f0edba2e5d4d38516e5765c1aaa8932c51e
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.5
 
 Tags: 9.5.7-alpine, 9.5-alpine
-GitCommit: c844ef624823fac9f0e40695d5d01a622f5fd71a
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.5/alpine
 
 Tags: 9.4.12, 9.4
-GitCommit: 548a270a6c16913a82d77503aba5814601ed4f58
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.4
 
 Tags: 9.4.12-alpine, 9.4-alpine
-GitCommit: 6420763a8acd9ba12d34b2bd76e6d6927d2c36a5
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.4/alpine
 
 Tags: 9.3.17, 9.3
-GitCommit: 347593c5d25935dc1480adc6079400c2faf7ae5f
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.3
 
 Tags: 9.3.17-alpine, 9.3-alpine
-GitCommit: 9ff1e6fb304f67eb3b6d946000c69838324dc693
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.3/alpine
 
 Tags: 9.2.21, 9.2
-GitCommit: 937cc2b25a6db9dafb60241185d492917dc842b0
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.2
 
 Tags: 9.2.21-alpine, 9.2-alpine
-GitCommit: 87202c7e94944885c994cf1454c19a549bb7ac5b
+GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.2/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.7, 2.2
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
 Directory: 2.2/slim
 
 Tags: 2.2.7-alpine, 2.2-alpine
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
 Directory: 2.3/slim
 
 Tags: 2.3.4-alpine, 2.3-alpine
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
 Directory: 2.4/slim
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: be55938d970a392e7d41f17131a091b0a9f4bebc
+GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `openjdk`: `debian 7u131-2.6.9-2~deb8u1`, `debian 9~b170-2`
- `postgres`: adjust `/var/run/postgresql` permissions for any-user (docker-library/postgres#289)
- `ruby`: bundler 1.15.0