### PR TITLE
[ROS] add ROS Lunar and update tag of other distros

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,25 +1,32 @@
 # maintainer: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 
-indigo-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
+indigo-ros-core:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/indigo/indigo-ros-core
+indigo-ros-base:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/indigo/indigo-ros-base
+indigo-robot:       git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/indigo/indigo-robot
+indigo-perception:  git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/indigo/indigo-perception
+indigo:             git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/indigo/indigo-ros-base
 # Docker EOL: 2019-04
 # LTS
 
-jade-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
+jade-ros-core:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/jade/jade-ros-base
 # Docker EOL: 2017-04
 
-kinetic-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-core
-kinetic-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
-kinetic-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-robot
-kinetic-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-perception
-kinetic:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
-latest:              git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
+kinetic-ros-core:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-ros-core
+kinetic-ros-base:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-ros-base
+kinetic-robot:       git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-robot
+kinetic-perception:  git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-perception
+kinetic:             git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-ros-base
+latest:              git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/kinetic/kinetic-ros-base
 # Docker EOL: 2021-04
 # LTS
+
+lunar-ros-core:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/lunar/lunar-ros-core
+lunar-ros-base:    git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/lunar/lunar-ros-base
+lunar-robot:       git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/lunar/lunar-robot
+lunar-perception:  git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/lunar/lunar-perception
+lunar:             git://github.com/osrf/docker_images@2edd7b26e2e81d76425b91ce34b5135c63810851 ros/lunar/lunar-ros-base
+# Docker EOL: 2019-05


### PR DESCRIPTION
Adding the latest release of ROS: Lunar Loggerhead
Fix the build of all other ROS images by installing locales

See the ROS wiki for more information on changes and migration:
http://wiki.ros.org/lunar

Thanks!