### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/a09ad0056e1b95de7d448187770f6264d9e25fe2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/c3066d832b6eb6691ef96860dcba19791e4332b7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -8,16 +8,16 @@ Tags: 10.3.0, 10.3
 GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
 Directory: 10.3
 
-Tags: 10.2.5, 10.2
-GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
+Tags: 10.2.6, 10.2, 10, latest
+GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
 Directory: 10.2
 
-Tags: 10.1.23, 10.1, 10, latest
+Tags: 10.1.23, 10.1
 GitCommit: 352f47fdb034a359e27ef6223f252a9e75e2f596
 Directory: 10.1
 
-Tags: 10.0.30, 10.0
-GitCommit: 21eed39fdd34c84ecd83cc077ad3253cfa875c5c
+Tags: 10.0.31, 10.0
+GitCommit: fc9e999ca57555c0669cfc67906f0c705bda7e41
 Directory: 10.0
 
 Tags: 5.5.56, 5.5, 5

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,11 +8,11 @@ Tags: 10.3.0, 10.3
 GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
 Directory: 10.3
 
-Tags: 10.2.6, 10.2, 10, latest
+Tags: 10.2.6, 10.2
 GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
 Directory: 10.2
 
-Tags: 10.1.23, 10.1
+Tags: 10.1.23, 10.1, 10, latest
 GitCommit: 352f47fdb034a359e27ef6223f252a9e75e2f596
 Directory: 10.1
 

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+GitCommit: c280358006777004381dde9c64ad54d4876a7cf3
 Directory: 6/jre7
 
 Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
-GitCommit: aceabe036433c68b278767811bac728c6db4f8b3
+GitCommit: c280358006777004381dde9c64ad54d4876a7cf3
 Directory: 6/jre8
 
 Tags: 7.0.78-jre7, 7.0-jre7, 7-jre7, 7.0.78, 7.0, 7
-GitCommit: 9355db128c52e0463e37d2fbd267c0ea33ed0b19
+GitCommit: 612749027978d45b348c04a692f267e4052f3c71
 Directory: 7/jre7
 
 Tags: 7.0.78-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.78-alpine, 7.0-alpine, 7-alpine
@@ -21,7 +21,7 @@ GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
 Directory: 7/jre7-alpine
 
 Tags: 7.0.78-jre8, 7.0-jre8, 7-jre8
-GitCommit: 9355db128c52e0463e37d2fbd267c0ea33ed0b19
+GitCommit: 612749027978d45b348c04a692f267e4052f3c71
 Directory: 7/jre8
 
 Tags: 7.0.78-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -29,7 +29,7 @@ GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
 Directory: 7/jre8-alpine
 
 Tags: 8.0.44-jre7, 8.0-jre7, 8.0.44, 8.0
-GitCommit: eba2c31453300691978be256d5416821a788850d
+GitCommit: 37d3fe38619a328aefbe7e7c4bfff043f8be8489
 Directory: 8.0/jre7
 
 Tags: 8.0.44-jre7-alpine, 8.0-jre7-alpine, 8.0.44-alpine, 8.0-alpine
@@ -37,7 +37,7 @@ GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.44-jre8, 8.0-jre8
-GitCommit: eba2c31453300691978be256d5416821a788850d
+GitCommit: 37d3fe38619a328aefbe7e7c4bfff043f8be8489
 Directory: 8.0/jre8
 
 Tags: 8.0.44-jre8-alpine, 8.0-jre8-alpine
@@ -45,7 +45,7 @@ GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.15-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.15, 8.5, 8, latest
-GitCommit: 0f2fe0306c1d86ea66daf581f741c76745ee5414
+GitCommit: 7f37b0e675efd7f654e1fcbfbf6628f25b68f605
 Directory: 8.5/jre8
 
 Tags: 8.5.15-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.15-alpine, 8.5-alpine, 8-alpine, alpine
@@ -53,7 +53,7 @@ GitCommit: 82b1da640aa15ff2e9713e59dba3dbf7487d6815
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M21-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M21, 9.0.0, 9.0, 9
-GitCommit: 62e08b2f650bc7c097740bef4f1cda0e138a8827
+GitCommit: f34b65f30d1f1dd1c85390ea095eef4dad8fc819
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M21-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M21-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine


### PR DESCRIPTION
- `mariadb`: `10.2.6+maria~jessie` (which is the first "stable" 10.2 release), `10.0.31+maria-1~jessie`
- `tomcat`: openssl package bumps