### PR TITLE
Update mongo to 3.5.7

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.15, 3.0
-GitCommit: 40d62a73bbd4e20d90ec859a8af483f70b1e5fd4
+GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.0
 
 Tags: 3.0.15-windowsservercore, 3.0-windowsservercore
@@ -14,7 +14,7 @@ Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.13, 3.2
-GitCommit: 1bf5765ba4a8a46a70f5b2b634ef2070b4b89455
+GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.2
 
 Tags: 3.2.13-windowsservercore, 3.2-windowsservercore
@@ -23,7 +23,7 @@ Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.4, 3.4, 3, latest
-GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
+GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.4
 
 Tags: 3.4.4-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
@@ -31,11 +31,11 @@ GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.6, 3.5, unstable
-GitCommit: 43961bc0aeeef095f34aa4bb9bf9950e2f862242
+Tags: 3.5.7, 3.5, unstable
+GitCommit: 04d1eaa89239434eaaa8433067bffc8a1be8cae8
 Directory: 3.5
 
-Tags: 3.5.6-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
-GitCommit: 52ed5feba01538e24831b06ab8e9ad3019fb5036
+Tags: 3.5.7-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+GitCommit: b380604c031e2e13884538fead9780ea77ce2b59
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Add `--bind_ip_all` in default `CMD` for 3.5+ and skip initdb logic if we detect it's unnecessary.