### PR TITLE
[ROS] Updating Indigo, Jade, Kinetic

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,25 +1,25 @@
 # maintainer: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 
-indigo-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/indigo/indigo-ros-base
+indigo-ros-core:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/indigo/indigo-ros-core
+indigo-ros-base:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/indigo/indigo-ros-base
+indigo-robot:       git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/indigo/indigo-robot
+indigo-perception:  git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/indigo/indigo-perception
+indigo:             git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/indigo/indigo-ros-base
 # Docker EOL: 2019-04
 # LTS
 
-jade-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/jade/jade-ros-base
+jade-ros-core:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/jade/jade-ros-core
+jade-ros-base:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/jade/jade-ros-base
+jade-robot:       git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/jade/jade-robot
+jade-perception:  git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/jade/jade-perception
+jade:             git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/jade/jade-ros-base
 # Docker EOL: 2017-04
 
-kinetic-ros-core:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-core
-kinetic-ros-base:    git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
-kinetic-robot:       git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-robot
-kinetic-perception:  git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-perception
-kinetic:             git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
-latest:              git://github.com/osrf/docker_images@d9efe4367b9d376fd97a154bdaba896ca0382645 ros/kinetic/kinetic-ros-base
+kinetic-ros-core:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-ros-core
+kinetic-ros-base:    git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-ros-base
+kinetic-robot:       git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-robot
+kinetic-perception:  git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-perception
+kinetic:             git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-ros-base
+latest:              git://github.com/osrf/docker_images@7d44b3a7768b3863667dd4ec55137b7796ed5cf2 ros/kinetic/kinetic-ros-base
 # Docker EOL: 2021-04
 # LTS


### PR DESCRIPTION
Making use of charmap included in base image for all other tags,
as the locals package no longer ships with official Ubuntu.
Just built Indigo, Jade, Kinetic locally, but if something changes between now and a merge, feel free to let us know. 

P.S. Is there a way we can get notifications automatically from our official library build failures?
The missing locals package issue snuck up on us, as we've only really PR'ed for version bumps in the past. However we would like have a way to be more responsive to issues other than periodically noticing the official library image becoming stale. 