### PR TITLE
Bump Traefik to v1.3.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,12 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
-             Vincent Demeester <vincent@sbr.pm> (@vdemeester)
+             Vincent Demeester <vincent@sbr.pm> (@vdemeester),
+             Ludovic Fernandez <ludovic@containo.us> (@ldez)
+             
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.0-rc2, 1.3.0-rc2, v1.3, 1.3, raclette
-GitCommit: 9be98ef312ed6bdeb57fd3708be355978393041c
+Tags: v1.3.0-rc3, 1.3.0-rc3, v1.3, 1.3, raclette
+GitCommit: 30ac6799a25b679aae46e7f0b54deec7b15ece9d
 
-Tags: v1.3.0-rc2-alpine, 1.3.0-rc2-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 9be98ef312ed6bdeb57fd3708be355978393041c
+Tags: v1.3.0-rc3-alpine, 1.3.0-rc3-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 30ac6799a25b679aae46e7f0b54deec7b15ece9d
 Directory: alpine
 
 Tags: v1.2.3, 1.2.3, v1.2, 1.2, morbier, latest


### PR DESCRIPTION
Hello,

This PR updates traefik to v1.3.0-rc3.
It also adds @ldez to maintainers.

/cc @vdemeester @ldez 

Cheers