### PR TITLE
update Clojure commit

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,7 +1,7 @@
 Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: f0fd68d6a197b4d1852aefab698b35ce1ea9881e
+GitCommit: adeda5b2e562fef82b9aca22e9770e312841dc0f
 
 Tags: lein-2.7.1, lein, latest
 Directory: debian/lein


### PR DESCRIPTION
This is a minor implementation change that doesn't affect version. We are packaging the latest stable Clojure JAR file into the image so users don't have to download it every time.

Details https://github.com/Quantisan/docker-clojure/pull/35