### PR TITLE
Upgrade Node to 8.0.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/e866277fa5a05cc0fafb14ffc406343b9c7ef9f7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/20f3de9046e2472b70d57d8b11be9cea7c4863bc/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 7.10.0, 7.10, 7, latest
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
-Directory: 7.10
+Tags: 8.0.0, 8.0, 8, latest
+GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
+Directory: 8.0
 
-Tags: 7.10.0-alpine, 7.10-alpine, 7-alpine, alpine
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
-Directory: 7.10/alpine
+Tags: 8.0.0-alpine, 8.0-alpine, 8-alpine, alpine
+GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
+Directory: 8.0/alpine
 
-Tags: 7.10.0-onbuild, 7.10-onbuild, 7-onbuild, onbuild
-GitCommit: 2e7fd977fb10088c82c559926580b60a47f40732
-Directory: 7.10/onbuild
+Tags: 8.0.0-onbuild, 8.0-onbuild, 8-onbuild, onbuild
+GitCommit: 20f3de9046e2472b70d57d8b11be9cea7c4863bc
+Directory: 8.0/onbuild
 
-Tags: 7.10.0-slim, 7.10-slim, 7-slim, slim
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
-Directory: 7.10/slim
+Tags: 8.0.0-slim, 8.0-slim, 8-slim, slim
+GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
+Directory: 8.0/slim
 
-Tags: 7.10.0-wheezy, 7.10-wheezy, 7-wheezy, wheezy
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
-Directory: 7.10/wheezy
+Tags: 8.0.0-wheezy, 8.0-wheezy, 8-wheezy, wheezy
+GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
+Directory: 8.0/wheezy
 
 Tags: 6.10.3, 6.10, 6, boron
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 6.10
 
 Tags: 6.10.3-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 6.10/alpine
 
 Tags: 6.10.3-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
@@ -36,19 +36,19 @@ GitCommit: ffecb0e9ca258d6b20ff60b30956bd33f7357142
 Directory: 6.10/onbuild
 
 Tags: 6.10.3-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 6.10/slim
 
 Tags: 6.10.3-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 6.10/wheezy
 
 Tags: 4.8.3, 4.8, 4, argon
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 4.8
 
 Tags: 4.8.3-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 4.8/alpine
 
 Tags: 4.8.3-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
@@ -56,10 +56,10 @@ GitCommit: 974c2a3c3cc488c3491a7ffd85e90c079d0d78e1
 Directory: 4.8/onbuild
 
 Tags: 4.8.3-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 4.8/slim
 
 Tags: 4.8.3-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 581eebd097343c9f1c1ceb5260cd2ec770410e29
+GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
This PR updates the latest `node` Docker Image to version 8.0.0 of Node.js. This update also includes updated versions of `yarn` (v0.24.6) and Alpine Linux (3.6) for the new 8.0.0 image only. 

Changeset: https://github.com/nodejs/docker-node/compare/581eebd097343c9f1c1ceb5260cd2ec770410e29...09e42c172ffd6f8631fb1cb7a0785fd890c0f11a

Related: nodejs/node#12220
Related: nodejs/docker-node#411
Related: nodejs/docker-node#412
Related: nodejs/docker-node#113

Signed-off-by: Hans Kristian Flaatten <hans@starefossen.com>