### PR TITLE
Bump Traefik to v1.3.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,19 +1,11 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Vincent Demeester <vincent@sbr.pm> (@vdemeester),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
-             
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.0-rc3, 1.3.0-rc3, v1.3, 1.3, raclette
-GitCommit: 30ac6799a25b679aae46e7f0b54deec7b15ece9d
+Tags: v1.3.0, 1.3.0, v1.3, 1.3, raclette, latest
+GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
 
-Tags: v1.3.0-rc3-alpine, 1.3.0-rc3-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 30ac6799a25b679aae46e7f0b54deec7b15ece9d
-Directory: alpine
-
-Tags: v1.2.3, 1.2.3, v1.2, 1.2, morbier, latest
-GitCommit: 50d631ddf197da6228172cb86ab6098d875a6ea0
-
-Tags: v1.2.3-alpine, 1.2.3-alpine, v1.2-alpine, 1.2-alpine, morbier-alpine
-GitCommit: 50d631ddf197da6228172cb86ab6098d875a6ea0
-Directory: alpine
+Tags: v1.3.0-alptine, 1.3.0-alptine, v1.3-alptine, 1.3-alptine, raclette-alptine
+GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
+Directory: alptine

--- a/library/traefik
+++ b/library/traefik
@@ -6,6 +6,6 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 Tags: v1.3.0, 1.3.0, v1.3, 1.3, raclette, latest
 GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
 
-Tags: v1.3.0-alptine, 1.3.0-alptine, v1.3-alptine, 1.3-alptine, raclette-alptine
+Tags: v1.3.0-alpine, 1.3.0-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
 GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
-Directory: alptine
+Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates traefik to 1.3.0.

/cc @vdemeester @emilevauge

Cheers
