### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,8 +1,20 @@
-# this file is generated via https://github.com/docker-library/docker/blob/88c8e8f75ff252bdbef4d63d8c2f437fc905ebad/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/e7e2e3119360567641d334f1d274952236632357/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
+
+Tags: 17.06.0-ce-rc1, 17.06.0-ce, 17.06.0, 17.06-rc, rc, test
+GitCommit: e7e2e3119360567641d334f1d274952236632357
+Directory: 17.06-rc
+
+Tags: 17.06.0-ce-rc1-dind, 17.06.0-ce-dind, 17.06.0-dind, 17.06-rc-dind, rc-dind, test-dind
+GitCommit: e7e2e3119360567641d334f1d274952236632357
+Directory: 17.06-rc/dind
+
+Tags: 17.06.0-ce-rc1-git, 17.06.0-ce-git, 17.06.0-git, 17.06-rc-git, rc-git, test-git
+GitCommit: e7e2e3119360567641d334f1d274952236632357
+Directory: 17.06-rc/git
 
 Tags: 17.05.0-ce, 17.05.0, 17.05, 17, latest, edge
 GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
@@ -15,6 +27,18 @@ Directory: 17.05/dind
 Tags: 17.05.0-ce-git, 17.05.0-git, 17.05-git, 17-git, git, edge-git
 GitCommit: ce78a19aac321bbe50d060426b5b633cb5f74825
 Directory: 17.05/git
+
+Tags: 17.03.2-ce-rc1, 17.03.2-ce, 17.03.2, 17.03-rc
+GitCommit: 2c75eb72ab98b95256be008aa93efdec289d96e8
+Directory: 17.03-rc
+
+Tags: 17.03.2-ce-rc1-dind, 17.03.2-ce-dind, 17.03.2-dind, 17.03-rc-dind
+GitCommit: 2c75eb72ab98b95256be008aa93efdec289d96e8
+Directory: 17.03-rc/dind
+
+Tags: 17.03.2-ce-rc1-git, 17.03.2-ce-git, 17.03.2-git, 17.03-rc-git
+GitCommit: 2c75eb72ab98b95256be008aa93efdec289d96e8
+Directory: 17.03-rc/git
 
 Tags: 17.03.1-ce, 17.03.1, 17.03, stable
 GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/445ba23ad32bf53dba66ce6309cab168c9307ce2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/495a742832974d434c6e3356e19c93b0e82543c8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -20,6 +20,10 @@ Directory: 1.7/wheezy
 Tags: 1.7.6-alpine, 1.7-alpine
 GitCommit: 9e519a8844c25e38fe67547e8f681ada486e473b
 Directory: 1.7/alpine
+
+Tags: 1.7.6-alpine3.6, 1.7-alpine3.6
+GitCommit: 495a742832974d434c6e3356e19c93b0e82543c8
+Directory: 1.7/alpine3.6
 
 Tags: 1.7.6-alpine3.5, 1.7-alpine3.5
 GitCommit: 9e519a8844c25e38fe67547e8f681ada486e473b
@@ -50,6 +54,10 @@ Directory: 1.8/stretch
 Tags: 1.8.3-alpine, 1.8-alpine, 1-alpine, alpine
 GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65
 Directory: 1.8/alpine
+
+Tags: 1.8.3-alpine3.6, 1.8-alpine3.6, 1-alpine3.6, alpine3.6
+GitCommit: 495a742832974d434c6e3356e19c93b0e82543c8
+Directory: 1.8/alpine3.6
 
 Tags: 1.8.3-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore
 GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.6, 10.2
 GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
 Directory: 10.2
 
-Tags: 10.1.23, 10.1, 10, latest
-GitCommit: 352f47fdb034a359e27ef6223f252a9e75e2f596
+Tags: 10.1.24, 10.1, 10, latest
+GitCommit: 9ac6a8d627c15e7cecb59e82e3c712d8c71d209e
 Directory: 10.1
 
 Tags: 10.0.31, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -31,11 +31,11 @@ GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.7, 3.5, unstable
-GitCommit: 04d1eaa89239434eaaa8433067bffc8a1be8cae8
+Tags: 3.5.8, 3.5, unstable
+GitCommit: 45055cc0c67da614a3edf24369fb1484701f88e3
 Directory: 3.5
 
-Tags: 3.5.7-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+Tags: 3.5.8-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
 GitCommit: b380604c031e2e13884538fead9780ea77ce2b59
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/owncloud
+++ b/library/owncloud
@@ -28,18 +28,18 @@ Tags: 8.2.11-fpm, 8.2-fpm, 8-fpm
 GitCommit: 3182c1fc072fb43c165d65de7bee16aa2374efd7
 Directory: 8.2/fpm
 
-Tags: 9.0.9-apache, 9.0-apache, 9.0.9, 9.0
-GitCommit: f6016dc858a63c398df0e6797e5b45ca0eaca336
+Tags: 9.0.10-apache, 9.0-apache, 9.0.10, 9.0
+GitCommit: 6bb84a4253c8a84af6a9b3968eb61388c65be5fb
 Directory: 9.0/apache
 
-Tags: 9.0.9-fpm, 9.0-fpm
-GitCommit: f6016dc858a63c398df0e6797e5b45ca0eaca336
+Tags: 9.0.10-fpm, 9.0-fpm
+GitCommit: 6bb84a4253c8a84af6a9b3968eb61388c65be5fb
 Directory: 9.0/fpm
 
-Tags: 9.1.5-apache, 9.1-apache, 9-apache, apache, 9.1.5, 9.1, 9, latest
-GitCommit: 167aa3b02320358a8cc3cdbbbc3ffb4643d6e369
+Tags: 9.1.6-apache, 9.1-apache, 9-apache, apache, 9.1.6, 9.1, 9, latest
+GitCommit: 4a90ae0bfeec972185fd920130b70b6c51eec6f4
 Directory: 9.1/apache
 
-Tags: 9.1.5-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 167aa3b02320358a8cc3cdbbbc3ffb4643d6e369
+Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm, fpm
+GitCommit: 4a90ae0bfeec972185fd920130b70b6c51eec6f4
 Directory: 9.1/fpm


### PR DESCRIPTION
- `docker`: 17.06.0-ce-rc1, 17.03.2-ce-rc1
- `golang`: `alpine3.6` variants (docker-library/golang#162)
- `mariadb`: `10.1.24+maria-1~jessie`
- `mongo`: 3.5.8
- `owncloud`: 9.0.10, 9.1.6