### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.12, 4.4, 4, latest
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
-GitCommit: 4438745d601d10d300e363f24205a3ca75307803
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
-GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
 Directory: 3.0

--- a/library/ghost
+++ b/library/ghost
@@ -1,13 +1,13 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/7251ebfe67deb5452377435b0645a10fe81399b5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/ee2ce866bd53499316d32bd915eca326af6707f2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 0.11.9, 0.11, 0, latest
-GitCommit: 8435a22109f8d1556c3e824b1ca3cfadd2454f37
-Directory: debian
+GitCommit: ee2ce866bd53499316d32bd915eca326af6707f2
+Directory: 0.11/debian
 
 Tags: 0.11.9-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: 8435a22109f8d1556c3e824b1ca3cfadd2454f37
-Directory: alpine
+GitCommit: ee2ce866bd53499316d32bd915eca326af6707f2
+Directory: 0.11/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -17,5 +17,5 @@ GitCommit: 1883f2ec8be5f2a0cd176673a249c618ad7976ba
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 1883f2ec8be5f2a0cd176673a249c618ad7976ba
+GitCommit: 656b3859734d70b47386fd8bac58d5f719df596b
 Directory: 2.4/alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -16,24 +16,24 @@ Tags: 7u131-jdk, 7u131, 7-jdk, 7
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jdk
 
-Tags: 7u121-jdk-alpine, 7u121-alpine, 7-jdk-alpine, 7-alpine
-GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
+Tags: 7u131-jdk-alpine, 7u131-alpine, 7-jdk-alpine, 7-alpine
+GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jdk/alpine
 
 Tags: 7u131-jre, 7-jre
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jre
 
-Tags: 7u121-jre-alpine, 7-jre-alpine
-GitCommit: 0476812eabd178c77534f3c03bd0a2673822d7b9
+Tags: 7u131-jre-alpine, 7-jre-alpine
+GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jre/alpine
 
 Tags: 8u131-jdk, 8u131, 8-jdk, 8, jdk, latest
 GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jdk
 
-Tags: 8u121-jdk-alpine, 8u121-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
+Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 8-jdk/alpine
 
 Tags: 8u131-jdk-windowsservercore, 8u131-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
@@ -50,8 +50,8 @@ Tags: 8u131-jre, 8-jre, jre
 GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jre
 
-Tags: 8u121-jre-alpine, 8-jre-alpine, jre-alpine
-GitCommit: 4e39684901490c13eaef7892c44e39043d7c4bed
+Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
+GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 8-jre/alpine
 
 Tags: 9-b170-jdk, 9-b170, 9-jdk, 9


### PR DESCRIPTION
- `bash`: Alpine 3.6 (tianon/docker-bash#5)
- `ghost`: multi-version directory refactor (docker-library/ghost#66)
- `httpd`: Alpine 3.6 for 2.4 (docker-library/httpd#53)
- `openjdk`: Alpine 3.6 for 7 and 8 to get newer Java (docker-library/openjdk#118)