### PR TITLE
Removing cache from build, adding wheezy beta

### DIFF
--- a/library/fsharp
+++ b/library/fsharp
@@ -3,7 +3,7 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 
 Tags: latest, 4, 4.1, 4.1.18
-GitCommit: 2201a2c453ca69249bf6f4c4c121e8bb2a847cf7
+GitCommit: ad4c4d67a1975b2b0ff0acc49dc46b3271836831
 Directory: 4.1.18/mono
 
 Tags: 4.1.18-wheezy-slim

--- a/library/fsharp
+++ b/library/fsharp
@@ -6,8 +6,8 @@ Tags: latest, 4, 4.1, 4.1.18
 GitCommit: 2201a2c453ca69249bf6f4c4c121e8bb2a847cf7
 Directory: 4.1.18/mono
 
-Tags: 4.1.18-wheezy
-GitCommit: 0d86b281d7e8fccfe463d098310a5fd521f0276a
+Tags: 4.1.18-wheezy-slim
+GitCommit: 33b5be9aea66ea1d258daf23055fa6d9bcb164ff
 Directory: 4.1.18/mono-wheezy
 
 Tags: 4.1.0.1

--- a/library/fsharp
+++ b/library/fsharp
@@ -3,8 +3,12 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 
 Tags: latest, 4, 4.1, 4.1.18
-GitCommit: a28196740e38035beea04c41d5862136413281e3
+GitCommit: 2201a2c453ca69249bf6f4c4c121e8bb2a847cf7
 Directory: 4.1.18/mono
+
+Tags: 4.1.18-wheezy-beta
+GitCommit: 0d86b281d7e8fccfe463d098310a5fd521f0276a
+Directory: 4.1.18/mono-wheezy
 
 Tags: 4.1.0.1
 GitCommit: a28196740e38035beea04c41d5862136413281e3

--- a/library/fsharp
+++ b/library/fsharp
@@ -6,7 +6,7 @@ Tags: latest, 4, 4.1, 4.1.18
 GitCommit: 2201a2c453ca69249bf6f4c4c121e8bb2a847cf7
 Directory: 4.1.18/mono
 
-Tags: 4.1.18-wheezy-beta
+Tags: 4.1.18-wheezy
 GitCommit: 0d86b281d7e8fccfe463d098310a5fd521f0276a
 Directory: 4.1.18/mono-wheezy
 


### PR DESCRIPTION
Cached artifacts from the FSharp build weren't removed, wasting almost 200 MB.  Cleaning this up as well as environment variables that are used for the FSharp build only.

Also adding an image based on debian rather than larger ubuntu to beta test with users ahead of an official switch to debian based images.