### PR TITLE
Adding SWI-Prolog official image.

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -2,5 +2,5 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
 Tags: latest, 7.5.11
-GitCommit: 6adb96cb5bcd670c593452add9de417f841617aa
+GitCommit: e8d1f0bf3db5e9cbfa331aba06bb740a76a81f83
 Directory: 7.5.11/stretch

--- a/library/swipl
+++ b/library/swipl
@@ -1,6 +1,6 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
-Tags: latest, 7.5.7
-GitCommit: 05c70112197e4c59da8af37743a493ca9a3266fb
-Directory: 7.5.7/jessie
+Tags: latest, 7.5.11
+GitCommit: 379993742ae105d4db2395bfeb0aa0441df54b56
+Directory: 7.5.11/stretch

--- a/library/swipl
+++ b/library/swipl
@@ -2,5 +2,5 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
 Tags: latest, 7.5.11
-GitCommit: 379993742ae105d4db2395bfeb0aa0441df54b56
+GitCommit: 6adb96cb5bcd670c593452add9de417f841617aa
 Directory: 7.5.11/stretch

--- a/library/swipl
+++ b/library/swipl
@@ -1,0 +1,6 @@
+Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
+GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
+
+Tags: latest, 7.5.7
+GitCommit: 05c70112197e4c59da8af37743a493ca9a3266fb
+Directory: 7.5.7/jessie


### PR DESCRIPTION
This adds an official image for SWI-Prolog.

Supporting docs are submitted in a PR: https://github.com/docker-library/docs/pull/920

Here is a very quick "hello world" test for the image:
```console
# echo 'hello:-write("Hello, world!"),nl,halt.' >> hello.pl; swipl -q -f hello.pl -t hello; rm hello.pl
Hello, world!
```

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/SWI-Prolog
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - language stack
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/920
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)