### PR TITLE
Publish 2.3.11, 3.2.1 and 3.1.5, and apply fix to 3.0.9 of neo4j.

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -9,22 +9,42 @@ Maintainers: Ben Butler-Cole <ben@neotechnology.com> (@benbc),
              Steven R Baker <steven.baker@neotechnology.com> (@srbaker),
              Praveena Fernandes <praveena.fernandes@neotechnology.com> (@praveenag)
 
-Tags: 3.2.0, 3.2, latest
+Tags: 3.2.1, 3.2, latest
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 3.2.1/community
+
+Tags: 3.2.1-enterprise, 3.2-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 3.2.1/enterprise
+
+Tags: 3.2.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: c0364e1bcbc35a536abb93ec88dc3bfc288b23bf
 Directory: 3.2.0/community
 
-Tags: 3.2.0-enterprise, 3.2-enterprise, enterprise
+Tags: 3.2.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: c0364e1bcbc35a536abb93ec88dc3bfc288b23bf
 Directory: 3.2.0/enterprise
 
-Tags: 3.1.4, 3.1
+Tags: 3.1.5, 3.1
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 3.1.5/community
+
+Tags: 3.1.5-enterprise, 3.1-enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 3.1.5/enterprise
+
+Tags: 3.1.4
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 86c2eb04e9f44e2c6febf5c14d0a7fe67c81f35c
 Directory: 3.1.4/community
 
-Tags: 3.1.4-enterprise, 3.1-enterprise
+Tags: 3.1.4-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 86c2eb04e9f44e2c6febf5c14d0a7fe67c81f35c
 Directory: 3.1.4/enterprise
@@ -71,12 +91,12 @@ Directory: 3.1.0/enterprise
 
 Tags: 3.0.9, 3.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 9d66d834e455a0db1a2f5d65ebd4123d4721ae44
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
 Directory: 3.0.9/community
 
 Tags: 3.0.9-enterprise, 3.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 9d66d834e455a0db1a2f5d65ebd4123d4721ae44
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
 Directory: 3.0.9/enterprise
 
 Tags: 3.0.8

--- a/library/neo4j
+++ b/library/neo4j
@@ -189,12 +189,22 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 36ac547bcffcce2c7c0f249b340d062ba08e2598
 Directory: 3.0.0/enterprise
 
-Tags: 2.3.10, 2.3
+Tags: 2.3.11, 2.3
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 2.3.11/community
+
+Tags: 2.3.11-enterprise, 2.3-enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: ae826519a7acf389396ab6c388fe299c21b41107
+Directory: 2.3.11/enterprise
+
+Tags: 2.3.10
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d5355408a618e3f7c9797baa55ae298c3493e900
 Directory: 2.3.10/community
 
-Tags: 2.3.10-enterprise, 2.3-enterprise
+Tags: 2.3.10-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d5355408a618e3f7c9797baa55ae298c3493e900
 Directory: 2.3.10/enterprise


### PR DESCRIPTION
This includes the fixes in https://github.com/neo4j/docker-neo4j/pull/91
for configuration via environment variables in 3.x releases.