### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.4.0, 5.4, 5, latest
-GitCommit: f9b79ebc2e8fd42372b8f302321585c4d09f9ccc
+Tags: 5.4.1, 5.4, 5, latest
+GitCommit: ca669a81afb503dedac6ba1bb8bef2abc158f081
 Directory: 5
 
-Tags: 5.4.0-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: f9b79ebc2e8fd42372b8f302321585c4d09f9ccc
+Tags: 5.4.1-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: ca669a81afb503dedac6ba1bb8bef2abc158f081
 Directory: 5/alpine
 
 Tags: 2.4.5, 2.4, 2

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.4.0, 5.4, 5, latest
-GitCommit: 69daf8cf674823df85e2d48489d5c26f1c2f7d8a
+Tags: 5.4.1, 5.4, 5, latest
+GitCommit: 8b5427a374fe93fe87f31e1249f0d64a09c02307
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.4.0, 5.4, 5, latest
-GitCommit: 17f03721f0d21cd1dae3077f3dad4b3b489a9557
+Tags: 5.4.1, 5.4, 5, latest
+GitCommit: fcab4d9ce9b16bb2b14f263fc05d54204300a86b
 Directory: 5
 
-Tags: 5.4.0-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: 17f03721f0d21cd1dae3077f3dad4b3b489a9557
+Tags: 5.4.1-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: fcab4d9ce9b16bb2b14f263fc05d54204300a86b
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -36,6 +36,6 @@ GitCommit: 45055cc0c67da614a3edf24369fb1484701f88e3
 Directory: 3.5
 
 Tags: 3.5.8-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
-GitCommit: b380604c031e2e13884538fead9780ea77ce2b59
+GitCommit: 3fd2ca2e905e3b826e0244bb73a55e61e8db298e
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/php
+++ b/library/php
@@ -5,85 +5,85 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.5-cli, 7.1-cli, 7-cli, cli, 7.1.5, 7.1, 7, latest
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1
 
 Tags: 7.1.5-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/alpine
 
 Tags: 7.1.5-apache, 7.1-apache, 7-apache, apache
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/apache
 
 Tags: 7.1.5-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/fpm
 
 Tags: 7.1.5-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.5-zts, 7.1-zts, 7-zts, zts
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/zts
 
 Tags: 7.1.5-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.19-cli, 7.0-cli, 7.0.19, 7.0
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0
 
 Tags: 7.0.19-alpine, 7.0-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/alpine
 
 Tags: 7.0.19-apache, 7.0-apache
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/apache
 
 Tags: 7.0.19-fpm, 7.0-fpm
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/fpm
 
 Tags: 7.0.19-fpm-alpine, 7.0-fpm-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.19-zts, 7.0-zts
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/zts
 
 Tags: 7.0.19-zts-alpine, 7.0-zts-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.30-cli, 5.6-cli, 5-cli, 5.6.30, 5.6, 5
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6
 
 Tags: 5.6.30-alpine, 5.6-alpine, 5-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/alpine
 
 Tags: 5.6.30-apache, 5.6-apache, 5-apache
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/apache
 
 Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/fpm
 
 Tags: 5.6.30-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.30-zts, 5.6-zts, 5-zts
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/zts
 
 Tags: 5.6.30-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-GitCommit: 76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68
+GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/zts/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.10, 3.6, 3, latest
-GitCommit: 58ff0d1f137e0708cb757e5929f7d0bf20e303c8
+GitCommit: 4761fd0c03b8ca4e81967019e564d0659e4b7b74
 Directory: 3.6/debian
 
 Tags: 3.6.10-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.10-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 2ddb3e04aceedf1c33b522c16a8c33046757289c
+GitCommit: 4761fd0c03b8ca4e81967019e564d0659e4b7b74
 Directory: 3.6/alpine
 
 Tags: 3.6.10-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/ruby
+++ b/library/ruby
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
-GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
+GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
+GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
-GitCommit: b12b0fd99eed0dc416f3f85d4643be69c44e4fa7
+GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
@@ -21,15 +21,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.7, 2.2
-GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
+GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
-GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
+GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/slim
 
 Tags: 2.2.7-alpine, 2.2-alpine
-GitCommit: 869369d45905b991585920ec2f44a81abd08e2e6
+GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -37,15 +37,15 @@ GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
-GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
+GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
-GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
+GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/slim
 
 Tags: 2.3.4-alpine, 2.3-alpine
-GitCommit: d2644c44a3e2a8a07f604dc4667aafdc9ac04cef
+GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -53,15 +53,15 @@ GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
-GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
+GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
-GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
+GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/slim
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 0011ab1a6a0d7452d81e5e7dde02ac0753e466aa
+GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `elasticsearch`: 5.4.1
- `kibana`: 5.4.1
- `logstash`: 5.4.1
- `mongo`: 3.5.8
- `php`: `pecl update-channels` (docker-library/php#445)
- `rabbitmq`: be explicit about allowing `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` (docker-library/rabbitmq#159)
- `ruby`: bundler 1.15.1