### PR TITLE
Add "--depth" flag to "bashbrew children" and "bashbrew parents"

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-deps.go
+++ b/bashbrew/go/src/bashbrew/cmd-deps.go
@@ -15,6 +15,11 @@ func cmdParents(c *cli.Context) error {
 	return cmdFamily(true, c)
 }
 
+type topsortDepthNodes struct {
+	depth int
+	nodes []*topsort.Node
+}
+
 func cmdFamily(parents bool, c *cli.Context) error {
 	depsRepos, err := repos(c.Bool("all"), c.Args()...)
 	if err != nil {
@@ -23,6 +28,7 @@ func cmdFamily(parents bool, c *cli.Context) error {
 
 	uniq := c.Bool("uniq")
 	applyConstraints := c.Bool("apply-constraints")
+	depth := c.Int("depth")
 
 	allRepos, err := repos(true)
 	if err != nil {
@@ -85,24 +91,41 @@ func cmdFamily(parents bool, c *cli.Context) error {
 			}
 
 			for _, tag := range r.Tags("", uniq, entry) {
-				nodes := []*topsort.Node{}
+				nodes := []topsortDepthNodes{}
 				if parents {
-					nodes = append(nodes, network.Get(tag).InboundEdges...)
+					nodes = append(nodes, topsortDepthNodes{
+						depth: 1,
+						nodes: network.Get(tag).InboundEdges,
+					})
 				} else {
-					nodes = append(nodes, network.Get(tag).OutboundEdges...)
+					nodes = append(nodes, topsortDepthNodes{
+						depth: 1,
+						nodes: network.Get(tag).OutboundEdges,
+					})
 				}
 				for len(nodes) > 0 {
-					node := nodes[0]
+					depthNodes := nodes[0]
 					nodes = nodes[1:]
-					if seen[node] {
+					if depth > 0 && depthNodes.depth > depth {
 						continue
 					}
-					seen[node] = true
-					fmt.Printf("%s\n", node.Name)
-					if parents {
-						nodes = append(nodes, node.InboundEdges...)
-					} else {
-						nodes = append(nodes, node.OutboundEdges...)
+					for _, node := range depthNodes.nodes {
+						if seen[node] {
+							continue
+						}
+						seen[node] = true
+						fmt.Printf("%s\n", node.Name)
+						if parents {
+							nodes = append(nodes, topsortDepthNodes{
+								depth: depthNodes.depth + 1,
+								nodes: node.InboundEdges,
+							})
+						} else {
+							nodes = append(nodes, topsortDepthNodes{
+								depth: depthNodes.depth + 1,
+								nodes: node.OutboundEdges,
+							})
+						}
 					}
 				}
 			}

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -172,6 +172,11 @@ func main() {
 			Name:  "apply-constraints",
 			Usage: "apply Constraints as if repos were building",
 		},
+		"depth": cli.IntFlag{
+			Name:  "depth",
+			Value: 0,
+			Usage: "maximum number of levels to traverse (0 for unlimited)",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -244,7 +249,6 @@ func main() {
 			Action: cmdPutShared,
 		},
 
-		// TODO --depth flag for children and parents
 		{
 			Name: "children",
 			Aliases: []string{
@@ -255,6 +259,7 @@ func main() {
 			Usage: `print the repos built FROM a given repo or repo:tag`,
 			Flags: []cli.Flag{
 				commonFlags["apply-constraints"],
+				commonFlags["depth"],
 			},
 			Before: subcommandBeforeFactory("children"),
 			Action: cmdOffspring,
@@ -270,6 +275,7 @@ func main() {
 			Usage: `print the repos this repo or repo:tag is FROM`,
 			Flags: []cli.Flag{
 				commonFlags["apply-constraints"],
+				commonFlags["depth"],
 			},
 			Before: subcommandBeforeFactory("parents"),
 			Action: cmdParents,


### PR DESCRIPTION
```console
$ diff -u <(bashbrew children --depth 2 alpine) <(bashbrew children --depth 3 alpine)
--- /dev/fd/63	2017-06-02 07:29:56.871863245 -0700
+++ /dev/fd/62	2017-06-02 07:29:56.872863215 -0700
@@ -578,6 +578,20 @@
 zookeeper:3.4.10
 zookeeper:3.4
 zookeeper:latest
+maven:3.5.0-jdk-7-onbuild-alpine
+maven:3.5-jdk-7-onbuild-alpine
+maven:3-jdk-7-onbuild-alpine
+maven:3.5.0-jdk-8-onbuild-alpine
+maven:3.5.0-onbuild-alpine
+maven:3.5-jdk-8-onbuild-alpine
+maven:3.5-onbuild-alpine
+maven:3-jdk-8-onbuild-alpine
+maven:3-onbuild-alpine
+maven:onbuild-alpine
+orientdb:2.2.21-spatial
+clojure:lein-2.7.1-alpine-onbuild
+clojure:lein-alpine-onbuild
+clojure:alpine-onbuild
 notary:server
 notary:server-0.5.0
 notary:signer

$ bashbrew parents maven:onbuild-alpine
maven:3-jdk-8-alpine
openjdk:8-jdk-alpine
alpine:3.6

$ bashbrew parents --depth 1 maven:onbuild-alpine
maven:3-jdk-8-alpine

$ bashbrew parents --depth 2 maven:onbuild-alpine
maven:3-jdk-8-alpine
openjdk:8-jdk-alpine
```