### PR TITLE
Fix architecture-specific values inherited from the global entry

### DIFF
--- a/bashbrew/go/src/bashbrew/git.go
+++ b/bashbrew/go/src/bashbrew/git.go
@@ -20,6 +20,9 @@ func gitCache() string {
 }
 
 func gitCommand(args ...string) *exec.Cmd {
+	if debugFlag {
+		fmt.Printf("$ git %q\n", args)
+	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = gitCache()
 	return cmd

--- a/bashbrew/go/src/bashbrew/sort.go
+++ b/bashbrew/go/src/bashbrew/sort.go
@@ -97,6 +97,9 @@ func sortRepoObjects(rs []*Repo, applyConstraints bool) ([]*Repo, error) {
 			if applyConstraints && r.SkipConstraints(entry) {
 				continue
 			}
+			if !entry.HasArchitecture(arch) {
+				continue
+			}
 
 			from, err := r.DockerFrom(&entry)
 			if err != nil {

--- a/bashbrew/go/vendor/manifest
+++ b/bashbrew/go/vendor/manifest
@@ -10,7 +10,7 @@
 		{
 			"importpath": "github.com/docker-library/go-dockerlibrary",
 			"repository": "https://github.com/docker-library/go-dockerlibrary",
-			"revision": "663a091da13fc848e27a16048fb39c4e4067056e",
+			"revision": "ce3ef0e05c16a5202b2c3dae35ef6a832eb18d7a",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
See also https://github.com/docker-library/go-dockerlibrary/pull/12.