### PR TITLE
Refactor bashbrew release Dockerfile to use "bashbrew arches" in the released binary names

### DIFF
--- a/bashbrew/Dockerfile.release
+++ b/bashbrew/Dockerfile.release
@@ -16,29 +16,48 @@ COPY go .
 RUN set -ex; \
 	mkdir bin; \
 	for osArch in \
-		darwin/amd64 \
-		linux/amd64 \
-		linux/arm64 \
-		linux/ppc64le \
-		linux/s390x \
-		windows/amd64 \
+		amd64 \
+		arm32v5 \
+		arm32v6 \
+		arm32v7 \
+		arm64v8 \
+		darwin-amd64 \
+		i386 \
+		ppc64le \
+		s390x \
+		windows-amd64 \
 	; do \
-		os="${osArch%%/*}"; \
-		arch="${osArch#$os/}"; \
-# TODO GOARM
+		os="${osArch%%-*}"; \
+		[ "$os" != "$osArch" ] || os='linux'; \
+		export GOOS="$os"; \
+		arch="${osArch#${os}-}"; \
+		unset GOARM GO386; \
+		case "$arch" in \
+			arm32v*) export GOARCH='arm' GOARM="${arch#arm32v}" ;; \
+# no GOARM for arm64 (yet?) -- https://github.com/golang/go/blob/1e72bf62183ea21b9affffd4450d44d994393899/src/cmd/internal/objabi/util.go#L40
+			arm64v*) export GOARCH='arm64' ;; \
+			i386)    export GOARCH='386' ;; \
+			*)       export GOARCH="$arch" ;; \
+		esac; \
 		\
 		[ "$os" = 'windows' ] && ext='.exe' || ext=''; \
 		\
-		GOOS="$os" GOARCH="$arch" \
-			go build \
-				-a -v \
-				-ldflags '-s -w' \
-				-tags netgo -installsuffix netgo \
-				-o "bin/bashbrew-$os-$arch$ext" \
-				./src/bashbrew; \
+		go build \
+			-a -v \
+			-ldflags '-s -w' \
+# see https://github.com/golang/go/issues/9737#issuecomment-276817652 (and following comments) -- installsuffix is necessary (for now) to keep ARM
+# can remove "$osArch" from "installsuffix" in Go 1.10+ (https://github.com/golang/go/commit/1b53f15ebb00dd158af674df410c7941abb2b933)
+			-tags netgo -installsuffix "netgo-$osArch" \
+			-o "bin/bashbrew-$osArch$ext" \
+			./src/bashbrew; \
 		\
+		case "$GOARCH" in \
+# manifest-tool and GOARM aren't friends yet
+# ... and estesp is probably a big fat "lololol" on supporting i386 :D
+			arm|386) continue ;; \
+		esac; \
 # TODO verify GPG signatures for manifest-tool releases
-		wget -O "bin/manifest-tool-$os-$arch$ext" "https://github.com/estesp/manifest-tool/releases/download/v${MANIFEST_TOOL_VERSION}/manifest-tool-$os-$arch$ext"; \
+		wget -O "bin/manifest-tool-$osArch$ext" "https://github.com/estesp/manifest-tool/releases/download/v${MANIFEST_TOOL_VERSION}/manifest-tool-$GOOS-$GOARCH$ext"; \
 	done; \
 	ls -l bin; \
 	file bin/*


### PR DESCRIPTION
```
+ file bin/bashbrew-amd64 bin/bashbrew-arm32v5 bin/bashbrew-arm32v6 bin/bashbrew-arm32v7 bin/bashbrew-arm64v8 bin/bashbrew-darwin-amd64 bin/bashbrew-i386 bin/bashbrew-ppc64le bin/bashbrew-s390x bin/bashbrew-windows-amd64.exe bin/manifest-tool-amd64 bin/manifest-tool-arm64v8 bin/manifest-tool-darwin-amd64 bin/manifest-tool-ppc64le bin/manifest-tool-s390x bin/manifest-tool-windows-amd64.exe
bin/bashbrew-amd64:                  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
bin/bashbrew-arm32v5:                ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
bin/bashbrew-arm32v6:                ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
bin/bashbrew-arm32v7:                ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
bin/bashbrew-arm64v8:                ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
bin/bashbrew-darwin-amd64:           Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
bin/bashbrew-i386:                   ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, stripped
bin/bashbrew-ppc64le:                ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, stripped
bin/bashbrew-s390x:                  ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, stripped
bin/bashbrew-windows-amd64.exe:      PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
bin/manifest-tool-amd64:             ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=9c5441ad0c18e839627e0b61c2369292831c18a5, not stripped
bin/manifest-tool-arm64v8:           ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
bin/manifest-tool-darwin-amd64:      Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
bin/manifest-tool-ppc64le:           ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, not stripped
bin/manifest-tool-s390x:             ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, not stripped
bin/manifest-tool-windows-amd64.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
 ---> 0acd3cdb36b1
Removing intermediate container ee37fa20846d
Successfully built 0acd3cdb36b1
```