### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.12, 4.4, 4, latest
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
-GitCommit: a4c649c11bcd28ca806860ff8b55ee423eb94a0d
+GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
 Directory: 3.0

--- a/library/gcc
+++ b/library/gcc
@@ -6,24 +6,24 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2016-08-03
 Tags: 4.9.4, 4.9, 4
-GitCommit: a6501411006ac7e1bd75067bed7f5914a621b7fb
+GitCommit: 8654fc1f330d411c1f4a6b648e4da649f8c9a90d
 Directory: 4.9
 # Docker EOL: 2017-08-03
 
 # Last Modified: 2016-06-03
 Tags: 5.4.0, 5.4, 5
-GitCommit: a6501411006ac7e1bd75067bed7f5914a621b7fb
+GitCommit: 8654fc1f330d411c1f4a6b648e4da649f8c9a90d
 Directory: 5
 # Docker EOL: 2017-06-03
 
 # Last Modified: 2016-12-21
 Tags: 6.3.0, 6.3, 6
-GitCommit: a6501411006ac7e1bd75067bed7f5914a621b7fb
+GitCommit: 8654fc1f330d411c1f4a6b648e4da649f8c9a90d
 Directory: 6
 # Docker EOL: 2017-12-21
 
 # Last Modified: 2017-05-02
 Tags: 7.1.0, 7.1, 7, latest
-GitCommit: a6501411006ac7e1bd75067bed7f5914a621b7fb
+GitCommit: 8654fc1f330d411c1f4a6b648e4da649f8c9a90d
 Directory: 7
 # Docker EOL: 2018-05-02

--- a/library/httpd
+++ b/library/httpd
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.32, 2.2
-GitCommit: 1883f2ec8be5f2a0cd176673a249c618ad7976ba
+GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2
 
 Tags: 2.2.32-alpine, 2.2-alpine
-GitCommit: 1883f2ec8be5f2a0cd176673a249c618ad7976ba
+GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
-GitCommit: 1883f2ec8be5f2a0cd176673a249c618ad7976ba
+GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
-GitCommit: 656b3859734d70b47386fd8bac58d5f719df596b
+GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.4/alpine

--- a/library/memcached
+++ b/library/memcached
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.36, 1.4, 1, latest
-GitCommit: 3f8f0356ad0a9ab23ae0ad8410540f7343ae8fb1
+Tags: 1.4.37, 1.4, 1, latest
+GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
 Directory: debian
 
-Tags: 1.4.36-alpine, 1.4-alpine, 1-alpine, alpine
-GitCommit: 3f8f0356ad0a9ab23ae0ad8410540f7343ae8fb1
+Tags: 1.4.37-alpine, 1.4-alpine, 1-alpine, alpine
+GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
 Directory: alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,28 +1,36 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/20694c47e7f2f7ab8946767b1dfcc7ff5e582534/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/d365e45c022bcd901a9770b18b48c2aa29e4cc4c/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 10.0.5-apache, 10.0-apache, 10-apache, 10.0.5, 10.0, 10
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 10.0/apache
 
 Tags: 10.0.5-fpm, 10.0-fpm, 10-fpm
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 10.0/fpm
 
-Tags: 11.0.3-apache, 11.0-apache, 11-apache, apache, 11.0.3, 11.0, 11, latest
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+Tags: 11.0.3-apache, 11.0-apache, 11-apache, 11.0.3, 11.0, 11
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 11.0/apache
 
-Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm, fpm
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 11.0/fpm
 
+Tags: 12.0.0-apache, 12.0-apache, 12-apache, apache, 12.0.0, 12.0, 12, latest
+GitCommit: 8198762ec5e898be8f41ebf3a9aa31b24b39006e
+Directory: 12.0/apache
+
+Tags: 12.0.0-fpm, 12.0-fpm, 12-fpm, fpm
+GitCommit: 8198762ec5e898be8f41ebf3a9aa31b24b39006e
+Directory: 12.0/fpm
+
 Tags: 9.0.58-apache, 9.0-apache, 9-apache, 9.0.58, 9.0, 9
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 9.0/apache
 
 Tags: 9.0.58-fpm, 9.0-fpm, 9-fpm
-GitCommit: 71199bd69ad66f50f92c12ea72887eeeae5c6780
+GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 9.0/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -9,7 +9,7 @@ GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.6
 
 Tags: 9.6.3-alpine, 9.6-alpine, 9-alpine, alpine
-GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
+GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.6/alpine
 
 Tags: 9.5.7, 9.5
@@ -17,7 +17,7 @@ GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.5
 
 Tags: 9.5.7-alpine, 9.5-alpine
-GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
+GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.5/alpine
 
 Tags: 9.4.12, 9.4
@@ -25,7 +25,7 @@ GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.4
 
 Tags: 9.4.12-alpine, 9.4-alpine
-GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
+GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.4/alpine
 
 Tags: 9.3.17, 9.3
@@ -33,7 +33,7 @@ GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.3
 
 Tags: 9.3.17-alpine, 9.3-alpine
-GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
+GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.3/alpine
 
 Tags: 9.2.21, 9.2
@@ -41,5 +41,5 @@ GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.2
 
 Tags: 9.2.21-alpine, 9.2-alpine
-GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
+GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.2/alpine

--- a/library/python
+++ b/library/python
@@ -1,23 +1,27 @@
-# this file is generated via https://github.com/docker-library/python/blob/c5b36c38823ca6a1301ad39cbf3ece75d77c5600/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/0edfe01ac242743dfe14836bccf8620703f4d753/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.13, 2.7, 2
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7
 
 Tags: 2.7.13-slim, 2.7-slim, 2-slim
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/alpine
 
+Tags: 2.7.13-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
+GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
+Directory: 2.7/alpine3.6
+
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
-GitCommit: a33fcb6adc834c2fdddd894fd0bbfc2609488e69
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/wheezy
 
 Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
@@ -30,19 +34,19 @@ Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: a33fcb6adc834c2fdddd894fd0bbfc2609488e69
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -50,19 +54,19 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.6, 3.4
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.4
 
 Tags: 3.4.6-slim, 3.4-slim
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.4/slim
 
 Tags: 3.4.6-alpine, 3.4-alpine
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.4/alpine
 
 Tags: 3.4.6-wheezy, 3.4-wheezy
-GitCommit: a33fcb6adc834c2fdddd894fd0bbfc2609488e69
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.4/wheezy
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
@@ -70,15 +74,15 @@ GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.3, 3.5
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.5
 
 Tags: 3.5.3-slim, 3.5-slim
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.5/slim
 
 Tags: 3.5.3-alpine, 3.5-alpine
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.5/alpine
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
@@ -91,16 +95,20 @@ Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.1, 3.6, 3, latest
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.6
 
 Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.6/slim
 
 Tags: 3.6.1-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: cd1f11aa745a05ddf6329678d5b12a097084681b
+GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 3.6/alpine
+
+Tags: 3.6.1-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
+GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
+Directory: 3.6/alpine3.6
 
 Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
 GitCommit: 7eca63adca38729424a9bab957f006f5caad870f

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.10, 3.6, 3, latest
-GitCommit: 4761fd0c03b8ca4e81967019e564d0659e4b7b74
+GitCommit: a6cb36022a5c1a17df78cfafe45a73d941ad4eb8
 Directory: 3.6/debian
 
 Tags: 3.6.10-management, 3.6-management, 3-management, management
@@ -13,7 +13,7 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.10-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 4761fd0c03b8ca4e81967019e564d0659e4b7b74
+GitCommit: a6cb36022a5c1a17df78cfafe45a73d941ad4eb8
 Directory: 3.6/alpine
 
 Tags: 3.6.10-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
- `bash`: update git.savannah.gnu.org URLs
- `gcc`: update git.savannah.gnu.org URLs
- `httpd`: update git.savannah.gnu.org URLs
- `memcached`: 1.4.37
- `nextcloud`: add 12.0 (https://github.com/nextcloud/docker/pull/85)
- `postgres`: update git.savannah.gnu.org URLs
- `python`: add Alpine 3.6 variants (docker-library/python#201, docker-library/python#203)
- `rabbitmq`: fix "unbound variable" error (docker-library/rabbitmq#161)