### PR TITLE
version bump: erlang otp-19.3.5

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,14 +1,26 @@
-# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/65d3a1ff75dfe46467b2fc93a0fd6f5009ba02f4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/7b0e42e619b46d87fe6c41a018dcb7e065e6b0ed/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
-Tags: 19.3.3, 19.3, 19, latest
-GitCommit: 232e8eda4a1f00ffd9f417f86a4212fa4d39e441
+Tags: 20.0-rc2
+GitCommit: 60279df11f4f11abfdce15599d24ad73c1aefbe1
+Directory: 20
+
+Tags: 20.0-rc2-slim
+GitCommit: 60279df11f4f11abfdce15599d24ad73c1aefbe1
+Directory: 20/slim
+
+Tags: 20.0-rc2-alpine
+GitCommit: 60279df11f4f11abfdce15599d24ad73c1aefbe1
+Directory: 20/alpine
+
+Tags: 19.3.5, 19.3, 19, latest
+GitCommit: 7b0e42e619b46d87fe6c41a018dcb7e065e6b0ed
 Directory: 19
 
-Tags: 19.3.3-slim, 19.3-slim, 19-slim, slim
-GitCommit: 232e8eda4a1f00ffd9f417f86a4212fa4d39e441
+Tags: 19.3.5-slim, 19.3-slim, 19-slim, slim
+GitCommit: 7b0e42e619b46d87fe6c41a018dcb7e065e6b0ed
 Directory: 19/slim
 
 Tags: 18.3.4.5, 18.3.4, 18.3, 18


### PR DESCRIPTION
also have the 20.0-rc2 for brave people to test play with, add the alpine based image;
the `latest` tag is still pointing to 19.