### PR TITLE
Add "arch" function for "bashbrew cat" to access the current architecture string

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-cat.go
+++ b/bashbrew/go/src/bashbrew/cmd-cat.go
@@ -42,6 +42,9 @@ func cmdCat(c *cli.Context) error {
 		"i": func() int {
 			return i
 		},
+		"arch": func() string {
+			return arch
+		},
 	}).Parse(format)
 	if err != nil {
 		return cli.NewMultiError(tmplMultiErr, err)


### PR DESCRIPTION
```console
$ bashbrew cat --format '{{ arch }}' ubuntu
amd64
$ bashbrew --arch=s390x cat --format '{{ arch }}' ubuntu
s390x
$ BASHBREW_ARCH=s390x bashbrew cat --format '{{ arch }}' ubuntu
s390x
```