### PR TITLE
Update Solr to 6.6.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,28 +1,38 @@
 # maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
 # maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
 
-5.5.4: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
-5.5: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
-5: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5
+5.5.4: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5
+5.5: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5
+5: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5
 
-5.5.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 5.5/alpine
+5.5.4-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
+5.5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
+5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
 
-6.3.0: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3
-6.3: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3
+6.3.0: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3
+6.3: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3
 
-6.3.0-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3/alpine
-6.3-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.3/alpine
+6.3.0-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3/alpine
+6.3-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3/alpine
 
-6.4.2: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
-6.4: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4
+6.4.2: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4
+6.4: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4
 
-6.4.2-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
-6.4-alpine: git://github.com/docker-solr/docker-solr@1ccf51aaeef0636445f670d9fd083730d4a6e9c1 6.4/alpine
+6.4.2-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4/alpine
+6.4-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4/alpine
 
-6.5.1: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5
-6.5: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5
+6.5.1: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5
+6.5: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5
 
-6.5.1-alpine: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5/alpine
-6.5-alpine: git://github.com/docker-solr/docker-solr@9a5abca27d60292ce0dc6dcb41bb3d6fed5c54dc 6.5/alpine
+6.5.1-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5/alpine
+6.5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5/alpine
+
+6.6.0: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6
+6.6: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6
+6: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6
+latest: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6
+
+6.6.0-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
+6.6-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
+6-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
+alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/www-announce/201706.mbox/browser
Changes: https://lucene.apache.org/solr/6_6_0/changes/Changes.html

On the docker-solr side:

- fixed #116 "While creating container, solr user is added to group nobody instead of group solr"