### PR TITLE
Rapidoid v5.3.5

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -1,5 +1,5 @@
 Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski)
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
-Tags: 5.3.4, 5.3, 5, latest
-GitCommit: 7d2e37df8a87985f267aa4e77f4f15744c411d62
+Tags: 5.3.5, 5.3, 5, latest
+GitCommit: 7a40ffa3a8963fb77514a92e6ab7d25802c0e431

--- a/test/tests/rapidoid-load-balancer/run.sh
+++ b/test/tests/rapidoid-load-balancer/run.sh
@@ -11,10 +11,10 @@ image="$1"
 # Use a client image with curl for testing
 clientImage='buildpack-deps:jessie-curl'
 
-app1id="$(docker run -d "$image" on.port=80 id=app1 app.services=ping,status)"
-app2id="$(docker run -d "$image" on.port=80 id=app2 app.services=ping,status)"
+app1id="$(docker run -d "$image" rapidoid.port=80 id=app1 app.services=ping,status)"
+app2id="$(docker run -d "$image" rapidoid.port=80 id=app2 app.services=ping,status)"
 
-proxyid="$(docker run -d --link "$app1id":app1 --link "$app2id":app2 "$image" on.port=80 '/ -> http://app1, http://app2' app.services=ping)"
+proxyid="$(docker run -d --link "$app1id":app1 --link "$app2id":app2 "$image" rapidoid.port=80 '/ -> http://app1, http://app2' app.services=ping)"
 
 trap "docker rm -vf $proxyid $app1id $app2id > /dev/null" EXIT
 


### PR DESCRIPTION
Starting from v5.3.5, the configuration entry `on.port` is renamed to `rapidoid.port`. The `rapidoid-load-balancer` test has been updated accordingly.