### PR TITLE
Update for Node v6.11.0 LTS and fix regression in Node v8.0.0-onbuild variant

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/20f3de9046e2472b70d57d8b11be9cea7c4863bc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/e2b78b4bde9440f2189007004a2ae4880f3eb030/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 8.0.0, 8.0, 8, latest
-GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
+GitCommit: 0a3a6dbbef745e908dbf83ca38e0fd06f869e061
 Directory: 8.0
 
 Tags: 8.0.0-alpine, 8.0-alpine, 8-alpine, alpine
@@ -12,7 +12,7 @@ GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
 Directory: 8.0/alpine
 
 Tags: 8.0.0-onbuild, 8.0-onbuild, 8-onbuild, onbuild
-GitCommit: 20f3de9046e2472b70d57d8b11be9cea7c4863bc
+GitCommit: 0a3a6dbbef745e908dbf83ca38e0fd06f869e061
 Directory: 8.0/onbuild
 
 Tags: 8.0.0-slim, 8.0-slim, 8-slim, slim
@@ -23,25 +23,25 @@ Tags: 8.0.0-wheezy, 8.0-wheezy, 8-wheezy, wheezy
 GitCommit: 09e42c172ffd6f8631fb1cb7a0785fd890c0f11a
 Directory: 8.0/wheezy
 
-Tags: 6.10.3, 6.10, 6, boron
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
-Directory: 6.10
+Tags: 6.11.0, 6.11, 6, boron
+GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Directory: 6.11
 
-Tags: 6.10.3-alpine, 6.10-alpine, 6-alpine, boron-alpine
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
-Directory: 6.10/alpine
+Tags: 6.11.0-alpine, 6.11-alpine, 6-alpine, boron-alpine
+GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Directory: 6.11/alpine
 
-Tags: 6.10.3-onbuild, 6.10-onbuild, 6-onbuild, boron-onbuild
-GitCommit: ffecb0e9ca258d6b20ff60b30956bd33f7357142
-Directory: 6.10/onbuild
+Tags: 6.11.0-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
+GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Directory: 6.11/onbuild
 
-Tags: 6.10.3-slim, 6.10-slim, 6-slim, boron-slim
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
-Directory: 6.10/slim
+Tags: 6.11.0-slim, 6.11-slim, 6-slim, boron-slim
+GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Directory: 6.11/slim
 
-Tags: 6.10.3-wheezy, 6.10-wheezy, 6-wheezy, boron-wheezy
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
-Directory: 6.10/wheezy
+Tags: 6.11.0-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
+GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Directory: 6.11/wheezy
 
 Tags: 4.8.3, 4.8, 4, argon
 GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365


### PR DESCRIPTION
Related: https://github.com/nodejs/docker-node/pull/427
Related: https://github.com/nodejs/docker-node/pull/426