### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/87dfadb46c2a905abb1bcd383ec15028e4454435/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/6fc30526e3abd620ebd439d215184d895d10f018/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,24 +6,28 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2016-08-03
 Tags: 4.9.4, 4.9, 4
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
 Directory: 4.9
 # Docker EOL: 2017-08-03
 
 # Last Modified: 2016-06-03
 Tags: 5.4.0, 5.4, 5
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
 Directory: 5
 # Docker EOL: 2017-06-03
 
 # Last Modified: 2016-12-21
 Tags: 6.3.0, 6.3, 6
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
 Directory: 6
 # Docker EOL: 2017-12-21
 
 # Last Modified: 2017-05-02
 Tags: 7.1.0, 7.1, 7, latest
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
 Directory: 7
 # Docker EOL: 2018-05-02

--- a/library/mongo
+++ b/library/mongo
@@ -1,41 +1,57 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/5f4bcf4bec163ef05b4fc67d5c92762989dbde06/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/624e95231d63042af46de4a35b9955fb6cc9aac0/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 3.0.15, 3.0
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.0/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
 GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.0
 
 Tags: 3.0.15-windowsservercore, 3.0-windowsservercore
+Architectures: windows-amd64
 GitCommit: 40d62a73bbd4e20d90ec859a8af483f70b1e5fd4
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.13, 3.2
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
 GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.2
 
 Tags: 3.2.13-windowsservercore, 3.2-windowsservercore
+Architectures: windows-amd64
 GitCommit: 1bf5765ba4a8a46a70f5b2b634ef2070b4b89455
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.4.4, 3.4, 3, latest
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
 GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
 Directory: 3.4
 
 Tags: 3.4.4-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+Architectures: windows-amd64
 GitCommit: 8f2bcee7f80c90ff79f282d99ee89f3ea1dcbca4
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.5.8, 3.5, unstable
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.5/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
 GitCommit: 45055cc0c67da614a3edf24369fb1484701f88e3
 Directory: 3.5
 
 Tags: 3.5.8-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+Architectures: windows-amd64
 GitCommit: 3fd2ca2e905e3b826e0244bb73a55e61e8db298e
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,63 +1,77 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/a080def2a36003e85485d07b3f047bd3c91508c2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/efbcd4f8e42e510ef561a7ce518633f0eba33992/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
 Tags: 6b38-jdk, 6b38, 6-jdk, 6
+Architectures: amd64, arm32v7, i386
 GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
 Directory: 6-jdk
 
 Tags: 6b38-jre, 6-jre
+Architectures: amd64, arm32v7, i386
 GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
 Directory: 6-jre
 
 Tags: 7u131-jdk, 7u131, 7-jdk, 7
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jdk
 
 Tags: 7u131-jdk-alpine, 7u131-alpine, 7-jdk-alpine, 7-alpine
+Architectures: amd64
 GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jdk/alpine
 
 Tags: 7u131-jre, 7-jre
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jre
 
 Tags: 7u131-jre-alpine, 7-jre-alpine
+Architectures: amd64
 GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jre/alpine
 
 Tags: 8u131-jdk, 8u131, 8-jdk, 8, jdk, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jdk
 
 Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+Architectures: amd64
 GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 8-jdk/alpine
 
 Tags: 8u131-jdk-windowsservercore, 8u131-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Architectures: windows-amd64
 GitCommit: 9745c87a15896ec558429a826e23926e721e4846
 Directory: 8-jdk/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 8u131-jdk-nanoserver, 8u131-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
+Architectures: windows-amd64
 GitCommit: 9745c87a15896ec558429a826e23926e721e4846
 Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 8u131-jre, 8-jre, jre
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
 Directory: 8-jre
 
 Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
+Architectures: amd64
 GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 8-jre/alpine
 
 Tags: 9-b170-jdk, 9-b170, 9-jdk, 9
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jdk
 
 Tags: 9-b170-jre, 9-jre
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jre

--- a/library/pypy
+++ b/library/pypy
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-5.7.1, 2-5.7, 2-5, 2
-GitCommit: 92891392566f11de4b80fafe1b2383490350be47
+GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
 Directory: 2
 
 Tags: 2-5.7.1-slim, 2-5.7-slim, 2-5-slim, 2-slim
-GitCommit: 92891392566f11de4b80fafe1b2383490350be47
+GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
 Directory: 2/slim
 
 Tags: 2-5.7.1-onbuild, 2-5.7-onbuild, 2-5-onbuild, 2-onbuild
@@ -17,11 +17,11 @@ GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
 Tags: 3-5.7.1, 3-5.7, 3-5, 3, latest
-GitCommit: 92891392566f11de4b80fafe1b2383490350be47
+GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
 Directory: 3
 
 Tags: 3-5.7.1-slim, 3-5.7-slim, 3-5-slim, 3-slim, slim
-GitCommit: 92891392566f11de4b80fafe1b2383490350be47
+GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
 Directory: 3/slim
 
 Tags: 3-5.7.1-onbuild, 3-5.7-onbuild, 3-5-onbuild, 3-onbuild, onbuild

--- a/library/redis
+++ b/library/redis
@@ -1,49 +1,59 @@
-# this file is generated via https://github.com/docker-library/redis/blob/9db642535f941a70f033c82ab82da58c3e1d23a2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/016e0d738031c00bb6cfa4a433e763413e14b757/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 3.0.7, 3.0
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.0
 
 Tags: 3.0.7-32bit, 3.0-32bit
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.0/32bit
 
 Tags: 3.0.7-alpine, 3.0-alpine
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.0/alpine
 
 Tags: 3.0.504-windowsservercore, 3.0-windowsservercore
+Architectures: windows-amd64
 GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.0.504-nanoserver, 3.0-nanoserver
+Architectures: windows-amd64
 GitCommit: ad72d7a7f3c05a9b658ec64894d4193c89bba01b
 Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 3.2.9, 3.2, 3, latest
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.2
 
 Tags: 3.2.9-32bit, 3.2-32bit, 3-32bit, 32bit
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.2/32bit
 
 Tags: 3.2.9-alpine, 3.2-alpine, 3-alpine, alpine
-GitCommit: 24aa66d88990e0eeec71bd39862744fdb7b862e4
+Architectures: amd64
+GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.2/alpine
 
 Tags: 3.2.100-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
+Architectures: windows-amd64
 GitCommit: 709e6a8df205f73afcc6f6257cab104175de1f5f
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.100-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
+Architectures: windows-amd64
 GitCommit: 2daf4fd7d858c8f2ad9694c4f460b8c6a7f782aa
 Directory: 3.2/windows/nanoserver
 Constraints: nanoserver

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,40 +4,40 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.7.5-apache, 4.7-apache, 4-apache, apache, 4.7.5, 4.7, 4, latest, 4.7.5-php5.6-apache, 4.7-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.7.5-php5.6, 4.7-php5.6, 4-php5.6, php5.6
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-apache, 4.8-apache, 4-apache, apache, 4.8.0, 4.8, 4, latest, 4.8.0-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.0-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/apache
 
-Tags: 4.7.5-fpm, 4.7-fpm, 4-fpm, fpm, 4.7.5-php5.6-fpm, 4.7-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.0-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm
 
-Tags: 4.7.5-fpm-alpine, 4.7-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.7.5-php5.6-fpm-alpine, 4.7-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.0-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm-alpine
 
-Tags: 4.7.5-php7.0-apache, 4.7-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.7.5-php7.0, 4.7-php7.0, 4-php7.0, php7.0
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.0-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/apache
 
-Tags: 4.7.5-php7.0-fpm, 4.7-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm
 
-Tags: 4.7.5-php7.0-fpm-alpine, 4.7-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm-alpine
 
-Tags: 4.7.5-php7.1-apache, 4.7-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.7.5-php7.1, 4.7-php7.1, 4-php7.1, php7.1
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.0-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/apache
 
-Tags: 4.7.5-php7.1-fpm, 4.7-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/fpm
 
-Tags: 4.7.5-php7.1-fpm-alpine, 4.7-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-GitCommit: d122aa204948aecd651af435fe4ca058bb99545d
+Tags: 4.8.0-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `gcc`: multiarch (docker-library/gcc#36)
- `mongo`: explicit `Architectures`
- `openjdk`: multiarch (docker-library/openjdk#121)
- `pypy`: update `pip` installation to match recent Python changes (docker-library/pypy#15)
- `redis`: smaller Debian-based images (docker-library/redis#94), multiarch (docker-library/redis#95)
- `wordpress`: 4.8