### PR TITLE
Bumps Consul to 0.8.4.

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,4 @@
 # maintainer: James Phillips <james@hashicorp.com> (@slackpad)
 
-latest: git://github.com/hashicorp/docker-consul@b018ca790f1fabf4175cdde857e33803153a5b02 0.X
-0.8.3: git://github.com/hashicorp/docker-consul@b018ca790f1fabf4175cdde857e33803153a5b02 0.X
+latest: git://github.com/hashicorp/docker-consul@bd6dfdff679131b7c39ca956d6905c28fcb54dab 0.X
+0.8.4: git://github.com/hashicorp/docker-consul@bd6dfdff679131b7c39ca956d6905c28fcb54dab 0.X


### PR DESCRIPTION
This also includes:

* Bumps Alpine base to 3.6 to addresss zlib CVEs.
* Removes obsolete CLI RPC port expose.
* Sets a fixed key server since the default was timing out.