### PR TITLE
Aerospike 3.13.0.1

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,6 +1,6 @@
 # maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)
 
 
-3.12.1: git://github.com/aerospike/aerospike-server.docker@b956cea63cb9e48e9cd7d60daab64331917be39c
+3.13.0.1: git://github.com/aerospike/aerospike-server.docker@325c0b8a906823e7ad3afd543d4fe13789ef5664
 3.12.1.1: git://github.com/aerospike/aerospike-server.docker@03fe0e974b0866334e06a4655c17928ad2d5dbb0
-latest: git://github.com/aerospike/aerospike-server.docker@03fe0e974b0866334e06a4655c17928ad2d5dbb0
+latest: git://github.com/aerospike/aerospike-server.docker@325c0b8a906823e7ad3afd543d4fe13789ef5664


### PR DESCRIPTION
Aerospike server 3.13.0.1
(Jump Version required prior to upgrading from  versions prior to 3.13.0.1 )

http://www.aerospike.com/download/server/notes.html#3.13.0.1