### PR TITLE
Upgrading Vault image alpine to 3.6, removing jq

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -2,7 +2,7 @@
 
 0.6.4: git://github.com/hashicorp/docker-vault@c087a27b5ec93445e89dc46f25af973f114f1399 0.6.4
 0.6.5: git://github.com/hashicorp/docker-vault@c087a27b5ec93445e89dc46f25af973f114f1399 0.6.5
-0.7.0: git://github.com/hashicorp/docker-vault@e0a91ac0bc931fca599d14c0593cc8e28c56a30d 0.7.0
-0.7.2: git://github.com/hashicorp/docker-vault@9a0b4b5039b66f4a9591b8be6ff79c15c112f882 0.7.2
-0.7.3: git://github.com/hashicorp/docker-vault@8ae11b6202496a6a9d1e9a5fff99e8cbc5e31838 0.7.3
-latest: git://github.com/hashicorp/docker-vault@8ae11b6202496a6a9d1e9a5fff99e8cbc5e31838 0.7.3
+0.7.0: git://github.com/hashicorp/docker-vault@02af9417ae42bf6290b4b36c2188b1836f1017a8 0.7.0
+0.7.2: git://github.com/hashicorp/docker-vault@02af9417ae42bf6290b4b36c2188b1836f1017a8 0.7.2
+0.7.3: git://github.com/hashicorp/docker-vault@02af9417ae42bf6290b4b36c2188b1836f1017a8 0.7.3
+latest: git://github.com/hashicorp/docker-vault@02af9417ae42bf6290b4b36c2188b1836f1017a8 0.7.3


### PR DESCRIPTION
This is to address the vulnerabilities listed on the docker hub page.