### PR TITLE
Aerospike 3.14.0

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -2,5 +2,5 @@
 
 
 3.13.0.1: git://github.com/aerospike/aerospike-server.docker@325c0b8a906823e7ad3afd543d4fe13789ef5664
-3.12.1.1: git://github.com/aerospike/aerospike-server.docker@03fe0e974b0866334e06a4655c17928ad2d5dbb0
-latest: git://github.com/aerospike/aerospike-server.docker@325c0b8a906823e7ad3afd543d4fe13789ef5664
+3.14.0: git://github.com/aerospike/aerospike-server.docker@01158e0954d503f9c845fdc379fff7fc58828c48
+latest: git://github.com/aerospike/aerospike-server.docker@01158e0954d503f9c845fdc379fff7fc58828c48


### PR DESCRIPTION
 Release Date: June 6 2017

    When upgrading, please follow the upgrade and protocol-switching PREREQUISITES for 3.13.0.1.
        See Aerospike documentation for Upgrade to 3.13
http://www.aerospike.com/docs/operations/upgrade/cluster_to_3_13
Improvements

    [AER-5658] - (KVS) Deprecated set-delete and associated functionality.
    [AER-5593] - (SINDEX) Simplified garbage collection configuration.
    [AER-5603] - (CLUSTER) Disallowed setting heartbeat protocol to v2, deprecated paxos-max-cluster-size.
    [AER-5652] - (CLUSTER) Server now runs only paxos-protocol v5, deprecated paxos-protocol.