### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -16,18 +16,6 @@ Tags: 8.3.3-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
 GitCommit: cd3080d2d4e057c1de914bca1d85a0023f8d455d
 Directory: 8.3/fpm-alpine
 
-Tags: 8.2.8-apache, 8.2-apache, 8.2.8, 8.2
-GitCommit: e4afe0e66bb0c410d62fc9953a0a3a060fe72057
-Directory: 8.2/apache
-
-Tags: 8.2.8-fpm, 8.2-fpm
-GitCommit: e4afe0e66bb0c410d62fc9953a0a3a060fe72057
-Directory: 8.2/fpm
-
-Tags: 8.2.8-fpm-alpine, 8.2-fpm-alpine
-GitCommit: e4afe0e66bb0c410d62fc9953a0a3a060fe72057
-Directory: 8.2/fpm-alpine
-
 Tags: 7.55-apache, 7-apache, 7.55, 7
 GitCommit: 93cbfde03f3ae733d3b4ba489c6cedac307e5373
 Directory: 7/apache

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,37 +1,45 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/6c318716176795fcd2784b9996bae18a4fbd34e6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/f99e17d0be49185244ed1c5deb941e1ec867d998/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.4.27, 1.4
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a11db1597f9be5365028673df4d05b2ea854b3ed
 Directory: 1.4
 
 Tags: 1.4.27-alpine, 1.4-alpine
+Architectures: amd64
 GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.4/alpine
 
 Tags: 1.5.19, 1.5
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
+Architectures: amd64
 GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
 Tags: 1.6.12, 1.6
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
 Directory: 1.6
 
 Tags: 1.6.12-alpine, 1.6-alpine
+Architectures: amd64
 GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
 Directory: 1.6/alpine
 
 Tags: 1.7.5, 1.7, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
 Directory: 1.7
 
 Tags: 1.7.5-alpine, 1.7-alpine, 1-alpine, alpine
+Architectures: amd64
 GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
 Directory: 1.7/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -1,21 +1,25 @@
-# this file is generated via https://github.com/docker-library/httpd/blob/12bf8c8883340c98b3988a7bade8ef2d0d6dcf8a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/httpd/blob/a2ef6c0d25f80355f434d9405aa25aa562bfebd3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.32, 2.2
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2
 
 Tags: 2.2.32-alpine, 2.2-alpine
+Architectures: amd64
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
+Architectures: amd64
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.4/alpine

--- a/library/memcached
+++ b/library/memcached
@@ -1,13 +1,15 @@
-# this file is generated via https://github.com/docker-library/memcached/blob/f824f7200908afa68fe4b93a2455ab8872d4402c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/memcached/blob/0642c9f9a9ef8087e6fa7fe848ee7fe5cc9a13ca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.4.37, 1.4, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
 Directory: debian
 
 Tags: 1.4.37-alpine, 1.4-alpine, 1-alpine, alpine
+Architectures: amd64
 GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
 Directory: alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -12,25 +12,17 @@ GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
 Directory: 10.0/fpm
 
 Tags: 11.0.3-apache, 11.0-apache, 11-apache, 11.0.3, 11.0, 11
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
+GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
 Directory: 11.0/apache
 
 Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
+GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
 Directory: 11.0/fpm
 
 Tags: 12.0.0-apache, 12.0-apache, 12-apache, apache, 12.0.0, 12.0, 12, latest
-GitCommit: 8198762ec5e898be8f41ebf3a9aa31b24b39006e
+GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
 Directory: 12.0/apache
 
 Tags: 12.0.0-fpm, 12.0-fpm, 12-fpm, fpm
-GitCommit: 8198762ec5e898be8f41ebf3a9aa31b24b39006e
+GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
 Directory: 12.0/fpm
-
-Tags: 9.0.58-apache, 9.0-apache, 9-apache, 9.0.58, 9.0, 9
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
-Directory: 9.0/apache
-
-Tags: 9.0.58-fpm, 9.0-fpm, 9-fpm
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
-Directory: 9.0/fpm

--- a/library/php
+++ b/library/php
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.1.5-cli, 7.1-cli, 7-cli, cli, 7.1.5, 7.1, 7, latest
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-cli, 7.1-cli, 7-cli, cli, 7.1.6, 7.1, 7, latest
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1
 
-Tags: 7.1.5-alpine, 7.1-alpine, 7-alpine, alpine
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-alpine, 7.1-alpine, 7-alpine, alpine
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/alpine
 
-Tags: 7.1.5-apache, 7.1-apache, 7-apache, apache
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-apache, 7.1-apache, 7-apache, apache
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/apache
 
-Tags: 7.1.5-fpm, 7.1-fpm, 7-fpm, fpm
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-fpm, 7.1-fpm, 7-fpm, fpm
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/fpm
 
-Tags: 7.1.5-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/fpm/alpine
 
-Tags: 7.1.5-zts, 7.1-zts, 7-zts, zts
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-zts, 7.1-zts, 7-zts, zts
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/zts
 
-Tags: 7.1.5-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+Tags: 7.1.6-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.20-cli, 7.0-cli, 7.0.20, 7.0

--- a/library/postgres
+++ b/library/postgres
@@ -1,45 +1,55 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/a9c1b15a7adf7cb2bc42fac776656aff7dd7994e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/d1c4c70ee967e6727fdcb0d96f05418fd7d3ed87/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 9.6.3, 9.6, 9, latest
+Architectures: amd64, i386, ppc64le
 GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.6
 
 Tags: 9.6.3-alpine, 9.6-alpine, 9-alpine, alpine
+Architectures: amd64
 GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.6/alpine
 
 Tags: 9.5.7, 9.5
+Architectures: amd64, i386, ppc64le
 GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.5
 
 Tags: 9.5.7-alpine, 9.5-alpine
+Architectures: amd64
 GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.5/alpine
 
 Tags: 9.4.12, 9.4
+Architectures: amd64, i386, ppc64le
 GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.4
 
 Tags: 9.4.12-alpine, 9.4-alpine
+Architectures: amd64
 GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.4/alpine
 
 Tags: 9.3.17, 9.3
+Architectures: amd64, i386, ppc64le
 GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.3
 
 Tags: 9.3.17-alpine, 9.3-alpine
+Architectures: amd64
 GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.3/alpine
 
 Tags: 9.2.21, 9.2
+Architectures: amd64, i386, ppc64le
 GitCommit: 54053ad27ac099abff3d4964bf7460fb9c541d5d
 Directory: 9.2
 
 Tags: 9.2.21-alpine, 9.2-alpine
+Architectures: amd64
 GitCommit: 2b0f642834a9ab4bad3155ff4a2a0e3ee457b75b
 Directory: 9.2/alpine

--- a/library/pypy
+++ b/library/pypy
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.7.1, 2-5.7, 2-5, 2
-GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
+Tags: 2-5.8.0, 2-5.8, 2-5, 2
+GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
 Directory: 2
 
-Tags: 2-5.7.1-slim, 2-5.7-slim, 2-5-slim, 2-slim
-GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
+Tags: 2-5.8.0-slim, 2-5.8-slim, 2-5-slim, 2-slim
+GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
 Directory: 2/slim
 
-Tags: 2-5.7.1-onbuild, 2-5.7-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.8.0-onbuild, 2-5.8-onbuild, 2-5-onbuild, 2-onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-5.7.1, 3-5.7, 3-5, 3, latest
-GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
+Tags: 3-5.8.0, 3-5.8, 3-5, 3, latest
+GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
 Directory: 3
 
-Tags: 3-5.7.1-slim, 3-5.7-slim, 3-5-slim, 3-slim, slim
-GitCommit: 198e58cdc844d14e2a3ab0a8c55e379de28ec79c
+Tags: 3-5.8.0-slim, 3-5.8-slim, 3-5-slim, 3-slim, slim
+GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
 Directory: 3/slim
 
-Tags: 3-5.7.1-onbuild, 3-5.7-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Tags: 3-5.8.0-onbuild, 3-5.8-onbuild, 3-5-onbuild, 3-onbuild, onbuild
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -13,7 +13,7 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.10-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: a6cb36022a5c1a17df78cfafe45a73d941ad4eb8
+GitCommit: bc90c8e432c340b6b2dd2ca05f99243f61bc3211
 Directory: 3.6/alpine
 
 Tags: 3.6.10-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,61 +1,75 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/d70d05cfa398310f7a02c7bca5db2eb4ad5ef417/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/8df795c4dc6619e97e5d4fd94731703e6a01355e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
 Directory: 6/jre7
 
 Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
 Directory: 6/jre8
 
 Tags: 7.0.78-jre7, 7.0-jre7, 7-jre7, 7.0.78, 7.0, 7
-GitCommit: a436a06d8fb281a85596dab283a1ee41193b97b3
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 7/jre7
 
 Tags: 7.0.78-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.78-alpine, 7.0-alpine, 7-alpine
-GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 7/jre7-alpine
 
 Tags: 7.0.78-jre8, 7.0-jre8, 7-jre8
-GitCommit: a436a06d8fb281a85596dab283a1ee41193b97b3
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 7/jre8
 
 Tags: 7.0.78-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-GitCommit: b6c19ae93937a18a8bb93c13ce8c8b07c428b3fc
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 7/jre8-alpine
 
 Tags: 8.0.44-jre7, 8.0-jre7, 8.0.44, 8.0
-GitCommit: b1a8927025d9a0c01494d7fbc1ae06cd269bb2f8
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.0/jre7
 
 Tags: 8.0.44-jre7-alpine, 8.0-jre7-alpine, 8.0.44-alpine, 8.0-alpine
-GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.44-jre8, 8.0-jre8
-GitCommit: b1a8927025d9a0c01494d7fbc1ae06cd269bb2f8
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.0/jre8
 
 Tags: 8.0.44-jre8-alpine, 8.0-jre8-alpine
-GitCommit: 86d4d5031e14a9274e1fa2bd4211ab03440e883d
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.15-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.15, 8.5, 8, latest
-GitCommit: 2b8ccaf69e5f338e04a04ee934a69c37384dd1e2
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.5/jre8
 
 Tags: 8.5.15-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.15-alpine, 8.5-alpine, 8-alpine, alpine
-GitCommit: 82b1da640aa15ff2e9713e59dba3dbf7487d6815
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M21-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M21, 9.0.0, 9.0, 9
-GitCommit: 888959b490387f1f7fcb8c117b23b4423f9f1bef
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M21-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M21-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
-GitCommit: 0f87a57ed953808a7c8d4ffaab5b112c42fb7431
+Architectures: amd64
+GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `drupal`: remove 8.2 again (docker-library/drupal#86)
- `haproxy`: multiarch (docker-library/haproxy#41)
- `httpd`: multiarch (docker-library/httpd#55)
- `memcached`: multiarch (docker-library/memcached#19)
- `nextcloud`: remove EOL 9.0, use upstream-recommended opcache settings
- `php`: 7.1.6
- `postgres`: multiarch (docker-library/postgres#298)
- `pypy`: 5.8.0
- `rabbitmq`: install `procps` for `rabbitmqctl wait` (docker-library/rabbitmq#163)
- `tomcat`: multiarch (docker-library/tomcat#73)