### PR TITLE
Add "SharedTags" support to "diff-pr.sh"

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -87,6 +87,22 @@ archesListTemplate='
 		{{- end -}}
 	{{- end -}}
 '
+# ... and SharedTags
+sharedTagsListTemplate='
+	{{- range $group := .Manifest.GetSharedTagGroups -}}
+		{{- range $tag := $group.SharedTags -}}
+			{{- join ":" $.RepoName $tag -}}
+			{{- " -- " -}}
+			{{- range $i, $e := $group.Entries -}}
+				{{- if gt $i 0 -}}
+					{{- ", " -}}
+				{{- end -}}
+				{{- join ":" $.RepoName ($e.Tags | last) -}}
+			{{- end -}}
+			{{- "\n" -}}
+		{{- end -}}
+	{{- end -}}
+'
 
 # TODO something less hacky than "git archive" hackery, like a "bashbrew archive" or "bashbrew context" or something
 template='
@@ -184,6 +200,7 @@ git -C temp init --quiet
 
 bashbrew list "${images[@]}" | sort -V > temp/_bashbrew-list || :
 bashbrew cat --format "$archesListTemplate" "${images[@]}" | sort -V > temp/_bashbrew-arches || :
+bashbrew cat --format "$sharedTagsListTemplate" "${images[@]}" | grep -vE '^$' | sort -V > temp/_bashbrew-shared-tags || :
 for image in "${images[@]}"; do
 	if script="$(bashbrew cat -f "$template" "$image")"; then
 		mkdir tar
@@ -200,6 +217,7 @@ git -C oi checkout --quiet pull
 git -C temp rm --quiet -rf . || :
 bashbrew list "${images[@]}" | sort -V > temp/_bashbrew-list || :
 bashbrew cat --format "$archesListTemplate" "${images[@]}" | sort -V > temp/_bashbrew-arches || :
+bashbrew cat --format "$sharedTagsListTemplate" "${images[@]}" | grep -vE '^$' | sort -V > temp/_bashbrew-shared-tags || :
 script="$(bashbrew cat -f "$template" "${images[@]}")"
 mkdir tar
 ( eval "$script" | tar -xiC tar )


### PR DESCRIPTION
Example output of this bashbrew template (assuming `hello-world` had been converted to use `SharedTags`):

```console
$ bashbrew cat --format "$sharedTagsListTemplate" --all | grep -vE '^$'
hello-world:latest -- hello-world:linux, hello-world:nanoserver
```

This is part of the work to support https://github.com/docker-library/official-images/issues/2289. :+1: