### PR TITLE
Reference the 7.4.6 release.

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -1,10 +1,10 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/docker
 
-Tags: 7.4.5, 7.4, latest
-GitCommit: 866dff0b76231906e1efdeafd63fe522d20b6c05
-Directory: 7.4/7.4.5
+Tags: 7.4.6, 7.4, latest
+GitCommit: fb5ac90d57ebb78b00fe1bdb306bef7ad268cce5
+Directory: 7.4/7.4.6
 
-Tags: web-connector-7.4.5, web-connector-7.4, web-connector
-GitCommit: 866dff0b76231906e1efdeafd63fe522d20b6c05
-Directory: 7.4/7.4.5/web-connector
+Tags: web-connector-7.4.6, web-connector-7.4, web-connector
+GitCommit: fb5ac90d57ebb78b00fe1bdb306bef7ad268cce5
+Directory: 7.4/7.4.6/web-connector


### PR DESCRIPTION
The new Convertigo 7.4.6 is released.
Thank you for the upgrade.