### PR TITLE
Validate (and deduplicate) Architectures values

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-put-shared.go
+++ b/bashbrew/go/src/bashbrew/cmd-put-shared.go
@@ -22,14 +22,13 @@ func entriesToManifestToolYaml(r Repo, entries ...*manifest.Manifest2822Entry) (
 
 			var ociArch architecture.OCIPlatform
 			if ociArch, ok = architecture.SupportedArches[arch]; !ok {
-				// skip unsupported arches
-				// TODO turn this into explicit validation checks at "parse" time instead (so that unsupported arches result in concrete user-facing errors long before this block of code)
-				continue
+				// this should never happen -- the parser validates Architectures
+				panic("somehow, an unsupported architecture slipped past the parser validation: " + arch)
 			}
 
 			var archNamespace string
 			if archNamespace, ok = archNamespaces[arch]; !ok || archNamespace == "" {
-				fmt.Fprintf(os.Stderr, "warning: no arch-namespace specified for %q; skipping %q\n", arch, r.EntryIdentifier(*entry))
+				fmt.Fprintf(os.Stderr, "warning: no arch-namespace specified for %q; skipping (%q)\n", arch, r.EntryIdentifier(*entry))
 				continue
 			}
 

--- a/bashbrew/go/vendor/manifest
+++ b/bashbrew/go/vendor/manifest
@@ -10,7 +10,7 @@
 		{
 			"importpath": "github.com/docker-library/go-dockerlibrary",
 			"repository": "https://github.com/docker-library/go-dockerlibrary",
-			"revision": "4fd80f3c84b66d3a62d907359f540c9417745f79",
+			"revision": "29d359eaa1fda9e522de1ee6994edf8c85eb5665",
 			"branch": "master"
 		},
 		{

--- a/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/example_test.go
+++ b/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/example_test.go
@@ -19,7 +19,7 @@ GitFetch: refs/heads/master
 GitRepo: https://github.com/docker-library/golang.git
 SharedTags: latest
 arm64v8-GitRepo: https://github.com/docker-library/golang.git
-Architectures: amd64
+Architectures: amd64, amd64
 
 
  # hi
@@ -57,7 +57,7 @@ ppc64le-Directory: 1.5/ppc64le
 SharedTags: raspbian
 GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 Tags: raspbian-s390x
-Architectures: s390x
+Architectures: s390x, i386
 
 
 `)))
@@ -115,7 +115,7 @@ i: g@h j
 	//
 	// Tags: raspbian-s390x
 	// SharedTags: raspbian
-	// Architectures: s390x
+	// Architectures: i386, s390x
 	// GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 	//
 	// Shared Tag Groups:


### PR DESCRIPTION
See https://github.com/docker-library/go-dockerlibrary/pull/14.

This will cause us to error out on invalid `Architectures` values. :+1: