### PR TITLE
Maven 3.5.0 with openjdk 8u131

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -1,57 +1,29 @@
 # maintainer: Carlos Sanchez <carlos@apache.org> (@carlossg)
 
-3.5.0-jdk-7: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7
-3.5-jdk-7: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7
-3-jdk-7: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7
+3.5.0-jdk-7: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-7
+3.5-jdk-7: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-7
+3-jdk-7: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-7
 
-3.5.0-jdk-7-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7/onbuild
-3.5-jdk-7-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7/onbuild
-3-jdk-7-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-7/onbuild
+3.5.0-jdk-7-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-7
+3.5-jdk-7-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-7
+3-jdk-7-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-7
 
-3.5.0-jdk-7-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7
-3.5-jdk-7-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7
-3-jdk-7-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7
+3.5.0-jdk-8: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+3.5.0: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+3.5-jdk-8: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+3.5: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+3-jdk-8: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+3: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
+latest: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-8
 
-3.5.0-jdk-7-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7/onbuild
-3.5-jdk-7-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7/onbuild
-3-jdk-7-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-7/onbuild
+3.5.0-jdk-8-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+3.5.0-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+3.5-jdk-8-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+3.5-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+3-jdk-8-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+3-alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
+alpine: git://github.com/carlossg/docker-maven@2357d3394f19730172ac9c7f4afe7cf052f36b4d jdk-8
 
-3.5.0-jdk-8: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-3.5.0: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-3.5-jdk-8: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-3.5: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-3-jdk-8: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-3: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-latest: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8
-
-3.5.0-jdk-8-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-3.5.0-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-3.5-jdk-8-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-3.5-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-3-jdk-8-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-3-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-8/onbuild
-
-3.5.0-jdk-8-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-3.5.0-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-3.5-jdk-8-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-3.5-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-3-jdk-8-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-3-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8
-
-3.5.0-jdk-8-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-3.5.0-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-3.5-jdk-8-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-3.5-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-3-jdk-8-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-3-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-onbuild-alpine: git://github.com/carlossg/docker-maven@7e98522ee97c73c22da1b62329a0f20757bad5fb jdk-8/onbuild
-
-3.5.0-jdk-9: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9
-3.5-jdk-9: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9
-3-jdk-9: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9
-
-3.5.0-jdk-9-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9/onbuild
-3.5-jdk-9-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9/onbuild
-3-jdk-9-onbuild: git://github.com/carlossg/docker-maven@ecf54b9839caed8aa2bcf9b8f7bb19594634ee89 jdk-9/onbuild
+3.5.0-jdk-9: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-9
+3.5-jdk-9: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-9
+3-jdk-9: git://github.com/carlossg/docker-maven@0490eff01e529b2d94789511b008d01a7b314953 jdk-9


### PR DESCRIPTION
Fixes https://github.com/carlossg/docker-maven/issues/26
Remove deprecated onbuild tags

I assume new builds will pull the latest base image