### PR TITLE
Upgrade Node to 8.1.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,24 +3,24 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.1.1, 8.1, 8, latest
-GitCommit: 31cfb8b96b69351b3552592dd1e2d62e73a5c5b9
+Tags: 8.1.2, 8.1, 8, latest
+GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
 Directory: 8.1
 
-Tags: 8.1.1-alpine, 8.1-alpine, 8-alpine, alpine
-GitCommit: 31cfb8b96b69351b3552592dd1e2d62e73a5c5b9
+Tags: 8.1.2-alpine, 8.1-alpine, 8-alpine, alpine
+GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
 Directory: 8.1/alpine
 
-Tags: 8.1.1-onbuild, 8.1-onbuild, 8-onbuild, onbuild
-GitCommit: 31cfb8b96b69351b3552592dd1e2d62e73a5c5b9
+Tags: 8.1.2-onbuild, 8.1-onbuild, 8-onbuild, onbuild
+GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
 Directory: 8.1/onbuild
 
-Tags: 8.1.1-slim, 8.1-slim, 8-slim, slim
-GitCommit: 31cfb8b96b69351b3552592dd1e2d62e73a5c5b9
+Tags: 8.1.2-slim, 8.1-slim, 8-slim, slim
+GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
 Directory: 8.1/slim
 
-Tags: 8.1.1-wheezy, 8.1-wheezy, 8-wheezy, wheezy
-GitCommit: 31cfb8b96b69351b3552592dd1e2d62e73a5c5b9
+Tags: 8.1.2-wheezy, 8.1-wheezy, 8-wheezy, wheezy
+GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
 Directory: 8.1/wheezy
 
 Tags: 6.11.0, 6.11, 6, boron


### PR DESCRIPTION
Upgrade Node to 8.1.2.

Related: nodejs/docker-node#434

Signed-off-by: Hans Kristian Flaatten <hans@starefossen.com>