### PR TITLE
add Grav CMS

### DIFF
--- a/library/grav
+++ b/library/grav
@@ -1,0 +1,15 @@
+Maintainers: Frieder Paape <grav-gitub@paape.io> (@lead4good)
+GitRepo: https://github.com/lead4good/docker-grav.git
+
+Tags: 1.2-apache, 1.2.4-apache, apache, 1.2, 1.2.4, latest
+GitCommit: ec61bbe2f87c6e046ac20b7b6427518e4cbd7e30
+Directory: 1.2/apache
+
+Tags: 1.2-fpm, 1.2.4-fpm, fpm
+GitCommit: ec61bbe2f87c6e046ac20b7b6427518e4cbd7e30
+Directory: 1.2/fpm
+
+Tags: 1.2-fpm-alpine, 1.2.4-fpm-alpine, fpm-alpine
+GitCommit: ec61bbe2f87c6e046ac20b7b6427518e4cbd7e30
+Directory: 1.2/fpm-alpine
+


### PR DESCRIPTION
I followed all the guidelines and orientated the code according to the wordpress  and drupal official images. Upstream currently does not sign the binaries. Also there is currently no simple way to find the current stable version so I omitted the `update.sh` which automatically updates version numbers for now.

@rhukster could you - representing upstream - comment on the following todos?
- [ ] Sign releases
- [ ] Provide stable way to query current release versions
- [ ] Eventually step in as maintainer of this image

You can find the docs [here](https://github.com/lead4good/docs/tree/master/grav)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/lead4good/docs/tree/master/grav
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)