### PR TITLE
Bump Traefik to v1.3.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,9 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.0, 1.3.0, v1.3, 1.3, raclette, latest
-GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
+Tags: v1.3.1, 1.3.1, v1.3, 1.3, raclette, latest
+GitCommit: a27a863dddee34155fb25d5f43968c9481747e93
 
-Tags: v1.3.0-alpine, 1.3.0-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 9ccd85a426ec167ad8c5e441f91fdff1790461b7
+Tags: v1.3.1-alpine, 1.3.1-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: a27a863dddee34155fb25d5f43968c9481747e93
 Directory: alpine
+


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.3.1.

/cc @vdemeester @ldez

Cheers
