### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/6fc30526e3abd620ebd439d215184d895d10f018/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/3b33871fe9558262cb5ed6253d358f76710e9ccb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,28 +6,28 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2016-08-03
 Tags: 4.9.4, 4.9, 4
-Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
 Directory: 4.9
 # Docker EOL: 2017-08-03
 
 # Last Modified: 2016-06-03
 Tags: 5.4.0, 5.4, 5
-Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
 Directory: 5
 # Docker EOL: 2017-06-03
 
 # Last Modified: 2016-12-21
 Tags: 6.3.0, 6.3, 6
-Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
 Directory: 6
 # Docker EOL: 2017-12-21
 
 # Last Modified: 2017-05-02
 Tags: 7.1.0, 7.1, 7, latest
-Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: cf8ed54e56859767257c6bc6d38b3d6e0490fdc4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
 Directory: 7
 # Docker EOL: 2018-05-02

--- a/library/ghost
+++ b/library/ghost
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.9, 0.11, 0, latest
-GitCommit: ee2ce866bd53499316d32bd915eca326af6707f2
+Tags: 0.11.10, 0.11, 0, latest
+GitCommit: 9bc8fab01a6858c113e07486ed071c656af8c335
 Directory: 0.11/debian
 
-Tags: 0.11.9-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: ee2ce866bd53499316d32bd915eca326af6707f2
+Tags: 0.11.10-alpine, 0.11-alpine, 0-alpine, alpine
+GitCommit: 9bc8fab01a6858c113e07486ed071c656af8c335
 Directory: 0.11/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
 Directory: 1.6/alpine
 
-Tags: 1.7.5, 1.7, 1, latest
+Tags: 1.7.6, 1.7, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
+GitCommit: 0ffcb61acdee528597854ca4a220493098b5a59b
 Directory: 1.7
 
-Tags: 1.7.5-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 1848d2933afbefd0e0a068dc7b5a753ab7842e6c
+GitCommit: 0ffcb61acdee528597854ca4a220493098b5a59b
 Directory: 1.7/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -8,7 +8,7 @@ Tags: 3.0.15, 3.0
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.0/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 8df1bc6fda6141aac6ab7a550edc4dc120d40a0b
+GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
 Directory: 3.0
 
 Tags: 3.0.15-windowsservercore, 3.0-windowsservercore
@@ -21,7 +21,7 @@ Tags: 3.2.14, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 333b2d1a5dae3d40e31da7459f6dfb8a1847e890
+GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
 Directory: 3.2
 
 Tags: 3.2.14-windowsservercore, 3.2-windowsservercore
@@ -34,7 +34,7 @@ Tags: 3.4.5, 3.4, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: e25d020918434d29378b4ca58c34843c215cd043
+GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
 Directory: 3.4
 
 Tags: 3.4.5-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
@@ -47,7 +47,7 @@ Tags: 3.5.8, 3.5, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.5/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 45055cc0c67da614a3edf24369fb1484701f88e3
+GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
 Directory: 3.5
 
 Tags: 3.5.8-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore

--- a/library/openjdk
+++ b/library/openjdk
@@ -41,7 +41,7 @@ Directory: 8-jdk
 
 Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 Architectures: amd64
-GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
+GitCommit: 238cc35696423794b1951fc63d4cc9ffb8ca9685
 Directory: 8-jdk/alpine
 
 Tags: 8u131-jdk-windowsservercore, 8u131-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
@@ -63,7 +63,7 @@ Directory: 8-jre
 
 Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
+GitCommit: 238cc35696423794b1951fc63d4cc9ffb8ca9685
 Directory: 8-jre/alpine
 
 Tags: 9-b170-jdk, 9-b170, 9-jdk, 9

--- a/library/ruby
+++ b/library/ruby
@@ -1,69 +1,85 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/230d21cfe8280d4f154b94681eab3e22065f4ea6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/48ad4b7d1c2d581ab2426b460e331a5ea023425a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.1.10, 2.1
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1/slim
 
 Tags: 2.1.10-alpine, 2.1-alpine
+Architectures: amd64
 GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1/alpine
 
 Tags: 2.1.10-onbuild, 2.1-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.1/onbuild
 
 Tags: 2.2.7, 2.2
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/slim
 
 Tags: 2.2.7-alpine, 2.2-alpine
+Architectures: amd64
 GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/slim
 
 Tags: 2.3.4-alpine, 2.3-alpine
+Architectures: amd64
 GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/slim
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
+Architectures: amd64
 GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
 Directory: 2.4/onbuild


### PR DESCRIPTION
- `gcc`: remove `i386` (see https://github.com/docker-library/gcc/issues/38)
- `ghost`: 0.11.10
- `haproxy`: 1.7.6
- `mongo`: use `ARG` such that `Dockerfile` can build with `mongodb-enterprise` instead of `mongodb-org`
- `openjdk`: alpine 8.131.11-r2
- `ruby`: multiarch (docker-library/ruby#133)