### PR TITLE
Update busybox tarball commits (no content changes)

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -7,25 +7,25 @@ GitRepo: https://github.com/docker-library/busybox.git
 GitCommit: 13f14c6b73f4baf975b725fd12952d3c7272c410
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e93396e651d5e9da8a79d37d144f664b063a997a
+amd64-GitCommit: bf085cb0632a2a7fb0a7722c88afc04fab5e871f
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: ef413f51e0470fd28d45e0ef36d829c05819f629
+arm32v6-GitCommit: b9291ee9abc522d076ac67678b154cf5c84bc149
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f128a9b735838620cb0c6751172efe0d64010f84
+arm32v7-GitCommit: 56073c8807db2a80f345fed2e0164ef4db6f17fd
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 86716e0538b5408c0281ebdbc2c36be376339afb
+arm64v8-GitCommit: 456e9021be627cad59a28f45d2f1e0d6b43c320d
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: bc740b1b367cf99b5efb33ee37cb98c59e66cebe
+i386-GitCommit: 32b1217a59c165feb98083bcb730433ae2a68e82
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 1de4548001b86484407fb3da70d0b6d37de80a69
+ppc64le-GitCommit: 55e485a458b3ce337a3e6df71ed05b2af44fa487
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: a9260cdbd7381b9bfd8c6e30be9409a751a9d7a6
+s390x-GitCommit: e4fe2dcdd3a50eb316a803413349d0c075dfea8c
 
 Tags: 1.26.2-uclibc, 1.26-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm64v8, i386


### PR DESCRIPTION
These commits are now generated in a reproducible way, so if the tarball contents and parent commits don't change, the commit hash will come out the same.

There is zero change in any content here (and thus no rebuilds required).