### PR TITLE
Update docker-library images

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,89 +1,110 @@
-# this file is generated via https://github.com/docker-library/php/blob/9b4c15f44bedb0bd1dc438cee525b66bef8769d8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/18c5298e551f4f445c8fc2ed2d93b394d76cecc1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.6-cli, 7.1-cli, 7-cli, cli, 7.1.6, 7.1, 7, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.1
 
 Tags: 7.1.6-alpine, 7.1-alpine, 7-alpine, alpine
+Architectures: amd64
 GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/alpine
 
 Tags: 7.1.6-apache, 7.1-apache, 7-apache, apache
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.1/apache
 
 Tags: 7.1.6-fpm, 7.1-fpm, 7-fpm, fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.1/fpm
 
 Tags: 7.1.6-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Architectures: amd64
 GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.6-zts, 7.1-zts, 7-zts, zts
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.1/zts
 
 Tags: 7.1.6-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Architectures: amd64
 GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.20-cli, 7.0-cli, 7.0.20, 7.0
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.0
 
 Tags: 7.0.20-alpine, 7.0-alpine
+Architectures: amd64
 GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
 Directory: 7.0/alpine
 
 Tags: 7.0.20-apache, 7.0-apache
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.0/apache
 
 Tags: 7.0.20-fpm, 7.0-fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.0/fpm
 
 Tags: 7.0.20-fpm-alpine, 7.0-fpm-alpine
+Architectures: amd64
 GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.20-zts, 7.0-zts
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 7.0/zts
 
 Tags: 7.0.20-zts-alpine, 7.0-zts-alpine
+Architectures: amd64
 GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.30-cli, 5.6-cli, 5-cli, 5.6.30, 5.6, 5
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 5.6
 
 Tags: 5.6.30-alpine, 5.6-alpine, 5-alpine
+Architectures: amd64
 GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/alpine
 
 Tags: 5.6.30-apache, 5.6-apache, 5-apache
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 5.6/apache
 
 Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 5.6/fpm
 
 Tags: 5.6.30-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Architectures: amd64
 GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.30-zts, 5.6-zts, 5-zts
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
 Directory: 5.6/zts
 
 Tags: 5.6.30-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Architectures: amd64
 GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -1,120 +1,148 @@
-# this file is generated via https://github.com/docker-library/python/blob/0edfe01ac242743dfe14836bccf8620703f4d753/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/8baafd1c6ba34b41b63968cbe386fb45e42fa37f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.13, 2.7, 2
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7
 
 Tags: 2.7.13-slim, 2.7-slim, 2-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
+Architectures: amd64
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/alpine
 
 Tags: 2.7.13-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
+Architectures: amd64
 GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
+Architectures: amd64, arm32v7, i386
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/wheezy
 
 Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
 Tags: 2.7.13-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
+Architectures: windows-amd64
 GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, i386
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.6, 3.4
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4
 
 Tags: 3.4.6-slim, 3.4-slim
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/slim
 
 Tags: 3.4.6-alpine, 3.4-alpine
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/alpine
 
 Tags: 3.4.6-wheezy, 3.4-wheezy
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, i386
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/wheezy
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.3, 3.5
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5
 
 Tags: 3.5.3-slim, 3.5-slim
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5/slim
 
 Tags: 3.5.3-alpine, 3.5-alpine
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5/alpine
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
 Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
+Architectures: windows-amd64
 GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.1, 3.6, 3, latest
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6
 
 Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6/slim
 
 Tags: 3.6.1-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
+Architectures: amd64
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6/alpine
 
 Tags: 3.6.1-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
-GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
+Architectures: amd64
+GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/onbuild
 
 Tags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
+Architectures: windows-amd64
 GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: 41c44367d9c1996a587e2bcc9462e4794f533c15
+GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.1/passenger
 
 Tags: 3.2.6, 3.2
@@ -17,7 +17,7 @@ GitCommit: b994741065b7a297d030b7826c478655a10f26bd
 Directory: 3.2
 
 Tags: 3.2.6-passenger, 3.2-passenger
-GitCommit: 41c44367d9c1996a587e2bcc9462e4794f533c15
+GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.2/passenger
 
 Tags: 3.3.3, 3.3, 3, latest
@@ -25,5 +25,5 @@ GitCommit: 5453a92c4f8d18e59de9162c4030fb277bc72e8f
 Directory: 3.3
 
 Tags: 3.3.3-passenger, 3.3-passenger, 3-passenger, passenger
-GitCommit: 41c44367d9c1996a587e2bcc9462e4794f533c15
+GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.3/passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,55 +1,67 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/e6af22dc6f8553e62acc0c29d6e4e86b2287daf7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/f5ccd855ad76431bad039d592ea63a4a9db498ff/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.8.0-apache, 4.8-apache, 4-apache, apache, 4.8.0, 4.8, 4, latest, 4.8.0-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.0-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/apache
 
 Tags: 4.8.0-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.0-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm
 
 Tags: 4.8.0-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.0-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Architectures: amd64
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm-alpine
 
 Tags: 4.8.0-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.0-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/apache
 
 Tags: 4.8.0-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm
 
 Tags: 4.8.0-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Architectures: amd64
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm-alpine
 
 Tags: 4.8.0-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.0-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/apache
 
 Tags: 4.8.0-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/fpm
 
 Tags: 4.8.0-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Architectures: amd64
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-1.1.0, cli-1.1, cli-1, cli, cli-1.1.0-php5.6, cli-1.1-php5.6, cli-1-php5.6, cli-php5.6
+Architectures: amd64
 GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
 Directory: php5.6/cli
 
 Tags: cli-1.1.0-php7.0, cli-1.1-php7.0, cli-1-php7.0, cli-php7.0
+Architectures: amd64
 GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
 Directory: php7.0/cli
 
 Tags: cli-1.1.0-php7.1, cli-1.1-php7.1, cli-1-php7.1, cli-php7.1
+Architectures: amd64
 GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
 Directory: php7.1/cli


### PR DESCRIPTION
- `php`: multiarch (docker-library/php#454)
- `python`: multiarch (docker-library/python#205, docker-library/python#206)
- `redmine`: passenger 5.1.5
- `wordpress`: multiarch (docker-library/wordpress#223) -- slightly cheated by pointing it at the `library/php` file contents from this PR