### PR TITLE
Update docker-library images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64
 GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
-Tags: 1.6.12, 1.6
+Tags: 1.6.13, 1.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
+GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6
 
-Tags: 1.6.12-alpine, 1.6-alpine
+Tags: 1.6.13-alpine, 1.6-alpine
 Architectures: amd64
-GitCommit: 17bcf2ad461996045a6818c2b7414483caca3213
+GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6/alpine
 
 Tags: 1.7.6, 1.7, 1, latest

--- a/library/irssi
+++ b/library/irssi
@@ -1,13 +1,15 @@
-# this file is generated via https://github.com/jessfraz/irssi/blob/b8e0a2171a759a9c34783557261727b0697f3f62/generate-stackbrew-library.sh
+# this file is generated via https://github.com/jessfraz/irssi/blob/29e5068c23e0f12f3db8d99f3a7dcff5329ecad0/generate-stackbrew-library.sh
 
 Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.0.3, 1.0, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
 Directory: debian
 
 Tags: 1.0.3-alpine, 1.0-alpine, 1-alpine, alpine
-GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
+Architectures: amd64
+GitCommit: 2de872565753ebbd85924d6c80be891ad184f89b
 Directory: alpine

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/8baafd1c6ba34b41b63968cbe386fb45e42fa37f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/73d283d3dccd196f758466f29a715e6ab9b533a7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -145,4 +145,35 @@ Tags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windo
 Architectures: windows-amd64
 GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/windows/windowsservercore
+Constraints: windowsservercore
+
+Tags: 3.6.2rc1, 3.6-rc, rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc
+
+Tags: 3.6.2rc1-slim, 3.6-rc-slim, rc-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc/slim
+
+Tags: 3.6.2rc1-alpine, 3.6-rc-alpine, rc-alpine
+Architectures: amd64
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc/alpine
+
+Tags: 3.6.2rc1-alpine3.6, 3.6-rc-alpine3.6, rc-alpine3.6
+Architectures: amd64
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc/alpine3.6
+
+Tags: 3.6.2rc1-onbuild, 3.6-rc-onbuild, rc-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc/onbuild
+
+Tags: 3.6.2rc1-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
+Architectures: windows-amd64
+GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+Directory: 3.6-rc/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,21 +1,25 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/79277042564875d55e4b05a60c65b6eb46651a94/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/9106c7dde0fbc609967fcb49ba4d473ecccfc1d6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.10, 3.6, 3, latest
-GitCommit: a6cb36022a5c1a17df78cfafe45a73d941ad4eb8
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 192f4c2055cc97cd8200c80c97b9e66115c13790
 Directory: 3.6/debian
 
 Tags: 3.6.10-management, 3.6-management, 3-management, management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.10-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: bc90c8e432c340b6b2dd2ca05f99243f61bc3211
+Architectures: amd64
+GitCommit: 192f4c2055cc97cd8200c80c97b9e66115c13790
 Directory: 3.6/alpine
 
 Tags: 3.6.10-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Architectures: amd64
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/alpine/management


### PR DESCRIPTION
- `haproxy`: 1.6.13
- `irssi`: Alpine 3.6 (docker-library/irssi#16), multiarch (docker-library/irssi#15)
- `python`: 3.6.2rc1
- `rabbitmq`: Debian Stretch and Alpine 3.6 (docker-library/rabbitmq#166), multiarch (docker-library/rabbitmq#167)