### PR TITLE
Remove Mosquitto 1.4.10 (fails to build)

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -6,10 +6,6 @@ GitCommit: 0bb602ed7a89da80d25e6b959a130fdcf0556be5
 GitFetch:  refs/heads/develop
 Directory: docker/1.4.12
 
-Tags: 1.4.10
-GitCommit: 53616be0e296f6186f52c791e241c76d53380078
-Directory: docker/1.4.10
-
 Tags: 1.4.8
 GitCommit: 25a1f7d1994fd4b8d1d25ab0275f7a8f071abfb1
 Directory: docker/1.4.8


### PR DESCRIPTION
```
Sending build context to Docker daemon 10.24 kB
Step 1/7 : FROM alpine:3.5
 ---> 8b613b705735
Step 2/7 : MAINTAINER David Audet <david.audet@ca.com>
 ---> Running in 6ea6b9cdf53b
 ---> ff52f1ca8414
Removing intermediate container 6ea6b9cdf53b
Step 3/7 : LABEL Description "Eclipse Mosquitto MQTT Broker"
 ---> Running in d13d0b52b232
 ---> 2de57e632f00
Removing intermediate container d13d0b52b232
Step 4/7 : RUN apk --no-cache add mosquitto=1.4.10-r2 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto
 ---> Running in 83c73d80573f
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  mosquitto-1.4.12-r0:
    breaks: world[mosquitto=1.4.10-r2]
Removing intermediate container 83c73d80573f
The command '/bin/sh -c apk --no-cache add mosquitto=1.4.10-r2 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto' returned a non-zero code: 1
```

FYI @daudetCA

This is as was discussed on https://github.com/docker-library/official-images/pull/3053 -- the tags will still be available for pull, but we'll stop trying to rebuild them (which now fails) and they will no longer be listed as "Supported".