### PR TITLE
Remove more Mosquitto versions (1.4.8 and 1.4.4)

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -5,11 +5,3 @@ Tags: 1.4.12, latest
 GitCommit: 0bb602ed7a89da80d25e6b959a130fdcf0556be5
 GitFetch:  refs/heads/develop
 Directory: docker/1.4.12
-
-Tags: 1.4.8
-GitCommit: 25a1f7d1994fd4b8d1d25ab0275f7a8f071abfb1
-Directory: docker/1.4.8
-
-Tags: 1.4.4
-GitCommit: 25a1f7d1994fd4b8d1d25ab0275f7a8f071abfb1
-Directory: docker/1.4.4


### PR DESCRIPTION
```
Sending build context to Docker daemon 10.24 kB
Step 1/7 : FROM alpine:3.4
 ---> 25fe527f52de
Step 2/7 : MAINTAINER David Audet <david.audet@ca.com>
 ---> Running in bb1c518392ca
 ---> 8e0c3acc2c08
Removing intermediate container bb1c518392ca
Step 3/7 : LABEL Description "Eclipse Mosquitto MQTT Broker"
 ---> Running in 4610cfca0b9e
 ---> 14dcc9a5d673
Removing intermediate container 4610cfca0b9e
Step 4/7 : RUN apk --no-cache add mosquitto=1.4.8-r2 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto
 ---> Running in 35a446310c8c
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  mosquitto-1.4.12-r0:
    breaks: world[mosquitto=1.4.8-r2]
Removing intermediate container 35a446310c8c
The command '/bin/sh -c apk --no-cache add mosquitto=1.4.8-r2 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto' returned a non-zero code: 1
```

```
Sending build context to Docker daemon  10.24kB
Step 1/7 : FROM alpine:3.3
 ---> 461b3f7c318a
Step 2/7 : MAINTAINER David Audet <david.audet@ca.com>
 ---> Using cache
 ---> f05278c09470
Step 3/7 : LABEL Description "Eclipse Mosquitto MQTT Broker"
 ---> Using cache
 ---> d4ea5530de3a
Step 4/7 : RUN apk --no-cache add mosquitto=1.4.4-r0 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto
 ---> Running in c851aecffcb9
fetch http://dl-cdn.alpinelinux.org/alpine/v3.3/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.3/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  mosquitto-1.4.12-r0:
    breaks: world[mosquitto=1.4.4-r0]
Removing intermediate container c851aecffcb9
The command '/bin/sh -c apk --no-cache add mosquitto=1.4.4-r0 &&     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log &&     cp /etc/mosquitto/mosquitto.conf /mosquitto/config &&     chown -R mosquitto:mosquitto /mosquitto' returned a non-zero code: 1
```

FYI @daudetCA

See also #3094 and #3053.