### PR TITLE
Update docker-library images

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,5 +4,5 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.5.2, 0.5, 0, latest
-GitCommit: 0b6b28b5b0957cc491d406b798ece911a6fa5b26
+Tags: 0.6.0, 0.6, 0, latest
+GitCommit: ef0fdf96ba90c0020776bca367cb838910aca339

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,16 +1,16 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/9106c7dde0fbc609967fcb49ba4d473ecccfc1d6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/7eed5476d6153d05e5a0245ccfe28d893b0b369e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.10, 3.6, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 192f4c2055cc97cd8200c80c97b9e66115c13790
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
+GitCommit: 7eed5476d6153d05e5a0245ccfe28d893b0b369e
 Directory: 3.6/debian
 
 Tags: 3.6.10-management, 3.6-management, 3-management, management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 

--- a/library/redis
+++ b/library/redis
@@ -33,27 +33,27 @@ Constraints: nanoserver
 
 Tags: 3.2.9, 3.2, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
+GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2
 
 Tags: 3.2.9-32bit, 3.2-32bit, 3-32bit, 32bit
 Architectures: amd64
-GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
+GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2/32bit
 
 Tags: 3.2.9-alpine, 3.2-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
+GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2/alpine
 
 Tags: 3.2.100-windowsservercore, 3.2-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 709e6a8df205f73afcc6f6257cab104175de1f5f
+GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.2.100-nanoserver, 3.2-nanoserver, 3-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 2daf4fd7d858c8f2ad9694c4f460b8c6a7f782aa
+GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
- `julia`: 0.6.0
- `rabbitmq`: adjust `erlang-base-hipe` install for multiarch and exclude Debian+`ppc64le` for now (docker-library/rabbitmq#170)
- `redis`: minor comment adjustment (typo fix)