### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,29 +1,21 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/4e4394f9563a109180289d8eb2ff3bc6c1e2dcb2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/47a72b6f1962df04a62616b1c3c32e85b5410639/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.4.1, 5.4, 5, latest
-GitCommit: ca669a81afb503dedac6ba1bb8bef2abc158f081
+Tags: 5.4.2, 5.4, 5, latest
+GitCommit: 6e38c9184a91b0b554459e2e52b4ad05413c6107
 Directory: 5
 
-Tags: 5.4.1-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: ca669a81afb503dedac6ba1bb8bef2abc158f081
+Tags: 5.4.2-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: 6e38c9184a91b0b554459e2e52b4ad05413c6107
 Directory: 5/alpine
 
 Tags: 2.4.5, 2.4, 2
-GitCommit: ee9ba02f90f6b34ca33c20140ecff2b6db7c0c90
+GitCommit: 56476e6c40c7ad5715e3c1f696548bac27dae086
 Directory: 2.4
 
 Tags: 2.4.5-alpine, 2.4-alpine, 2-alpine
-GitCommit: ee9ba02f90f6b34ca33c20140ecff2b6db7c0c90
+GitCommit: 56476e6c40c7ad5715e3c1f696548bac27dae086
 Directory: 2.4/alpine
-
-Tags: 1.7.6, 1.7, 1
-GitCommit: ffd7a19f1e68329cc310f145c232e83abec09067
-Directory: 1.7
-
-Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine
-GitCommit: 5727443ead111be19b55bfe5412dae5133cab8b1
-Directory: 1.7/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.4.1, 5.4, 5, latest
-GitCommit: 8b5427a374fe93fe87f31e1249f0d64a09c02307
+Tags: 5.4.2, 5.4, 5, latest
+GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4
-GitCommit: 902581f626cba60693e32ca54f91f487b6be7e98
+GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
 Directory: 4.6
 
 Tags: 4.1.11, 4.1
-GitCommit: 144fccdd6a2c8c05fc79c27d3eb62a90b274f19b
+GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
 Directory: 4.1

--- a/library/logstash
+++ b/library/logstash
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.4.1, 5.4, 5, latest
-GitCommit: fcab4d9ce9b16bb2b14f263fc05d54204300a86b
+Tags: 5.4.2, 5.4, 5, latest
+GitCommit: 490a19e4869686e73bb71eeda233d2e886bde609
 Directory: 5
 
-Tags: 5.4.1-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: fcab4d9ce9b16bb2b14f263fc05d54204300a86b
+Tags: 5.4.2-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: 490a19e4869686e73bb71eeda233d2e886bde609
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2
-GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
+GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 2.4
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine
-GitCommit: 6e2d8dc1263d098129a264deeca065129b6c4bca
+GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 2.4/alpine
 
 Tags: 1.5.6, 1.5, 1
-GitCommit: 754eeb919e42b1f6f2708b73f6f13cbc06fd722c
+GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 1.5
 
 Tags: 1.5.6-alpine, 1.5-alpine, 1-alpine
-GitCommit: 7eaa1cd9db876cd1e57371a7a515988c9768e7cc
+GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 1.5/alpine


### PR DESCRIPTION
- `elasticsearch`: 5.4.2, remove EOL 1.7
- `kibana`: 5.4.2
- `logstash`: 5.4.2