### PR TITLE
python: Set the PATH to /usr/local/bin when searching for a Python

### DIFF
--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -3,7 +3,7 @@ set -e
 
 python=
 for c in pypy3 pypy python3 python; do
-	if command -v "$c" > /dev/null; then
+	if PATH=/usr/local/bin command -v "$c" > /dev/null; then
 		python="$c"
 		break
 	fi

--- a/test/tests/run-python-in-container.sh
+++ b/test/tests/run-python-in-container.sh
@@ -6,7 +6,7 @@ runDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 source "$runDir/run-in-container.sh" "$testDir" "$1" sh -ec '
 	for c in pypy3 pypy python3 python; do
-		if command -v "$c" > /dev/null; then
+		if PATH=/usr/local/bin command -v "$c" > /dev/null; then
 			exec "$c" "$@"
 		fi
 	done


### PR DESCRIPTION
* buildpack-deps:stretch has Python 3.5 installed which is detected before our custom Python 2.7 in these scripts. Search only in /usr/local/bin.

This is needed for docker-library/python#208