### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.06.0-ce-rc4, 17.06.0-ce, 17.06.0, 17.06-rc, rc, test
+Tags: 17.06.0-ce-rc5, 17.06.0-ce, 17.06.0, 17.06-rc, rc, test
 Architectures: amd64
-GitCommit: dab211d7162038d6d595017e4fd01dad78057d0b
+GitCommit: b39a2369d4017d89c6f369a63be5d59011d88fd5
 Directory: 17.06-rc
 
-Tags: 17.06.0-ce-rc4-dind, 17.06.0-ce-dind, 17.06.0-dind, 17.06-rc-dind, rc-dind, test-dind
+Tags: 17.06.0-ce-rc5-dind, 17.06.0-ce-dind, 17.06.0-dind, 17.06-rc-dind, rc-dind, test-dind
 Architectures: amd64
 GitCommit: e7e2e3119360567641d334f1d274952236632357
 Directory: 17.06-rc/dind
 
-Tags: 17.06.0-ce-rc4-git, 17.06.0-ce-git, 17.06.0-git, 17.06-rc-git, rc-git, test-git
+Tags: 17.06.0-ce-rc5-git, 17.06.0-ce-git, 17.06.0-git, 17.06-rc-git, rc-git, test-git
 Architectures: amd64
 GitCommit: e7e2e3119360567641d334f1d274952236632357
 Directory: 17.06-rc/git

--- a/library/drupal
+++ b/library/drupal
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.3-apache, 8.3-apache, 8-apache, apache, 8.3.3, 8.3, 8, latest
-GitCommit: cd3080d2d4e057c1de914bca1d85a0023f8d455d
+Tags: 8.3.4-apache, 8.3-apache, 8-apache, apache, 8.3.4, 8.3, 8, latest
+GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
 Directory: 8.3/apache
 
-Tags: 8.3.3-fpm, 8.3-fpm, 8-fpm, fpm
-GitCommit: cd3080d2d4e057c1de914bca1d85a0023f8d455d
+Tags: 8.3.4-fpm, 8.3-fpm, 8-fpm, fpm
+GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
 Directory: 8.3/fpm
 
-Tags: 8.3.3-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: cd3080d2d4e057c1de914bca1d85a0023f8d455d
+Tags: 8.3.4-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
 Directory: 8.3/fpm-alpine
 
-Tags: 7.55-apache, 7-apache, 7.55, 7
-GitCommit: 93cbfde03f3ae733d3b4ba489c6cedac307e5373
+Tags: 7.56-apache, 7-apache, 7.56, 7
+GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/apache
 
-Tags: 7.55-fpm, 7-fpm
-GitCommit: 93cbfde03f3ae733d3b4ba489c6cedac307e5373
+Tags: 7.56-fpm, 7-fpm
+GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/fpm
 
-Tags: 7.55-fpm-alpine, 7-fpm-alpine
-GitCommit: 93cbfde03f3ae733d3b4ba489c6cedac307e5373
+Tags: 7.56-fpm-alpine, 7-fpm-alpine
+GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/fpm-alpine

--- a/library/hylang
+++ b/library/hylang
@@ -4,4 +4,4 @@ Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag)
 Tags: 0.13.0, 0.13, 0, latest
 GitRepo: https://github.com/hylang/hy.git
 GitFetch: refs/tags/0.13.0
-GitCommit: b3005f1df1bd9143159e4c8de82a2bd8863acb6b
+GitCommit: 807b0b6d248fd341cbf87bf8bfa55caf5b83d655

--- a/library/kibana
+++ b/library/kibana
@@ -11,7 +11,3 @@ Directory: 5
 Tags: 4.6.4, 4.6, 4
 GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
 Directory: 4.6
-
-Tags: 4.1.11, 4.1
-GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
-Directory: 4.1

--- a/library/logstash
+++ b/library/logstash
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/logstash/blob/aa556fc3ae9d6cadc26390d8c57bc94710122b7d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/logstash/blob/ed8e1d89a264eed50f857601c7b4364af66155cd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -19,11 +19,3 @@ Directory: 2.4
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine
 GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 2.4/alpine
-
-Tags: 1.5.6, 1.5, 1
-GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
-Directory: 1.5
-
-Tags: 1.5.6-alpine, 1.5-alpine, 1-alpine
-GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
-Directory: 1.5/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -43,15 +43,15 @@ GitCommit: e25d020918434d29378b4ca58c34843c215cd043
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.8, 3.5, unstable
+Tags: 3.5.9, 3.5, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.5/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
+GitCommit: d291ed022225ad57d32c98668bcfd5a52baa2e13
 Directory: 3.5
 
-Tags: 3.5.8-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+Tags: 3.5.9-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3fd2ca2e905e3b826e0244bb73a55e61e8db298e
+GitCommit: d291ed022225ad57d32c98668bcfd5a52baa2e13
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.1.7, 3.1
-GitCommit: 665a1f399082dc01543b36c9aecd0cf4c5ee214e
+GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
@@ -13,7 +13,7 @@ GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.1/passenger
 
 Tags: 3.2.6, 3.2
-GitCommit: b994741065b7a297d030b7826c478655a10f26bd
+GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
 Directory: 3.2
 
 Tags: 3.2.6-passenger, 3.2-passenger
@@ -21,7 +21,7 @@ GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.2/passenger
 
 Tags: 3.3.3, 3.3, 3, latest
-GitCommit: 5453a92c4f8d18e59de9162c4030fb277bc72e8f
+GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
 Directory: 3.3
 
 Tags: 3.3.3-passenger, 3.3-passenger, 3-passenger, passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.1.0, cli-1.1, cli-1, cli, cli-1.1.0-php5.6, cli-1.1-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.2.1, cli-1.2, cli-1, cli, cli-1.2.1-php5.6, cli-1.2-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
 Directory: php5.6/cli
 
-Tags: cli-1.1.0-php7.0, cli-1.1-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.2.1-php7.0, cli-1.2-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
 Directory: php7.0/cli
 
-Tags: cli-1.1.0-php7.1, cli-1.1-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.2.1-php7.1, cli-1.2-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 0bd17ea187310d703d84feb5f412955d038e12fe
+GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
 Directory: php7.1/cli


### PR DESCRIPTION
- `docker`: 17.06.0-ce-rc5
- `drupal`: 8.3.4, 7.56
- `hylang`: ???
- `kibana`: remove 4.1 (EOL; https://www.elastic.co/support/eol)
- `logstash`: remove 1.5 (EOL; https://www.elastic.co/support/eol)
- `mongo`: 3.5.9
- `redmine`: `REDMINE_PLUGINS_MIGRATE` (docker-library/redmine#10)
- `wordpress`: cli 1.2.1