### PR TITLE
Remove Oracle Linux 5 images as it has reached EOL.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -33,5 +33,3 @@ Directory: OracleLinux/6.7
 Tags: 6.6
 Directory: OracleLinux/6.6
 
-Tags: 5, 5.11
-Directory: OracleLinux/5.11


### PR DESCRIPTION
I'm hoping this will remove the 5 and 5.11 tags from the Docker Hub official repo.


Signed-off-by: Avi Miller <avi.miller@oracle.com>