### PR TITLE
[nats-streaming] Release v0.5.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,6 +1,6 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 
-Tags: 0.4.0, latest
+Tags: 0.5.0, latest
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 048c972a51fdacfe406cc254cfde35b8bcc0e1aa
+GitCommit: 3301b7b0e11bfd128eb4ba572fc1fdbfaab8d3e3
 


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.5.0)