### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,21 +1,21 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/d8df3f7e1e330aec032af876a7611ae8d293d451/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/f6f09faf3e50e648ec11a9676a29dd1130604c2d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.17, 2.1
-GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
+Tags: 2.1.18, 2.1
+GitCommit: a78f0c2c40507f31a6b5048d029e77f5e3e5054b
 Directory: 2.1
 
-Tags: 2.2.9, 2.2, 2
-GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
+Tags: 2.2.10, 2.2, 2
+GitCommit: 92e76b1607393679735adf04a7c6bf08d66278b2
 Directory: 2.2
 
-Tags: 3.0.13, 3.0
-GitCommit: e80c6550afd16ead245ec73b16862984480a7cf9
+Tags: 3.0.14, 3.0
+GitCommit: aebf66bbd63d5b860410837810ae738d76a03932
 Directory: 3.0
 
-Tags: 3.10, 3, latest
-GitCommit: d83b850cd17bc9198876f8686197c730e29c7448
-Directory: 3.10
+Tags: 3.11.0, 3.11, 3, latest
+GitCommit: f6f09faf3e50e648ec11a9676a29dd1130604c2d
+Directory: 3.11

--- a/library/docker
+++ b/library/docker
@@ -1,65 +1,35 @@
-# this file is generated via https://github.com/docker-library/docker/blob/8390fd856922deec4ca7bf0004e6e8e81f60c9f2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/e68e4e6ec06c055a95d441144b0e34d0872f2665/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.06.0-ce-rc5, 17.06.0-ce, 17.06.0, 17.06-rc, rc, test
+Tags: 17.06.0-ce, 17.06.0, 17.06, 17, latest, edge
 Architectures: amd64
-GitCommit: b39a2369d4017d89c6f369a63be5d59011d88fd5
-Directory: 17.06-rc
+GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
+Directory: 17.06
 
-Tags: 17.06.0-ce-rc5-dind, 17.06.0-ce-dind, 17.06.0-dind, 17.06-rc-dind, rc-dind, test-dind
+Tags: 17.06.0-ce-dind, 17.06.0-dind, 17.06-dind, 17-dind, dind, edge-dind
 Architectures: amd64
-GitCommit: e7e2e3119360567641d334f1d274952236632357
-Directory: 17.06-rc/dind
+GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
+Directory: 17.06/dind
 
-Tags: 17.06.0-ce-rc5-git, 17.06.0-ce-git, 17.06.0-git, 17.06-rc-git, rc-git, test-git
+Tags: 17.06.0-ce-git, 17.06.0-git, 17.06-git, 17-git, git, edge-git
 Architectures: amd64
-GitCommit: e7e2e3119360567641d334f1d274952236632357
-Directory: 17.06-rc/git
+GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
+Directory: 17.06/git
 
-Tags: 17.05.0-ce, 17.05.0, 17.05, 17, latest, edge
+Tags: 17.03.2-ce, 17.03.2, 17.03, stable
 Architectures: amd64
-GitCommit: dab211d7162038d6d595017e4fd01dad78057d0b
-Directory: 17.05
-
-Tags: 17.05.0-ce-dind, 17.05.0-dind, 17.05-dind, 17-dind, dind, edge-dind
-Architectures: amd64
-GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
-Directory: 17.05/dind
-
-Tags: 17.05.0-ce-git, 17.05.0-git, 17.05-git, 17-git, git, edge-git
-Architectures: amd64
-GitCommit: ce78a19aac321bbe50d060426b5b633cb5f74825
-Directory: 17.05/git
-
-Tags: 17.03.2-ce-rc1, 17.03.2-ce, 17.03.2, 17.03-rc
-Architectures: amd64
-GitCommit: dab211d7162038d6d595017e4fd01dad78057d0b
-Directory: 17.03-rc
-
-Tags: 17.03.2-ce-rc1-dind, 17.03.2-ce-dind, 17.03.2-dind, 17.03-rc-dind
-Architectures: amd64
-GitCommit: 2c75eb72ab98b95256be008aa93efdec289d96e8
-Directory: 17.03-rc/dind
-
-Tags: 17.03.2-ce-rc1-git, 17.03.2-ce-git, 17.03.2-git, 17.03-rc-git
-Architectures: amd64
-GitCommit: 2c75eb72ab98b95256be008aa93efdec289d96e8
-Directory: 17.03-rc/git
-
-Tags: 17.03.1-ce, 17.03.1, 17.03, stable
-Architectures: amd64
-GitCommit: dab211d7162038d6d595017e4fd01dad78057d0b
+GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
 Directory: 17.03
 
-Tags: 17.03.1-ce-dind, 17.03.1-dind, 17.03-dind, stable-dind
+Tags: 17.03.2-ce-dind, 17.03.2-dind, 17.03-dind, stable-dind
 Architectures: amd64
 GitCommit: 5a196cae40e2a0ab5050cf6d79b697e032352b24
 Directory: 17.03/dind
 
-Tags: 17.03.1-ce-git, 17.03.1-git, 17.03-git, stable-git
+Tags: 17.03.2-ce-git, 17.03.2-git, 17.03-git, stable-git
 Architectures: amd64
 GitCommit: bf822e2b9b4f755156b825444562c9865f22557f
 Directory: 17.03/git

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.4.2, 5.4, 5, latest
-GitCommit: 6e38c9184a91b0b554459e2e52b4ad05413c6107
+Tags: 5.4.3, 5.4, 5, latest
+GitCommit: ea76a1f9e5589a1b9a9bcab1022df7953af81b87
 Directory: 5
 
-Tags: 5.4.2-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: 6e38c9184a91b0b554459e2e52b4ad05413c6107
+Tags: 5.4.3-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: ea76a1f9e5589a1b9a9bcab1022df7953af81b87
 Directory: 5/alpine
 
 Tags: 2.4.5, 2.4, 2

--- a/library/golang
+++ b/library/golang
@@ -5,25 +5,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9beta1, 1.9-rc, 1.9, rc
+Tags: 1.9beta2, 1.9-rc, 1.9, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e72fd691a065bfec94de67bf826e4ebe511c4d24
+GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
 Directory: 1.9-rc
 
-Tags: 1.9beta1-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
+Tags: 1.9beta2-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
 Architectures: amd64
-GitCommit: cdeca62eb84c34680e2f4ec018d1d6cfaa818681
+GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
 Directory: 1.9-rc/alpine
 
-Tags: 1.9beta1-windowsservercore, 1.9-rc-windowsservercore, 1.9-windowsservercore, rc-windowsservercore
+Tags: 1.9beta2-windowsservercore, 1.9-rc-windowsservercore, 1.9-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: cdeca62eb84c34680e2f4ec018d1d6cfaa818681
+GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
 Directory: 1.9-rc/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.9beta1-nanoserver, 1.9-rc-nanoserver, 1.9-nanoserver, rc-nanoserver
+Tags: 1.9beta2-nanoserver, 1.9-rc-nanoserver, 1.9-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: cdeca62eb84c34680e2f4ec018d1d6cfaa818681
+GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
 Directory: 1.9-rc/windows/nanoserver
 Constraints: nanoserver
 

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6/alpine
 
-Tags: 1.7.6, 1.7, 1, latest
+Tags: 1.7.7, 1.7, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ffcb61acdee528597854ca4a220493098b5a59b
+GitCommit: 045b267d8b5aba6903aa0d24ad740a8fbf272173
 Directory: 1.7
 
-Tags: 1.7.6-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.7-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 0ffcb61acdee528597854ca4a220493098b5a59b
+GitCommit: 045b267d8b5aba6903aa0d24ad740a8fbf272173
 Directory: 1.7/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.4.2, 5.4, 5, latest
-GitCommit: 19237835b8922f570fafad7cdc0576330d6f1a91
+Tags: 5.4.3, 5.4, 5, latest
+GitCommit: c334b2d83a17100180f1f1dff9f6778243397a80
 Directory: 5
 
 Tags: 4.6.4, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.4.2, 5.4, 5, latest
-GitCommit: 490a19e4869686e73bb71eeda233d2e886bde609
+Tags: 5.4.3, 5.4, 5, latest
+GitCommit: bdde1cd454f189dcad01c82a2ebaa729c406cc6f
 Directory: 5
 
-Tags: 5.4.2-alpine, 5.4-alpine, 5-alpine, alpine
-GitCommit: 490a19e4869686e73bb71eeda233d2e886bde609
+Tags: 5.4.3-alpine, 5.4-alpine, 5-alpine, alpine
+GitCommit: bdde1cd454f189dcad01c82a2ebaa729c406cc6f
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,11 +8,11 @@ Tags: 10.3.0, 10.3
 GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
 Directory: 10.3
 
-Tags: 10.2.6, 10.2
+Tags: 10.2.6, 10.2, 10, latest
 GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
 Directory: 10.2
 
-Tags: 10.1.24, 10.1, 10, latest
+Tags: 10.1.24, 10.1
 GitCommit: 9ac6a8d627c15e7cecb59e82e3c712d8c71d209e
 Directory: 10.1
 

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.37, 1.4, 1, latest
+Tags: 1.4.38, 1.4, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
+GitCommit: 61b99625db8e067f13d393c4a0c3676ffde547f8
 Directory: debian
 
-Tags: 1.4.37-alpine, 1.4-alpine, 1-alpine, alpine
+Tags: 1.4.38-alpine, 1.4-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 6325698211e3814cf7c9e1b46ddeead8315c8f09
+GitCommit: 61b99625db8e067f13d393c4a0c3676ffde547f8
 Directory: alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -54,22 +54,22 @@ Architectures: amd64
 GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.15-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.15, 8.5, 8, latest
+Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 3e2747c34ded033f4c7adf108f51f3634d025adf
 Directory: 8.5/jre8
 
-Tags: 8.5.15-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.15-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.16-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.16-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: ae0ff8626dbb002258c3fabdcba1682fa12d6f99
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M21-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M21, 9.0.0, 9.0, 9
+Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 1cb69781deeac97b2bb138054de3b2f35e9b49a0
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M21-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M21-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.0.M22-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M22-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: a7f6cf3172b5875be5108bfbbea87ecb94bc4626
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `cassandra` 2.1.18, 2.2.10, 3.11.0
- `docker` 17.06.0-ce, 17.03.2-ce
- `elasticsearch` 5.4.3
- `golang` 1.9beta2
- `haproxy` 1.7.7
- `kibana` 5.4.3
- `logstash` 5.4.3
- `mariadb` 10.2.x to latest
- `memcached` 1.4.38
- `tomcat` 8.5.16, 9.0.0.M22