### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -5,47 +5,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
 Tags: jessie-curl, curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
 Directory: jessie/curl
 
 Tags: jessie-scm, scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
 Tags: jessie, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: jessie
 
 Tags: sid-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
 Directory: sid/curl
 
 Tags: sid-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: sid/scm
 
 Tags: sid
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: sid
 
 Tags: stretch-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c7478e564dd5dc063cdb0231764379a6916fe525
 Directory: stretch/curl
 
 Tags: stretch-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
 Tags: stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: stretch
 
@@ -65,17 +65,17 @@ GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: trusty
 
 Tags: wheezy-curl
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
 Directory: wheezy/curl
 
 Tags: wheezy-scm
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: wheezy/scm
 
 Tags: wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: wheezy
 

--- a/library/busybox
+++ b/library/busybox
@@ -8,6 +8,9 @@ GitCommit: 13f14c6b73f4baf975b725fd12952d3c7272c410
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: bf085cb0632a2a7fb0a7722c88afc04fab5e871f
+# https://github.com/docker-library/busybox/tree/dist-arm32v5
+arm32v5-GitFetch: refs/heads/dist-arm32v5
+arm32v5-GitCommit: 4f1f4c6612baef9e8445476e10667d0367c046e3
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
 arm32v6-GitCommit: b9291ee9abc522d076ac67678b154cf5c84bc149
@@ -32,7 +35,7 @@ Architectures: amd64, arm64v8, i386
 Directory: uclibc
 
 Tags: 1.26.2-glibc, 1.26-glibc, 1-glibc, glibc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: glibc
 
 Tags: 1.26.2-musl, 1.26-musl, 1-musl, musl
@@ -40,8 +43,9 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: musl
 
 Tags: 1.26.2, 1.26, 1, latest
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
+arm32v5-Directory: glibc
 arm32v6-Directory: musl
 arm32v7-Directory: glibc
 arm64v8-Directory: uclibc

--- a/library/haproxy
+++ b/library/haproxy
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.4.27, 1.4
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a11db1597f9be5365028673df4d05b2ea854b3ed
 Directory: 1.4
 
@@ -15,7 +15,7 @@ GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.4/alpine
 
 Tags: 1.5.19, 1.5
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
 Directory: 1.5
 
@@ -25,7 +25,7 @@ GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
 Directory: 1.5/alpine
 
 Tags: 1.6.13, 1.6
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6
 
@@ -35,7 +35,7 @@ GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6/alpine
 
 Tags: 1.7.7, 1.7, 1, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 045b267d8b5aba6903aa0d24ad740a8fbf272173
 Directory: 1.7
 

--- a/library/httpd
+++ b/library/httpd
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.32, 2.2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2
 
@@ -15,7 +15,7 @@ GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.2/alpine
 
 Tags: 2.4.25, 2.4, 2, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3e9afb8de1eca87f72b63d767a99ef807829944f
 Directory: 2.4
 

--- a/library/irssi
+++ b/library/irssi
@@ -5,7 +5,7 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
 GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.0.3, 1.0, 1, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
 Directory: debian
 

--- a/library/memcached
+++ b/library/memcached
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.4.38, 1.4, 1, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 61b99625db8e067f13d393c4a0c3676ffde547f8
 Directory: debian
 

--- a/library/php
+++ b/library/php
@@ -5,106 +5,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.1.6-cli, 7.1-cli, 7-cli, cli, 7.1.6, 7.1, 7, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1
 
 Tags: 7.1.6-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/alpine
 
 Tags: 7.1.6-apache, 7.1-apache, 7-apache, apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/apache
 
 Tags: 7.1.6-fpm, 7.1-fpm, 7-fpm, fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/fpm
 
 Tags: 7.1.6-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.6-zts, 7.1-zts, 7-zts, zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/zts
 
 Tags: 7.1.6-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 3f43309a0d5a427f54dc885e0812068ee767c03e
+GitCommit: 53d257f279619be1712ce542fb8f43bbce453bc1
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.20-cli, 7.0-cli, 7.0.20, 7.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0
 
 Tags: 7.0.20-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/alpine
 
 Tags: 7.0.20-apache, 7.0-apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/apache
 
 Tags: 7.0.20-fpm, 7.0-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/fpm
 
 Tags: 7.0.20-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.20-zts, 7.0-zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/zts
 
 Tags: 7.0.20-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 66a746410bf607ce9b41046e2b42a619fc71d272
+GitCommit: 04a39b18812015e0ac7bfc84a1905897cad7b10d
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.30-cli, 5.6-cli, 5-cli, 5.6.30, 5.6, 5
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6
 
 Tags: 5.6.30-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/alpine
 
 Tags: 5.6.30-apache, 5.6-apache, 5-apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/apache
 
 Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/fpm
 
 Tags: 5.6.30-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.30-zts, 5.6-zts, 5-zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eadc27f12cfec58e270f8e37cd1b4ae9abcbb4eb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/zts
 
 Tags: 5.6.30-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: c48c629568bc166b58b271114d0b44ea6d5cfa09
+GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -10,7 +10,7 @@ GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7
 
 Tags: 2.7.13-slim, 2.7-slim, 2-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/slim
 
@@ -46,7 +46,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3
 
 Tags: 3.3.6-slim, 3.3-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/slim
 
@@ -71,7 +71,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4
 
 Tags: 3.4.6-slim, 3.4-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/slim
 
@@ -96,7 +96,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5
 
 Tags: 3.5.3-slim, 3.5-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5/slim
 
@@ -122,7 +122,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6
 
 Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6/slim
 
@@ -153,7 +153,7 @@ GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc
 
 Tags: 3.6.2rc1-slim, 3.6-rc-slim, rc-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc/slim
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.10, 3.6, 3, latest
-Architectures: amd64, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, i386, s390x
 GitCommit: 7eed5476d6153d05e5a0245ccfe28d893b0b369e
 Directory: 3.6/debian
 
 Tags: 3.6.10-management, 3.6-management, 3-management, management
-Architectures: amd64, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, i386, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 

--- a/library/redis
+++ b/library/redis
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 3.0.7, 3.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fa0e115934f352cbfa8d0d471b43a18e865e28b3
 Directory: 3.0
 
@@ -32,7 +32,7 @@ Directory: 3.0/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 3.2.9, 3.2, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
 Directory: 3.2
 

--- a/library/redmine
+++ b/library/redmine
@@ -12,18 +12,18 @@ Tags: 3.1.7-passenger, 3.1-passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.1/passenger
 
-Tags: 3.2.6, 3.2
-GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
+Tags: 3.2.7, 3.2
+GitCommit: 788b623617b2322527baaca85167738172c82d75
 Directory: 3.2
 
-Tags: 3.2.6-passenger, 3.2-passenger
+Tags: 3.2.7-passenger, 3.2-passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.2/passenger
 
-Tags: 3.3.3, 3.3, 3, latest
-GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
+Tags: 3.3.4, 3.3, 3, latest
+GitCommit: 5d8852cd7e9ce411887246cd398216dac993df41
 Directory: 3.3
 
-Tags: 3.3.3-passenger, 3.3-passenger, 3-passenger, passenger
+Tags: 3.3.4-passenger, 3.3-passenger, 3-passenger, passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.3/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -10,7 +10,7 @@ GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1
 
 Tags: 2.1.10-slim, 2.1-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
 Directory: 2.1/slim
 
@@ -30,7 +30,7 @@ GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/slim
 
@@ -50,7 +50,7 @@ GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/slim
 
@@ -70,7 +70,7 @@ GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/slim
 

--- a/library/tomcat
+++ b/library/tomcat
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
 Directory: 6/jre8
 
-Tags: 7.0.78-jre7, 7.0-jre7, 7-jre7, 7.0.78, 7.0, 7
+Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
 Directory: 7/jre7
 
-Tags: 7.0.78-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.78-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.79-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.79-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
 Directory: 7/jre7-alpine
 
-Tags: 7.0.78-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
 Directory: 7/jre8
 
-Tags: 7.0.78-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.79-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
 Directory: 7/jre8-alpine
 
-Tags: 8.0.44-jre7, 8.0-jre7, 8.0.44, 8.0
+Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
 Directory: 8.0/jre7
 
-Tags: 8.0.44-jre7-alpine, 8.0-jre7-alpine, 8.0.44-alpine, 8.0-alpine
+Tags: 8.0.45-jre7-alpine, 8.0-jre7-alpine, 8.0.45-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.44-jre8, 8.0-jre8
+Tags: 8.0.45-jre8, 8.0-jre8
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
 Directory: 8.0/jre8
 
-Tags: 8.0.44-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.45-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: 5ac222d258dc70c77bb3a9a4fab81ea286c9abd1
+GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest


### PR DESCRIPTION
- `buildpack-deps`: add `arm32v5`
- `busybox`: add `arm32v5`
- `haproxy`: add `arm32v5`
- `httpd`: add `arm32v5`
- `irssi`: add `arm32v5`
- `memcached`: add `arm32v5`
- `php`: remove MD5 verification (following upstream), add `arm32v5`
- `python`: add `arm32v5`
- `rabbitmq`: add `arm32v5`
- `redis`: add `arm32v5`
- `redmine`: 3.2.7, 3.3.4
- `ruby`: add `arm32v5`
- `tomcat`: 8.0.45, 7.0.79