### PR TITLE
Upgrade Node to 8.1.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,26 +1,26 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/a8eef541ef29ae81f53f0fdd177ec20bbead3ed2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/cce56a99b96d14f1f42fb1208e1542ec88358bb5/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.1.2, 8.1, 8, latest
-GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
+Tags: 8.1.3, 8.1, 8, latest
+GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
 Directory: 8.1
 
-Tags: 8.1.2-alpine, 8.1-alpine, 8-alpine, alpine
-GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
+Tags: 8.1.3-alpine, 8.1-alpine, 8-alpine, alpine
+GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
 Directory: 8.1/alpine
 
-Tags: 8.1.2-onbuild, 8.1-onbuild, 8-onbuild, onbuild
-GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
+Tags: 8.1.3-onbuild, 8.1-onbuild, 8-onbuild, onbuild
+GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
 Directory: 8.1/onbuild
 
-Tags: 8.1.2-slim, 8.1-slim, 8-slim, slim
-GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
+Tags: 8.1.3-slim, 8.1-slim, 8-slim, slim
+GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
 Directory: 8.1/slim
 
-Tags: 8.1.2-wheezy, 8.1-wheezy, 8-wheezy, wheezy
-GitCommit: 12ba2e5432cd50037b6c0cf53464b5063b028227
+Tags: 8.1.3-wheezy, 8.1-wheezy, 8-wheezy, wheezy
+GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
 Directory: 8.1/wheezy
 
 Tags: 6.11.0, 6.11, 6, boron


### PR DESCRIPTION
This PR update Node.js to version 8.1.3.

Related nodejs/docker-node#440
Signed-off-by: Hans Kristian Flaatten <hans@starefossen.com>