### PR TITLE
Update Adminer

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -2,7 +2,7 @@ Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
 Tags: 4.3.1-standalone, 4.3-standalone, 4-standalone, standalone, 4.3.1, 4.3, 4, latest
-GitCommit: e7677ec95176973e991b063d8782876207738ce1
+GitCommit: 73de6b9a7979ded5d2289fe015fffe81fa32e0a4
 Directory: 4.3
 
 Tags: 4.3.1-fastcgi, 4.3-fastcgi, 4-fastcgi, fastcgi


### PR DESCRIPTION
This includes the following bugfix:
- Add IPv6 support for standalone image (TimWolla/docker-adminer@73de6b9a7979ded5d2289fe015fffe81fa32e0a4)