### PR TITLE
Update manifest-tool to 0.6.0 and take advantage of new "tags:" support (for increased efficiency in pushing aliases)

### DIFF
--- a/bashbrew/Dockerfile.release
+++ b/bashbrew/Dockerfile.release
@@ -10,7 +10,7 @@ ENV GOPATH /usr/src/bashbrew:/usr/src/bashbrew/vendor
 ENV CGO_ENABLED 0
 
 # https://github.com/estesp/manifest-tool/releases
-ENV MANIFEST_TOOL_VERSION 0.5.0
+ENV MANIFEST_TOOL_VERSION 0.6.0
 # gpg: key 0F386284C03A1162: public key "Philip Estes <estesp@gmail.com>" imported
 ENV MANIFEST_TOOL_GPG_KEY 27F3EA268A97867EAF0BD05C0F386284C03A1162
 


### PR DESCRIPTION
See https://github.com/estesp/manifest-tool/releases/tag/v0.6.0 and especially https://github.com/estesp/manifest-tool/pull/32.

Thanks @estesp!! :+1: :heart:

This results in a pretty good speedup (for a tag with three additional aliases, this is essentially a 4x speedup since the bulk of the work mounting blobs, etc only happens once instead of four times).