### PR TITLE
Sentry 8.18

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/35aa3956a16cf82f7419481558132ff8bc8989b1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/7451b44273e5847a0ff261be45603693a21d162e/generate-stackbrew-library.sh
 
 Maintainers: Matt Robenolt <matt@sentry.io> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
 
-Tags: 8.16.1, 8.16
-GitCommit: 3b060a7ceaee5f5b0bdb6cf88e1e0559c62be709
-Directory: 8.16
-
-Tags: 8.16.1-onbuild, 8.16-onbuild
-GitCommit: 14a4752274f9627ab59cb02ad54801b04c8b3b1d
-Directory: 8.16/onbuild
-
-Tags: 8.17.0, 8.17, 8, latest
+Tags: 8.17.0, 8.17
 GitCommit: 35aa3956a16cf82f7419481558132ff8bc8989b1
 Directory: 8.17
 
-Tags: 8.17.0-onbuild, 8.17-onbuild, 8-onbuild, onbuild
+Tags: 8.17.0-onbuild, 8.17-onbuild
 GitCommit: 35aa3956a16cf82f7419481558132ff8bc8989b1
 Directory: 8.17/onbuild
+
+Tags: 8.18.0, 8.18, 8, latest
+GitCommit: 7451b44273e5847a0ff261be45603693a21d162e
+Directory: 8.18
+
+Tags: 8.18.0-onbuild, 8.18-onbuild, 8-onbuild, onbuild
+GitCommit: 7451b44273e5847a0ff261be45603693a21d162e
+Directory: 8.18/onbuild


### PR DESCRIPTION
🇺🇸 https://github.com/getsentry/sentry/releases/tag/8.18.0 🇺🇸 