### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,22 +1,22 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/13f14c6b73f4baf975b725fd12952d3c7272c410/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/cd0b6186427c463bb89b026960a40fb03430ed5a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 13f14c6b73f4baf975b725fd12952d3c7272c410
+GitCommit: cd0b6186427c463bb89b026960a40fb03430ed5a
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: bf085cb0632a2a7fb0a7722c88afc04fab5e871f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 4f1f4c6612baef9e8445476e10667d0367c046e3
+arm32v5-GitCommit: 64cf54c91cbb0342a462c598ffd96223bdd8d877
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
 arm32v6-GitCommit: b9291ee9abc522d076ac67678b154cf5c84bc149
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 56073c8807db2a80f345fed2e0164ef4db6f17fd
+arm32v7-GitCommit: 9b75d08b9e52d18d1d15a6816492a01083081b2f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 456e9021be627cad59a28f45d2f1e0d6b43c320d
@@ -31,7 +31,7 @@ s390x-GitFetch: refs/heads/dist-s390x
 s390x-GitCommit: e4fe2dcdd3a50eb316a803413349d0c075dfea8c
 
 Tags: 1.26.2-uclibc, 1.26-uclibc, 1-uclibc, uclibc
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: uclibc
 
 Tags: 1.26.2-glibc, 1.26-glibc, 1-glibc, glibc
@@ -45,9 +45,9 @@ Directory: musl
 Tags: 1.26.2, 1.26, 1, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
-arm32v5-Directory: glibc
+arm32v5-Directory: uclibc
 arm32v6-Directory: musl
-arm32v7-Directory: glibc
+arm32v7-Directory: uclibc
 arm64v8-Directory: uclibc
 i386-Directory: uclibc
 ppc64le-Directory: glibc

--- a/library/drupal
+++ b/library/drupal
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.4-apache, 8.3-apache, 8-apache, apache, 8.3.4, 8.3, 8, latest
-GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
+Tags: 8.3.5-apache, 8.3-apache, 8-apache, apache, 8.3.5, 8.3, 8, latest
+GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
 Directory: 8.3/apache
 
-Tags: 8.3.4-fpm, 8.3-fpm, 8-fpm, fpm
-GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
+Tags: 8.3.5-fpm, 8.3-fpm, 8-fpm, fpm
+GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
 Directory: 8.3/fpm
 
-Tags: 8.3.4-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: dca6f9267aa13ea85df1286f129b61d506273d06
+Tags: 8.3.5-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7

--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/3b33871fe9558262cb5ed6253d358f76710e9ccb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/e21e2f607ba2623b0d8fc8a9a6bbfad8df1cf511/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -18,12 +18,12 @@ GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
 Directory: 5
 # Docker EOL: 2017-06-03
 
-# Last Modified: 2016-12-21
-Tags: 6.3.0, 6.3, 6
+# Last Modified: 2017-07-04
+Tags: 6.4.0, 6.4, 6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
+GitCommit: c1fe37de30fbe69e83f042b4a9426b11cb624bca
 Directory: 6
-# Docker EOL: 2017-12-21
+# Docker EOL: 2018-07-04
 
 # Last Modified: 2017-05-02
 Tags: 7.1.0, 7.1, 7, latest

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.6, 10.2, 10, latest
 GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
 Directory: 10.2
 
-Tags: 10.1.24, 10.1
-GitCommit: 9ac6a8d627c15e7cecb59e82e3c712d8c71d209e
+Tags: 10.1.25, 10.1
+GitCommit: 477dd79ffb3a2ee2c5ca04fa23d207506a8a407f
 Directory: 10.1
 
 Tags: 10.0.31, 10.0

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.4.38, 1.4, 1, latest
+Tags: 1.4.39, 1.4, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 61b99625db8e067f13d393c4a0c3676ffde547f8
+GitCommit: f656df1a053eb804e8059385a564d6e97b4bc0ab
 Directory: debian
 
-Tags: 1.4.38-alpine, 1.4-alpine, 1-alpine, alpine
+Tags: 1.4.39-alpine, 1.4-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 61b99625db8e067f13d393c4a0c3676ffde547f8
+GitCommit: f656df1a053eb804e8059385a564d6e97b4bc0ab
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -30,16 +30,16 @@ GitCommit: 333b2d1a5dae3d40e31da7459f6dfb8a1847e890
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.5, 3.4, 3, latest
+Tags: 3.4.6, 3.4, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
+GitCommit: c02ca4cce8c69e5069b75cb574d1b99d7b4edaeb
 Directory: 3.4
 
-Tags: 3.4.5-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.4.6-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: e25d020918434d29378b4ca58c34843c215cd043
+GitCommit: c02ca4cce8c69e5069b75cb574d1b99d7b4edaeb
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/openjdk.git
 
 Tags: 6b38-jdk, 6b38, 6-jdk, 6
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
 Directory: 6-jdk
 
 Tags: 6b38-jre, 6-jre
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: bd3c2a9867c9dc6a9a8425a8df5c54edf0cbf2cc
 Directory: 6-jre
 
 Tags: 7u131-jdk, 7u131, 7-jdk, 7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jdk
 
@@ -25,7 +25,7 @@ GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jdk/alpine
 
 Tags: 7u131-jre, 7-jre
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93316d3b14379d29fe0cd363bd6839eb8dd8cc7b
 Directory: 7-jre
 
@@ -35,8 +35,8 @@ GitCommit: 43e145f3fc5fd98a141f0c1c6fe90b9ea93977da
 Directory: 7-jre/alpine
 
 Tags: 8u131-jdk, 8u131, 8-jdk, 8, jdk, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ae4562dcd2d99eb9d6224517f9e6b4ab4c2b4672
 Directory: 8-jdk
 
 Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
@@ -57,8 +57,8 @@ Directory: 8-jdk/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 8u131-jre, 8-jre, jre
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 415b0cc42d91ef5d70597d8a24d942967728242b
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ae4562dcd2d99eb9d6224517f9e6b4ab4c2b4672
 Directory: 8-jre
 
 Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
@@ -67,11 +67,11 @@ GitCommit: 238cc35696423794b1951fc63d4cc9ffb8ca9685
 Directory: 8-jre/alpine
 
 Tags: 9-b170-jdk, 9-b170, 9-jdk, 9
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jdk
 
 Tags: 9-b170-jre, 9-jre
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c34391ea981c804c097981bad8403ec4bd934285
 Directory: 9-jre

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,45 +1,29 @@
-# this file is generated via https://github.com/docker-library/owncloud/blob/37fb493d8bdd4e0d65285b0474d91bce5a8260b5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/owncloud/blob/d451be9d45c19ef9fe357a75245ff4f36495176f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 8.0.16-apache, 8.0-apache, 8.0.16, 8.0
-GitCommit: 2c9fddfe6a17a2c1d631dd7a6f1c7f87763f7d10
-Directory: 8.0/apache
+Tags: 10.0.2-apache, 10.0-apache, 10-apache, apache, 10.0.2, 10.0, 10, latest
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Directory: 10.0/apache
 
-Tags: 8.0.16-fpm, 8.0-fpm
-GitCommit: 2c9fddfe6a17a2c1d631dd7a6f1c7f87763f7d10
-Directory: 8.0/fpm
+Tags: 10.0.2-fpm, 10.0-fpm, 10-fpm, fpm
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Directory: 10.0/fpm
 
-Tags: 8.1.12-apache, 8.1-apache, 8.1.12, 8.1
-GitCommit: 2e581bdb03a2961e5dad7764f59ff363da94e6fb
-Directory: 8.1/apache
+Tags: 9.1.6-apache, 9.1-apache, 9-apache, 9.1.6, 9.1, 9
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Directory: 9.1/apache
 
-Tags: 8.1.12-fpm, 8.1-fpm
-GitCommit: 2e581bdb03a2961e5dad7764f59ff363da94e6fb
-Directory: 8.1/fpm
-
-Tags: 8.2.11-apache, 8.2-apache, 8-apache, 8.2.11, 8.2, 8
-GitCommit: 3182c1fc072fb43c165d65de7bee16aa2374efd7
-Directory: 8.2/apache
-
-Tags: 8.2.11-fpm, 8.2-fpm, 8-fpm
-GitCommit: 3182c1fc072fb43c165d65de7bee16aa2374efd7
-Directory: 8.2/fpm
+Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Directory: 9.1/fpm
 
 Tags: 9.0.10-apache, 9.0-apache, 9.0.10, 9.0
-GitCommit: 6bb84a4253c8a84af6a9b3968eb61388c65be5fb
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
 Directory: 9.0/apache
 
 Tags: 9.0.10-fpm, 9.0-fpm
-GitCommit: 6bb84a4253c8a84af6a9b3968eb61388c65be5fb
+GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
 Directory: 9.0/fpm
-
-Tags: 9.1.6-apache, 9.1-apache, 9-apache, apache, 9.1.6, 9.1, 9, latest
-GitCommit: 4a90ae0bfeec972185fd920130b70b6c51eec6f4
-Directory: 9.1/apache
-
-Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm, fpm
-GitCommit: 4a90ae0bfeec972185fd920130b70b6c51eec6f4
-Directory: 9.1/fpm

--- a/library/python
+++ b/library/python
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 
 Tags: 2.7.13, 2.7, 2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7
 
@@ -25,12 +25,12 @@ GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
 Directory: 2.7/wheezy
 
 Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
 Directory: 2.7/onbuild
 
@@ -41,7 +41,7 @@ Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.3.6, 3.3
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3
 
@@ -56,17 +56,17 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.3/wheezy
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.3/onbuild
 
 Tags: 3.4.6, 3.4
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4
 
@@ -81,17 +81,17 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/alpine
 
 Tags: 3.4.6-wheezy, 3.4-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.4/wheezy
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.4/onbuild
 
 Tags: 3.5.3, 3.5
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5
 
@@ -106,7 +106,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.5/alpine
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
 Directory: 3.5/onbuild
 
@@ -117,7 +117,7 @@ Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.1, 3.6, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6
 
@@ -137,7 +137,7 @@ GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/onbuild
 
@@ -148,7 +148,7 @@ Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.2rc1, 3.6-rc, rc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc
 
@@ -168,7 +168,7 @@ GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc/alpine3.6
 
 Tags: 3.6.2rc1-onbuild, 3.6-rc-onbuild, rc-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc/onbuild
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/1c0e9a4aef4fc3b917a116d2a4ccced6842a26c4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/0faadd80976f6d1f0f1af215ca81ba1ccf6fb3a4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.56.0, 0.56, 0, latest
-GitCommit: f65fa9bf451f0e11e651ddd5b9399b8aacbc035c
+Tags: 0.57.0, 0.57, 0, latest
+GitCommit: 553d1aac431772a2a1d090d6f06bc44fb5e37501

--- a/library/ruby
+++ b/library/ruby
@@ -4,28 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.1.10, 2.1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
-Directory: 2.1
-
-Tags: 2.1.10-slim, 2.1-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
-Directory: 2.1/slim
-
-Tags: 2.1.10-alpine, 2.1-alpine
-Architectures: amd64
-GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
-Directory: 2.1/alpine
-
-Tags: 2.1.10-onbuild, 2.1-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
-Directory: 2.1/onbuild
-
 Tags: 2.2.7, 2.2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2
 
@@ -40,12 +20,12 @@ GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
 Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3
 
@@ -60,12 +40,12 @@ GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
 Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4
 
@@ -80,6 +60,6 @@ GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
 Directory: 2.4/onbuild

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.8.0-apache, 4.8-apache, 4-apache, apache, 4.8.0, 4.8, 4, latest, 4.8.0-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.0-php5.6, 4.8-php5.6, 4-php5.6, php5.6
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/apache
 
 Tags: 4.8.0-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.0-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm
 
@@ -20,12 +20,12 @@ GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php5.6/fpm-alpine
 
 Tags: 4.8.0-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.0-php7.0, 4.8-php7.0, 4-php7.0, php7.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/apache
 
 Tags: 4.8.0-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm
 
@@ -35,12 +35,12 @@ GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.0/fpm-alpine
 
 Tags: 4.8.0-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.0-php7.1, 4.8-php7.1, 4-php7.1, php7.1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/apache
 
 Tags: 4.8.0-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
 Directory: php7.1/fpm
 


### PR DESCRIPTION
- `busybox`: add `arm32v5` and `arm32v7` uClibc variants (docker-library/busybox#31)
- `drupal`: 8.3.5
- `gcc`: 6.4.0
- `mariadb`: 10.1.25
- `memcached`: 1.4.39
- `mongo`: 3.4.6
- `openjdk`: update 8 variants to `stretch` (docker-library/openjdk#124), `arm32v5`
- `owncloud`: 10.0, PHP 7 (docker-library/owncloud#89); remove EOL 8.2, 8.1, 8.0 (https://owncloud.org/changelog/)
- `python`: more `arm32v5`
- `rabbitmq`: comment update, no image changes
- `rocket.chat`: 0.57.0
- `ruby`: more `arm32v5`, remove EOL 2.1 (https://www.ruby-lang.org/en/downloads/branches/)
- `wordpress`: cli 1.2.1, add `arm32v5`