### PR TITLE
Bump Traefik to v1.3.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,10 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.2, 1.3.2, v1.3, 1.3, raclette, latest
-GitCommit: bbaf3645fda34c8c4921e4cabd1439f27f15d274
+Tags: v1.3.3, 1.3.3, v1.3, 1.3, raclette, latest
+GitCommit: 127ae9f3c881ce53f73f0fa0cd52fe947b77ef6b
 
-Tags: v1.3.2-alpine, 1.3.2-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: bbaf3645fda34c8c4921e4cabd1439f27f15d274
+Tags: v1.3.3-alpine, 1.3.3-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 127ae9f3c881ce53f73f0fa0cd52fe947b77ef6b
 Directory: alpine
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.3.3.

/cc @vdemeester @emilevauge

Cheers
