### PR TITLE
Add arm32v5 to Tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
 Directory: 6/jre7
 
 Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
 Directory: 6/jre8
 
 Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
 Directory: 7/jre7
 
@@ -25,7 +25,7 @@ GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
 Directory: 7/jre7-alpine
 
 Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
 Directory: 7/jre8
 
@@ -35,7 +35,7 @@ GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
 Directory: 7/jre8-alpine
 
 Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
 Directory: 8.0/jre7
 
@@ -45,7 +45,7 @@ GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.45-jre8, 8.0-jre8
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
 Directory: 8.0/jre8
 
@@ -55,7 +55,7 @@ GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3e2747c34ded033f4c7adf108f51f3634d025adf
 Directory: 8.5/jre8
 
@@ -65,7 +65,7 @@ GitCommit: ae0ff8626dbb002258c3fabdcba1682fa12d6f99
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1cb69781deeac97b2bb138054de3b2f35e9b49a0
 Directory: 9.0/jre8
 


### PR DESCRIPTION
Split off from https://github.com/docker-library/official-images/pull/3154 since it can be merged independently. :+1: