### PR TITLE
Add gnupg to all buildpack-deps:curl variants

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/buildpack-deps.git
 
 Tags: jessie-curl, curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: jessie/curl
 
 Tags: jessie-scm, scm
@@ -21,7 +21,7 @@ Directory: jessie
 
 Tags: sid-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: sid/curl
 
 Tags: sid-scm
@@ -36,7 +36,7 @@ Directory: sid
 
 Tags: stretch-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7478e564dd5dc063cdb0231764379a6916fe525
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: stretch/curl
 
 Tags: stretch-scm
@@ -51,7 +51,7 @@ Directory: stretch
 
 Tags: trusty-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: af914a5bde2a749884177393c8140384048dc5f9
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: trusty/curl
 
 Tags: trusty-scm
@@ -66,7 +66,7 @@ Directory: trusty
 
 Tags: wheezy-curl
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a0a59c61102e8b079d568db69368fb89421f75f2
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: wheezy/curl
 
 Tags: wheezy-scm
@@ -81,7 +81,7 @@ Directory: wheezy
 
 Tags: xenial-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: xenial/curl
 
 Tags: xenial-scm
@@ -96,7 +96,7 @@ Directory: xenial
 
 Tags: yakkety-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a94a81caf4d56853baade2cdd794dbe0c93396b2
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: yakkety/curl
 
 Tags: yakkety-scm
@@ -111,7 +111,7 @@ Directory: yakkety
 
 Tags: zesty-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
+GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: zesty/curl
 
 Tags: zesty-scm


### PR DESCRIPTION
See https://github.com/docker-library/buildpack-deps/pull/62.