### PR TITLE
We've moved all the Oracle Linux base images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,35 +1,35 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
-GitRepo: https://github.com/oracle/docker-images.git
-GitFetch: refs/heads/OracleLinux-images
-GitCommit: cb918bb1bca208835f6df035d0251e55c7148616
+GitRepo: https://github.com/oracle/ol-container-images.git
+GitFetch: refs/heads/master
+GitCommit: e5f119434d52adbae8438421f9b6f95b8928816e
 
 Tags: 7-slim
-Directory: OracleLinux/7-slim
+Directory: 7-slim
 
 Tags: latest, 7, 7.3
-Directory: OracleLinux/7.3
+Directory: 7.3
 
 Tags: 7.2
-Directory: OracleLinux/7.2
+Directory: 7.2
 
 Tags: 7.1
-Directory: OracleLinux/7.1
+Directory: 7.1
 
 Tags: 7.0
-Directory: OracleLinux/7.0
+Directory: 7.0
 
 Tags: 6-slim
-Directory: OracleLinux/6-slim
+Directory: 6-slim
 
 Tags: 6, 6.9
-Directory: OracleLinux/6.9
+Directory: 6.9
 
 Tags: 6.8
-Directory: OracleLinux/6.8
+Directory: 6.8
 
 Tags: 6.7
-Directory: OracleLinux/6.7
+Directory: 6.7
 
 Tags: 6.6
-Directory: OracleLinux/6.6
+Directory: 6.6
 


### PR DESCRIPTION
Our main repo was getting a little too big with all these images hiding in a branch, so we've split them out into their own repo.

Signed-off-by: Avi Miller <avi.miller@oracle.com>