### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/974626a5981ab3741c0a5186fa6b08f7a68cf729/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/7bbf2f06c74e0a8ca54c97f5a0f0b729b39011df/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
-Tags: jessie-curl, curl
+Tags: jessie-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: jessie/curl
 
-Tags: jessie-scm, scm
+Tags: jessie-scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
-Tags: jessie, latest
+Tags: jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: jessie
@@ -34,17 +34,17 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: sid
 
-Tags: stretch-curl
+Tags: stretch-curl, curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
 Directory: stretch/curl
 
-Tags: stretch-scm
+Tags: stretch-scm, scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
-Tags: stretch
+Tags: stretch, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
 Directory: stretch

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6/alpine
 
-Tags: 1.7.7, 1.7, 1, latest
+Tags: 1.7.8, 1.7, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 045b267d8b5aba6903aa0d24ad740a8fbf272173
+GitCommit: 9b5d5bf547d296049a8e8a22ac951e1b76f3179c
 Directory: 1.7
 
-Tags: 1.7.7-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.8-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 045b267d8b5aba6903aa0d24ad740a8fbf272173
+GitCommit: 9b5d5bf547d296049a8e8a22ac951e1b76f3179c
 Directory: 1.7/alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,28 +1,34 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/d365e45c022bcd901a9770b18b48c2aa29e4cc4c/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/315e2a7aef1a0a8086d4d0eac73cabdb820867f6/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 10.0.5-apache, 10.0-apache, 10-apache, 10.0.5, 10.0, 10
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 10.0/apache
 
 Tags: 10.0.5-fpm, 10.0-fpm, 10-fpm
-GitCommit: 749f25b93dc4644898b10f2f9524330051c42fe5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 10.0/fpm
 
 Tags: 11.0.3-apache, 11.0-apache, 11-apache, 11.0.3, 11.0, 11
-GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 11.0/apache
 
 Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm
-GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 11.0/fpm
 
 Tags: 12.0.0-apache, 12.0-apache, 12-apache, apache, 12.0.0, 12.0, 12, latest
-GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 12.0/apache
 
 Tags: 12.0.0-fpm, 12.0-fpm, 12-fpm, fpm
-GitCommit: 72ef7897e66f6657e81679386ab60a98ef6509f1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f4309b27dcce2def787aba243582a2a841b0f33e
 Directory: 12.0/fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -66,12 +66,12 @@ Architectures: amd64
 GitCommit: 238cc35696423794b1951fc63d4cc9ffb8ca9685
 Directory: 8-jre/alpine
 
-Tags: 9-b170-jdk, 9-b170, 9-jdk, 9
+Tags: 9-b177-jdk, 9-b177, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c34391ea981c804c097981bad8403ec4bd934285
+GitCommit: a5b8541f6a42366424c0f1fd0de027a1e1720114
 Directory: 9-jdk
 
-Tags: 9-b170-jre, 9-jre
+Tags: 9-b177-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c34391ea981c804c097981bad8403ec4bd934285
+GitCommit: a5b8541f6a42366424c0f1fd0de027a1e1720114
 Directory: 9-jre

--- a/library/php
+++ b/library/php
@@ -74,37 +74,37 @@ Architectures: amd64
 GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
 Directory: 7.0/zts/alpine
 
-Tags: 5.6.30-cli, 5.6-cli, 5-cli, 5.6.30, 5.6, 5
+Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6
 
-Tags: 5.6.30-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/alpine
 
-Tags: 5.6.30-apache, 5.6-apache, 5-apache
+Tags: 5.6.31-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/apache
 
-Tags: 5.6.30-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/fpm
 
-Tags: 5.6.30-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/fpm/alpine
 
-Tags: 5.6.30-zts, 5.6-zts, 5-zts
+Tags: 5.6.31-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/zts
 
-Tags: 5.6.30-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 3ee1cd8287f6fc7269a731ceb6199ec8dee8b727
+GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -147,33 +147,33 @@ GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.2rc1, 3.6-rc, rc
+Tags: 3.6.2rc2, 3.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
 Directory: 3.6-rc
 
-Tags: 3.6.2rc1-slim, 3.6-rc-slim, rc-slim
+Tags: 3.6.2rc2-slim, 3.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
 Directory: 3.6-rc/slim
 
-Tags: 3.6.2rc1-alpine, 3.6-rc-alpine, rc-alpine
+Tags: 3.6.2rc2-alpine, 3.6-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
 Directory: 3.6-rc/alpine
 
-Tags: 3.6.2rc1-alpine3.6, 3.6-rc-alpine3.6, rc-alpine3.6
+Tags: 3.6.2rc2-alpine3.6, 3.6-rc-alpine3.6, rc-alpine3.6
 Architectures: amd64
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
 Directory: 3.6-rc/alpine3.6
 
-Tags: 3.6.2rc1-onbuild, 3.6-rc-onbuild, rc-onbuild
+Tags: 3.6.2rc2-onbuild, 3.6-rc-onbuild, rc-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
 Directory: 3.6-rc/onbuild
 
-Tags: 3.6.2rc1-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
+Tags: 3.6.2rc2-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
+GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
 Directory: 3.6-rc/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
- `buildpack-deps`: switch `latest` to `stretch`
- `haproxy`: 1.7.8
- `nextcloud`: multiarch (https://github.com/nextcloud/docker/pull/113), APCu (https://github.com/nextcloud/docker/pull/121)
- `openjdk`: debian `9~b177-3`
- `php`: 5.6.31, 7.1.7, 7.0.21
- `python`: 3.6.2rc1