### PR TITLE
Adjust golang variants to be explicit (jessie, stretch, alpine3.4, alpine3.6, etc)

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/docker-library/golang/blob/97b2ff201ec59b9a037197d132c64eb937370c64/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/b994c30f158bfe63ee458e1465e7667606fa53a1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9beta2, 1.9-rc, 1.9, rc
+Tags: 1.9beta2-stretch, 1.9-rc-stretch, 1.9-stretch, rc-stretch, 1.9beta2, 1.9-rc, 1.9, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
-Directory: 1.9-rc
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.9-rc/stretch
 
-Tags: 1.9beta2-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
+Tags: 1.9beta2-alpine3.6, 1.9-rc-alpine3.6, 1.9-alpine3.6, rc-alpine3.6, 1.9beta2-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
 Architectures: amd64
-GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
-Directory: 1.9-rc/alpine
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.9-rc/alpine3.6
 
 Tags: 1.9beta2-windowsservercore, 1.9-rc-windowsservercore, 1.9-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
@@ -27,30 +27,30 @@ GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
 Directory: 1.9-rc/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8.3, 1.8, 1, latest
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 97b2ff201ec59b9a037197d132c64eb937370c64
-Directory: 1.8
-
-Tags: 1.8.3-onbuild, 1.8-onbuild, 1-onbuild, onbuild
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
-Directory: 1.8/onbuild
-
 Tags: 1.8.3-stretch, 1.8-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
 GitCommit: 97b2ff201ec59b9a037197d132c64eb937370c64
 Directory: 1.8/stretch
 
-Tags: 1.8.3-alpine, 1.8-alpine, 1-alpine, alpine
-Architectures: amd64
-GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65
-Directory: 1.8/alpine
+Tags: 1.8.3-jessie, 1.8-jessie, 1-jessie, jessie, 1.8.3, 1.8, 1, latest
+Architectures: amd64, arm32v7, i386, ppc64le, s390x
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.8/jessie
 
 Tags: 1.8.3-alpine3.6, 1.8-alpine3.6, 1-alpine3.6, alpine3.6
 Architectures: amd64
 GitCommit: 495a742832974d434c6e3356e19c93b0e82543c8
 Directory: 1.8/alpine3.6
+
+Tags: 1.8.3-alpine3.5, 1.8-alpine3.5, 1-alpine3.5, alpine3.5, 1.8.3-alpine, 1.8-alpine, 1-alpine, alpine
+Architectures: amd64
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.8/alpine3.5
+
+Tags: 1.8.3-onbuild, 1.8-onbuild, 1-onbuild, onbuild
+Architectures: amd64, arm32v7, i386, ppc64le, s390x
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/onbuild
 
 Tags: 1.8.3-windowsservercore, 1.8-windowsservercore, 1-windowsservercore, windowsservercore
 Architectures: windows-amd64
@@ -64,25 +64,15 @@ GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.7.6, 1.7
+Tags: 1.7.6-jessie, 1.7-jessie, 1.7.6, 1.7
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 97b2ff201ec59b9a037197d132c64eb937370c64
-Directory: 1.7
-
-Tags: 1.7.6-onbuild, 1.7-onbuild
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
-Directory: 1.7/onbuild
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.7/jessie
 
 Tags: 1.7.6-wheezy, 1.7-wheezy
 Architectures: amd64, arm32v7, i386
 GitCommit: 97b2ff201ec59b9a037197d132c64eb937370c64
 Directory: 1.7/wheezy
-
-Tags: 1.7.6-alpine, 1.7-alpine
-Architectures: amd64
-GitCommit: 9e519a8844c25e38fe67547e8f681ada486e473b
-Directory: 1.7/alpine
 
 Tags: 1.7.6-alpine3.6, 1.7-alpine3.6
 Architectures: amd64
@@ -93,6 +83,16 @@ Tags: 1.7.6-alpine3.5, 1.7-alpine3.5
 Architectures: amd64
 GitCommit: 9e519a8844c25e38fe67547e8f681ada486e473b
 Directory: 1.7/alpine3.5
+
+Tags: 1.7.6-alpine3.4, 1.7-alpine3.4, 1.7.6-alpine, 1.7-alpine
+Architectures: amd64
+GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+Directory: 1.7/alpine3.4
+
+Tags: 1.7.6-onbuild, 1.7-onbuild
+Architectures: amd64, arm32v7, i386, ppc64le, s390x
+GitCommit: 2372c8cafe9cc958bade33ad0b8b54de8869c21f
+Directory: 1.7/onbuild
 
 Tags: 1.7.6-windowsservercore, 1.7-windowsservercore
 Architectures: windows-amd64


### PR DESCRIPTION
See https://github.com/docker-library/golang/pull/170.