### PR TITLE
Update all node release line versions

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,65 +1,85 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/cce56a99b96d14f1f42fb1208e1542ec88358bb5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/0fcdf0b2660e73ab1054f932f4beac5b3946fb21/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.1.3, 8.1, 8, latest
-GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
+Tags: 8.1.4, 8.1, 8, latest
+GitCommit: a5e2d0fab5b14773e0fdc460c0b96d0f93a80ba2
 Directory: 8.1
 
-Tags: 8.1.3-alpine, 8.1-alpine, 8-alpine, alpine
-GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
+Tags: 8.1.4-alpine, 8.1-alpine, 8-alpine, alpine
+GitCommit: a5e2d0fab5b14773e0fdc460c0b96d0f93a80ba2
 Directory: 8.1/alpine
 
-Tags: 8.1.3-onbuild, 8.1-onbuild, 8-onbuild, onbuild
-GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
+Tags: 8.1.4-onbuild, 8.1-onbuild, 8-onbuild, onbuild
+GitCommit: a5e2d0fab5b14773e0fdc460c0b96d0f93a80ba2
 Directory: 8.1/onbuild
 
-Tags: 8.1.3-slim, 8.1-slim, 8-slim, slim
-GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
+Tags: 8.1.4-slim, 8.1-slim, 8-slim, slim
+GitCommit: a5e2d0fab5b14773e0fdc460c0b96d0f93a80ba2
 Directory: 8.1/slim
 
-Tags: 8.1.3-wheezy, 8.1-wheezy, 8-wheezy, wheezy
-GitCommit: f131cc81c04968f1a60092c5efef54ea276d8b20
+Tags: 8.1.4-wheezy, 8.1-wheezy, 8-wheezy, wheezy
+GitCommit: a5e2d0fab5b14773e0fdc460c0b96d0f93a80ba2
 Directory: 8.1/wheezy
 
-Tags: 6.11.0, 6.11, 6, boron
-GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Tags: 7.10.1, 7.10, 7
+GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Directory: 7.10
+
+Tags: 7.10.1-alpine, 7.10-alpine, 7-alpine
+GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Directory: 7.10/alpine
+
+Tags: 7.10.1-onbuild, 7.10-onbuild, 7-onbuild
+GitCommit: 0fcdf0b2660e73ab1054f932f4beac5b3946fb21
+Directory: 7.10/onbuild
+
+Tags: 7.10.1-slim, 7.10-slim, 7-slim
+GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Directory: 7.10/slim
+
+Tags: 7.10.1-wheezy, 7.10-wheezy, 7-wheezy
+GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Directory: 7.10/wheezy
+
+Tags: 6.11.1, 6.11, 6, boron
+GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11
 
-Tags: 6.11.0-alpine, 6.11-alpine, 6-alpine, boron-alpine
-GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Tags: 6.11.1-alpine, 6.11-alpine, 6-alpine, boron-alpine
+GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/alpine
 
-Tags: 6.11.0-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
-GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Tags: 6.11.1-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
+GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/onbuild
 
-Tags: 6.11.0-slim, 6.11-slim, 6-slim, boron-slim
-GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Tags: 6.11.1-slim, 6.11-slim, 6-slim, boron-slim
+GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/slim
 
-Tags: 6.11.0-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
-GitCommit: e2b78b4bde9440f2189007004a2ae4880f3eb030
+Tags: 6.11.1-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
+GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/wheezy
 
-Tags: 4.8.3, 4.8, 4, argon
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
+Tags: 4.8.4, 4.8, 4, argon
+GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8
 
-Tags: 4.8.3-alpine, 4.8-alpine, 4-alpine, argon-alpine
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
+Tags: 4.8.4-alpine, 4.8-alpine, 4-alpine, argon-alpine
+GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/alpine
 
-Tags: 4.8.3-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
-GitCommit: 974c2a3c3cc488c3491a7ffd85e90c079d0d78e1
+Tags: 4.8.4-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/onbuild
 
-Tags: 4.8.3-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
+Tags: 4.8.4-slim, 4.8-slim, 4-slim, argon-slim
+GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/slim
 
-Tags: 4.8.3-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: b10c352085bbb7933d22bba1215ada9d266dd365
+Tags: 4.8.4-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
This reintroduces node@7 since it also received a security patch.

https://github.com/nodejs/docker-node/pull/455
https://github.com/nodejs/docker-node/pull/458

https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/
https://nodejs.org/en/blog/release/v4.8.4/
https://nodejs.org/en/blog/release/v6.11.1/
https://nodejs.org/en/blog/release/v7.10.1/
https://nodejs.org/en/blog/release/v8.1.4/