### PR TITLE
Update spiped

### DIFF
--- a/library/spiped
+++ b/library/spiped
@@ -4,7 +4,7 @@ Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-spiped.git
 
 Tags: 1.6.0, 1.6, 1, latest
-GitCommit: c9dfc2d06685a700788f85d833875de31e0f2538
+GitCommit: 4d45a684a91cd50c98a79fbcabc479efe0b49dde
 Directory: 1.6
 
 Tags: 1.6.0-alpine, 1.6-alpine, 1-alpine, alpine


### PR DESCRIPTION
This updates the Debian based spiped image to Debian Stretch
(TimWolla/docker-spiped@4d45a684a91cd50c98a79fbcabc479efe0b49dde).