### PR TITLE
Revert "Gradle 4.0"

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -2,41 +2,41 @@ Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
 
 Tags: 3.5-jdk7, jdk7
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jdk7
 
 Tags: 3.5-jre7, jre7
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jre7
 
 Tags: 3.5-jdk7-alpine, jdk7-alpine
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jdk7-alpine
 
 Tags: 3.5-jre7-alpine, jre7-alpine
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jre7-alpine
 
 Tags: 3.5-jdk8, jdk8, 3.5-jdk, jdk, 3.5, latest
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jdk8
 
 Tags: 3.5-jre8, jre8, 3.5-jre, jre
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jre8
 
 Tags: 3.5-jdk8-alpine, jdk8-alpine, 3.5-jdk-alpine, jdk-alpine, 3.5-alpine, alpine
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jdk8-alpine
 
 Tags: 3.5-jre8-alpine, jre8-alpine, 3.5-jre-alpine, jre-alpine
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jre8-alpine
 
 Tags: 3.5-jdk9, jdk9
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jdk9
 
 Tags: 3.5-jre9, jre9
-GitCommit: 9a3c8777938e62faa46e33e12ef34540a41d42b3
+GitCommit: fac6450faeec2232e1ed15051a751236e40ffda2
 Directory: jre9


### PR DESCRIPTION
Reverts docker-library/official-images#3085 so that we can fix the 3.5 tags on the hub.

See https://github.com/docker-library/official-images/pull/3085#issuecomment-314640843

cc @keeganwitt