### PR TITLE
[nats] Release v1.0.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,14 +2,14 @@ Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
              Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
              Waldemar Salinas <wally@apcera.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 24da6ab2af9e849f6a96e32ed2efcb7c0799ab13
+GitCommit: 90d28dc0964ba4f4b811cf21d593496939bf7990
 
-Tags: 0.9.6, latest
+Tags: 1.0.0, latest
 
-Tags: 0.9.6-nanoserver, nanoserver
+Tags: 1.0.0-nanoserver, nanoserver
 Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.9.6-windowsservercore, windowsservercore
+Tags: 1.0.0-windowsservercore, windowsservercore
 Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v1.0.0)