### PR TITLE
Adjust architectures for windows based nats

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -7,9 +7,11 @@ GitCommit: 90d28dc0964ba4f4b811cf21d593496939bf7990
 Tags: 1.0.0, latest
 
 Tags: 1.0.0-nanoserver, nanoserver
+Architectures: windows-amd64
 Directory: windows/nanoserver
 Constraints: nanoserver
 
 Tags: 1.0.0-windowsservercore, windowsservercore
+Architectures: windows-amd64
 Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
cc @kozlovic

We changed our Windows builder to use Architectures like our non-amd64 Linux builders (and forgot to update this one).