### PR TITLE
Update spiped

### DIFF
--- a/library/spiped
+++ b/library/spiped
@@ -1,12 +1,14 @@
-# this file is generated via https://github.com/TimWolla/docker-spiped/blob/c9dfc2d06685a700788f85d833875de31e0f2538/generate-stackbrew-library.sh
+# this file is generated via https://github.com/TimWolla/docker-spiped/blob/bbdc0d01ce890ae6f67c747814f8039bcdf02fa1/generate-stackbrew-library.sh
 
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-spiped.git
 
 Tags: 1.6.0, 1.6, 1, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d45a684a91cd50c98a79fbcabc479efe0b49dde
 Directory: 1.6
 
 Tags: 1.6.0-alpine, 1.6-alpine, 1-alpine, alpine
+Architectures: amd64
 GitCommit: c9dfc2d06685a700788f85d833875de31e0f2538
 Directory: 1.6/alpine


### PR DESCRIPTION
This adds support for non-amd64 architectures in spiped
(TimWolla/docker-spiped@bbdc0d01ce890ae6f67c747814f8039bcdf02fa1).

-------

As hinted here: https://github.com/docker-library/official-images/pull/3182#issuecomment-314617149 :angel:. I also test i386 in my repository using Travis, the other arches are untested, because I lack the required hardware :smile:.