### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -4,6 +4,36 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
+Tags: artful-curl
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
+Directory: artful/curl
+
+Tags: artful-scm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
+Directory: artful/scm
+
+Tags: artful
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
+Directory: artful
+
+Tags: buster-curl
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 72021102be2a05177d2c01e466495ba1c9d0b4f5
+Directory: buster/curl
+
+Tags: buster-scm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1449b1e7ba5a389167893e6edb6245ca94cd4fd6
+Directory: buster/scm
+
+Tags: buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1449b1e7ba5a389167893e6edb6245ca94cd4fd6
+Directory: buster
+
 Tags: jessie-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402

--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.0.3, 1.0, 1, latest
+Tags: 1.0.4, 1.0, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
+GitCommit: a4fb389a6b0d6432f41e1a6b2b1f6aae6fc02ee1
 Directory: debian
 
-Tags: 1.0.3-alpine, 1.0-alpine, 1-alpine, alpine
+Tags: 1.0.4-alpine, 1.0-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 2de872565753ebbd85924d6c80be891ad184f89b
+GitCommit: a4fb389a6b0d6432f41e1a6b2b1f6aae6fc02ee1
 Directory: alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.3.0, 10.3
 GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
 Directory: 10.3
 
-Tags: 10.2.6, 10.2, 10, latest
-GitCommit: 60e0d2d15e74f6fed5b6cc0c2cab4b3f9def6e6e
+Tags: 10.2.7, 10.2, 10, latest
+GitCommit: bcf4518ad93834454bcca8029444231bc044afa3
 Directory: 10.2
 
 Tags: 10.1.25, 10.1

--- a/library/php
+++ b/library/php
@@ -4,107 +4,142 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
+Tags: 7.2.0alpha3-cli, 7.2-rc-cli, rc-cli, 7.2.0alpha3, 7.2-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc
+
+Tags: 7.2.0alpha3-alpine, 7.2-rc-alpine, rc-alpine
+Architectures: amd64
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/alpine
+
+Tags: 7.2.0alpha3-apache, 7.2-rc-apache, rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/apache
+
+Tags: 7.2.0alpha3-fpm, 7.2-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/fpm
+
+Tags: 7.2.0alpha3-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/fpm/alpine
+
+Tags: 7.2.0alpha3-zts, 7.2-rc-zts, rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/zts
+
+Tags: 7.2.0alpha3-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Architectures: amd64
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+Directory: 7.2-rc/zts/alpine
+
 Tags: 7.1.7-cli, 7.1-cli, 7-cli, cli, 7.1.7, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1
 
 Tags: 7.1.7-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/alpine
 
 Tags: 7.1.7-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/apache
 
 Tags: 7.1.7-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/fpm
 
 Tags: 7.1.7-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.7-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/zts
 
 Tags: 7.1.7-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 4976f9ac8d7beb87bf1ad94aa95b4c2d8c461d1d
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.21-cli, 7.0-cli, 7.0.21, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0
 
 Tags: 7.0.21-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/alpine
 
 Tags: 7.0.21-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/apache
 
 Tags: 7.0.21-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/fpm
 
 Tags: 7.0.21-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.21-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/zts
 
 Tags: 7.0.21-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 0bbf244ba381d1b6078fc094aa14244b544d41cf
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6
 
 Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/apache
 
 Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/fpm
 
 Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/zts
 
 Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 3632e1e8ce2d6aa7021560998b7acf43ad1a26d1
+GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/zts/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -1,16 +1,24 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/c070428e8c4c43b2d0608a1e77ae44f78220967e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/083fd3c293a01cf19bcb3c24a05db31f6a6b05bb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.1.7, 3.1
-GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
-Directory: 3.1
+Tags: 3.4.1, 3.4, 3, latest
+GitCommit: 083fd3c293a01cf19bcb3c24a05db31f6a6b05bb
+Directory: 3.4
 
-Tags: 3.1.7-passenger, 3.1-passenger
+Tags: 3.4.1-passenger, 3.4-passenger, 3-passenger, passenger
+GitCommit: 75ead634c9033abef6490ac6d167b597d9e109ea
+Directory: 3.4/passenger
+
+Tags: 3.3.4, 3.3
+GitCommit: 5d8852cd7e9ce411887246cd398216dac993df41
+Directory: 3.3
+
+Tags: 3.3.4-passenger, 3.3-passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
-Directory: 3.1/passenger
+Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
 GitCommit: 788b623617b2322527baaca85167738172c82d75
@@ -20,10 +28,10 @@ Tags: 3.2.7-passenger, 3.2-passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.2/passenger
 
-Tags: 3.3.4, 3.3, 3, latest
-GitCommit: 5d8852cd7e9ce411887246cd398216dac993df41
-Directory: 3.3
+Tags: 3.1.7, 3.1
+GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
+Directory: 3.1
 
-Tags: 3.3.4-passenger, 3.3-passenger, 3-passenger, passenger
+Tags: 3.1.7-passenger, 3.1-passenger
 GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
-Directory: 3.3/passenger
+Directory: 3.1/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,17 +6,17 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 6/jre7
 
 Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcffe2c06edc7a797e20161225eb59e97877ccb0
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 6/jre8
 
 Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 7/jre7
 
 Tags: 7.0.79-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.79-alpine, 7.0-alpine, 7-alpine
@@ -26,7 +26,7 @@ Directory: 7/jre7-alpine
 
 Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68ba169d29cbe2a68b3bc8549daadd9b0cb831c6
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 7/jre8
 
 Tags: 7.0.79-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -36,7 +36,7 @@ Directory: 7/jre8-alpine
 
 Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 8.0/jre7
 
 Tags: 8.0.45-jre7-alpine, 8.0-jre7-alpine, 8.0.45-alpine, 8.0-alpine
@@ -46,7 +46,7 @@ Directory: 8.0/jre7-alpine
 
 Tags: 8.0.45-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fcc0cd5d0992ec4a07f5844c98b0e3112a0568de
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 8.0/jre8
 
 Tags: 8.0.45-jre8-alpine, 8.0-jre8-alpine
@@ -56,7 +56,7 @@ Directory: 8.0/jre8-alpine
 
 Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e2747c34ded033f4c7adf108f51f3634d025adf
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 8.5/jre8
 
 Tags: 8.5.16-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.16-alpine, 8.5-alpine, 8-alpine, alpine
@@ -66,7 +66,7 @@ Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1cb69781deeac97b2bb138054de3b2f35e9b49a0
+GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
 Directory: 9.0/jre8
 
 Tags: 9.0.0.M22-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M22-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine


### PR DESCRIPTION
- `buildpack-deps`: add `buster` (docker-library/buildpack-deps#61), add `artful` (docker-library/buildpack-deps#63)
- `irssi`: 1.0.4
- `mariadb`: 10.2.7
- `php`: add 7.2.0alpha3 (docker-library/php#448)
- `redmine`: add 3.4 (docker-library/redmine#79)
- `tomcat`: adjust for `stretch` (docker-library/tomcat#76)