### PR TITLE
Update Adminer

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -1,10 +1,14 @@
+# this file is generated via https://github.com/TimWolla/docker-adminer/blob/6cdded81c255317d89b15981707f33b553b60c42/generate-stackbrew-library.sh
+
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
 Tags: 4.3.1-standalone, 4.3-standalone, 4-standalone, standalone, 4.3.1, 4.3, 4, latest
+Architectures: amd64
 GitCommit: 73de6b9a7979ded5d2289fe015fffe81fa32e0a4
 Directory: 4.3
 
 Tags: 4.3.1-fastcgi, 4.3-fastcgi, 4-fastcgi, fastcgi
+Architectures: amd64
 GitCommit: e7677ec95176973e991b063d8782876207738ce1
 Directory: 4.3/fastcgi


### PR DESCRIPTION
This adds support for non-amd64 architectures in Adminer
(TimWolla/docker-adminer@6cdded81c255317d89b15981707f33b553b60c42) [1].

[1] Technically it does not yet, because Alpine does not support
    non-amd64 yet, but this lays the foundation.