### PR TITLE
Update redmine entrypoint

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.1, 3.4, 3, latest
-GitCommit: 083fd3c293a01cf19bcb3c24a05db31f6a6b05bb
+GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.4
 
 Tags: 3.4.1-passenger, 3.4-passenger, 3-passenger, passenger
@@ -13,7 +13,7 @@ GitCommit: 75ead634c9033abef6490ac6d167b597d9e109ea
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
-GitCommit: 5d8852cd7e9ce411887246cd398216dac993df41
+GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
@@ -21,7 +21,7 @@ GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
-GitCommit: 788b623617b2322527baaca85167738172c82d75
+GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
@@ -29,7 +29,7 @@ GitCommit: 665769df8d46481583611c0cb96e57f5e3769550
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
-GitCommit: 05abd899196accf07c1b82607a95dd662ee3df93
+GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger


### PR DESCRIPTION
See https://github.com/docker-library/redmine/pull/80.

This should also fix the `mysql2` gem issues in https://github.com/docker-library/redmine/issues/78; since it won't be trying to install gems on run.