### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.10, 0.11, 0, latest
-GitCommit: 9bc8fab01a6858c113e07486ed071c656af8c335
+Tags: 0.11.11, 0.11, 0, latest
+GitCommit: 08813e7fac6ef9b0c5ae43b7f290b2c144661cfe
 Directory: 0.11/debian
 
-Tags: 0.11.10-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: 9bc8fab01a6858c113e07486ed071c656af8c335
+Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine, alpine
+GitCommit: 08813e7fac6ef9b0c5ae43b7f290b2c144661cfe
 Directory: 0.11/alpine

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/b994c30f158bfe63ee458e1465e7667606fa53a1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/b9d0e57cdfb6a25d76988801555e549d5bf7c562/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),

--- a/library/memcached
+++ b/library/memcached
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.4.39, 1.4, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f656df1a053eb804e8059385a564d6e97b4bc0ab
+GitCommit: 82e1de79eeb9ebc18669d01f1db410f2bee45f43
 Directory: debian
 
 Tags: 1.4.39-alpine, 1.4-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: f656df1a053eb804e8059385a564d6e97b4bc0ab
+GitCommit: 82e1de79eeb9ebc18669d01f1db410f2bee45f43
 Directory: alpine

--- a/library/mysql
+++ b/library/mysql
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.1, 8.0, 8
-GitCommit: dc60c4b80f3eb5b7ef8b9ae09f16f6fab7a2fbf5
+Tags: 8.0.2, 8.0, 8
+GitCommit: e207dbbdfd5c95e4b51bdc2dae62c5f72a1dd908
 Directory: 8.0
 
-Tags: 5.7.18, 5.7, 5, latest
-GitCommit: 6b1dc54320b03b83a89068f49cc796fea0ff6bb4
+Tags: 5.7.19, 5.7, 5, latest
+GitCommit: 0590e4efd2b31ec794383f084d419dea9bc752c4
 Directory: 5.7
 
-Tags: 5.6.36, 5.6
-GitCommit: 2bbab7b691b582e2df99dbd16525608adbff016e
+Tags: 5.6.37, 5.6
+GitCommit: 7ee927986b8c0cbfa6cdbb073a0e662bdb62c18a
 Directory: 5.6
 
-Tags: 5.5.56, 5.5
-GitCommit: e8a0ed55678d27039905c50f8327f3a367e92498
+Tags: 5.5.57, 5.5
+GitCommit: 08b08d88066bc27f82212631e1d3415b61097afe
 Directory: 5.5

--- a/library/python
+++ b/library/python
@@ -1,114 +1,64 @@
-# this file is generated via https://github.com/docker-library/python/blob/73d283d3dccd196f758466f29a715e6ab9b533a7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/870b3c63fc69d877ce967c64c672ea686e6fe6bb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 2.7.13, 2.7, 2
+Tags: 3.6.2-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
-Directory: 2.7
+GitCommit: c9954b06c8b178d7888bc1626bed5a14e43a9203
+Directory: 3.6/stretch
 
-Tags: 2.7.13-slim, 2.7-slim, 2-slim
+Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie, 3.6.2, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
-Directory: 2.7/slim
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.6/jessie
 
-Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
+Tags: 3.6.2-slim, 3.6-slim, 3-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.6/jessie/slim
+
+Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.6/jessie/onbuild
+
+Tags: 3.6.2-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
-Directory: 2.7/alpine
+GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+Directory: 3.6/alpine3.6
 
-Tags: 2.7.13-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
+Tags: 3.6.2-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.2-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: e81758e60c9214db0ab9da54c0e741b2a2d62e31
-Directory: 2.7/alpine3.6
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.6/alpine3.4
 
-Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1ca4a57b20a2f66328e5ef72df866f701c0cd306
-Directory: 2.7/wheezy
-
-Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7663560df7547e69d13b1b548675502f4e0917d1
-Directory: 2.7/onbuild
-
-Tags: 2.7.13-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
+Tags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
-Directory: 2.7/windows/windowsservercore
+GitCommit: 761d766baa0ff33754436c0a1fd9aedc68cf7947
+Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.6, 3.3
+Tags: 3.5.3-jessie, 3.5-jessie, 3.5.3, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.3
-
-Tags: 3.3.6-slim, 3.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.3/slim
-
-Tags: 3.3.6-alpine, 3.3-alpine
-Architectures: amd64
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.3/alpine
-
-Tags: 3.3.6-wheezy, 3.3-wheezy
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.3/wheezy
-
-Tags: 3.3.6-onbuild, 3.3-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
-Directory: 3.3/onbuild
-
-Tags: 3.4.6, 3.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.4
-
-Tags: 3.4.6-slim, 3.4-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.4/slim
-
-Tags: 3.4.6-alpine, 3.4-alpine
-Architectures: amd64
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.4/alpine
-
-Tags: 3.4.6-wheezy, 3.4-wheezy
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.4/wheezy
-
-Tags: 3.4.6-onbuild, 3.4-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
-Directory: 3.4/onbuild
-
-Tags: 3.5.3, 3.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.5
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.5/jessie
 
 Tags: 3.5.3-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.5/slim
-
-Tags: 3.5.3-alpine, 3.5-alpine
-Architectures: amd64
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.5/alpine
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.5/jessie/slim
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a9021f2134d953165b31d98cacb95aa34076f90
-Directory: 3.5/onbuild
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.5/jessie/onbuild
+
+Tags: 3.5.3-alpine3.4, 3.5-alpine3.4, 3.5.3-alpine, 3.5-alpine
+Architectures: amd64
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.5/alpine3.4
 
 Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
 Architectures: windows-amd64
@@ -116,64 +66,93 @@ GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.1, 3.6, 3, latest
+Tags: 3.4.6-jessie, 3.4-jessie, 3.4.6, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.6
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.4/jessie
 
-Tags: 3.6.1-slim, 3.6-slim, 3-slim, slim
+Tags: 3.4.6-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.6/slim
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.4/jessie/slim
 
-Tags: 3.6.1-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.4.6-onbuild, 3.4-onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.4/jessie/onbuild
+
+Tags: 3.4.6-wheezy, 3.4-wheezy
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+Directory: 3.4/wheezy
+
+Tags: 3.4.6-alpine3.4, 3.4-alpine3.4, 3.4.6-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.6/alpine
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.4/alpine3.4
 
-Tags: 3.6.1-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
-Architectures: amd64
-GitCommit: 88ba87d31a3033d4dbefecf44ce25aa1b69ab3e5
-Directory: 3.6/alpine3.6
-
-Tags: 3.6.1-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Tags: 3.3.6-jessie, 3.3-jessie, 3.3.6, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
-Directory: 3.6/onbuild
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.3/jessie
 
-Tags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.3.6-slim, 3.3-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.3/jessie/slim
+
+Tags: 3.3.6-onbuild, 3.3-onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.3/jessie/onbuild
+
+Tags: 3.3.6-wheezy, 3.3-wheezy
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+Directory: 3.3/wheezy
+
+Tags: 3.3.6-alpine3.4, 3.3-alpine3.4, 3.3.6-alpine, 3.3-alpine
+Architectures: amd64
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 3.3/alpine3.4
+
+Tags: 2.7.13-stretch, 2.7-stretch, 2-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c9954b06c8b178d7888bc1626bed5a14e43a9203
+Directory: 2.7/stretch
+
+Tags: 2.7.13-jessie, 2.7-jessie, 2-jessie, 2.7.13, 2.7, 2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 2.7/jessie
+
+Tags: 2.7.13-slim, 2.7-slim, 2-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 2.7/jessie/slim
+
+Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 2.7/jessie/onbuild
+
+Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+Directory: 2.7/wheezy
+
+Tags: 2.7.13-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
+Architectures: amd64
+GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+Directory: 2.7/alpine3.6
+
+Tags: 2.7.13-alpine3.4, 2.7-alpine3.4, 2-alpine3.4, 2.7.13-alpine, 2.7-alpine, 2-alpine
+Architectures: amd64
+GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+Directory: 2.7/alpine3.4
+
+Tags: 2.7.13-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
 GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
-Directory: 3.6/windows/windowsservercore
-Constraints: windowsservercore
-
-Tags: 3.6.2rc2, 3.6-rc, rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
-Directory: 3.6-rc
-
-Tags: 3.6.2rc2-slim, 3.6-rc-slim, rc-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
-Directory: 3.6-rc/slim
-
-Tags: 3.6.2rc2-alpine, 3.6-rc-alpine, rc-alpine
-Architectures: amd64
-GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
-Directory: 3.6-rc/alpine
-
-Tags: 3.6.2rc2-alpine3.6, 3.6-rc-alpine3.6, rc-alpine3.6
-Architectures: amd64
-GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
-Directory: 3.6-rc/alpine3.6
-
-Tags: 3.6.2rc2-onbuild, 3.6-rc-onbuild, rc-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d283d3dccd196f758466f29a715e6ab9b533a7
-Directory: 3.6-rc/onbuild
-
-Tags: 3.6.2rc2-windowsservercore, 3.6-rc-windowsservercore, rc-windowsservercore
-Architectures: windows-amd64
-GitCommit: 6db347bbd39cb34aa762bfb5807ed327e8d8b72c
-Directory: 3.6-rc/windows/windowsservercore
+Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -4,11 +4,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.4.1, 3.4, 3, latest
-GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
+Tags: 3.4.2, 3.4, 3, latest
+GitCommit: ef5e3f30a26cb30d91d940019c0e8719e3007eb3
 Directory: 3.4
 
-Tags: 3.4.1-passenger, 3.4-passenger, 3-passenger, passenger
+Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
 GitCommit: 75ead634c9033abef6490ac6d167b597d9e109ea
 Directory: 3.4/passenger
 

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.57.1, 0.57, 0, latest
-GitCommit: f8d2093db4e9863124a58a0eff04d90e7b537455
+Tags: 0.57.2, 0.57, 0, latest
+GitCommit: d2f032a8ba69919e6d0ccf66c6190383a31fa307

--- a/library/ruby
+++ b/library/ruby
@@ -6,17 +6,17 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.2.7, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
+GitCommit: b1a072ca6473efdb849f38eebe206f73c6f8578f
 Directory: 2.2
 
 Tags: 2.2.7-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
+GitCommit: b1a072ca6473efdb849f38eebe206f73c6f8578f
 Directory: 2.2/slim
 
 Tags: 2.2.7-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
+GitCommit: b1a072ca6473efdb849f38eebe206f73c6f8578f
 Directory: 2.2/alpine
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -26,17 +26,17 @@ Directory: 2.2/onbuild
 
 Tags: 2.3.4, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
+GitCommit: c46f549b57d34a16d0cbbead68eae188815b30a5
 Directory: 2.3
 
 Tags: 2.3.4-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
+GitCommit: c46f549b57d34a16d0cbbead68eae188815b30a5
 Directory: 2.3/slim
 
 Tags: 2.3.4-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
+GitCommit: c46f549b57d34a16d0cbbead68eae188815b30a5
 Directory: 2.3/alpine
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -46,17 +46,17 @@ Directory: 2.3/onbuild
 
 Tags: 2.4.1, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
+GitCommit: 8954b9635b143504e2fa21459cc8ce809d388242
 Directory: 2.4
 
 Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
+GitCommit: 8954b9635b143504e2fa21459cc8ce809d388242
 Directory: 2.4/slim
 
 Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
+GitCommit: 8954b9635b143504e2fa21459cc8ce809d388242
 Directory: 2.4/alpine
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild


### PR DESCRIPTION
- `ghost`: 0.11.11
- `golang`: minor comment change
- `memcached`: Alpine 3.6, Debian Stretch (docker-library/memcached#24), run tests during build, apply Alpine patch for segfault (docker-library/memcached#22)
- `mysql`: 8.0.2, 5.7.19, 5.6.37, 5.5.57
- `python`: add explicit `jessie` and `alpine3.4` aliases (docker-library/python#215), add `stretch` variant (docker-library/python#208)
- `redmine`: 3.4.2
- `rocket.chat`: 0.57.2
- `ruby`: bundler 1.15.2