### PR TITLE
[nats] Release v1.0.2

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,16 +2,16 @@ Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
              Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
              Waldemar Salinas <wally@apcera.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 90d28dc0964ba4f4b811cf21d593496939bf7990
+GitCommit: 4a2e6f17092b5b8481637c1881f781ae25374309
 
-Tags: 1.0.0, latest
+Tags: 1.0.2, latest
 
-Tags: 1.0.0-nanoserver, nanoserver
+Tags: 1.0.2-nanoserver, nanoserver
 Architectures: windows-amd64
 Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.0.0-windowsservercore, windowsservercore
+Tags: 1.0.2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
The Windows Docker Images were not working. This release fixes this.

Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v1.0.2)