### PR TITLE
Update Clear Linux Project.

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@deb1015d3d37aaeeb986297e1e65ddc4fff02a16
-base: git://github.com/clearlinux/docker-brew-clearlinux@deb1015d3d37aaeeb986297e1e65ddc4fff02a16
+latest: git://github.com/clearlinux/docker-brew-clearlinux@2493e930a906dc8ed618d3710dfaa194db4ebebe
+base: git://github.com/clearlinux/docker-brew-clearlinux@2493e930a906dc8ed618d3710dfaa194db4ebebe


### PR DESCRIPTION
Update Clear Linux base+latest images to release 16520.

I am a member of the Clear Linux Project team and am updating the images on behalf of the maintainer (@bryteise).