### PR TITLE
Update registry version for latest release

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -4,8 +4,10 @@
 # maintainer: Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 # maintainer: Derek McGowan <dmcg@drizz.net> (@dmcgowan)
 
-2: git://github.com/docker/distribution-library-image@576b139d6eac5b35c9b3e9fe6c2e5132b0c7e03b
-2.6: git://github.com/docker/distribution-library-image@576b139d6eac5b35c9b3e9fe6c2e5132b0c7e03b
-2.6.1: git://github.com/docker/distribution-library-image@576b139d6eac5b35c9b3e9fe6c2e5132b0c7e03b
-latest: git://github.com/docker/distribution-library-image@576b139d6eac5b35c9b3e9fe6c2e5132b0c7e03b
+2: git://github.com/docker/distribution-library-image@bc5d4f15a7e8d12ed6e5174ac4edab4b6032d09f
+2.6: git://github.com/docker/distribution-library-image@bc5d4f15a7e8d12ed6e5174ac4edab4b6032d09f
+2.6.2: git://github.com/docker/distribution-library-image@bc5d4f15a7e8d12ed6e5174ac4edab4b6032d09f
+2.5: git://github.com/docker/distribution-library-image@a878b04f22c48dd2fd49581bc74363ab8213b15b
+2.5.2: git://github.com/docker/distribution-library-image@a878b04f22c48dd2fd49581bc74363ab8213b15b
+latest: git://github.com/docker/distribution-library-image@bc5d4f15a7e8d12ed6e5174ac4edab4b6032d09f
 


### PR DESCRIPTION
Add 2.6.2 and 2.5.2 releases for CVE-2017-11468
