### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.5.0, 5.5, 5, latest
-GitCommit: 4da4e5e485e78c150b018364585d07434b704d95
+Tags: 5.5.1, 5.5, 5, latest
+GitCommit: 4369e593bab8b19ea5dc06d70cc2039c3460af46
 Directory: 5
 
-Tags: 5.5.0-alpine, 5.5-alpine, 5-alpine, alpine
-GitCommit: 4da4e5e485e78c150b018364585d07434b704d95
+Tags: 5.5.1-alpine, 5.5-alpine, 5-alpine, alpine
+GitCommit: 4369e593bab8b19ea5dc06d70cc2039c3460af46
 Directory: 5/alpine
 
-Tags: 2.4.5, 2.4, 2
-GitCommit: 56476e6c40c7ad5715e3c1f696548bac27dae086
+Tags: 2.4.6, 2.4, 2
+GitCommit: 8e87587ac5d6b44a8382a229162c88e65618c30a
 Directory: 2.4
 
-Tags: 2.4.5-alpine, 2.4-alpine, 2-alpine
-GitCommit: 56476e6c40c7ad5715e3c1f696548bac27dae086
+Tags: 2.4.6-alpine, 2.4-alpine, 2-alpine
+GitCommit: 8e87587ac5d6b44a8382a229162c88e65618c30a
 Directory: 2.4/alpine

--- a/library/golang
+++ b/library/golang
@@ -5,25 +5,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9beta2-stretch, 1.9-rc-stretch, 1.9-stretch, rc-stretch, 1.9beta2, 1.9-rc, 1.9, rc
+Tags: 1.9rc1-stretch, 1.9-rc-stretch, 1.9-stretch, rc-stretch, 1.9rc1, 1.9-rc, 1.9, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+GitCommit: 347de3fe79db411821e841f782c156f6fe1d9704
 Directory: 1.9-rc/stretch
 
-Tags: 1.9beta2-alpine3.6, 1.9-rc-alpine3.6, 1.9-alpine3.6, rc-alpine3.6, 1.9beta2-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
+Tags: 1.9rc1-alpine3.6, 1.9-rc-alpine3.6, 1.9-alpine3.6, rc-alpine3.6, 1.9rc1-alpine, 1.9-rc-alpine, 1.9-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 2a15dfff04accfd31c2a45b3bb7423aa86aa2d60
+GitCommit: 347de3fe79db411821e841f782c156f6fe1d9704
 Directory: 1.9-rc/alpine3.6
 
-Tags: 1.9beta2-windowsservercore, 1.9-rc-windowsservercore, 1.9-windowsservercore, rc-windowsservercore
+Tags: 1.9rc1-windowsservercore, 1.9-rc-windowsservercore, 1.9-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
+GitCommit: 347de3fe79db411821e841f782c156f6fe1d9704
 Directory: 1.9-rc/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.9beta2-nanoserver, 1.9-rc-nanoserver, 1.9-nanoserver, rc-nanoserver
+Tags: 1.9rc1-nanoserver, 1.9-rc-nanoserver, 1.9-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: cc59d934fca2e3a7dd8ebcd0eee82f34589f3bd3
+GitCommit: 347de3fe79db411821e841f782c156f6fe1d9704
 Directory: 1.9-rc/windows/nanoserver
 Constraints: nanoserver
 

--- a/library/httpd
+++ b/library/httpd
@@ -19,7 +19,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 109e6332af1ac4176aefd7aad1c28e42f9e10644
 Directory: 2.4
 
-Tags: 2.4.25-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.27-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: a1e7d8139ce7d7fcb3c439f96021eeca015a6c8d
+GitCommit: b86f02f7ac6f27a0915cbf17a35d978532eb839f
 Directory: 2.4/alpine

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.5.0, 5.5, 5, latest
-GitCommit: 4f425e9008de3d0375d1749d390029808aed8d96
+Tags: 5.5.1, 5.5, 5, latest
+GitCommit: 479d904c1a1043e179d157259fba96a9ca2e204f
 Directory: 5
 
-Tags: 5.5.0-alpine, 5.5-alpine, 5-alpine, alpine
-GitCommit: a418c50f6258665e72ef5f6275a69685a01107ef
+Tags: 5.5.1-alpine, 5.5-alpine, 5-alpine, alpine
+GitCommit: 479d904c1a1043e179d157259fba96a9ca2e204f
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/openjdk
+++ b/library/openjdk
@@ -98,12 +98,12 @@ Directory: 8-jre/alpine
 
 Tags: 9-b179-jdk, 9-b179, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e73f9d4dfc2eac73d068dcd12690c1c0b09ba769
+GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
 Directory: 9-jdk
 
 Tags: 9-b179-jdk-slim, 9-b179-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e73f9d4dfc2eac73d068dcd12690c1c0b09ba769
+GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
 Directory: 9-jdk/slim
 
 Tags: 9-b154-jdk-windowsservercore, 9-b154-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
@@ -120,10 +120,10 @@ Constraints: nanoserver
 
 Tags: 9-b179-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e73f9d4dfc2eac73d068dcd12690c1c0b09ba769
+GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
 Directory: 9-jre
 
 Tags: 9-b179-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e73f9d4dfc2eac73d068dcd12690c1c0b09ba769
+GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
 Directory: 9-jre/slim


### PR DESCRIPTION
- `elasticsearch`: 2.4.6, 5.5.1
- `golang`: 1.9rc1
- `httpd`: 2.4.27 (alpine; docker-library/httpd#68)
- `logstash`: 5.5.1
- `openjdk`: debian `9~b179-2`