### PR TITLE
sync up latest changes (20.0:alpine and rebar3.4.2)

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,22 +1,22 @@
-# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/7b0e42e619b46d87fe6c41a018dcb7e065e6b0ed/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/a4fdf1d5de39a423d3c56b8a4f8084adcfde0f0c/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
 Tags: 20.0.1, 20.0, 20, latest
-GitCommit: 25224b9f7b11af9db404c97433483619fdfed02b
+GitCommit: 7671f941c1525c689d53595b1aac66772dc7fabf
 Directory: 20
 
 Tags: 20.0.1-slim, 20.0-slim, 20-slim, slim
-GitCommit: 25224b9f7b11af9db404c97433483619fdfed02b
+GitCommit: 7671f941c1525c689d53595b1aac66772dc7fabf
 Directory: 20/slim
 
 Tags: 20.0.1-alpine, 20.0-alpine, 20-alpine, alpine
-GitCommit: 25224b9f7b11af9db404c97433483619fdfed02b
+GitCommit: 24ac339c0857ba7ba1bb98aad9f7898b2f65360c
 Directory: 20/alpine
 
 Tags: 19.3.6.1, 19.3.6, 19.3, 19
-GitCommit: fd534c28f30861d8536fb0f7452051a17f452243
+GitCommit: a9e5cdee4909cb1c9c2ea70595f5d32a46da885f
 Directory: 19
 
 Tags: 19.3.6.1-slim, 19.3.6-slim, 19.3-slim, 19-slim
@@ -24,7 +24,7 @@ GitCommit: fd534c28f30861d8536fb0f7452051a17f452243
 Directory: 19/slim
 
 Tags: 18.3.4.5, 18.3.4, 18.3, 18
-GitCommit: 1b03fdd83ec769e7962ec0dce01e25613a46dacf
+GitCommit: a9e5cdee4909cb1c9c2ea70595f5d32a46da885f
 Directory: 18
 
 Tags: 18.3.4.5-slim, 18.3.4-slim, 18.3-slim, 18-slim


### PR DESCRIPTION
1. current design of a minimal erlang alpine image (at <20MB) by `OTP_SMALL_BUILD=true`
   is proven not very useful, dropped that to build a full featured erlang,
   image size increased to ~65MB, is still acceptable.
2. @getong updated rebar3 to latest version in c0b/docker-erlang-otp#60
   this applies to 20 19 18;