### PR TITLE
Node: Add stretch and ppc64le

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,85 +1,125 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/2b30b83512fdb275531d3ff5f340531600a970ae/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/bc4e7eecfe9516e7fd42b8d951e30855ee614eff/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 8.2.1, 8.2, 8, latest
-GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 8.2
 
 Tags: 8.2.1-alpine, 8.2-alpine, 8-alpine, alpine
+Architectures: amd64
 GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
 Directory: 8.2/alpine
 
 Tags: 8.2.1-onbuild, 8.2-onbuild, 8-onbuild, onbuild
+Architectures: amd64, ppc64le
 GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
 Directory: 8.2/onbuild
 
 Tags: 8.2.1-slim, 8.2-slim, 8-slim, slim
-GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 8.2/slim
 
+Tags: 8.2.1-stretch, 8.2-stretch, 8-stretch, stretch
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
+Directory: 8.2/stretch
+
 Tags: 8.2.1-wheezy, 8.2-wheezy, 8-wheezy, wheezy
-GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
+Architectures: amd64
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 8.2/wheezy
 
 Tags: 7.10.1, 7.10, 7
-GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 7.10
 
 Tags: 7.10.1-alpine, 7.10-alpine, 7-alpine
+Architectures: amd64
 GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
 Directory: 7.10/alpine
 
 Tags: 7.10.1-onbuild, 7.10-onbuild, 7-onbuild
+Architectures: amd64, ppc64le
 GitCommit: 0fcdf0b2660e73ab1054f932f4beac5b3946fb21
 Directory: 7.10/onbuild
 
 Tags: 7.10.1-slim, 7.10-slim, 7-slim
-GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 7.10/slim
 
+Tags: 7.10.1-stretch, 7.10-stretch, 7-stretch
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
+Directory: 7.10/stretch
+
 Tags: 7.10.1-wheezy, 7.10-wheezy, 7-wheezy
-GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
+Architectures: amd64
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 7.10/wheezy
 
 Tags: 6.11.1, 6.11, 6, boron
-GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 6.11
 
 Tags: 6.11.1-alpine, 6.11-alpine, 6-alpine, boron-alpine
+Architectures: amd64
 GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/alpine
 
 Tags: 6.11.1-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
+Architectures: amd64, ppc64le
 GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
 Directory: 6.11/onbuild
 
 Tags: 6.11.1-slim, 6.11-slim, 6-slim, boron-slim
-GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 6.11/slim
 
+Tags: 6.11.1-stretch, 6.11-stretch, 6-stretch, boron-stretch
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
+Directory: 6.11/stretch
+
 Tags: 6.11.1-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
-GitCommit: bb200caf20280e436dedc56a5f194fd21e684758
+Architectures: amd64
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 6.11/wheezy
 
 Tags: 4.8.4, 4.8, 4, argon
-GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 4.8
 
 Tags: 4.8.4-alpine, 4.8-alpine, 4-alpine, argon-alpine
+Architectures: amd64
 GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/alpine
 
 Tags: 4.8.4-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+Architectures: amd64, ppc64le
 GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
 Directory: 4.8/onbuild
 
 Tags: 4.8.4-slim, 4.8-slim, 4-slim, argon-slim
-GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 4.8/slim
 
+Tags: 4.8.4-stretch, 4.8-stretch, 4-stretch, argon-stretch
+Architectures: amd64, ppc64le
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
+Directory: 4.8/stretch
+
 Tags: 4.8.4-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
+Architectures: amd64
+GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
See:
- https://github.com/nodejs/docker-node/pull/452
- https://github.com/nodejs/docker-node/pull/472
- https://github.com/nodejs/docker-node/pull/465

This adds ppc64le builds and a stretch variant.

This should work, but I'm not sure. Please tell me if we need to change anything 🙂

/cc @nodejs/docker @yhwang