### PR TITLE
Bump Traefik to v1.3.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,10 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.3, 1.3.3, v1.3, 1.3, raclette, latest
-GitCommit: 127ae9f3c881ce53f73f0fa0cd52fe947b77ef6b
+Tags: v1.3.4, 1.3.4, v1.3, 1.3, raclette, latest
+GitCommit: 33eb11c2139a48ac3725d39251b7d0f5610eaf36
 
-Tags: v1.3.3-alpine, 1.3.3-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 127ae9f3c881ce53f73f0fa0cd52fe947b77ef6b
+Tags: v1.3.4-alpine, 1.3.4-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 33eb11c2139a48ac3725d39251b7d0f5610eaf36
 Directory: alpine
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.3.4.

/cc @vdemeester @emilevauge
Cheers
