### PR TITLE
Perl: add 5.26, and update 5.22 and 5.24 point releases

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -11,7 +11,7 @@ Directory: 5.026.000-64bit,threaded
 Tags: 5.24, 5.24.2
 Directory: 5.024.002-64bit
 
-Tags: 5-threaded, 5.24-threaded, 5.24.2-threaded
+Tags: 5.24-threaded, 5.24.2-threaded
 Directory: 5.024.002-64bit,threaded
 
 Tags: 5.22, 5.22.4

--- a/library/perl
+++ b/library/perl
@@ -1,20 +1,22 @@
-# this file is generated via https://github.com/docker-library/python/blob/c5b36c38823ca6a1301ad39cbf3ece75d77c5600/generate-stackbrew-library.sh
-
-Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini)
+Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
+             Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
+GitCommit: 904ec9505b3d6b71e559d7e1c1d9629a15e3f2ef
 
-Tags: latest, 5, 5.24, 5.24.1
-GitCommit: 8b57a74dbc745fb2723bc60ba98768846dae37f6
-Directory: 5.024.001-64bit
+Tags: latest, 5, 5.26, 5.26.0
+Directory: 5.026.000-64bit
 
-Tags: threaded, 5-threaded, 5.24-threaded, 5.24.1-threaded
-GitCommit: 8b57a74dbc745fb2723bc60ba98768846dae37f6
-Directory: 5.024.001-64bit,threaded
+Tags: threaded, 5-threaded, 5.26-threaded, 5.26.0-threaded
+Directory: 5.026.000-64bit,threaded
 
-Tags: 5.22, 5.22.3
-GitCommit: 8b57a74dbc745fb2723bc60ba98768846dae37f6
-Directory: 5.022.003-64bit
+Tags: 5.24, 5.24.2
+Directory: 5.024.002-64bit
 
-Tags: 5.22-threaded, 5.22.3-threaded
-GitCommit: 8b57a74dbc745fb2723bc60ba98768846dae37f6
-Directory: 5.022.003-64bit,threaded
+Tags: threaded, 5-threaded, 5.24-threaded, 5.24.2-threaded
+Directory: 5.024.002-64bit,threaded
+
+Tags: 5.22, 5.22.4
+Directory: 5.022.004-64bit
+
+Tags: 5.22-threaded, 5.22.4-threaded
+Directory: 5.022.004-64bit,threaded

--- a/library/perl
+++ b/library/perl
@@ -1,5 +1,4 @@
-Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
-             Zak B. Elep <zakame@cpan.org> (@zakame)
+Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini), Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
 GitCommit: 904ec9505b3d6b71e559d7e1c1d9629a15e3f2ef
 
@@ -12,7 +11,7 @@ Directory: 5.026.000-64bit,threaded
 Tags: 5.24, 5.24.2
 Directory: 5.024.002-64bit
 
-Tags: threaded, 5-threaded, 5.24-threaded, 5.24.2-threaded
+Tags: 5-threaded, 5.24-threaded, 5.24.2-threaded
 Directory: 5.024.002-64bit,threaded
 
 Tags: 5.22, 5.22.4


### PR DESCRIPTION
Perl: add 5.26, and update 5.22 and 5.24 point releases

Add the new version of Perl 5 to the official images, as well as update
point releases for the last 2 versions.

cc @PeterMartini