### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.0, 10.3
-GitCommit: f76084f0f9dc13f29cce48c727440eb79b4e92fa
+GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.3
 
 Tags: 10.2.7, 10.2, 10, latest
-GitCommit: bcf4518ad93834454bcca8029444231bc044afa3
+GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.2
 
 Tags: 10.1.25, 10.1
-GitCommit: 477dd79ffb3a2ee2c5ca04fa23d207506a8a407f
+GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.1
 
 Tags: 10.0.31, 10.0
-GitCommit: fc9e999ca57555c0669cfc67906f0c705bda7e41
+GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.0
 
 Tags: 5.5.57, 5.5, 5
-GitCommit: 8cd4a85d5bf356ce647031553d834d4b60599438
+GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -17,16 +17,16 @@ GitCommit: 40d62a73bbd4e20d90ec859a8af483f70b1e5fd4
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.15, 3.2
+Tags: 3.2.16, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: d1c2ba0001233372a1ab8515ee5e1e968e0d64f9
+GitCommit: 61aabfb537a1fbcae44f02ab515df54395b68400
 Directory: 3.2
 
-Tags: 3.2.15-windowsservercore, 3.2-windowsservercore
+Tags: 3.2.16-windowsservercore, 3.2-windowsservercore
 Architectures: windows-amd64
-GitCommit: d1c2ba0001233372a1ab8515ee5e1e968e0d64f9
+GitCommit: 61aabfb537a1fbcae44f02ab515df54395b68400
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.18, 5.7, 5, latest
-GitCommit: e7c1c5c025d785a17d3e43c4f4e15b5407bd611d
+GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
 Directory: 5.7
 
 Tags: 5.6.36, 5.6
-GitCommit: edbc1e6dac94220100d38564a184c1261f37f56f
+GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
 Directory: 5.6
 
 Tags: 5.5.55, 5.5
-GitCommit: 285e82cc91a13587626c7f75bc56893a38c86b7a
+GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
 Directory: 5.5

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.18, 5.7, 5, latest
-GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
+GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
 Directory: 5.7
 
 Tags: 5.6.36, 5.6
-GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
+GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
 Directory: 5.6
 
 Tags: 5.5.55, 5.5
-GitCommit: 6c952606d78b4b0e1041ad91514aa0464ef2b608
+GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
 Directory: 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10-beta2, 10
 Architectures: amd64, i386, ppc64le
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 10
 
 Tags: 10-beta2-alpine, 10-alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 10/alpine
 
 Tags: 9.6.3, 9.6, 9, latest
 Architectures: amd64, i386, ppc64le
-GitCommit: 972294a377463156c8d61297320c872fc7d370a9
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.6
 
 Tags: 9.6.3-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.6/alpine
 
 Tags: 9.5.7, 9.5
 Architectures: amd64, i386, ppc64le
-GitCommit: 972294a377463156c8d61297320c872fc7d370a9
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.5
 
 Tags: 9.5.7-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.5/alpine
 
 Tags: 9.4.12, 9.4
 Architectures: amd64, i386, ppc64le
-GitCommit: 972294a377463156c8d61297320c872fc7d370a9
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.4
 
 Tags: 9.4.12-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.4/alpine
 
 Tags: 9.3.17, 9.3
 Architectures: amd64, i386, ppc64le
-GitCommit: 972294a377463156c8d61297320c872fc7d370a9
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.3
 
 Tags: 9.3.17-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.3/alpine
 
 Tags: 9.2.21, 9.2
 Architectures: amd64, i386, ppc64le
-GitCommit: 972294a377463156c8d61297320c872fc7d370a9
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.2
 
 Tags: 9.2.21-alpine, 9.2-alpine
 Architectures: amd64
-GitCommit: f3146f857b42bd4c4cb2be6134149fddee546584
+GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
 Directory: 9.2/alpine

--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 3.2.9, 3.2, 3
+Tags: 3.2.10, 3.2, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
+GitCommit: ebde981d2737c5a618481f766d253afff13aeb9f
 Directory: 3.2
 
-Tags: 3.2.9-32bit, 3.2-32bit, 3-32bit
+Tags: 3.2.10-32bit, 3.2-32bit, 3-32bit
 Architectures: amd64
-GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
+GitCommit: ebde981d2737c5a618481f766d253afff13aeb9f
 Directory: 3.2/32bit
 
-Tags: 3.2.9-alpine, 3.2-alpine, 3-alpine
+Tags: 3.2.10-alpine, 3.2-alpine, 3-alpine
 Architectures: amd64
-GitCommit: f131897d1f6305b8f6ebae695344f19c523e2c65
+GitCommit: ebde981d2737c5a618481f766d253afff13aeb9f
 Directory: 3.2/alpine
 
 Tags: 4.0.1, 4.0, 4, latest

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,70 +6,70 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: 0e18eab4234afbff617aee84e7156ac1b4fd67d5
 Directory: 6/jre7
 
 Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: 0e18eab4234afbff617aee84e7156ac1b4fd67d5
 Directory: 6/jre8
 
 Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 7/jre7
 
 Tags: 7.0.79-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.79-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 7/jre7-alpine
 
 Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 7/jre8
 
 Tags: 7.0.79-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: 6541873f38f72fdd2b4aab6afcf692f4a513b05d
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 7/jre8-alpine
 
 Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.0/jre7
 
 Tags: 8.0.45-jre7-alpine, 8.0-jre7-alpine, 8.0.45-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.45-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.0/jre8
 
 Tags: 8.0.45-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: 85d2a6e22292644d22d4dda933c56c7821e61b7c
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
+Tags: 8.5.19-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.19, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.5/jre8
 
-Tags: 8.5.16-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.16-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.19-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.19-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: ae0ff8626dbb002258c3fabdcba1682fa12d6f99
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
+Tags: 9.0.0.M25-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M25, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e45349ec3432c75ca5b7e2ef4cae95276c7dccc7
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M22-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M22-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.0.M25-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M25-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: a7f6cf3172b5875be5108bfbbea87ecb94bc4626
+GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.8.0-apache, 4.8-apache, 4-apache, apache, 4.8.0, 4.8, 4, latest, 4.8.0-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.0-php5.6, 4.8-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php5.6/apache
 
 Tags: 4.8.0-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.0-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php5.6/fpm
 
 Tags: 4.8.0-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.0-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
@@ -21,12 +21,12 @@ Directory: php5.6/fpm-alpine
 
 Tags: 4.8.0-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.0-php7.0, 4.8-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php7.0/apache
 
 Tags: 4.8.0-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php7.0/fpm
 
 Tags: 4.8.0-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
@@ -36,12 +36,12 @@ Directory: php7.0/fpm-alpine
 
 Tags: 4.8.0-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.0-php7.1, 4.8-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php7.1/apache
 
 Tags: 4.8.0-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
 Directory: php7.1/fpm
 
 Tags: 4.8.0-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine


### PR DESCRIPTION
- `mariadb`: docker-library/mariadb#115, docker-library/mariadb#117, docker-library/mariadb#118
- `mongo`: 3.2.16
- `percona`: docker-library/percona#46
- `postgres`: better shebang (docker-library/postgres#318)
- `redis`: 3.2.10
- `tomcat`: 9.0.0.M25, 8.5.19, fix dotted env (docker-library/tomcat#78)
- `wordpress`: use `libpng-dev` (docker-library/wordpress#227)
---
- `percona`: 5.7.18-16-1.jessie (docker-library/percona#47)