### PR TITLE
Support for new Ghost version 1.0

### DIFF
--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -22,7 +22,7 @@ _request() {
 	docker run --rm --link "$cid":ghost "$clientImage" \
 		curl -fs -X"$method" "$@" "http://ghost:2368/$url"
 }
-
+sleep 60
 # Make sure that Ghost is listening and ready
 . "$dir/../../retry.sh" '-t' '30' '_request GET / --output /dev/null'
 

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -27,10 +27,9 @@ _request() {
 . "$dir/../../retry.sh" '_request GET / --output /dev/null'
 
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
-if [[ $serverImage == ghost:1* ]]
-then
-	_request GET '/ghost/api/v0.1/authentication/setup/' | grep -q 'status":false'
-else
-	_request GET '/ghost/#/' -I | grep -q '^Location: .*setup'
-fi
+ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
+case "$ghostVersion" in
+	0.*) _request GET '/ghost/' -I | grep -q '^Location: .*setup' ;;
+	*)   _request GET '/ghost/api/v0.1/authentication/setup/' | grep -q 'status":false' ;;
+esac
 

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -24,7 +24,7 @@ _request() {
 }
 
 # Make sure that Ghost is listening and ready
-. "$dir/../../retry.sh" '_request GET / --output /dev/null'
+. "$dir/../../retry.sh -t 30 " '_request GET / --output /dev/null'
 
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 _request GET '/ghost/' -I | grep -q '^Location: .*setup'

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -24,7 +24,7 @@ _request() {
 }
 
 # Make sure that Ghost is listening and ready
-. "$dir/../../retry.sh -t 30 " '_request GET / --output /dev/null'
+. "$dir/../../retry.sh" '-t' '30' '_request GET / --output /dev/null'
 
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 _request GET '/ghost/' -I | grep -q '^Location: .*setup'


### PR DESCRIPTION
In the new 1.0 release of Ghost, the setup process is not initiated through a http redirect but via javascript.

So the previous test checking that `/ghost/` would send a redirect to `setup` fails.

The js version now checks an API, `/ghost/api/v0.1/authentication/setup/`
If setup hasn't occured yet, this API returns `{"setup":[{"status":false}]}`
Otherwise it returns `{"setup":[{"status":true}]}`

This PR updates the test done to check if image is unconfigured for ghost images `ghost:1*` (version 1)

It fixes the failed test in PR https://github.com/docker-library/ghost/pull/67 