### PR TITLE
Bump Traefik to v1.3.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,10 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.4, 1.3.4, v1.3, 1.3, raclette, latest
-GitCommit: 33eb11c2139a48ac3725d39251b7d0f5610eaf36
+Tags: v1.3.5, 1.3.5, v1.3, 1.3, raclette, latest
+GitCommit: 03da849385c1b10d2f9d8ca6b0de36626212f01d
 
-Tags: v1.3.4-alpine, 1.3.4-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 33eb11c2139a48ac3725d39251b7d0f5610eaf36
+Tags: v1.3.5-alpine, 1.3.5-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 03da849385c1b10d2f9d8ca6b0de36626212f01d
 Directory: alpine
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.3.5.

/cc @vdemeester @emilevauge

Cheers
