### PR TITLE
Update images, docker, ghost, percona, and redmine

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.07.0-ce-rc1, 17.07.0-ce, 17.07.0, 17.07-rc, rc, test
 Architectures: amd64
-GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
+GitCommit: 2288558e94f6b04f70c7db47766d37a09a1c8edb
 Directory: 17.07-rc
 
 Tags: 17.07.0-ce-rc1-dind, 17.07.0-ce-dind, 17.07.0-dind, 17.07-rc-dind, rc-dind, test-dind

--- a/library/ghost
+++ b/library/ghost
@@ -1,13 +1,21 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/ee2ce866bd53499316d32bd915eca326af6707f2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/3b687c492eb509ee9a09a8259389b7b2f13c8e42/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 0.11.11, 0.11, 0, latest
-GitCommit: 08813e7fac6ef9b0c5ae43b7f290b2c144661cfe
+Tags: 1.0.2, 1.0, 1, latest
+GitCommit: d0377bfe900f422f3a1e54789f05f5bd05bb8763
+Directory: 1.0/debian
+
+Tags: 1.0.2-alpine, 1.0-alpine, 1-alpine, alpine
+GitCommit: 3b687c492eb509ee9a09a8259389b7b2f13c8e42
+Directory: 1.0/alpine
+
+Tags: 0.11.11, 0.11, 0
+GitCommit: b8f9e827062ba916dd1b0dcb21a2da536114f451
 Directory: 0.11/debian
 
-Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine, alpine
-GitCommit: 08813e7fac6ef9b0c5ae43b7f290b2c144661cfe
+Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine
+GitCommit: b8f9e827062ba916dd1b0dcb21a2da536114f451
 Directory: 0.11/alpine

--- a/library/percona
+++ b/library/percona
@@ -9,7 +9,7 @@ GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
 Directory: 5.7
 
 Tags: 5.6.36, 5.6
-GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
+GitCommit: bfff0f74903bf6db64b5d1ca85968e3546f039a5
 Directory: 5.6
 
 Tags: 5.5.55, 5.5

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: ef5e3f30a26cb30d91d940019c0e8719e3007eb3
 Directory: 3.4
 
 Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: eb2aeb05b38cb597c7c599e02dd434ef6b7ce7da
+GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
@@ -17,7 +17,7 @@ GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
-GitCommit: eb2aeb05b38cb597c7c599e02dd434ef6b7ce7da
+GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
@@ -25,7 +25,7 @@ GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
-GitCommit: eb2aeb05b38cb597c7c599e02dd434ef6b7ce7da
+GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
@@ -33,5 +33,5 @@ GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: eb2aeb05b38cb597c7c599e02dd434ef6b7ce7da
+GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.1/passenger


### PR DESCRIPTION
- `docker` https://github.com/docker-library/docker/commit/2288558e94f6b04f70c7db47766d37a09a1c8edb
- `ghost` 1.0 https://github.com/docker-library/ghost/pull/67 (also bump node 4 to node 6 for 0.11)
- `percona` 5.6.36-82.1-1.jessie bump
- `redmine` passenger 5.1.7