### PR TITLE
Upgrades elixir to 1.5.1

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -3,16 +3,16 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.5.0, 1.5, latest
-GitCommit: 44078809bd868e654d93766f8ac3c778f688a951
+Tags: 1.5.1, 1.5, latest
+GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
 Directory: 1.5
 
-Tags: 1.5.0-slim, 1.5-slim, slim
-GitCommit: a57ae22bc9505ccdc7662f2556143e1048361d47
+Tags: 1.5.1-slim, 1.5-slim, slim
+GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
 Directory: 1.5/slim
 
-Tags: 1.5.0-alpine, 1.5-alpine, alpine
-GitCommit: a57ae22bc9505ccdc7662f2556143e1048361d47
+Tags: 1.5.1-alpine, 1.5-alpine, alpine
+GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
 Directory: 1.5/alpine
 
 Tags: 1.4.5, 1.4


### PR DESCRIPTION
for c0b/docker-elixir#38 for https://github.com/elixir-lang/elixir/releases/tag/v1.5.1