### PR TITLE
Update docker, drupal, ghost, php, wordpress

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -19,17 +19,17 @@ Architectures: amd64
 GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
 Directory: 17.07-rc/git
 
-Tags: 17.06.1-ce-rc2, 17.06.1-ce, 17.06.1, 17.06-rc
+Tags: 17.06.1-ce-rc3, 17.06.1-ce, 17.06.1, 17.06-rc
 Architectures: amd64
-GitCommit: f3b3989b217c4ed2bf655f904eed0812b01c3326
+GitCommit: 36afb3740b9f5a4a9f21521cdb32e27001dfab53
 Directory: 17.06-rc
 
-Tags: 17.06.1-ce-rc2-dind, 17.06.1-ce-dind, 17.06.1-dind, 17.06-rc-dind
+Tags: 17.06.1-ce-rc3-dind, 17.06.1-ce-dind, 17.06.1-dind, 17.06-rc-dind
 Architectures: amd64
 GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
 Directory: 17.06-rc/dind
 
-Tags: 17.06.1-ce-rc2-git, 17.06.1-ce-git, 17.06.1-git, 17.06-rc-git
+Tags: 17.06.1-ce-rc3-git, 17.06.1-ce-git, 17.06.1-git, 17.06-rc-git
 Architectures: amd64
 GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
 Directory: 17.06-rc/git

--- a/library/drupal
+++ b/library/drupal
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.3.5-apache, 8.3-apache, 8-apache, apache, 8.3.5, 8.3, 8, latest
-GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
+Tags: 8.3.6-apache, 8.3-apache, 8-apache, apache, 8.3.6, 8.3, 8, latest
+GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
 Directory: 8.3/apache
 
-Tags: 8.3.5-fpm, 8.3-fpm, 8-fpm, fpm
-GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
+Tags: 8.3.6-fpm, 8.3-fpm, 8-fpm, fpm
+GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
 Directory: 8.3/fpm
 
-Tags: 8.3.5-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: 36a2abd3450115ce71641f44b5bbceed114fb836
+Tags: 8.3.6-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7

--- a/library/ghost
+++ b/library/ghost
@@ -1,15 +1,55 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/3b687c492eb509ee9a09a8259389b7b2f13c8e42/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.0.2, 1.0, 1, latest
-GitCommit: d0377bfe900f422f3a1e54789f05f5bd05bb8763
+Tags: 1.5.0, 1.5, 1, latest
+GitCommit: 4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab
+Directory: 1.5/debian
+
+Tags: 1.5.0-alpine, 1.5-alpine, 1-alpine, alpine
+GitCommit: 4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab
+Directory: 1.5/alpine
+
+Tags: 1.4.0, 1.4
+GitCommit: 15d038088197ab5daa697910a8816c70b34640f2
+Directory: 1.4/debian
+
+Tags: 1.4.0-alpine, 1.4-alpine
+GitCommit: 15d038088197ab5daa697910a8816c70b34640f2
+Directory: 1.4/alpine
+
+Tags: 1.3.0, 1.3
+GitCommit: 9aeff503853b72b3885268e46dc591ca1f3451eb
+Directory: 1.3/debian
+
+Tags: 1.3.0-alpine, 1.3-alpine
+GitCommit: 9aeff503853b72b3885268e46dc591ca1f3451eb
+Directory: 1.3/alpine
+
+Tags: 1.2.0, 1.2
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
+Directory: 1.2/debian
+
+Tags: 1.2.0-alpine, 1.2-alpine
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
+Directory: 1.2/alpine
+
+Tags: 1.1.0, 1.1
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
+Directory: 1.1/debian
+
+Tags: 1.1.0-alpine, 1.1-alpine
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
+Directory: 1.1/alpine
+
+Tags: 1.0.2, 1.0
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
 Directory: 1.0/debian
 
-Tags: 1.0.2-alpine, 1.0-alpine, 1-alpine, alpine
-GitCommit: 3b687c492eb509ee9a09a8259389b7b2f13c8e42
+Tags: 1.0.2-alpine, 1.0-alpine
+GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
 Directory: 1.0/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/php
+++ b/library/php
@@ -74,39 +74,39 @@ Architectures: amd64
 GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 7.1/zts/alpine
 
-Tags: 7.0.21-cli, 7.0-cli, 7.0.21, 7.0
+Tags: 7.0.22-cli, 7.0-cli, 7.0.22, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0
 
-Tags: 7.0.21-alpine, 7.0-alpine
+Tags: 7.0.22-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/alpine
 
-Tags: 7.0.21-apache, 7.0-apache
+Tags: 7.0.22-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/apache
 
-Tags: 7.0.21-fpm, 7.0-fpm
+Tags: 7.0.22-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/fpm
 
-Tags: 7.0.21-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.22-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.21-zts, 7.0-zts
+Tags: 7.0.22-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/zts
 
-Tags: 7.0.21-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.22-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.8.0-apache, 4.8-apache, 4-apache, apache, 4.8.0, 4.8, 4, latest, 4.8.0-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.0-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+Tags: 4.8.1-apache, 4.8-apache, 4-apache, apache, 4.8.1, 4.8, 4, latest, 4.8.1-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.1-php5.6, 4.8-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php5.6/apache
 
-Tags: 4.8.0-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.0-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.8.1-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.1-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php5.6/fpm
 
-Tags: 4.8.0-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.0-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.8.1-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.1-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php5.6/fpm-alpine
 
-Tags: 4.8.0-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.0-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+Tags: 4.8.1-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.1-php7.0, 4.8-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.0/apache
 
-Tags: 4.8.0-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.8.1-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.0/fpm
 
-Tags: 4.8.0-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.8.1-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.0/fpm-alpine
 
-Tags: 4.8.0-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.0-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+Tags: 4.8.1-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.1-php7.1, 4.8-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.1/apache
 
-Tags: 4.8.0-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.8.1-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 203a081f7c5122f539e8be6690dfce891c1ee2e6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.1/fpm
 
-Tags: 4.8.0-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.8.1-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 0a5405cca8daf0338cf32dc7be26f4df5405cfb6
+GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker` bump to `17.06.1-ce-rc3`
- `drupal` bump to `8.3.6`
- `ghost` add `1.1` through `1.5`
- `php` bump to `7.0.22`
- `wordpress` bump to `4.8.1`

Did not include `tomcat` changes since they were a downgrade.  Apparently tomcat `8.5.19` and `9.0.0.M25` had "a regression" and so the solution was to [remove them from mirrors](http://tomcat.10.x6.nabble.com/svn-commit-r20731-in-release-tomcat-tomcat-8-v8-5-19-tomcat-9-v9-0-0-M25-td5066057.html), but [`M26`](http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-9-0-0-M26-td5066066.html) and [`8.5.20`](http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-5-20-td5066073.html) are in release process.