### PR TITLE
update centos monthly images as of 20170801

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -5,11 +5,11 @@ Constraints: !aufs
 
 Tags: latest, centos7, 7
 GitFetch: refs/heads/CentOS-7
-GitCommit: e37f28d8f4a2a5970ee9dec81d49d483ac1e4ae8
+GitCommit: 3bcede00b70b87e870c48b449d89ac5ad96269d5
 
 Tags: centos6, 6
 GitFetch: refs/heads/CentOS-6
-GitCommit: 60bcbc5398e633a7982126fc1cc125b91a0f2113
+GitCommit: 4921b2bfbe7477feb2d6d35c8ce82c08153ab606
 
 Tags: centos7.3.1611, 7.3.1611
 GitFetch: refs/heads/CentOS-7.3.1611


### PR DESCRIPTION
Updated monthly image, does not include 7.4.1708 code yet. 