### PR TITLE
Update docker-library images

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,74 +4,74 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0beta1-cli, 7.2-rc-cli, rc-cli, 7.2.0beta1, 7.2-rc, rc
+Tags: 7.2.0beta2-cli, 7.2-rc-cli, rc-cli, 7.2.0beta2, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc
 
-Tags: 7.2.0beta1-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0beta2-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/alpine
 
-Tags: 7.2.0beta1-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0beta2-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/apache
 
-Tags: 7.2.0beta1-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0beta2-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/fpm
 
-Tags: 7.2.0beta1-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0beta2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/fpm/alpine
 
-Tags: 7.2.0beta1-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0beta2-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/zts
 
-Tags: 7.2.0beta1-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0beta2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: 518094b3d32ffd46676e8d6dfba13cd76f08a238
+GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
 Directory: 7.2-rc/zts/alpine
 
-Tags: 7.1.7-cli, 7.1-cli, 7-cli, cli, 7.1.7, 7.1, 7, latest
+Tags: 7.1.8-cli, 7.1-cli, 7-cli, cli, 7.1.8, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1
 
-Tags: 7.1.7-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.1.8-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/alpine
 
-Tags: 7.1.7-apache, 7.1-apache, 7-apache, apache
+Tags: 7.1.8-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/apache
 
-Tags: 7.1.7-fpm, 7.1-fpm, 7-fpm, fpm
+Tags: 7.1.8-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/fpm
 
-Tags: 7.1.7-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.1.8-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/fpm/alpine
 
-Tags: 7.1.7-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.8-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/zts
 
-Tags: 7.1.7-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.8-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.22-cli, 7.0-cli, 7.0.22, 7.0

--- a/library/ruby
+++ b/library/ruby
@@ -1,65 +1,65 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/48ad4b7d1c2d581ab2426b460e331a5ea023425a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/05a198ca89a5cb563a857d0d6f060abcbd6eb8e4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.2.7, 2.2
+Tags: 2.4.1-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.1, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff427d10f40d1e19d2581346610ef47a83c4b8dc
-Directory: 2.2
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.4/jessie
 
-Tags: 2.2.7-slim, 2.2-slim
+Tags: 2.4.1-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.1-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff427d10f40d1e19d2581346610ef47a83c4b8dc
-Directory: 2.2/slim
-
-Tags: 2.2.7-alpine, 2.2-alpine
-Architectures: amd64
-GitCommit: ff427d10f40d1e19d2581346610ef47a83c4b8dc
-Directory: 2.2/alpine
-
-Tags: 2.2.7-onbuild, 2.2-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
-Directory: 2.2/onbuild
-
-Tags: 2.3.4, 2.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 00ade5b52c4d0a3400cba91e3972cf950b6854f7
-Directory: 2.3
-
-Tags: 2.3.4-slim, 2.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 00ade5b52c4d0a3400cba91e3972cf950b6854f7
-Directory: 2.3/slim
-
-Tags: 2.3.4-alpine, 2.3-alpine
-Architectures: amd64
-GitCommit: 00ade5b52c4d0a3400cba91e3972cf950b6854f7
-Directory: 2.3/alpine
-
-Tags: 2.3.4-onbuild, 2.3-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
-Directory: 2.3/onbuild
-
-Tags: 2.4.1, 2.4, 2, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1824c6ec7555c92c61d335136da9a6fb6665de2a
-Directory: 2.4
-
-Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1824c6ec7555c92c61d335136da9a6fb6665de2a
-Directory: 2.4/slim
-
-Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
-Architectures: amd64
-GitCommit: 1824c6ec7555c92c61d335136da9a6fb6665de2a
-Directory: 2.4/alpine
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.4/jessie/slim
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
-Directory: 2.4/onbuild
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.4/jessie/onbuild
+
+Tags: 2.4.1-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
+Architectures: amd64
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.4/alpine3.4
+
+Tags: 2.3.4-jessie, 2.3-jessie, 2.3.4, 2.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.3/jessie
+
+Tags: 2.3.4-slim-jessie, 2.3-slim-jessie, 2.3.4-slim, 2.3-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.3/jessie/slim
+
+Tags: 2.3.4-onbuild, 2.3-onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.3/jessie/onbuild
+
+Tags: 2.3.4-alpine3.4, 2.3-alpine3.4, 2.3.4-alpine, 2.3-alpine
+Architectures: amd64
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.3/alpine3.4
+
+Tags: 2.2.7-jessie, 2.2-jessie, 2.2.7, 2.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.2/jessie
+
+Tags: 2.2.7-slim-jessie, 2.2-slim-jessie, 2.2.7-slim, 2.2-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.2/jessie/slim
+
+Tags: 2.2.7-onbuild, 2.2-onbuild
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.2/jessie/onbuild
+
+Tags: 2.2.7-alpine3.4, 2.2-alpine3.4, 2.2.7-alpine, 2.2-alpine
+Architectures: amd64
+GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+Directory: 2.2/alpine3.4

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,18 +1,8 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/8df795c4dc6619e97e5d4fd94731703e6a01355e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/0849543c8ed4ab5e1acc458e939f5753ea27eb9e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
-
-Tags: 6.0.53-jre7, 6.0-jre7, 6-jre7, 6.0.53, 6.0, 6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e18eab4234afbff617aee84e7156ac1b4fd67d5
-Directory: 6/jre7
-
-Tags: 6.0.53-jre8, 6.0-jre8, 6-jre8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e18eab4234afbff617aee84e7156ac1b4fd67d5
-Directory: 6/jre8
 
 Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -54,22 +44,22 @@ Architectures: amd64
 GitCommit: a227157792e94c669148c3c2a09072fb317070e0
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.19-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.19, 8.5, 8, latest
+Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: 59c92f282053ececa51e2afe06b6c979abae9922
 Directory: 8.5/jre8
 
-Tags: 8.5.19-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.19-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.16-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.16-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: be1d4e9c614f7021770e581d507845c93b6f77f9
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M25-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M25, 9.0.0, 9.0, 9
+Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: 85113c9c4b08f19200b286b858703410d1c7bb76
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M25-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M25-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.0.M22-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M22-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: 33b4b8602e4ead0ba2c3ea42a9946f87cacb1d99
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `php`: 7.1.8, 7.2.0beta2
- `ruby`: add explicit `jessie` and `alpine3.4` aliases (docker-library/ruby#142)
- `tomcat`: remove 6 (EOL; https://tomcat.apache.org/tomcat-60-eol.html); downgrade to 9.0.0.M22 and 8.5.16 (http://tomcat.10.x6.nabble.com/Default-servlet-regressions-td5065899.html)