### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,6 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
+Tags: 8.4.0-alpha1-apache, 8.4-rc-apache, rc-apache, 8.4.0-alpha1, 8.4-rc, rc
+GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Directory: 8.4-rc/apache
+
+Tags: 8.4.0-alpha1-fpm, 8.4-rc-fpm, rc-fpm
+GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Directory: 8.4-rc/fpm
+
+Tags: 8.4.0-alpha1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Directory: 8.4-rc/fpm-alpine
+
 Tags: 8.3.6-apache, 8.3-apache, 8-apache, apache, 8.3.6, 8.3, 8, latest
 GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
 Directory: 8.3/apache

--- a/library/ghost
+++ b/library/ghost
@@ -1,61 +1,21 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/fabb247507dc8b2d20c5795d688c4167b98caf4a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.5.0, 1.5, 1, latest
-GitCommit: 4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab
-Directory: 1.5/debian
+GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+Directory: 1/debian
 
 Tags: 1.5.0-alpine, 1.5-alpine, 1-alpine, alpine
-GitCommit: 4c1b126867a8c4c5ffa3aef8d4731d98e3d653ab
-Directory: 1.5/alpine
-
-Tags: 1.4.0, 1.4
-GitCommit: 15d038088197ab5daa697910a8816c70b34640f2
-Directory: 1.4/debian
-
-Tags: 1.4.0-alpine, 1.4-alpine
-GitCommit: 15d038088197ab5daa697910a8816c70b34640f2
-Directory: 1.4/alpine
-
-Tags: 1.3.0, 1.3
-GitCommit: 9aeff503853b72b3885268e46dc591ca1f3451eb
-Directory: 1.3/debian
-
-Tags: 1.3.0-alpine, 1.3-alpine
-GitCommit: 9aeff503853b72b3885268e46dc591ca1f3451eb
-Directory: 1.3/alpine
-
-Tags: 1.2.0, 1.2
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.2/debian
-
-Tags: 1.2.0-alpine, 1.2-alpine
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.2/alpine
-
-Tags: 1.1.0, 1.1
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.1/debian
-
-Tags: 1.1.0-alpine, 1.1-alpine
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.1/alpine
-
-Tags: 1.0.2, 1.0
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.0/debian
-
-Tags: 1.0.2-alpine, 1.0-alpine
-GitCommit: 34ab977f879ef312ae4dcd80af57ceaa52982eb9
-Directory: 1.0/alpine
+GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0
-GitCommit: b8f9e827062ba916dd1b0dcb21a2da536114f451
-Directory: 0.11/debian
+GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+Directory: 0/debian
 
 Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine
-GitCommit: b8f9e827062ba916dd1b0dcb21a2da536114f451
-Directory: 0.11/alpine
+GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+Directory: 0/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -43,15 +43,15 @@ GitCommit: c02ca4cce8c69e5069b75cb574d1b99d7b4edaeb
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.10, 3.5, unstable
+Tags: 3.5.11, 3.5, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.5/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 7900cc8b57ad4e638bcf9f92fef3d85eb86e714a
+GitCommit: 3ad550a37fcde2739997d896e6a7b759a85498b6
 Directory: 3.5
 
-Tags: 3.5.10-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
+Tags: 3.5.11-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
 Architectures: windows-amd64
-GitCommit: 7900cc8b57ad4e638bcf9f92fef3d85eb86e714a
+GitCommit: 3ad550a37fcde2739997d896e6a7b759a85498b6
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
- `drupal`: 8.4.0-alpha1 (docker-library/drupal#88)
- `ghost`: drop to only two versions (docker-library/ghost#72)
- `mongo`: 3.5.11