### PR TITLE
Update docker-library images

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,32 +3,32 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 10.0.5-apache, 10.0-apache, 10-apache, 10.0.5, 10.0, 10
+Tags: 10.0.6-apache, 10.0-apache, 10-apache, 10.0.6, 10.0, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: e714562be972718c33d06d875e4d53ac63a9aeec
 Directory: 10.0/apache
 
-Tags: 10.0.5-fpm, 10.0-fpm, 10-fpm
+Tags: 10.0.6-fpm, 10.0-fpm, 10-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: e714562be972718c33d06d875e4d53ac63a9aeec
 Directory: 10.0/fpm
 
-Tags: 11.0.3-apache, 11.0-apache, 11-apache, 11.0.3, 11.0, 11
+Tags: 11.0.4-apache, 11.0-apache, 11-apache, 11.0.4, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
 Directory: 11.0/apache
 
-Tags: 11.0.3-fpm, 11.0-fpm, 11-fpm
+Tags: 11.0.4-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
 Directory: 11.0/fpm
 
-Tags: 12.0.0-apache, 12.0-apache, 12-apache, apache, 12.0.0, 12.0, 12, latest
+Tags: 12.0.1-apache, 12.0-apache, 12-apache, apache, 12.0.1, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
 Directory: 12.0/apache
 
-Tags: 12.0.0-fpm, 12.0-fpm, 12-fpm, fpm
+Tags: 12.0.1-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59da82a5b2fa585327173de28590cf4b66052aa7
+GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
 Directory: 12.0/fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -96,14 +96,14 @@ Architectures: amd64
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 8-jre/alpine
 
-Tags: 9-b179-jdk, 9-b179, 9-jdk, 9
+Tags: 9-b181-jdk, 9-b181, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
+GitCommit: e6bb2aec350db6d636bfde423d6fbf45b5eee6a6
 Directory: 9-jdk
 
-Tags: 9-b179-jdk-slim, 9-b179-slim, 9-jdk-slim, 9-slim
+Tags: 9-b181-jdk-slim, 9-b181-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
+GitCommit: e6bb2aec350db6d636bfde423d6fbf45b5eee6a6
 Directory: 9-jdk/slim
 
 Tags: 9-b154-jdk-windowsservercore, 9-b154-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
@@ -118,12 +118,12 @@ GitCommit: ba6f55a8a023c30b212e08dd5ea89951a96992ae
 Directory: 9-jdk/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 9-b179-jre, 9-jre
+Tags: 9-b181-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
+GitCommit: e6bb2aec350db6d636bfde423d6fbf45b5eee6a6
 Directory: 9-jre
 
-Tags: 9-b179-jre-slim, 9-jre-slim
+Tags: 9-b181-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa4a339f9aa5a0ef0eaac0c08297b796b2ef81ae
+GitCommit: e6bb2aec350db6d636bfde423d6fbf45b5eee6a6
 Directory: 9-jre/slim

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: ef5e3f30a26cb30d91d940019c0e8719e3007eb3
+GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.4
 
 Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
@@ -13,7 +13,7 @@ GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
-GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
+GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
@@ -21,7 +21,7 @@ GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
-GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
+GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
@@ -29,7 +29,7 @@ GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
-GitCommit: 2cb323bae92d7bdb9266f2b89e82e54ec9947e49
+GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger

--- a/library/ruby
+++ b/library/ruby
@@ -4,6 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
+Tags: 2.4.1-stretch, 2.4-stretch, 2-stretch, stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98d971fb71e696bf6783388d0e2c4171c97f0459
+Directory: 2.4/stretch
+
+Tags: 2.4.1-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
+Directory: 2.4/stretch/slim
+
 Tags: 2.4.1-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.1, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
@@ -11,13 +21,18 @@ Directory: 2.4/jessie
 
 Tags: 2.4.1-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.1-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
+
+Tags: 2.4.1-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
+Architectures: amd64
+GitCommit: a7a74d43ec21a6e589113be56024df083ff320ab
+Directory: 2.4/alpine3.6
 
 Tags: 2.4.1-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
@@ -31,7 +46,7 @@ Directory: 2.3/jessie
 
 Tags: 2.3.4-slim-jessie, 2.3-slim-jessie, 2.3.4-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -51,7 +66,7 @@ Directory: 2.2/jessie
 
 Tags: 2.2.7-slim-jessie, 2.2-slim-jessie, 2.2.7-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.7-onbuild, 2.2-onbuild


### PR DESCRIPTION
- `nextcloud`: 10.0.6, 11.0.4, 12.0.1; redis 3.1.3 (nextcloud/docker#138)
- `openjdk`: debian `9~b181-1`
- `redmine`: `bundle install` if necessary (docker-library/redmine#84)
- `ruby`: add `stretch` (docker-library/ruby#144), add `alpine3.6` (docker-library/ruby#145)