### PR TITLE
Update Clear Linux Project.

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@2493e930a906dc8ed618d3710dfaa194db4ebebe
-base: git://github.com/clearlinux/docker-brew-clearlinux@2493e930a906dc8ed618d3710dfaa194db4ebebe
+latest: git://github.com/clearlinux/docker-brew-clearlinux@1856b9f9d8340774f4a77171bac9e1476fc0b8c1
+base: git://github.com/clearlinux/docker-brew-clearlinux@1856b9f9d8340774f4a77171bac9e1476fc0b8c1


### PR DESCRIPTION
Update Clear Linux base+latest images to release 16880.

I am submitting this image update on behalf of @bryteise.