### PR TITLE
Bump FSharp to 5.1.25, mono 5.0.1.1, Jessie

### DIFF
--- a/library/fsharp
+++ b/library/fsharp
@@ -2,13 +2,13 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 
-Tags: latest, 4, 4.1, 4.1.18
+Tags: latest, 4, 4.1, 4.1.25
+GitCommit: 96cd7752113e7b4e32fbd6437600816f4b361994
+Directory: 4.1.25/mono
+
+Tags: 4.1.18
 GitCommit: ad4c4d67a1975b2b0ff0acc49dc46b3271836831
 Directory: 4.1.18/mono
-
-Tags: 4.1.18-wheezy-slim
-GitCommit: 33b5be9aea66ea1d258daf23055fa6d9bcb164ff
-Directory: 4.1.18/mono-wheezy
 
 Tags: 4.1.0.1
 GitCommit: a28196740e38035beea04c41d5862136413281e3


### PR DESCRIPTION
Version update for FSharp - this uses the msbuild tooling that is included with mono 5.0.

Mono 5.0 supports Debian Jessie, so this also moves the official image up to a Debian Jessie base.