### PR TITLE
Oracle Linux 7.4 released.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,12 +1,15 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/ol-container-images.git
 GitFetch: refs/heads/master
-GitCommit: e5f119434d52adbae8438421f9b6f95b8928816e
+GitCommit: da78602b8541faa928cbdda02463db1280523712
 
 Tags: 7-slim
 Directory: 7-slim
 
-Tags: latest, 7, 7.3
+Tags: latest, 7, 7.4
+Directory: 7.4
+
+Tags: 7.3
 Directory: 7.3
 
 Tags: 7.2


### PR DESCRIPTION
The images have passed QA and are ready to be published.

Signed-off-by: Avi Miller <avi.miller@oracle.com>