### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.07.0-ce-rc1, 17.07.0-ce, 17.07.0, 17.07-rc, rc, test
+Tags: 17.07.0-ce-rc2, 17.07.0-ce, 17.07.0, 17.07-rc, rc, test
 Architectures: amd64
-GitCommit: 2288558e94f6b04f70c7db47766d37a09a1c8edb
+GitCommit: 38f9cbf2cbfaecf291141665234425d8affbbede
 Directory: 17.07-rc
 
-Tags: 17.07.0-ce-rc1-dind, 17.07.0-ce-dind, 17.07.0-dind, 17.07-rc-dind, rc-dind, test-dind
+Tags: 17.07.0-ce-rc2-dind, 17.07.0-ce-dind, 17.07.0-dind, 17.07-rc-dind, rc-dind, test-dind
 Architectures: amd64
 GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
 Directory: 17.07-rc/dind
 
-Tags: 17.07.0-ce-rc1-git, 17.07.0-ce-git, 17.07.0-git, 17.07-rc-git, rc-git, test-git
+Tags: 17.07.0-ce-rc2-git, 17.07.0-ce-git, 17.07.0-git, 17.07-rc-git, rc-git, test-git
 Architectures: amd64
 GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
 Directory: 17.07-rc/git
 
-Tags: 17.06.1-ce-rc3, 17.06.1-ce, 17.06.1, 17.06-rc
+Tags: 17.06.1-ce-rc4, 17.06.1-ce, 17.06.1, 17.06-rc
 Architectures: amd64
-GitCommit: 36afb3740b9f5a4a9f21521cdb32e27001dfab53
+GitCommit: 85ba25f3cc07e170c983f4c13947a2786d6bd33d
 Directory: 17.06-rc
 
-Tags: 17.06.1-ce-rc3-dind, 17.06.1-ce-dind, 17.06.1-dind, 17.06-rc-dind
+Tags: 17.06.1-ce-rc4-dind, 17.06.1-ce-dind, 17.06.1-dind, 17.06-rc-dind
 Architectures: amd64
 GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
 Directory: 17.06-rc/dind
 
-Tags: 17.06.1-ce-rc3-git, 17.06.1-ce-git, 17.06.1-git, 17.06-rc-git
+Tags: 17.06.1-ce-rc4-git, 17.06.1-ce-git, 17.06.1-git, 17.06-rc-git
 Architectures: amd64
 GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
 Directory: 17.06-rc/git

--- a/library/python
+++ b/library/python
@@ -40,14 +40,14 @@ GitCommit: 761d766baa0ff33754436c0a1fd9aedc68cf7947
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.3-jessie, 3.5-jessie, 3.5.3, 3.5
+Tags: 3.5.4-jessie, 3.5-jessie, 3.5.4, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/jessie
 
-Tags: 3.5.3-slim, 3.5-slim
+Tags: 3.5.4-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
@@ -55,25 +55,25 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
 Directory: 3.5/jessie/onbuild
 
-Tags: 3.5.3-alpine3.4, 3.5-alpine3.4, 3.5.3-alpine, 3.5-alpine
+Tags: 3.5.4-alpine3.4, 3.5-alpine3.4, 3.5.4-alpine, 3.5-alpine
 Architectures: amd64
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/alpine3.4
 
-Tags: 3.5.3-windowsservercore, 3.5-windowsservercore
+Tags: 3.5.4-windowsservercore, 3.5-windowsservercore
 Architectures: windows-amd64
-GitCommit: db2d58d73043c85ceecc8e675372b4dc6a77d136
+GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.6-jessie, 3.4-jessie, 3.4.6, 3.4
+Tags: 3.4.7-jessie, 3.4-jessie, 3.4.7, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/jessie
 
-Tags: 3.4.6-slim, 3.4-slim
+Tags: 3.4.7-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
@@ -81,14 +81,14 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
 Directory: 3.4/jessie/onbuild
 
-Tags: 3.4.6-wheezy, 3.4-wheezy
+Tags: 3.4.7-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/wheezy
 
-Tags: 3.4.6-alpine3.4, 3.4-alpine3.4, 3.4.6-alpine, 3.4-alpine
+Tags: 3.4.7-alpine3.4, 3.4-alpine3.4, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/alpine3.4
 
 Tags: 3.3.6-jessie, 3.3-jessie, 3.3.6, 3.3

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.57.2, 0.57, 0, latest
-GitCommit: d2f032a8ba69919e6d0ccf66c6190383a31fa307
+Tags: 0.57.3, 0.57, 0, latest
+GitCommit: fc51a438acecd050f8437974098ee5e691cd7013

--- a/library/ruby
+++ b/library/ruby
@@ -31,12 +31,12 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.1-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: a7a74d43ec21a6e589113be56024df083ff320ab
+GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.1-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.4-jessie, 2.3-jessie, 2.3.4, 2.3
@@ -56,7 +56,7 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.4-alpine3.4, 2.3-alpine3.4, 2.3.4-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.7-jessie, 2.2-jessie, 2.2.7, 2.2
@@ -76,5 +76,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.7-alpine3.4, 2.2-alpine3.4, 2.2.7-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
 Directory: 2.2/alpine3.4

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 7/jre7
 
 Tags: 7.0.79-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.79-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 7/jre7-alpine
 
 Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 7/jre8
 
 Tags: 7.0.79-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 7/jre8-alpine
 
 Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 8.0/jre7
 
 Tags: 8.0.45-jre7-alpine, 8.0-jre7-alpine, 8.0.45-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.45-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 8.0/jre8
 
 Tags: 8.0.45-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: a227157792e94c669148c3c2a09072fb317070e0
+GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.16-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.16, 8.5, 8, latest
+Tags: 8.5.20-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.20, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59c92f282053ececa51e2afe06b6c979abae9922
+GitCommit: ec4d672211c919aad07ac7bebe7c6f26373ee467
 Directory: 8.5/jre8
 
-Tags: 8.5.16-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.16-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.20-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.20-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: be1d4e9c614f7021770e581d507845c93b6f77f9
+GitCommit: 9040855496452d91d7b0d8abbfd70c60448a07a1
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M22-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M22, 9.0.0, 9.0, 9
+Tags: 9.0.0.M26-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M26, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 85113c9c4b08f19200b286b858703410d1c7bb76
+GitCommit: 77323f32b92405944da026c68428e3180e6bc33a
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M22-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M22-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.0.M26-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M26-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 33b4b8602e4ead0ba2c3ea42a9946f87cacb1d99
+GitCommit: dcadb55c324ad088e5e34b5bc6f1202e025ea848
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.2.1, cli-1.2, cli-1, cli, cli-1.2.1-php5.6, cli-1.2-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.3.0, cli-1.3, cli-1, cli, cli-1.3.0-php5.6, cli-1.3-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
+GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
 Directory: php5.6/cli
 
-Tags: cli-1.2.1-php7.0, cli-1.2-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.3.0-php7.0, cli-1.3-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
+GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
 Directory: php7.0/cli
 
-Tags: cli-1.2.1-php7.1, cli-1.2-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.3.0-php7.1, cli-1.3-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 648a2715dad185ad90155350b48f190b3f95ae21
+GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
 Directory: php7.1/cli


### PR DESCRIPTION
- `docker`: 17.06.1-ce-rc4, 17.07.0-ce-rc2
- `python`: 3.4.7, 3.5.4
- `rocket.chat`: 0.57.3
- `ruby`: use `libressl` for Alpine 3.6+ (docker-library/ruby#147)
- `tomcat`: 8.5.20, 9.0.0.M26
- `wordpress`: cli 1.3.0