### PR TITLE
composer: patch 1.5.1

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -1,10 +1,10 @@
-# this file was generated using https://github.com/composer/docker/blob/1176669e10e371d2e829e477505d7e449c8d5e24/generate-manifest.sh
+# this file was generated using https://github.com/composer/docker/blob/0759dcda9eb27ee6467166b658de3e03dea4e732/generate-manifest.sh
 
 Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
-Tags: 1.5.0, 1.5, 1, latest
-GitCommit: 1253f8214b6bf1849a8de27344b1cbfc101ca707
+Tags: 1.5.1, 1.5, 1, latest
+GitCommit: ecdc4620499d2b6be574679af0105c5d8b99e6e6
 Directory: 1.5
 
 Tags: 1.4.3, 1.4


### PR DESCRIPTION
  * Fixed regression in GitLabDriver with repos containing >100 branches or tags
  * Fixed sub-directory call support to respect the COMPOSER env var