### PR TITLE
Update node to 8.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/bc4e7eecfe9516e7fd42b8d951e30855ee614eff/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/cc495dbadbd5eb80978faafe4b43c35bace6c2c0/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.2.1, 8.2, 8, latest
+Tags: 8.3.0, 8.3, 8, latest
 Architectures: amd64, ppc64le, s390x
-GitCommit: 9b863beddf7dee9b8a6eba0dd8334b1d7980f958
-Directory: 8.2
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3
 
-Tags: 8.2.1-alpine, 8.2-alpine, 8-alpine, alpine
+Tags: 8.3.0-alpine, 8.3-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
-Directory: 8.2/alpine
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3/alpine
 
-Tags: 8.2.1-onbuild, 8.2-onbuild, 8-onbuild, onbuild
+Tags: 8.3.0-onbuild, 8.3-onbuild, 8-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x
-GitCommit: f547c4c7281027d5d90f4665815140126e1f70d5
-Directory: 8.2/onbuild
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3/onbuild
 
-Tags: 8.2.1-slim, 8.2-slim, 8-slim, slim
+Tags: 8.3.0-slim, 8.3-slim, 8-slim, slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: 9b863beddf7dee9b8a6eba0dd8334b1d7980f958
-Directory: 8.2/slim
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3/slim
 
-Tags: 8.2.1-stretch, 8.2-stretch, 8-stretch, stretch
+Tags: 8.3.0-stretch, 8.3-stretch, 8-stretch, stretch
 Architectures: amd64, ppc64le, s390x
-GitCommit: 9b863beddf7dee9b8a6eba0dd8334b1d7980f958
-Directory: 8.2/stretch
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3/stretch
 
-Tags: 8.2.1-wheezy, 8.2-wheezy, 8-wheezy, wheezy
+Tags: 8.3.0-wheezy, 8.3-wheezy, 8-wheezy, wheezy
 Architectures: amd64
-GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
-Directory: 8.2/wheezy
+GitCommit: cc495dbadbd5eb80978faafe4b43c35bace6c2c0
+Directory: 8.3/wheezy
 
 Tags: 7.10.1, 7.10, 7
 Architectures: amd64, ppc64le, s390x


### PR DESCRIPTION
See https://nodejs.org/en/blog/release/v8.3.0/

https://github.com/nodejs/docker-node/pull/499