### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.5.1, 1.5, 1, latest
-GitCommit: 326658162ed2538aee76a10e4eb96b3bdfddc07b
+Tags: 1.5.2, 1.5, 1, latest
+GitCommit: a9b023e922f4f44c4c15f765973c2939f1be9b12
 Directory: 1/debian
 
-Tags: 1.5.1-alpine, 1.5-alpine, 1-alpine, alpine
-GitCommit: 326658162ed2538aee76a10e4eb96b3bdfddc07b
+Tags: 1.5.2-alpine, 1.5-alpine, 1-alpine, alpine
+GitCommit: a9b023e922f4f44c4c15f765973c2939f1be9b12
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.7, 10.2, 10, latest
 GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.2
 
-Tags: 10.1.25, 10.1
-GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
+Tags: 10.1.26, 10.1
+GitCommit: b43b9ec1eac3f8fc6ad6ad5ea85fb301b2a0c95b
 Directory: 10.1
 
 Tags: 10.0.32, 10.0

--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10-beta2, 10
+Tags: 10-beta3, 10
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: a42e1249e16d8eb0c164104410f78f3dcebe6406
 Directory: 10
 
-Tags: 10-beta2-alpine, 10-alpine
+Tags: 10-beta3-alpine, 10-alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 3aeab631baeee5b6c872c750259764fd5960deca
 Directory: 10/alpine
 
-Tags: 9.6.3, 9.6, 9, latest
+Tags: 9.6.4, 9.6, 9, latest
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: bef7a7e02643bb0f104ba346395d3cdb78db1480
 Directory: 9.6
 
-Tags: 9.6.3-alpine, 9.6-alpine, 9-alpine, alpine
+Tags: 9.6.4-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 58ed93931d38f96981fb3e971217e6619d23f75a
 Directory: 9.6/alpine
 
-Tags: 9.5.7, 9.5
+Tags: 9.5.8, 9.5
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 8836191de6100bfae541c6d9a02cb4ec6e97471e
 Directory: 9.5
 
-Tags: 9.5.7-alpine, 9.5-alpine
+Tags: 9.5.8-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: a1b76e5704e4d8f40c736454eccba863a7be75e4
 Directory: 9.5/alpine
 
-Tags: 9.4.12, 9.4
+Tags: 9.4.13, 9.4
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 9e6a83faa9859b35fc4df18be513320c00ecd493
 Directory: 9.4
 
-Tags: 9.4.12-alpine, 9.4-alpine
+Tags: 9.4.13-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 9d16e9e237b271da39d05d95af24724e79181b19
 Directory: 9.4/alpine
 
-Tags: 9.3.17, 9.3
+Tags: 9.3.18, 9.3
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: ef1e190d84d5ef8c763cb96aeec3356916444efc
 Directory: 9.3
 
-Tags: 9.3.17-alpine, 9.3-alpine
+Tags: 9.3.18-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: ce13cadcb81160cf57bce87b4131cffe36359fcd
 Directory: 9.3/alpine
 
-Tags: 9.2.21, 9.2
+Tags: 9.2.22, 9.2
 Architectures: amd64, i386, ppc64le
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: de4122a80157b1a0a73c14bdd4f11479011a2a51
 Directory: 9.2
 
-Tags: 9.2.21-alpine, 9.2-alpine
+Tags: 9.2.22-alpine, 9.2-alpine
 Architectures: amd64
-GitCommit: 2f0f505894f10c2e65a38591ec0cd417dbcc03e6
+GitCommit: 49a7e2bf209f8344e8240ddbc3a1368c6b72129e
 Directory: 9.2/alpine


### PR DESCRIPTION
- `ghost`: 1.5.2
- `mariadb`: 10.1.26
- `postgres`: 9.6.4, 9.4.13, 9.3.18, 10beta3, 9.5.8, 9.2.22