### PR TITLE
Update rust architectures

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -4,11 +4,11 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
 GitRepo: https://github.com/rust-lang-nursery/docker-rust.git
 
 Tags: 1.19.0-stretch, 1-stretch, 1.19-stretch, stretch, 1.19.0, 1, 1.19, latest
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 01ce3e6230bc87557058a38b342f9e15aae3856c
+Architectures: amd64, arm32v7, i386
+GitCommit: 106c4be7e3d29a38c6953c30fccd54c6ce366157
 Directory: 1.19.0/stretch
 
 Tags: 1.19.0-jessie, 1-jessie, 1.19-jessie, jessie
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 01ce3e6230bc87557058a38b342f9e15aae3856c
+Architectures: amd64, arm32v7, i386
+GitCommit: 106c4be7e3d29a38c6953c30fccd54c6ce366157
 Directory: 1.19.0/jessie


### PR DESCRIPTION
Drop ppc64le and s390x since the builds are broken and we don't have any
active demand for those images.