### PR TITLE
composer: fix cleanup in Dockerfile

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -4,21 +4,9 @@ Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
 Tags: 1.5.1, 1.5, 1, latest
-GitCommit: ecdc4620499d2b6be574679af0105c5d8b99e6e6
+GitCommit: ea0ec1efa4b15f4ad7b809793eecbb76633dcbb8
 Directory: 1.5
 
 Tags: 1.4.3, 1.4
-GitCommit: 1176669e10e371d2e829e477505d7e449c8d5e24
+GitCommit: ea0ec1efa4b15f4ad7b809793eecbb76633dcbb8
 Directory: 1.4
-
-Tags: 1.3.3, 1.3
-GitCommit: 8ec8fa3b1170930e931e00d3963750005dd492b0
-Directory: 1.3
-
-Tags: 1.2.4, 1.2
-GitCommit: 8ec8fa3b1170930e931e00d3963750005dd492b0
-Directory: 1.2
-
-Tags: 1.1.3, 1.1
-GitCommit: 8ec8fa3b1170930e931e00d3963750005dd492b0
-Directory: 1.1


### PR DESCRIPTION
A cache directory was left in `/tmp` that should not be there, causing issues for some users.
Also drops older tags.