### PR TITLE
[ROS] Adding support for Debian and arm

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -1,32 +1,157 @@
-# maintainer: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
+# this file is generated via https://github.com/osrf/docker_images/blob/7ba58fc107b368d6409c22161070eb93e562f240/ros/create_dockerlibrary.py
 
-indigo-ros-core:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/indigo/indigo-ros-core
-indigo-ros-base:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/indigo/indigo-ros-base
-indigo-robot:       git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/indigo/indigo-robot
-indigo-perception:  git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/indigo/indigo-perception
-indigo:             git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/indigo/indigo-ros-base
-# Docker EOL: 2019-04
-# LTS
+Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
+GitRepo: https://github.com/osrf/docker_images.git
 
-jade-ros-core:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/jade/jade-ros-core
-jade-ros-base:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/jade/jade-ros-base
-jade-robot:       git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/jade/jade-robot
-jade-perception:  git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/jade/jade-perception
-jade:             git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/jade/jade-ros-base
-# Docker EOL: 2017-04
+################################################################################
+# Release: indigo
 
-kinetic-ros-core:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-ros-core
-kinetic-ros-base:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-ros-base
-kinetic-robot:       git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-robot
-kinetic-perception:  git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-perception
-kinetic:             git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-ros-base
-latest:              git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/kinetic/kinetic-ros-base
-# Docker EOL: 2021-04
-# LTS
+########################################
+# Distro: ubuntu:trusty
 
-lunar-ros-core:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/lunar/lunar-ros-core
-lunar-ros-base:    git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/lunar/lunar-ros-base
-lunar-robot:       git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/lunar/lunar-robot
-lunar-perception:  git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/lunar/lunar-perception
-lunar:             git://github.com/osrf/docker_images@113c7241bac8ca94c238b1a5bf5ce71ee2a7f219 ros/lunar/lunar-ros-base
-# Docker EOL: 2019-05
+Tags: indigo-ros-core, indigo-ros-core-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/indigo/ubuntu/trusty/ros-core
+
+Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/indigo/ubuntu/trusty/ros-base
+
+Tags: indigo-robot, indigo-robot-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/indigo/ubuntu/trusty/robot
+
+Tags: indigo-perception, indigo-perception-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/indigo/ubuntu/trusty/perception
+
+
+################################################################################
+# Release: jade
+
+########################################
+# Distro: ubuntu:trusty
+
+Tags: jade-ros-core, jade-ros-core-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/jade/ubuntu/trusty/ros-core
+
+Tags: jade-ros-base, jade-ros-base-trusty, jade
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/jade/ubuntu/trusty/ros-base
+
+Tags: jade-robot, jade-robot-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/jade/ubuntu/trusty/robot
+
+Tags: jade-perception, jade-perception-trusty
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/jade/ubuntu/trusty/perception
+
+
+################################################################################
+# Release: kinetic
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: kinetic-ros-core, kinetic-ros-core-xenial
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/ubuntu/xenial/ros-core
+
+Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic, latest
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/ubuntu/xenial/ros-base
+
+Tags: kinetic-robot, kinetic-robot-xenial
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/ubuntu/xenial/robot
+
+Tags: kinetic-perception, kinetic-perception-xenial
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/ubuntu/xenial/perception
+
+########################################
+# Distro: debian:jessie
+
+Tags: kinetic-ros-core-jessie
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/debian/jessie/ros-core
+
+Tags: kinetic-ros-base-jessie
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/debian/jessie/ros-base
+
+Tags: kinetic-robot-jessie
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/debian/jessie/robot
+
+Tags: kinetic-perception-jessie
+Architectures: amd64, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/kinetic/debian/jessie/perception
+
+
+################################################################################
+# Release: lunar
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: lunar-ros-core, lunar-ros-core-xenial
+Architectures: amd64, arm64v8, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/ubuntu/xenial/ros-core
+
+Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
+Architectures: amd64, arm64v8, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/ubuntu/xenial/ros-base
+
+Tags: lunar-robot, lunar-robot-xenial
+Architectures: amd64, arm64v8, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/ubuntu/xenial/robot
+
+Tags: lunar-perception, lunar-perception-xenial
+Architectures: amd64, arm64v8, arm32v7
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/ubuntu/xenial/perception
+
+########################################
+# Distro: debian:stretch
+
+Tags: lunar-ros-core-stretch
+Architectures: amd64, arm64v8
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/debian/stretch/ros-core
+
+Tags: lunar-ros-base-stretch
+Architectures: amd64, arm64v8
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/debian/stretch/ros-base
+
+Tags: lunar-robot-stretch
+Architectures: amd64, arm64v8
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/debian/stretch/robot
+
+Tags: lunar-perception-stretch
+Architectures: amd64, arm64v8
+GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+Directory: ros/lunar/debian/stretch/perception


### PR DESCRIPTION
Adding additionally supported distros and architectures such as debian and arm.
Auto generation of dockerfiles has been improved to support auto generation of dockerfiles, the nested folders for distros and tags, as well as for the new manifest type. 
Not much has changed with the dockerfiles themselves, as some additional package installment is done to support debian's lean base image and a compromise towards a more reliable p80 keyserver.