### PR TITLE
[ROS] Fixing error in arch listing

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -64,22 +64,22 @@ Directory: ros/jade/ubuntu/trusty/perception
 # Distro: ubuntu:xenial
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
-Architectures: amd64, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic, latest
-Architectures: amd64, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
-Architectures: amd64, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
-Architectures: amd64, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/ubuntu/xenial/perception
 
@@ -87,22 +87,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 # Distro: debian:jessie
 
 Tags: kinetic-ros-core-jessie
-Architectures: amd64, arm32v7
+Architectures: amd64, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/debian/jessie/ros-core
 
 Tags: kinetic-ros-base-jessie
-Architectures: amd64, arm32v7
+Architectures: amd64, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/debian/jessie/ros-base
 
 Tags: kinetic-robot-jessie
-Architectures: amd64, arm32v7
+Architectures: amd64, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/debian/jessie/robot
 
 Tags: kinetic-perception-jessie
-Architectures: amd64, arm32v7
+Architectures: amd64, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/kinetic/debian/jessie/perception
 
@@ -114,22 +114,22 @@ Directory: ros/kinetic/debian/jessie/perception
 # Distro: ubuntu:xenial
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
-Architectures: amd64, arm64v8, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
-Architectures: amd64, arm64v8, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
-Architectures: amd64, arm64v8, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
-Architectures: amd64, arm64v8, arm32v7
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
 Directory: ros/lunar/ubuntu/xenial/perception
 


### PR DESCRIPTION
Sorry, @mikaelarguedas spotted the [ROS wiki page](http://wiki.ros.org/kinetic/Installation) for kinetic was not in sync with the [buildfarm](http://build.ros.org/).
* added arm64v8 support in kinetic for xenial/jessie 
* and omitted arm32v7 in kinetic for jessie

Thanks @mikaelarguedas !