### PR TITLE
Odoo: update maintainer and 20170815 release refs

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,11 +1,11 @@
-# maintainer: Aaron Bohy <aab@odoo.com> (@aab-odoo)
+# maintainer: Simon Lejeune <sle@odoo.com> (@sle-odoo)
 
-8.0: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 8.0
-8: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 8.0
+8.0: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 8.0
+8: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 8.0
 
-9.0: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 9.0
-9: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 9.0
+9.0: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 9.0
+9: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 9.0
 
-10.0: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 10.0
-10: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 10.0
-latest: git://github.com/odoo/docker@f8af1a80b14d9e594fdef4df2ff78e655352473c 10.0
+10.0: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 10.0
+10: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 10.0
+latest: git://github.com/odoo/docker@f432264ad15ce8e3326f281394e1900eb9d1c903 10.0


### PR DESCRIPTION
@sle-odoo has been doing most of the follow-up on Odoo's official Dockerfiles lately, so it makes sense to contact him about it in the future.

Also this bumps up the releases to 20170815, to include the latest bugfixes, long overdue.

Thanks a lot!