### PR TITLE
Updatesto gcc, ghost, nextcloud, rabbitmq, and wordpress

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: c1fe37de30fbe69e83f042b4a9426b11cb624bca
 Directory: 6
 # Docker EOL: 2018-07-04
 
-# Last Modified: 2017-05-02
-Tags: 7.1.0, 7.1, 7, latest
+# Last Modified: 2017-08-14
+Tags: 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
+GitCommit: 3ccb804e330766ba05abe7fe990512f152a08254
 Directory: 7
-# Docker EOL: 2018-05-02
+# Docker EOL: 2018-08-14

--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.5.2, 1.5, 1, latest
-GitCommit: a9b023e922f4f44c4c15f765973c2939f1be9b12
+Tags: 1.6.1, 1.6, 1, latest
+GitCommit: 3989f7fc344559a0d65208a56ddf1adc1b7753ac
 Directory: 1/debian
 
-Tags: 1.5.2-alpine, 1.5-alpine, 1-alpine, alpine
-GitCommit: a9b023e922f4f44c4c15f765973c2939f1be9b12
+Tags: 1.6.1-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 3989f7fc344559a0d65208a56ddf1adc1b7753ac
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -23,12 +23,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
 Directory: 11.0/fpm
 
-Tags: 12.0.1-apache, 12.0-apache, 12-apache, apache, 12.0.1, 12.0, 12, latest
+Tags: 12.0.2-apache, 12.0-apache, 12-apache, apache, 12.0.2, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
+GitCommit: 2220249a20b6b92e25f51eb7c1f39a77b7838c49
 Directory: 12.0/apache
 
-Tags: 12.0.1-fpm, 12.0-fpm, 12-fpm, fpm
+Tags: 12.0.2-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
+GitCommit: 2220249a20b6b92e25f51eb7c1f39a77b7838c49
 Directory: 12.0/fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.10, 3.6, 3, latest
+Tags: 3.6.11, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, i386, s390x
-GitCommit: 7eed5476d6153d05e5a0245ccfe28d893b0b369e
+GitCommit: 7d76799247764423a69438f72961ef0581788e07
 Directory: 3.6/debian
 
-Tags: 3.6.10-management, 3.6-management, 3-management, management
+Tags: 3.6.11-management, 3.6-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, i386, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
-Tags: 3.6.10-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.11-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: 192f4c2055cc97cd8200c80c97b9e66115c13790
+GitCommit: 8047bd34685f27bea47dcd646d3b6332b0ec22d3
 Directory: 3.6/alpine
 
-Tags: 3.6.10-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.6.11-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/alpine/management

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.8.1-apache, 4.8-apache, 4-apache, apache, 4.8.1, 4.8, 4, latest, 4.8.1-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.1-php5.6, 4.8-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php5.6/apache
 
 Tags: 4.8.1-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.1-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php5.6/fpm
 
 Tags: 4.8.1-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.1-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php5.6/fpm-alpine
 
 Tags: 4.8.1-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.1-php7.0, 4.8-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.0/apache
 
 Tags: 4.8.1-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.0/fpm
 
 Tags: 4.8.1-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.0/fpm-alpine
 
 Tags: 4.8.1-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.1-php7.1, 4.8-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.1/apache
 
 Tags: 4.8.1-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.1/fpm
 
 Tags: 4.8.1-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: c3c8a37506b1bd79ae05e547faa3d31c84620051
+GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `gcc` bump to `7.2.0`
- `ghost` bump to `1.6.1`
- `nextcloud` bump to `12.0.2` fixes https://github.com/nextcloud/docker/issues/145
- `rabbitmq` bump to `3.6.11`
- `wordpress` support newlines in sql password https://github.com/docker-library/wordpress/pull/234