### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,47 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.07.0-ce-rc2, 17.07.0-ce, 17.07.0, 17.07-rc, rc, test
+Tags: 17.07.0-ce-rc3, 17.07.0-ce, 17.07.0, 17.07-rc, rc, test
 Architectures: amd64
-GitCommit: 38f9cbf2cbfaecf291141665234425d8affbbede
+GitCommit: ea685128f1db54d575ab464c66b73907e4838c8b
 Directory: 17.07-rc
 
-Tags: 17.07.0-ce-rc2-dind, 17.07.0-ce-dind, 17.07.0-dind, 17.07-rc-dind, rc-dind, test-dind
+Tags: 17.07.0-ce-rc3-dind, 17.07.0-ce-dind, 17.07.0-dind, 17.07-rc-dind, rc-dind, test-dind
 Architectures: amd64
 GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
 Directory: 17.07-rc/dind
 
-Tags: 17.07.0-ce-rc2-git, 17.07.0-ce-git, 17.07.0-git, 17.07-rc-git, rc-git, test-git
+Tags: 17.07.0-ce-rc3-git, 17.07.0-ce-git, 17.07.0-git, 17.07-rc-git, rc-git, test-git
 Architectures: amd64
 GitCommit: c49283cd0ab1dff78a4cb1b5c62618b8b1744595
 Directory: 17.07-rc/git
 
-Tags: 17.06.1-ce-rc4, 17.06.1-ce, 17.06.1, 17.06-rc
+Tags: 17.06.1-ce, 17.06.1, 17.06, 17, edge, stable, latest
 Architectures: amd64
-GitCommit: 85ba25f3cc07e170c983f4c13947a2786d6bd33d
-Directory: 17.06-rc
-
-Tags: 17.06.1-ce-rc4-dind, 17.06.1-ce-dind, 17.06.1-dind, 17.06-rc-dind
-Architectures: amd64
-GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
-Directory: 17.06-rc/dind
-
-Tags: 17.06.1-ce-rc4-git, 17.06.1-ce-git, 17.06.1-git, 17.06-rc-git
-Architectures: amd64
-GitCommit: f60aacc67bcba2d5b45c28665742a60b99d24466
-Directory: 17.06-rc/git
-
-Tags: 17.06.0-ce, 17.06.0, 17.06, 17, edge, stable, latest
-Architectures: amd64
-GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
+GitCommit: e7f88c3e252b1a79f2c655b1d0ae2314666d2677
 Directory: 17.06
 
-Tags: 17.06.0-ce-dind, 17.06.0-dind, 17.06-dind, 17-dind, edge-dind, stable-dind, dind
+Tags: 17.06.1-ce-dind, 17.06.1-dind, 17.06-dind, 17-dind, edge-dind, stable-dind, dind
 Architectures: amd64
 GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
 Directory: 17.06/dind
 
-Tags: 17.06.0-ce-git, 17.06.0-git, 17.06-git, 17-git, edge-git, stable-git, git
+Tags: 17.06.1-ce-git, 17.06.1-git, 17.06-git, 17-git, edge-git, stable-git, git
 Architectures: amd64
 GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
 Directory: 17.06/git

--- a/library/drupal
+++ b/library/drupal
@@ -4,28 +4,28 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.0-alpha1-apache, 8.4-rc-apache, rc-apache, 8.4.0-alpha1, 8.4-rc, rc
-GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Tags: 8.4.0-beta1-apache, 8.4-rc-apache, rc-apache, 8.4.0-beta1, 8.4-rc, rc
+GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/apache
 
-Tags: 8.4.0-alpha1-fpm, 8.4-rc-fpm, rc-fpm
-GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Tags: 8.4.0-beta1-fpm, 8.4-rc-fpm, rc-fpm
+GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/fpm
 
-Tags: 8.4.0-alpha1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
-GitCommit: 952fad40d62705da159b713d4c8c48b1cc1080fd
+Tags: 8.4.0-beta1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/fpm-alpine
 
-Tags: 8.3.6-apache, 8.3-apache, 8-apache, apache, 8.3.6, 8.3, 8, latest
-GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
+Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest
+GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/apache
 
-Tags: 8.3.6-fpm, 8.3-fpm, 8-fpm, fpm
-GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
+Tags: 8.3.7-fpm, 8.3-fpm, 8-fpm, fpm
+GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm
 
-Tags: 8.3.6-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
-GitCommit: 9f8ce73be0a63586b26b6467310fb572be8209d2
+Tags: 8.3.7-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.5.1, 5.5, 5, latest
-GitCommit: 4369e593bab8b19ea5dc06d70cc2039c3460af46
+Tags: 5.5.2, 5.5, 5, latest
+GitCommit: 094b4b6bff8626a2391404413a2e338c48ef7a26
 Directory: 5
 
-Tags: 5.5.1-alpine, 5.5-alpine, 5-alpine, alpine
-GitCommit: 4369e593bab8b19ea5dc06d70cc2039c3460af46
+Tags: 5.5.2-alpine, 5.5-alpine, 5-alpine, alpine
+GitCommit: 094b4b6bff8626a2391404413a2e338c48ef7a26
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.6.1, 1.6, 1, latest
-GitCommit: 3989f7fc344559a0d65208a56ddf1adc1b7753ac
+Tags: 1.6.2, 1.6, 1, latest
+GitCommit: 914dd83f68f171b8c472f39c152fd6c901998046
 Directory: 1/debian
 
-Tags: 1.6.1-alpine, 1.6-alpine, 1-alpine, alpine
-GitCommit: 3989f7fc344559a0d65208a56ddf1adc1b7753ac
+Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
+GitCommit: 914dd83f68f171b8c472f39c152fd6c901998046
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: 900676649347a83b314fd7b33e0a52265e168577
 Directory: 1.6/alpine
 
-Tags: 1.7.8, 1.7, 1, latest
+Tags: 1.7.9, 1.7, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b5d5bf547d296049a8e8a22ac951e1b76f3179c
+GitCommit: 394255fbe76c57a9f2e0775e3e69df714e801b46
 Directory: 1.7
 
-Tags: 1.7.8-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.9-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 9b5d5bf547d296049a8e8a22ac951e1b76f3179c
+GitCommit: 394255fbe76c57a9f2e0775e3e69df714e801b46
 Directory: 1.7/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.5.1, 5.5, 5, latest
-GitCommit: 912e443dcc59e658c4c1eff0976e6054087f87fb
+Tags: 5.5.2, 5.5, 5, latest
+GitCommit: c6a6b5a2d71b8f99a4292307bfcc9417843efadc
 Directory: 5
 
-Tags: 4.6.5, 4.6, 4
-GitCommit: 493a24c88deff8080aa781f0596deab8b33e5992
+Tags: 4.6.6, 4.6, 4
+GitCommit: febc4b766dabfc5a30f04373337cd0a0ec997bb2
 Directory: 4.6

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.5.1, 5.5, 5, latest
-GitCommit: 479d904c1a1043e179d157259fba96a9ca2e204f
+Tags: 5.5.2, 5.5, 5, latest
+GitCommit: 3822f5ee79034aff41bc62d45d713fd38f0fc447
 Directory: 5
 
-Tags: 5.5.1-alpine, 5.5-alpine, 5-alpine, alpine
-GitCommit: 479d904c1a1043e179d157259fba96a9ca2e204f
+Tags: 5.5.2-alpine, 5.5-alpine, 5-alpine, alpine
+GitCommit: 3822f5ee79034aff41bc62d45d713fd38f0fc447
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.3.0, 10.3
 GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
 Directory: 10.3
 
-Tags: 10.2.7, 10.2, 10, latest
-GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
+Tags: 10.2.8, 10.2, 10, latest
+GitCommit: e841926a0c09fb1d1d7dd79131f9d8e3a09619ec
 Directory: 10.2
 
 Tags: 10.1.26, 10.1

--- a/library/php
+++ b/library/php
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0beta2-cli, 7.2-rc-cli, rc-cli, 7.2.0beta2, 7.2-rc, rc
+Tags: 7.2.0beta3-cli, 7.2-rc-cli, rc-cli, 7.2.0beta3, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc
 
-Tags: 7.2.0beta2-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0beta3-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/alpine
 
-Tags: 7.2.0beta2-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0beta3-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/apache
 
-Tags: 7.2.0beta2-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0beta3-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/fpm
 
-Tags: 7.2.0beta2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0beta3-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/fpm/alpine
 
-Tags: 7.2.0beta2-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0beta3-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/zts
 
-Tags: 7.2.0beta2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0beta3-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: 35b926a0d011e7860904700cbed64d53a2527cad
+GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.8-cli, 7.1-cli, 7-cli, cli, 7.1.8, 7.1, 7, latest

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,16 +1,16 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/0faadd80976f6d1f0f1af215ca81ba1ccf6fb3a4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/2a6e03ce7ded1a02a894e89e17927dc4c5a03736/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.11, 3.6, 3, latest
-Architectures: amd64, arm32v5, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, s390x
 GitCommit: 7d76799247764423a69438f72961ef0581788e07
 Directory: 3.6/debian
 
 Tags: 3.6.11-management, 3.6-management, 3-management, management
-Architectures: amd64, arm32v5, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.57.3, 0.57, 0, latest
-GitCommit: fc51a438acecd050f8437974098ee5e691cd7013
+Tags: 0.58.1, 0.58, 0, latest
+GitCommit: 55d53045c88052f1f4c47910aedacbc2d2bde20b

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,44 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.79-jre7, 7.0-jre7, 7-jre7, 7.0.79, 7.0, 7
+Tags: 7.0.81-jre7, 7.0-jre7, 7-jre7, 7.0.81, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: ab435d680d56084ebe0419adfb31cc58df3624dd
 Directory: 7/jre7
 
-Tags: 7.0.79-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.79-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.81-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.81-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 0e9a915bf893faa9160ab1a144c7ba5049a4fe27
 Directory: 7/jre7-alpine
 
-Tags: 7.0.79-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.81-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: ab435d680d56084ebe0419adfb31cc58df3624dd
 Directory: 7/jre8
 
-Tags: 7.0.79-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.81-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 0e9a915bf893faa9160ab1a144c7ba5049a4fe27
 Directory: 7/jre8-alpine
 
-Tags: 8.0.45-jre7, 8.0-jre7, 8.0.45, 8.0
+Tags: 8.0.46-jre7, 8.0-jre7, 8.0.46, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 5c8b74e495a1b63116b524407941b15eef58a7fe
 Directory: 8.0/jre7
 
-Tags: 8.0.45-jre7-alpine, 8.0-jre7-alpine, 8.0.45-alpine, 8.0-alpine
+Tags: 8.0.46-jre7-alpine, 8.0-jre7-alpine, 8.0.46-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 03255da1fc6f0e3ab4a3507cb9e28d707fc921d0
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.45-jre8, 8.0-jre8
+Tags: 8.0.46-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 5c8b74e495a1b63116b524407941b15eef58a7fe
 Directory: 8.0/jre8
 
-Tags: 8.0.45-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.46-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: f6dc3671bf56465917b52c8df4356fa8f0ebafcd
+GitCommit: 03255da1fc6f0e3ab4a3507cb9e28d707fc921d0
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.20-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.20, 8.5, 8, latest


### PR DESCRIPTION
- `docker`: 17.06.1-ce, 17.07.0-ce-rc3
- `drupal`: 8.3.7, 8.4.0-beta1
- `elasticsearch`: 5.5.2
- `ghost`: 1.6.2, ghost-cli 1.1.1
- `haproxy`: 1.7.9
- `kibana`: 4.6.6, 5.5.2
- `logstash`: 5.5.2
- `mariadb`: 10.2.8
- `php`: 7.2.0beta3
- `rabbitmq`: add `arm64v8` (docker-library/rabbitmq#177)
- `rocket.chat`: 0.58.1
- `tomcat`: 8.0.46, 7.0.81