### PR TITLE
Update clojure to latest commit

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,7 +1,7 @@
 Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: adeda5b2e562fef82b9aca22e9770e312841dc0f
+GitCommit: c142e677d92def9acff1e7d24f165e30c4fa7fa1
 
 Tags: lein-2.7.1, lein, latest
 Directory: debian/lein
@@ -15,8 +15,8 @@ Directory: alpine/lein
 Tags: lein-2.7.1-alpine-onbuild, lein-alpine-onbuild, alpine-onbuild
 Directory: alpine/lein/onbuild
 
-Tags: boot-2.7.1, boot
+Tags: boot-2.7.2, boot
 Directory: debian/boot
 
-Tags: boot-2.7.1-alpine, boot-alpine
+Tags: boot-2.7.2-alpine, boot-alpine
 Directory: alpine/boot


### PR DESCRIPTION
This updates the boot build tool from 2.7.1 to 2.7.2.