### PR TITLE
Mono: remove arm64v8 from 4.8 images

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -20,7 +20,7 @@ GitCommit: 39b989ea0ef3e787fb75410521217cb7cb7df05e
 Directory: 5.0.1.1
 
 Tags: 4.8.0.524, 4.8.0, 4.8, 4
-Architectures: amd64, i386, arm32v7, arm64v8
+Architectures: amd64, i386, arm32v7
 GitCommit: 0d987d93235630e05a14983c7f87500ab33c90da
 Directory: 4.8.0.524
 


### PR DESCRIPTION
It uses Debian Wheezy as the base which doesn't work for arm64v8.

/cc @tianon 