### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -98,23 +98,23 @@ Directory: 8-jre/alpine
 
 Tags: 9-b181-jdk, 9-b181, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dce6353dcbb15f09479e7043f48082051967139
+GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
 Directory: 9-jdk
 
 Tags: 9-b181-jdk-slim, 9-b181-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dce6353dcbb15f09479e7043f48082051967139
+GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
 Directory: 9-jdk/slim
 
 Tags: 9-b154-jdk-windowsservercore, 9-b154-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
 Architectures: windows-amd64
-GitCommit: ba6f55a8a023c30b212e08dd5ea89951a96992ae
+GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
 Directory: 9-jdk/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 9-b154-jdk-nanoserver, 9-b154-nanoserver, 9-jdk-nanoserver, 9-nanoserver
 Architectures: windows-amd64
-GitCommit: ba6f55a8a023c30b212e08dd5ea89951a96992ae
+GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
 Directory: 9-jdk/windows/nanoserver
 Constraints: nanoserver
 

--- a/library/ruby
+++ b/library/ruby
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.4.1-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98d971fb71e696bf6783388d0e2c4171c97f0459
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/stretch
 
 Tags: 2.4.1-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.1-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.1, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/jessie
 
 Tags: 2.4.1-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.1-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -31,22 +31,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.1-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.1-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
+GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.4-jessie, 2.3-jessie, 2.3.4, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
 Directory: 2.3/jessie
 
 Tags: 2.3.4-slim-jessie, 2.3-slim-jessie, 2.3.4-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
+GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -56,17 +56,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.4-alpine3.4, 2.3-alpine3.4, 2.3.4-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
+GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.7-jessie, 2.2-jessie, 2.2.7, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
+GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
 Directory: 2.2/jessie
 
 Tags: 2.2.7-slim-jessie, 2.2-slim-jessie, 2.2.7-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 445b7e4b78763ae70ef2951dbd78d777edb68358
+GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -76,5 +76,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.7-alpine3.4, 2.2-alpine3.4, 2.2.7-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: ecbfdeb2b71e155222b1d3df0a33685247f00616
+GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `openjdk`: use `jshell` as the default command for 9+ JDK images (docker-library/openjdk#141)
- `ruby`: bundler 1.15.4