### PR TITLE
Bump Traefik to v1.3.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,10 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.5, 1.3.5, v1.3, 1.3, raclette, latest
-GitCommit: 03da849385c1b10d2f9d8ca6b0de36626212f01d
+Tags: v1.3.6, 1.3.6, v1.3, 1.3, raclette, latest
+GitCommit: 0b1f920bf43e4ba5e8bab3a25af80870b1c342a8
 
-Tags: v1.3.5-alpine, 1.3.5-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 03da849385c1b10d2f9d8ca6b0de36626212f01d
+Tags: v1.3.6-alpine, 1.3.6-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 0b1f920bf43e4ba5e8bab3a25af80870b1c342a8
 Directory: alpine
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.3.6.

/cc @vdemeester @emilevauge

Cheers
