### PR TITLE
Drop Node.js v7.10.x

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/c044d61e6d02756bb8ed1557b2f0c7a0d7fead6f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/a2600f4e0e4af5abd4a8e2a88cf46337500dbe7c/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
@@ -32,36 +32,6 @@ Tags: 8.4.0-wheezy, 8.4-wheezy, 8-wheezy, wheezy
 Architectures: amd64
 GitCommit: c044d61e6d02756bb8ed1557b2f0c7a0d7fead6f
 Directory: 8.4/wheezy
-
-Tags: 7.10.1, 7.10, 7
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
-Directory: 7.10
-
-Tags: 7.10.1-alpine, 7.10-alpine, 7-alpine
-Architectures: amd64
-GitCommit: 0aadad9c44ff26afc81469d77df9b948be47c312
-Directory: 7.10/alpine
-
-Tags: 7.10.1-onbuild, 7.10-onbuild, 7-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 0fcdf0b2660e73ab1054f932f4beac5b3946fb21
-Directory: 7.10/onbuild
-
-Tags: 7.10.1-slim, 7.10-slim, 7-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
-Directory: 7.10/slim
-
-Tags: 7.10.1-stretch, 7.10-stretch, 7-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
-Directory: 7.10/stretch
-
-Tags: 7.10.1-wheezy, 7.10-wheezy, 7-wheezy
-Architectures: amd64
-GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
-Directory: 7.10/wheezy
 
 Tags: 6.11.2, 6.11, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7


### PR DESCRIPTION
Node.js v7.10.x is no longer actively maintained.

See:

- https://github.com/nodejs/LTS
- https://github.com/nodejs/docker-node/pull/509