### PR TITLE
Update clojure to latest commit (w/ boot-bin 2.7.2)

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,7 +1,7 @@
 Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: c142e677d92def9acff1e7d24f165e30c4fa7fa1
+GitCommit: 54d3dcd9756fb53c489eb9cb8debd80a1a5f6430
 
 Tags: lein-2.7.1, lein, latest
 Directory: debian/lein


### PR DESCRIPTION
I missed a piece of the boot update in the clojure build. See https://github.com/Quantisan/docker-clojure/issues/36 for details. But this should fix it.