### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,21 +1,25 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/f6f09faf3e50e648ec11a9676a29dd1130604c2d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/2f94f18213b571dbd5c9f89925d14bd4bc41d528/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.18, 2.1
+Architectures: amd64, i386
 GitCommit: a78f0c2c40507f31a6b5048d029e77f5e3e5054b
 Directory: 2.1
 
 Tags: 2.2.10, 2.2, 2
+Architectures: amd64, i386
 GitCommit: 92e76b1607393679735adf04a7c6bf08d66278b2
 Directory: 2.2
 
 Tags: 3.0.14, 3.0
+Architectures: amd64, i386
 GitCommit: aebf66bbd63d5b860410837810ae738d76a03932
 Directory: 3.0
 
 Tags: 3.11.0, 3.11, 3, latest
+Architectures: amd64, i386
 GitCommit: f6f09faf3e50e648ec11a9676a29dd1130604c2d
 Directory: 3.11

--- a/library/drupal
+++ b/library/drupal
@@ -1,41 +1,50 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/bd0f1c85b015a1cefe7ebaeba5b1061fd8ac6555/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/4cabbdd883753a3b20d826cf5fed5e741291827b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
 Tags: 8.4.0-beta1-apache, 8.4-rc-apache, rc-apache, 8.4.0-beta1, 8.4-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/apache
 
 Tags: 8.4.0-beta1-fpm, 8.4-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/fpm
 
 Tags: 8.4.0-beta1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64
 GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
 Directory: 8.4-rc/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/apache
 
 Tags: 8.3.7-fpm, 8.3-fpm, 8-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm
 
 Tags: 8.3.7-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Architectures: amd64
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/apache
 
 Tags: 7.56-fpm, 7-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/fpm
 
 Tags: 7.56-fpm-alpine, 7-fpm-alpine
+Architectures: amd64
 GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -1,21 +1,25 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/fabb247507dc8b2d20c5795d688c4167b98caf4a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/8d1ed041ef46982fe5a15bed9e662c0045b23c75/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.7.0, 1.7, 1, latest
-GitCommit: 2f5e955ee916bea8e9e817b3dc2072280165f14d
+Tags: 1.7.1, 1.7, 1, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 66a991905bf1ede03705bf28fea4c630f0421347
 Directory: 1/debian
 
-Tags: 1.7.0-alpine, 1.7-alpine, 1-alpine, alpine
-GitCommit: 2f5e955ee916bea8e9e817b3dc2072280165f14d
+Tags: 1.7.1-alpine, 1.7-alpine, 1-alpine, alpine
+Architectures: amd64
+GitCommit: 66a991905bf1ede03705bf28fea4c630f0421347
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
 Directory: 0/debian
 
 Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine
+Architectures: amd64
 GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
 Directory: 0/alpine

--- a/library/julia
+++ b/library/julia
@@ -1,8 +1,9 @@
-# this file is generated via https://github.com/docker-library/julia/blob/7cdd4477e389248fd42f9bf6a5d34324be1fbdc4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/4eff23fd0270ed08c727f1ddb10c497559732c22/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
 Tags: 0.6.0, 0.6, 0, latest
-GitCommit: ef0fdf96ba90c0020776bca367cb838910aca339
+Architectures: amd64, arm32v7, i386
+GitCommit: 4eff23fd0270ed08c727f1ddb10c497559732c22

--- a/library/owncloud
+++ b/library/owncloud
@@ -1,29 +1,35 @@
-# this file is generated via https://github.com/docker-library/owncloud/blob/d451be9d45c19ef9fe357a75245ff4f36495176f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/owncloud/blob/aad7b27a8d2dab3e417a94071d1acf6a795a2aed/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.2-apache, 10.0-apache, 10-apache, apache, 10.0.2, 10.0, 10, latest
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 10.0/apache
 
 Tags: 10.0.2-fpm, 10.0-fpm, 10-fpm, fpm
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 10.0/fpm
 
 Tags: 9.1.6-apache, 9.1-apache, 9-apache, 9.1.6, 9.1, 9
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.1/apache
 
 Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.1/fpm
 
 Tags: 9.0.10-apache, 9.0-apache, 9.0.10, 9.0
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.0/apache
 
 Tags: 9.0.10-fpm, 9.0-fpm
-GitCommit: d451be9d45c19ef9fe357a75245ff4f36495176f
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.0/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -1,29 +1,35 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/089d2c270aeab809000d301b409d200914eb5aa9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/ae4d6e7d038eb080a55fc3d8d91594505e0f4030/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-5.8.0, 2-5.8, 2-5, 2
-GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
 Directory: 2
 
 Tags: 2-5.8.0-slim, 2-5.8-slim, 2-5-slim, 2-slim
-GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
 Directory: 2/slim
 
 Tags: 2-5.8.0-onbuild, 2-5.8-onbuild, 2-5-onbuild, 2-onbuild
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
 Tags: 3-5.8.0, 3-5.8, 3-5, 3, latest
-GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
+Architectures: amd64
+GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
 Directory: 3
 
 Tags: 3-5.8.0-slim, 3-5.8-slim, 3-5-slim, 3-slim, slim
-GitCommit: bff939590214797aeb1f5d1c30166edceef2eb6d
+Architectures: amd64
+GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
 Directory: 3/slim
 
 Tags: 3-5.8.0-onbuild, 3-5.8-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Architectures: amd64
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild

--- a/library/redmine
+++ b/library/redmine
@@ -9,7 +9,7 @@ GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.4
 
 Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
+GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
@@ -17,7 +17,7 @@ GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
-GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
+GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
@@ -25,7 +25,7 @@ GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
-GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
+GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
@@ -33,5 +33,5 @@ GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: ded105e314a3b60130573e300931b149daf8fd8c
+GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.1/passenger


### PR DESCRIPTION
- `cassandra`: multiarch (docker-library/cassandra#115)
- `drupal`: multiarch (docker-library/drupal#90)
- `ghost`: 1.7.1, multiarch (docker-library/ghost#82)
- `julia`: multiarch (docker-library/julia#15)
- `owncloud`: multiarch (docker-library/owncloud#91)
- `pypy`: multiarch (docker-library/pypy#16)
- `redmine`: passenger 5.1.8