### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.7.1, 1.7, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 66a991905bf1ede03705bf28fea4c630f0421347
+GitCommit: 81e8d8cbda409c01c4355f1e1172c10139196256
 Directory: 1/debian
 
 Tags: 1.7.1-alpine, 1.7-alpine, 1-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+GitCommit: 81e8d8cbda409c01c4355f1e1172c10139196256
 Directory: 0/debian
 
 Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.0, 1.5, 1, latest
+Tags: 1.5.1, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc88c3d1a1b737e34a14e08b47ffd7bd5c8984b9
+GitCommit: 47577ad04041d83146439243e35f809b88236466
 Directory: debian
 
-Tags: 1.5.0-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.1-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: cc88c3d1a1b737e34a14e08b47ffd7bd5c8984b9
+GitCommit: 47577ad04041d83146439243e35f809b88236466
 Directory: alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -98,12 +98,12 @@ Directory: 8-jre/alpine
 
 Tags: 9-b181-jdk, 9-b181, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
+GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
 Directory: 9-jdk
 
 Tags: 9-b181-jdk-slim, 9-b181-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2493b1043e8581e2c22db2ce4ff0e217457a37ca
+GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
 Directory: 9-jdk/slim
 
 Tags: 9-b154-jdk-windowsservercore, 9-b154-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
@@ -120,10 +120,10 @@ Constraints: nanoserver
 
 Tags: 9-b181-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dce6353dcbb15f09479e7043f48082051967139
+GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
 Directory: 9-jre
 
 Tags: 9-b181-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dce6353dcbb15f09479e7043f48082051967139
+GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
 Directory: 9-jre/slim

--- a/library/percona
+++ b/library/percona
@@ -8,8 +8,8 @@ Tags: 5.7.18, 5.7, 5, latest
 GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
 Directory: 5.7
 
-Tags: 5.6.36, 5.6
-GitCommit: bfff0f74903bf6db64b5d1ca85968e3546f039a5
+Tags: 5.6.37, 5.6
+GitCommit: a49009485acc80aee9be0837eef49f0808cd8ac7
 Directory: 5.6
 
 Tags: 5.5.57, 5.5

--- a/library/redmine
+++ b/library/redmine
@@ -1,11 +1,12 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/083fd3c293a01cf19bcb3c24a05db31f6a6b05bb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/10bdb805ef3e5a3edd4cd1a79369ae2bfdc6e3f9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.4
 
 Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
@@ -13,7 +14,8 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
-GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
@@ -21,7 +23,8 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
-GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
@@ -29,7 +32,8 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
-GitCommit: bcaee7ff541b6ff01b7593e44444b3d561f67472
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.1
 
 Tags: 3.1.7-passenger, 3.1-passenger


### PR DESCRIPTION
- `ghost`: gosu 1.10 (more arches)
- `memcached`: 1.5.1
- `openjdk`: debian `9~b181-4`
- `percona`: 5.6.37
- `redmine`: multiarch (docker-library/redmine#87)