### PR TITLE
Bump Traefik to v1.3.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,10 +3,10 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.3.6, 1.3.6, v1.3, 1.3, raclette, latest
-GitCommit: 0b1f920bf43e4ba5e8bab3a25af80870b1c342a8
+Tags: v1.3.7, 1.3.7, v1.3, 1.3, raclette, latest
+GitCommit: 871d6c731511ed011b8b14fb6ae7942cc0df2929
 
-Tags: v1.3.6-alpine, 1.3.6-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 0b1f920bf43e4ba5e8bab3a25af80870b1c342a8
+Tags: v1.3.7-alpine, 1.3.7-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
+GitCommit: 871d6c731511ed011b8b14fb6ae7942cc0df2929
 Directory: alpine
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.3.7.

/cc @vdemeester @emilevauge

Cheers
