### PR TITLE
Update Ghost for multiarch again

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -16,7 +16,7 @@ Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 81e8d8cbda409c01c4355f1e1172c10139196256
+GitCommit: 0a3f9385d624bc3511b4f702671dcc27ae96de66
 Directory: 0/debian
 
 Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine


### PR DESCRIPTION
This adds a few more packages for compiling "sqlite3".

https://github.com/docker-library/ghost/pull/85