### PR TITLE
Haxe: add stretch variant and use it as the default

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,35 +1,51 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 3.1.3, 3.1
-GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
-Directory: 3.1
+Tags: 3.4.2-stretch, 3.4-stretch, 3.4.2, 3.4, latest
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.4/stretch
 
-Tags: 3.1.3-onbuild, 3.1-onbuild
-GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
-Directory: 3.1/onbuild
+Tags: 3.4.2-jessie, 3.4-jessie
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.4/jessie
 
-Tags: 3.2.1, 3.2
-GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
-Directory: 3.2
+Tags: 3.4.2-onbuild, 3.4-onbuild
+GitCommit: 8e6c65a2d72c239e8ddaf5af9157bb146d71016d
+Directory: 3.4/onbuild
 
-Tags: 3.2.1-onbuild, 3.2-onbuild
-GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
-Directory: 3.2/onbuild
+Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.3/stretch
 
-Tags: 3.3.0-rc.1, 3.3.0, 3.3
-GitCommit: 0f4f8783c73fb791c0265680df8bc851727d2297
-Directory: 3.3
+Tags: 3.3.0-rc.1-jessie, 3.3.0-jessie, 3.3-jessie
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.3/jessie
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
 GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.3/onbuild
 
-Tags: 3.4.2, 3.4, latest
-GitCommit: 8e6c65a2d72c239e8ddaf5af9157bb146d71016d
-Directory: 3.4
+Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.2/stretch
 
-Tags: 3.4.2-onbuild, 3.4-onbuild
-GitCommit: 8e6c65a2d72c239e8ddaf5af9157bb146d71016d
-Directory: 3.4/onbuild
+Tags: 3.2.1-jessie, 3.2-jessie
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.2/jessie
+
+Tags: 3.2.1-onbuild, 3.2-onbuild
+GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
+Directory: 3.2/onbuild
+
+Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.1/stretch
+
+Tags: 3.1.3-jessie, 3.1-jessie
+GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+Directory: 3.1/jessie
+
+Tags: 3.1.3-onbuild, 3.1-onbuild
+GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
+Directory: 3.1/onbuild
 


### PR DESCRIPTION
 * Add stretch variant and use it as the default.
 * Sort versions such that latest is on top.
 * Provide jessie for backward compat.