### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,7 +16,7 @@ Directory: artful/scm
 
 Tags: artful
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: artful
 
 Tags: buster-curl
@@ -31,7 +31,7 @@ Directory: buster/scm
 
 Tags: buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1449b1e7ba5a389167893e6edb6245ca94cd4fd6
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: buster
 
 Tags: jessie-curl
@@ -46,7 +46,7 @@ Directory: jessie/scm
 
 Tags: jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: jessie
 
 Tags: sid-curl
@@ -61,7 +61,7 @@ Directory: sid/scm
 
 Tags: sid
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: sid
 
 Tags: stretch-curl, curl
@@ -76,7 +76,7 @@ Directory: stretch/scm
 
 Tags: stretch, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: stretch
 
 Tags: trusty-curl
@@ -91,7 +91,7 @@ Directory: trusty/scm
 
 Tags: trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: trusty
 
 Tags: wheezy-curl
@@ -106,7 +106,7 @@ Directory: wheezy/scm
 
 Tags: wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: wheezy
 
 Tags: xenial-curl
@@ -121,7 +121,7 @@ Directory: xenial/scm
 
 Tags: xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: xenial
 
 Tags: zesty-curl
@@ -136,5 +136,5 @@ Directory: zesty/scm
 
 Tags: zesty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 587934fb063d770d0611e94b57c9dd7a38edf928
+GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
 Directory: zesty

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,32 +3,22 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 10.0.6-apache, 10.0-apache, 10-apache, 10.0.6, 10.0, 10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e714562be972718c33d06d875e4d53ac63a9aeec
-Directory: 10.0/apache
-
-Tags: 10.0.6-fpm, 10.0-fpm, 10-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e714562be972718c33d06d875e4d53ac63a9aeec
-Directory: 10.0/fpm
-
 Tags: 11.0.4-apache, 11.0-apache, 11-apache, 11.0.4, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
+GitCommit: 6ed3dfe5568941b482cd7d19a39bd19dec05f642
 Directory: 11.0/apache
 
 Tags: 11.0.4-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 444cd43edfdeef05744a5641c913b03583de7894
+GitCommit: 6ed3dfe5568941b482cd7d19a39bd19dec05f642
 Directory: 11.0/fpm
 
 Tags: 12.0.2-apache, 12.0-apache, 12-apache, apache, 12.0.2, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2220249a20b6b92e25f51eb7c1f39a77b7838c49
+GitCommit: 6ed3dfe5568941b482cd7d19a39bd19dec05f642
 Directory: 12.0/apache
 
 Tags: 12.0.2-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2220249a20b6b92e25f51eb7c1f39a77b7838c49
+GitCommit: 6ed3dfe5568941b482cd7d19a39bd19dec05f642
 Directory: 12.0/fpm

--- a/library/ruby
+++ b/library/ruby
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.4.1-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/stretch
 
 Tags: 2.4.1-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.1-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.1, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/jessie
 
 Tags: 2.4.1-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.1-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -31,22 +31,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.1-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.1-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 627e55f6a1ec8d63b5c3671e25c70bdae412ef56
+GitCommit: 135c84979b1401a6963e75f3c95161bfe5be2336
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.4-jessie, 2.3-jessie, 2.3.4, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
+GitCommit: d2a85bf5a3799c0592140ff66b269c823b813998
 Directory: 2.3/jessie
 
 Tags: 2.3.4-slim-jessie, 2.3-slim-jessie, 2.3.4-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
+GitCommit: d2a85bf5a3799c0592140ff66b269c823b813998
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.4-onbuild, 2.3-onbuild
@@ -56,17 +56,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.4-alpine3.4, 2.3-alpine3.4, 2.3.4-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: f9327a002f9f197843829ecccb3aeeec102034d0
+GitCommit: d2a85bf5a3799c0592140ff66b269c823b813998
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.7-jessie, 2.2-jessie, 2.2.7, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
+GitCommit: ab1275096a39d8952d1ede12d0a701cef9cb77d3
 Directory: 2.2/jessie
 
 Tags: 2.2.7-slim-jessie, 2.2-slim-jessie, 2.2.7-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
+GitCommit: ab1275096a39d8952d1ede12d0a701cef9cb77d3
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.7-onbuild, 2.2-onbuild
@@ -76,5 +76,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.7-alpine3.4, 2.2-alpine3.4, 2.2.7-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 5f1f63541ced4c2c87e3441ce2d05a69b71a6912
+GitCommit: ab1275096a39d8952d1ede12d0a701cef9cb77d3
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `buildpack-deps`: add `dpkg-dev` (docker-library/buildpack-deps#65)
- `nextcloud`: remove EOL 10.0 (https://github.com/nextcloud/docker/pull/146), update permissions for non-root usage (https://github.com/nextcloud/docker/pull/131)
- `ruby`: rubygems 2.6.13