### PR TITLE
Bump Traefik to v1.4.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,6 +3,13 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
+Tags: v1.4.0-rc1, 1.4.0-rc1, v1.4, 1.4, roquefort
+GitCommit: e926214258069c7e7a8cf1e7cac8ad14d177b11f
+
+Tags: v1.4.0-rc1-alpine, 1.4.0-rc1-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
+GitCommit: e926214258069c7e7a8cf1e7cac8ad14d177b11f
+Directory: alpine
+
 Tags: v1.3.7, 1.3.7, v1.3, 1.3, raclette, latest
 GitCommit: 871d6c731511ed011b8b14fb6ae7942cc0df2929
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.0-rc1.

/cc @vdemeester @emilevauge

Cheers
