### PR TITLE
Upgrade PHP to 7.0 for MediaWiki LTS wikimedia/mediawiki-docker#37

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -1,7 +1,7 @@
 Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Ryan Kaldari <rkaldari@wikimedia.org> (@kaldari)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 659cf5aedb8f785bb400a63f9c450f458ead260c
+GitCommit: 4f836fabe384623b9a6d9e43a5d025c267bfe496
 
 Tags: stable, latest, 1.29, 1.29.1
 Directory: stable


### PR DESCRIPTION
cc/ @addshore @legoktm