### PR TITLE
haxe: add windowsservercore variant

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -2,50 +2,82 @@ Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.4.2-stretch, 3.4-stretch, 3.4.2, 3.4, latest
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.4/stretch
 
 Tags: 3.4.2-jessie, 3.4-jessie
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.4/jessie
 
 Tags: 3.4.2-onbuild, 3.4-onbuild
+Architectures: amd64
 GitCommit: 8e6c65a2d72c239e8ddaf5af9157bb146d71016d
 Directory: 3.4/onbuild
 
+Tags: 3.4.2-windowsservercore, 3.4-windowsservercore
+Architectures: windows-amd64
+GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
+Directory: 3.4/windowsservercore
+
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.3/stretch
 
 Tags: 3.3.0-rc.1-jessie, 3.3.0-jessie, 3.3-jessie
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.3/jessie
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
+Architectures: amd64
 GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.3/onbuild
 
+Tags: 3.3.0-rc.1-windowsservercore, 3.3.0-windowsservercore, 3.3-windowsservercore
+Architectures: windows-amd64
+GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
+Directory: 3.3/windowsservercore
+
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.2/stretch
 
 Tags: 3.2.1-jessie, 3.2-jessie
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.2/jessie
 
 Tags: 3.2.1-onbuild, 3.2-onbuild
+Architectures: amd64
 GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.2/onbuild
 
+Tags: 3.2.1-windowsservercore, 3.2-windowsservercore
+Architectures: windows-amd64
+GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
+Directory: 3.2/windowsservercore
+
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.1/stretch
 
 Tags: 3.1.3-jessie, 3.1-jessie
+Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
 Directory: 3.1/jessie
 
 Tags: 3.1.3-onbuild, 3.1-onbuild
+Architectures: amd64
 GitCommit: e0f9cb5a3cc190acd42565113e3380b5853f5746
 Directory: 3.1/onbuild
+
+Tags: 3.1.3-windowsservercore, 3.1-windowsservercore
+Architectures: windows-amd64
+GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
+Directory: 3.1/windowsservercore
 

--- a/library/haxe
+++ b/library/haxe
@@ -20,6 +20,7 @@ Tags: 3.4.2-windowsservercore, 3.4-windowsservercore
 Architectures: windows-amd64
 GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.4/windowsservercore
+Constraints: windowsservercore
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: amd64
@@ -40,6 +41,7 @@ Tags: 3.3.0-rc.1-windowsservercore, 3.3.0-windowsservercore, 3.3-windowsserverco
 Architectures: windows-amd64
 GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.3/windowsservercore
+Constraints: windowsservercore
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
 Architectures: amd64
@@ -60,6 +62,7 @@ Tags: 3.2.1-windowsservercore, 3.2-windowsservercore
 Architectures: windows-amd64
 GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.2/windowsservercore
+Constraints: windowsservercore
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
 Architectures: amd64
@@ -80,4 +83,5 @@ Tags: 3.1.3-windowsservercore, 3.1-windowsservercore
 Architectures: windows-amd64
 GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.1/windowsservercore
+Constraints: windowsservercore
 


### PR DESCRIPTION
Add windowsservercore variant.

Currently there is no prebuilt 64bit haxe/neko binary release, so nanoserver can't be supported yet.