### PR TITLE
ArangoDB: we've changed our download URL.

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,10 +1,10 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.8: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
-2.8.11: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
+2.8: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
+2.8.11: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
 
 
-3.2: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
-3.2.2: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
-latest: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+3.2: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce stretch/3.2.2
+3.2.2: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce stretch/3.2.2
+latest: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce stretch/3.2.2

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,10 +1,10 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.8: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
-2.8.11: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
+2.8: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
+2.8.11: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
 
 
-3.2: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
-3.2.2: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
-latest: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+3.2: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+3.2.2: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+latest: https://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2

--- a/library/arangodb
+++ b/library/arangodb
@@ -1,10 +1,10 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 
-2.8: git://github.com/arangodb/arangodb-docker@05366cb4c6a6aab8e1ff9ca74c81b09d9a57b5b5 jessie/2.8.11
-2.8.11: git://github.com/arangodb/arangodb-docker@05366cb4c6a6aab8e1ff9ca74c81b09d9a57b5b5 jessie/2.8.11
+2.8: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
+2.8.11: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 jessie/2.8.11
 
 
-3.2: git://github.com/arangodb/arangodb-docker@aecd03e23898c9659d4611d9696b257086da08ff stretch/3.2.2
-3.2.2: git://github.com/arangodb/arangodb-docker@aecd03e23898c9659d4611d9696b257086da08ff stretch/3.2.2
-latest: git://github.com/arangodb/arangodb-docker@aecd03e23898c9659d4611d9696b257086da08ff stretch/3.2.2
+3.2: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+3.2.2: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2
+latest: git://github.com/arangodb/arangodb-docker@19afd5ff9838df07d372d15326e94eed7b0b4591 stretch/3.2.2


### PR DESCRIPTION
We have changed our download architecture. 
The way we've used curl in the docker will make it not to follow redirects, thus we'd like to change existing images.