### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.8.0, 1.8, 1, latest
+Tags: 1.8.1, 1.8, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2e32ab6f300fd45bf7ecd06988bc3463e4f0a031
+GitCommit: 0dbad8d90ca8030174619199cef955040eba1e82
 Directory: 1/debian
 
-Tags: 1.8.0-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.1-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 2e32ab6f300fd45bf7ecd06988bc3463e4f0a031
+GitCommit: 0dbad8d90ca8030174619199cef955040eba1e82
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.18, 5.7, 5, latest
-GitCommit: 48c7ca0ae7473f3127650f45f21e8ea85d7bb4d2
+Tags: 5.7.19, 5.7, 5, latest
+GitCommit: bded1be561f9480c248058840644be09d3282e44
 Directory: 5.7
 
 Tags: 5.6.37, 5.6

--- a/library/php
+++ b/library/php
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0beta3-cli, 7.2-rc-cli, rc-cli, 7.2.0beta3, 7.2-rc, rc
+Tags: 7.2.0RC1-cli, 7.2-rc-cli, rc-cli, 7.2.0RC1, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc
 
-Tags: 7.2.0beta3-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0RC1-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/alpine
 
-Tags: 7.2.0beta3-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0RC1-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/apache
 
-Tags: 7.2.0beta3-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0RC1-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/fpm
 
-Tags: 7.2.0beta3-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0RC1-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/fpm/alpine
 
-Tags: 7.2.0beta3-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0RC1-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/zts
 
-Tags: 7.2.0beta3-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0RC1-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: c8a1150f4b3cf8afe862084da8a40c7cfcf75b4e
+GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.8-cli, 7.1-cli, 7-cli, cli, 7.1.8, 7.1, 7, latest
@@ -74,39 +74,39 @@ Architectures: amd64
 GitCommit: 903540ea7918b5cabed6b32e81f8518f9e6f204f
 Directory: 7.1/zts/alpine
 
-Tags: 7.0.22-cli, 7.0-cli, 7.0.22, 7.0
+Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0
 
-Tags: 7.0.22-alpine, 7.0-alpine
+Tags: 7.0.23-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/alpine
 
-Tags: 7.0.22-apache, 7.0-apache
+Tags: 7.0.23-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/apache
 
-Tags: 7.0.22-fpm, 7.0-fpm
+Tags: 7.0.23-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/fpm
 
-Tags: 7.0.22-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.23-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.22-zts, 7.0-zts
+Tags: 7.0.23-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/zts
 
-Tags: 7.0.22-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.23-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 2630167f7e69394bdd91f240443a0a521fd7872d
+GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5

--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10-beta3, 10
+Tags: 10-beta4, 10
 Architectures: amd64, i386, ppc64le
-GitCommit: a42e1249e16d8eb0c164104410f78f3dcebe6406
+GitCommit: 43f393cccec4b3c6066531fc5c3d594327825940
 Directory: 10
 
-Tags: 10-beta3-alpine, 10-alpine
+Tags: 10-beta4-alpine, 10-alpine
 Architectures: amd64
-GitCommit: 3aeab631baeee5b6c872c750259764fd5960deca
+GitCommit: ee1bb1f51c9bae5be684a4797f934dbb943e3267
 Directory: 10/alpine
 
-Tags: 9.6.4, 9.6, 9, latest
+Tags: 9.6.5, 9.6, 9, latest
 Architectures: amd64, i386, ppc64le
-GitCommit: bef7a7e02643bb0f104ba346395d3cdb78db1480
+GitCommit: c6d76847c03ff9bc95ab11ebac769cf24e163ca6
 Directory: 9.6
 
-Tags: 9.6.4-alpine, 9.6-alpine, 9-alpine, alpine
+Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64
-GitCommit: 58ed93931d38f96981fb3e971217e6619d23f75a
+GitCommit: d1725ffa8ba29ed7649bd453065eb392f63a3113
 Directory: 9.6/alpine
 
-Tags: 9.5.8, 9.5
+Tags: 9.5.9, 9.5
 Architectures: amd64, i386, ppc64le
-GitCommit: 8836191de6100bfae541c6d9a02cb4ec6e97471e
+GitCommit: 8904bffa5e197cd016e0d6349d1db8b480fa28a9
 Directory: 9.5
 
-Tags: 9.5.8-alpine, 9.5-alpine
+Tags: 9.5.9-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: a1b76e5704e4d8f40c736454eccba863a7be75e4
+GitCommit: 9e862fa9b1d510c618d51e5d2c63f439d15381ff
 Directory: 9.5/alpine
 
-Tags: 9.4.13, 9.4
+Tags: 9.4.14, 9.4
 Architectures: amd64, i386, ppc64le
-GitCommit: 9e6a83faa9859b35fc4df18be513320c00ecd493
+GitCommit: 96498cc9b353adf67b8bada27b4aaf1fde858bd8
 Directory: 9.4
 
-Tags: 9.4.13-alpine, 9.4-alpine
+Tags: 9.4.14-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: 9d16e9e237b271da39d05d95af24724e79181b19
+GitCommit: b2649f97aee8bca9f4e65a2c050f66fe255ec9f3
 Directory: 9.4/alpine
 
-Tags: 9.3.18, 9.3
+Tags: 9.3.19, 9.3
 Architectures: amd64, i386, ppc64le
-GitCommit: ef1e190d84d5ef8c763cb96aeec3356916444efc
+GitCommit: b8bc661d9222e4f91b291368a1f7f92ee67ac627
 Directory: 9.3
 
-Tags: 9.3.18-alpine, 9.3-alpine
+Tags: 9.3.19-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: ce13cadcb81160cf57bce87b4131cffe36359fcd
+GitCommit: b1fc9b6f7506ea7357f48fb0125e8b7a3c1d96e9
 Directory: 9.3/alpine
 
-Tags: 9.2.22, 9.2
+Tags: 9.2.23, 9.2
 Architectures: amd64, i386, ppc64le
-GitCommit: de4122a80157b1a0a73c14bdd4f11479011a2a51
+GitCommit: 7b518a11cf0d1bcebbf27b3cbbc64cb69839db11
 Directory: 9.2
 
-Tags: 9.2.22-alpine, 9.2-alpine
+Tags: 9.2.23-alpine, 9.2-alpine
 Architectures: amd64
-GitCommit: 49a7e2bf209f8344e8240ddbc3a1368c6b72129e
+GitCommit: b3cb99032a600a27dcb8f3c52f14c72fd22d477f
 Directory: 9.2/alpine


### PR DESCRIPTION
- `ghost`: 1.8.1
- `percona`: 5.7.19
- `php`: 7.0.23, 7.2.0RC1
- `postgres`: 10beta4, 9.2.23, 9.3.19, 9.4.14, 9.5.9, 9.6.5