### PR TITLE
Add tomee Architectures based on openjdk base image Architectures

### DIFF
--- a/library/tomee
+++ b/library/tomee
@@ -2,17 +2,22 @@ Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars),
              Otavio Santana <otaviojava@apache.org> (@otaviojava)
 GitRepo: https://github.com/tomitribe/docker-tomee.git
 GitCommit: 2a6fed6d93248bb53e8d81bee2e7259c42480137
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 
 Tags: 6-jre-1.7.4-jaxrs
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 6-jre-1.7.4-jaxrs
 
 Tags: 6-jre-1.7.4-plume
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 6-jre-1.7.4-plume
 
 Tags: 6-jre-1.7.4-plus
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 6-jre-1.7.4-plus
 
 Tags: 6-jre-1.7.4-webprofile
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 6-jre-1.7.4-webprofile
 
 Tags: 7-jre-1.7.4-jaxrs


### PR DESCRIPTION
cc @lordofthejars @otaviojava -- does this seem sane to you?  I've personally tested this on `s390x` (and successfully run at least `tomee:7-jre-1.7.4-webprofile`), and it seems like `tomee`'s upstream tarballs really should "just work" anywhere `openjdk` does.

See https://github.com/docker-library/official-images#architectures-other-than-amd64, https://github.com/docker-library/official-images#multiple-architectures, and https://github.com/docker-library/official-images/issues/2289 for more details about multiarch + official images. :+1:

I've also got a script which generates this file now, but it depends on having the `bashbrew` tool installed locally to scrape the architectures of `openjdk`: (run from a checkout of the `tomee` repo)

```bash
#!/usr/bin/env bash
set -Eeuo pipefail

self="$(basename "$BASH_SOURCE")"
cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"

versions=( */ )
versions=( "${versions[@]%/}" )

latest="$(echo "${versions[*]}" | xargs -n1 | grep -- '-webprofile$' | sort -V | tail -1)"
declare -A aliases=(
	["$latest"]='latest'
)

getArches() {
	local repo="$1"; shift
	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'

	eval "declare -g -A parentRepoToArches=( $(
		find -name 'Dockerfile' -exec awk '
				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
					print "'"$officialImagesUrl"'" $2
				}
			' '{}' + \
			| sort -u \
			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
	) )"
}
getArches 'tomee'

declare -A versionArches=() popularArches=()
mostPopularArches=
mostPopularArchesN=0

for version in "${versions[@]}"; do
	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
	arches="${parentRepoToArches[$parent]}"

	versionArches["$version"]="$arches"

	n="${popularArches["$arches"]:-0}"
	(( n++ )) || :
	popularArches["$arches"]="$n"

	if [ "$n" -gt "$mostPopularArchesN" ]; then
		mostPopularArches="$arches"
		mostPopularArchesN="$n"
	fi
done

# prints "$2$1$3$1...$N"
join() {
	local sep="$1"; shift
	local out; printf -v out "${sep//%/%%}%s" "$@"
	echo "${out#$sep}"
}

commit="$(git log -1 --format='format:%H' HEAD --)"
cat <<-EOH
Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars),
             Otavio Santana <otaviojava@apache.org> (@otaviojava)
GitRepo: https://github.com/tomitribe/docker-tomee.git
GitCommit: $commit
Architectures: $(join ', ' $mostPopularArches)
EOH

for version in "${versions[@]}"; do
	arches="${versionArches[$version]}"

	echo
	echo "Tags: $(join ', ' $version ${aliases[$version]:-})"
	if [ "$arches" != "$mostPopularArches" ]; then
		echo "Architectures: $(join ', ' $arches)"
	fi
	echo "Directory: $version"
done
```

I'd be happy to send a PR of this script too if it's interesting, but I can also just save it to run again if it's ever needed. :smile: