### PR TITLE
Update mongo-express to version 0.42.2

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.40.0: git://github.com/mongo-express/mongo-express-docker@bbe8d015485c29b3bea01b7eb88ac56349fc17ae
-0.40: git://github.com/mongo-express/mongo-express-docker@bbe8d015485c29b3bea01b7eb88ac56349fc17ae
-latest: git://github.com/mongo-express/mongo-express-docker@bbe8d015485c29b3bea01b7eb88ac56349fc17ae
+0.42.2: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3
+0.42: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3
+latest: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,5 +1,5 @@
 # maintainer: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
-0.42.2: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3
-0.42: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3
-latest: git://github.com/mongo-express/mongo-express-docker@cae023b5ee921453563a875d192475f2d86115f3
+0.42.2: git://github.com/mongo-express/mongo-express-docker@c65871c94790ca0446ec222c5961a2d01c701cc0
+0.42: git://github.com/mongo-express/mongo-express-docker@c65871c94790ca0446ec222c5961a2d01c701cc0
+latest: git://github.com/mongo-express/mongo-express-docker@c65871c94790ca0446ec222c5961a2d01c701cc0


### PR DESCRIPTION
This mongo-express update includes:

- Fixup removed global window define added for debug
- Use a stream for exporting
- Support for connection strings so it works easily with atlas
- Fix linting issues
- Remove async since authenticating is async anyway
- Don't pass options to client connection
- Fixed remove default connection string
- Fixed some typos
- Fixed default port for mongodb