### PR TITLE
Update erlang with multiple architectures

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,40 +1,49 @@
-# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/a4fdf1d5de39a423d3c56b8a4f8084adcfde0f0c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/e7d145c915458e5bbb857a57c9aad7125f95a853/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
 Tags: 20.0.4, 20.0, 20, latest
-GitCommit: 1f97f0584dfe0253b7c831a8c8fd5115f59a07ff
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 20
 
 Tags: 20.0.4-slim, 20.0-slim, 20-slim, slim
-GitCommit: 1f97f0584dfe0253b7c831a8c8fd5115f59a07ff
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 20/slim
 
 Tags: 20.0.4-alpine, 20.0-alpine, 20-alpine, alpine
-GitCommit: 1f97f0584dfe0253b7c831a8c8fd5115f59a07ff
+Architectures: amd64
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 20/alpine
 
 Tags: 19.3.6.2, 19.3.6, 19.3, 19
-GitCommit: 8e68446c17aaf5bd3c6ab204b920cb01f269438f
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 19
 
 Tags: 19.3.6.2-slim, 19.3.6-slim, 19.3-slim, 19-slim
-GitCommit: 98222f1cd2c0d266f8c3a225fcb719c4e6d053c4
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 19/slim
 
 Tags: 18.3.4.5, 18.3.4, 18.3, 18
-GitCommit: 8e68446c17aaf5bd3c6ab204b920cb01f269438f
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 18
 
 Tags: 18.3.4.5-slim, 18.3.4-slim, 18.3-slim, 18-slim
-GitCommit: 1b03fdd83ec769e7962ec0dce01e25613a46dacf
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 18/slim
 
 Tags: 17.5.6.9, 17.5.6, 17.5, 17
-GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 17
 
 Tags: 17.5.6.9-slim, 17.5.6-slim, 17.5-slim, 17-slim
-GitCommit: ea32d5f6f1735f9f55bee04b112166da96eb9c73
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: e7d145c915458e5bbb857a57c9aad7125f95a853
 Directory: 17/slim


### PR DESCRIPTION
See https://github.com/c0b/docker-erlang-otp/pull/70. :metal:

cc @c0b