### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.0-beta1-apache, 8.4-rc-apache, rc-apache, 8.4.0-beta1, 8.4-rc, rc
+Tags: 8.4.0-rc1-apache, 8.4-rc-apache, rc-apache, 8.4.0-rc1, 8.4-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
+GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
 Directory: 8.4-rc/apache
 
-Tags: 8.4.0-beta1-fpm, 8.4-rc-fpm, rc-fpm
+Tags: 8.4.0-rc1-fpm, 8.4-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
+GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
 Directory: 8.4-rc/fpm
 
-Tags: 8.4.0-beta1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.4.0-rc1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 2cbb3819480ebfa62053c75de2710659cbb8f66e
+GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
 Directory: 8.4-rc/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest

--- a/library/mongo
+++ b/library/mongo
@@ -30,16 +30,16 @@ GitCommit: 61aabfb537a1fbcae44f02ab515df54395b68400
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.7, 3.4, 3, latest
+Tags: 3.4.8, 3.4, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: ee34922c3e5e6f1b4f7c02dc633744c349ee8ace
+GitCommit: 7d14eb15d70155db3cf2bf346ab44f5c679346fd
 Directory: 3.4
 
-Tags: 3.4.7-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.4.8-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: ee34922c3e5e6f1b4f7c02dc633744c349ee8ace
+GitCommit: 7d14eb15d70155db3cf2bf346ab44f5c679346fd
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/php
+++ b/library/php
@@ -1,11 +1,11 @@
-# this file is generated via https://github.com/docker-library/php/blob/179431c325c8c20e18ca9354c3d128a85a8eb770/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/925ea64fe2661a4f9d9d3d20cdb305673fc3de6d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0RC1-cli, 7.2-rc-cli, rc-cli, 7.2.0RC1, 7.2-rc, rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc
 
@@ -15,12 +15,12 @@ GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/alpine
 
 Tags: 7.2.0RC1-apache, 7.2-rc-apache, rc-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/apache
 
 Tags: 7.2.0RC1-fpm, 7.2-rc-fpm, rc-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/fpm
 
@@ -30,7 +30,7 @@ GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/fpm/alpine
 
 Tags: 7.2.0RC1-zts, 7.2-rc-zts, rc-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/zts
 
@@ -40,7 +40,7 @@ GitCommit: e40afc3c7605f78cf2c5c0a1c419f9cf849d07c9
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1
 
@@ -50,12 +50,12 @@ GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/alpine
 
 Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/apache
 
 Tags: 7.1.9-fpm, 7.1-fpm, 7-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/fpm
 
@@ -65,7 +65,7 @@ GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/zts
 
@@ -75,7 +75,7 @@ GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0
 
@@ -85,12 +85,12 @@ GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/alpine
 
 Tags: 7.0.23-apache, 7.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/apache
 
 Tags: 7.0.23-fpm, 7.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/fpm
 
@@ -100,7 +100,7 @@ GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.23-zts, 7.0-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/zts
 
@@ -110,7 +110,7 @@ GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6
 
@@ -120,12 +120,12 @@ GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/apache
 
 Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/fpm
 
@@ -135,7 +135,7 @@ GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
 Directory: 5.6/zts
 


### PR DESCRIPTION
- `drupal`: 8.4.0-rc1
- `mongo`: 3.4.8
- `php`: remove `arm32v5` (docker-library/php#491; most recent build took ~10hr)