### PR TITLE
Add a "--dry-run" flag to "build", "tag", "push", and "put-shared"

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/codegangsta/cli"
@@ -15,6 +16,7 @@ func cmdPush(c *cli.Context) error {
 
 	uniq := c.Bool("uniq")
 	namespace := c.String("namespace")
+	dryRun := c.Bool("dry-run")
 
 	if namespace == "" {
 		return fmt.Errorf(`"--namespace" is a required flag for "push"`)
@@ -36,12 +38,14 @@ func cmdPush(c *cli.Context) error {
 				lastUpdated := fetchDockerHubTagMeta(tag).lastUpdatedTime()
 				if created.After(lastUpdated) {
 					fmt.Printf("Pushing %s\n", tag)
-					err = dockerPush(tag)
-					if err != nil {
-						return cli.NewMultiError(fmt.Errorf(`failed pushing %q`, tag), err)
+					if !dryRun {
+						err = dockerPush(tag)
+						if err != nil {
+							return cli.NewMultiError(fmt.Errorf(`failed pushing %q`, tag), err)
+						}
 					}
 				} else {
-					fmt.Printf("Skipping %s (created %s, last updated %s)\n", tag, created.Local().Format(time.RFC3339), lastUpdated.Local().Format(time.RFC3339))
+					fmt.Fprintf(os.Stderr, "skipping %s (created %s, last updated %s)\n", tag, created.Local().Format(time.RFC3339), lastUpdated.Local().Format(time.RFC3339))
 				}
 			}
 		}

--- a/bashbrew/go/src/bashbrew/cmd-tag.go
+++ b/bashbrew/go/src/bashbrew/cmd-tag.go
@@ -15,6 +15,7 @@ func cmdTag(c *cli.Context) error {
 
 	uniq := c.Bool("uniq")
 	namespace := c.String("namespace")
+	dryRun := c.Bool("dry-run")
 
 	if namespace == "" {
 		return fmt.Errorf(`"--namespace" is a required flag for "tag"`)
@@ -34,9 +35,11 @@ func cmdTag(c *cli.Context) error {
 			for _, tag := range r.Tags("", uniq, entry) {
 				namespacedTag := path.Join(namespace, tag)
 				fmt.Printf("Tagging %s\n", namespacedTag)
-				err = dockerTag(tag, namespacedTag)
-				if err != nil {
-					return cli.NewMultiError(fmt.Errorf(`failed tagging %q as %q`, tag, namespacedTag), err)
+				if !dryRun {
+					err = dockerTag(tag, namespacedTag)
+					if err != nil {
+						return cli.NewMultiError(fmt.Errorf(`failed tagging %q as %q`, tag, namespacedTag), err)
+					}
 				}
 			}
 		}

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -198,6 +198,10 @@ func main() {
 			Value: 0,
 			Usage: "maximum number of levels to traverse (0 for unlimited)",
 		},
+		"dry-run": cli.BoolFlag{
+			Name:  "dry-run",
+			Usage: "do everything except the final action (for testing whether actions will be performed)",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -234,6 +238,7 @@ func main() {
 					EnvVar: flagEnvVars["pull"],
 					Usage:  `pull FROM before building (always, missing, never)`,
 				},
+				commonFlags["dry-run"],
 			},
 			Before: subcommandBeforeFactory("build"),
 			Action: cmdBuild,
@@ -245,6 +250,7 @@ func main() {
 				commonFlags["all"],
 				commonFlags["uniq"],
 				commonFlags["namespace"],
+				commonFlags["dry-run"],
 			},
 			Before: subcommandBeforeFactory("tag"),
 			Action: cmdTag,
@@ -256,6 +262,7 @@ func main() {
 				commonFlags["all"],
 				commonFlags["uniq"],
 				commonFlags["namespace"],
+				commonFlags["dry-run"],
 			},
 			Before: subcommandBeforeFactory("push"),
 			Action: cmdPush,
@@ -266,6 +273,7 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["namespace"],
+				commonFlags["dry-run"],
 			},
 			Before: subcommandBeforeFactory("put-shared"),
 			Action: cmdPutShared,


### PR DESCRIPTION
The intention is to use this for doing `put-shared` on our "heavy hitters" (repositories which we've been asked to leave at least 15 minutes in between pushes of any of them, so as to be kind to the automated build queues), allowing us to determine whether we need to do a push before we invoke it and then force a 15 minute wait before pushing another repository.