### PR TITLE
Update openjdk to non-headless on non-slim images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -16,7 +16,7 @@ Directory: 6-jdk/slim
 
 Tags: 6b38-jre, 6-jre
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 6-jre
 
 Tags: 6b38-jre-slim, 6-jre-slim
@@ -41,7 +41,7 @@ Directory: 7-jdk/alpine
 
 Tags: 7u151-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 7-jre
 
 Tags: 7u151-jre-slim, 7-jre-slim
@@ -83,7 +83,7 @@ Constraints: nanoserver
 
 Tags: 8u141-jre, 8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a23a228bda7d2edeb4132fffd2d08c1e1fcf4ac
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 8-jre
 
 Tags: 8u141-jre-slim, 8-jre-slim, jre-slim
@@ -98,7 +98,7 @@ Directory: 8-jre/alpine
 
 Tags: 9-b181-jdk, 9-b181, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 9-jdk
 
 Tags: 9-b181-jdk-slim, 9-b181-slim, 9-jdk-slim, 9-slim
@@ -120,7 +120,7 @@ Constraints: nanoserver
 
 Tags: 9-b181-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9865ab7ac7d26a1ba05d5eadde059c01873bc12d
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 9-jre
 
 Tags: 9-b181-jre-slim, 9-jre-slim

--- a/test/config.sh
+++ b/test/config.sh
@@ -233,7 +233,7 @@ globalExcludeTests+=(
 	# https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477
 	[clearlinux_no-hard-coded-passwords]=1
 
-	# alpine/slim openjdk images are non-headless and so can't do font stuff
+	# alpine/slim openjdk images are headless and so can't do font stuff
 	[openjdk:alpine_java-uimanager-font]=1
 	[openjdk:slim_java-uimanager-font]=1
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -129,6 +129,7 @@ imageTests+=(
 	'
 	[openjdk]='
 		java-hello-world
+		java-uimanager-font
 	'
 	[percona]='
 	'
@@ -231,6 +232,10 @@ globalExcludeTests+=(
 	# clearlinux has no /etc/password
 	# https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477
 	[clearlinux_no-hard-coded-passwords]=1
+
+	# alpine/slim openjdk images are non-headless and so can't do font stuff
+	[openjdk:alpine_java-uimanager-font]=1
+	[openjdk:slim_java-uimanager-font]=1
 
 	# no "native" dependencies
 	[ruby:alpine_ruby-bundler]=1

--- a/test/tests/java-uimanager-font/container.java
+++ b/test/tests/java-uimanager-font/container.java
@@ -1,0 +1,48 @@
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
+
+public class container {
+	static int exitVal = 0;
+
+	/**
+	 * Tests the UIManager a bit.	Doing this kills a lot of OpenJDK builds.
+	 *
+	 * Note these functions are used in a headless application, a web app.
+	 * The fonts are needed to create PDFs reliably.
+	 *
+	 * If this succeeds, the first line it prints to stdout is Success
+	 * and it returns a return code (exit value) of 0 (zero)
+	 *
+	 * If there's a failure, the first line consists of Failed, and the return code is 1 (one)
+	 */
+	public static void main(String[] args) {
+		
+		try {
+			String family = UIManager.getFont("Label.font").getFamily();
+		} catch (Throwable t) {
+			bad("Could not get the default font's family", t);
+		}
+
+		try {
+			LookAndFeel look = UIManager.getLookAndFeel();
+		} catch (Throwable t) {
+			bad("Error getting the look and feel class name", t);
+		}
+
+		try {
+			LookAndFeel metal = new javax.swing.plaf.metal.MetalLookAndFeel();
+			UIManager.setLookAndFeel(metal);
+			String family = UIManager.getFont("Label.font").getFamily();
+		} catch (Throwable t) {
+			bad("Error making a Metal look/feel, setting it to the UIManager, or getting its font...", t);
+		}
+
+		System.exit(exitVal);
+	}
+
+	private static void bad(String msg, Throwable t) {
+		exitVal = 1;
+		System.err.println(msg);
+		t.printStackTrace(System.err);
+	}
+}

--- a/test/tests/java-uimanager-font/run.sh
+++ b/test/tests/java-uimanager-font/run.sh
@@ -1,0 +1,1 @@
+../run-java-in-container.sh


### PR DESCRIPTION
Add test for openjdk non-headless: uimanager-font

contains: https://github.com/docker-library/openjdk/pull/143