### PR TITLE
Bump Traefik to v1.3.8 & v1.4.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -11,7 +11,7 @@ arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.4.0-rc2-alpine, 1.4.0-rc2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64
 GitCommit: 958f6030439804adb1f273e5a0cebd131c6d097e
 Directory: alpine
 
@@ -23,6 +23,6 @@ arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64
 GitCommit: d8e45a67e2f7693f78e3fba70285cb9a1942dc59
 Directory: alpine

--- a/library/traefik
+++ b/library/traefik
@@ -10,10 +10,16 @@ Tags: v1.4.0-rc1-alpine, 1.4.0-rc1-alpine, v1.4-alpine, 1.4-alpine, roquefort-al
 GitCommit: e926214258069c7e7a8cf1e7cac8ad14d177b11f
 Directory: alpine
 
-Tags: v1.3.7, 1.3.7, v1.3, 1.3, raclette, latest
-GitCommit: 871d6c731511ed011b8b14fb6ae7942cc0df2929
+Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 0d6fceb44fd48e7b05bffe13a1a6209dbee20c04
+amd64-Directory: scratch/amd64
+arm32v6-Directory: scratch/arm
+arm64v8-Directory: scratch/arm64
 
-Tags: v1.3.7-alpine, 1.3.7-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine
-GitCommit: 871d6c731511ed011b8b14fb6ae7942cc0df2929
-Directory: alpine
-
+Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 0d6fceb44fd48e7b05bffe13a1a6209dbee20c04
+amd64-Directory: alpine/amd64
+arm32v6-Directory: alpine/arm
+arm64v8-Directory: alpine/arm64

--- a/library/traefik
+++ b/library/traefik
@@ -5,24 +5,24 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v1.4.0-rc2, 1.4.0-rc2, v1.4, 1.4, roquefort
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 958f6030439804adb1f273e5a0cebd131c6d097e
+GitCommit: 57f83af9d2719e5f25e6c769fd2640f973b519dc
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.4.0-rc2-alpine, 1.4.0-rc2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
 Architectures: amd64
-GitCommit: 958f6030439804adb1f273e5a0cebd131c6d097e
+GitCommit: 57f83af9d2719e5f25e6c769fd2640f973b519dc
 Directory: alpine
 
 Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: d8e45a67e2f7693f78e3fba70285cb9a1942dc59
+GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
 Architectures: amd64
-GitCommit: d8e45a67e2f7693f78e3fba70285cb9a1942dc59
+GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
 Directory: alpine

--- a/library/traefik
+++ b/library/traefik
@@ -3,23 +3,26 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
              Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.0-rc1, 1.4.0-rc1, v1.4, 1.4, roquefort
-GitCommit: e926214258069c7e7a8cf1e7cac8ad14d177b11f
+Tags: v1.4.0-rc2, 1.4.0-rc2, v1.4, 1.4, roquefort
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 958f6030439804adb1f273e5a0cebd131c6d097e
+amd64-Directory: scratch/amd64
+arm32v6-Directory: scratch/arm
+arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.0-rc1-alpine, 1.4.0-rc1-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-GitCommit: e926214258069c7e7a8cf1e7cac8ad14d177b11f
+Tags: v1.4.0-rc2-alpine, 1.4.0-rc2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 958f6030439804adb1f273e5a0cebd131c6d097e
 Directory: alpine
 
 Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0d6fceb44fd48e7b05bffe13a1a6209dbee20c04
+GitCommit: d8e45a67e2f7693f78e3fba70285cb9a1942dc59
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0d6fceb44fd48e7b05bffe13a1a6209dbee20c04
-amd64-Directory: alpine/amd64
-arm32v6-Directory: alpine/arm
-arm64v8-Directory: alpine/arm64
+GitCommit: d8e45a67e2f7693f78e3fba70285cb9a1942dc59
+Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.3.8 & v1.4.0-rc2.

/cc @vdemeester @emilevauge

Cheers