### PR TITLE
[ROS] Version bump for Jade

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -10,22 +10,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 # Distro: ubuntu:trusty
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/perception
 
@@ -37,22 +37,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 # Distro: ubuntu:trusty
 
 Tags: jade-ros-core, jade-ros-core-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-core
 
 Tags: jade-ros-base, jade-ros-base-trusty, jade
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-base
 
 Tags: jade-robot, jade-robot-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/robot
 
 Tags: jade-perception, jade-perception-trusty
-Architectures: amd64, arm32v7
+Architectures: amd64
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/perception
 

--- a/library/ros
+++ b/library/ros
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/osrf/docker_images/blob/7ba58fc107b368d6409c22161070eb93e562f240/ros/create_dockerlibrary.py
+# this file is generated via https://github.com/osrf/docker_images/blob/3e8b29c44f02c85b71a156be51c94902d4092929/ros/create_dockerlibrary.py
 
 Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
@@ -11,22 +11,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -38,22 +38,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: jade-ros-core, jade-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-core
 
 Tags: jade-ros-base, jade-ros-base-trusty, jade
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-base
 
 Tags: jade-robot, jade-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/robot
 
 Tags: jade-perception, jade-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/perception
 
 
@@ -65,22 +65,22 @@ Directory: ros/jade/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 ########################################
@@ -88,22 +88,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: kinetic-ros-core-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/ros-core
 
 Tags: kinetic-ros-base-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/ros-base
 
 Tags: kinetic-robot-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/robot
 
 Tags: kinetic-perception-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/perception
 
 
@@ -115,22 +115,22 @@ Directory: ros/kinetic/debian/jessie/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -138,20 +138,20 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/perception


### PR DESCRIPTION
Also, omitting arm32v7 from tags using ubuntu trusty until upstream cloud image issue is resolved.  
This is so that jenkins build farm for dockerhub can compete arm32v7 job for remaining distros.  
https://bugs.launchpad.net/cloud-images/+bug/1711735