### PR TITLE
Build manifest-tool from source to apply a minor patch

### DIFF
--- a/bashbrew/.bashbrew-arch-to-goenv.sh
+++ b/bashbrew/.bashbrew-arch-to-goenv.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -euo pipefail
+
+# usage: (from within another script)
+#   eval "$(./.bashbrew-arch-to-goenv.sh)"
+# since we need those new environment variables in our other script
+
+bashbrewArch="$1"; shift # "amd64", "arm32v5", "windows-amd64", etc.
+
+os="${bashbrewArch%%-*}"
+[ "$os" != "$bashbrewArch" ] || os='linux'
+printf 'export GOOS="%s"\n' "$os"
+
+arch="${bashbrewArch#${os}-}"
+case "$arch" in
+	arm32v*)
+		printf 'export GOARCH="%s"\n' 'arm'
+		printf 'export GOARM="%s"\n' "${arch#arm32v}"
+		;;
+
+	arm64v*)
+		printf 'export GOARCH="%s"\n' 'arm64'
+		# no GOARM for arm64 (yet?) -- https://github.com/golang/go/blob/1e72bf62183ea21b9affffd4450d44d994393899/src/cmd/internal/objabi/util.go#L40
+		#printf 'export GOARM="%s"\n' "${arch#arm64v}"
+		printf 'unset GOARM\n'
+		;;
+
+	i386)
+		printf 'export GOARCH="%s"\n' '386'
+		printf 'unset GOARM\n'
+		;;
+
+	*)
+		printf 'export GOARCH="%s"\n' "$arch"
+		printf 'unset GOARM\n'
+		;;
+esac

--- a/bashbrew/.dockerignore
+++ b/bashbrew/.dockerignore
@@ -6,3 +6,4 @@ go/bin
 go/pkg
 go/vendor/bin
 go/vendor/pkg
+!.bashbrew-arch-to-goenv.sh

--- a/bashbrew/Dockerfile.release
+++ b/bashbrew/Dockerfile.release
@@ -9,20 +9,7 @@ WORKDIR /usr/src/bashbrew
 ENV GOPATH /usr/src/bashbrew:/usr/src/bashbrew/vendor
 ENV CGO_ENABLED 0
 
-# https://github.com/estesp/manifest-tool/releases
-ENV MANIFEST_TOOL_VERSION 0.6.0
-# gpg: key 0F386284C03A1162: public key "Philip Estes <estesp@gmail.com>" imported
-ENV MANIFEST_TOOL_GPG_KEY 27F3EA268A97867EAF0BD05C0F386284C03A1162
-
-COPY go .
-
-RUN set -ex; \
-	\
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$MANIFEST_TOOL_GPG_KEY"; \
-	\
-	mkdir bin; \
-	for osArch in \
+ENV BASHBREW_ARCHES \
 		amd64 \
 		arm32v5 \
 		arm32v6 \
@@ -32,43 +19,70 @@ RUN set -ex; \
 		i386 \
 		ppc64le \
 		s390x \
-		windows-amd64 \
-	; do \
-		os="${osArch%%-*}"; \
-		[ "$os" != "$osArch" ] || os='linux'; \
-		export GOOS="$os"; \
-		arch="${osArch#${os}-}"; \
-		unset GOARM GO386; \
-		case "$arch" in \
-			arm32v*) export GOARCH='arm' GOARM="${arch#arm32v}" ;; \
-# no GOARM for arm64 (yet?) -- https://github.com/golang/go/blob/1e72bf62183ea21b9affffd4450d44d994393899/src/cmd/internal/objabi/util.go#L40
-			arm64v*) export GOARCH='arm64' ;; \
-			i386)    export GOARCH='386' ;; \
-			*)       export GOARCH="$arch" ;; \
-		esac; \
-		\
-		[ "$os" = 'windows' ] && ext='.exe' || ext=''; \
-		\
-		go build \
-			-a -v \
-			-ldflags '-s -w' \
+		windows-amd64
+
+COPY .bashbrew-arch-to-goenv.sh /usr/local/bin/
+
+# https://github.com/estesp/manifest-tool/releases
+ENV MANIFEST_TOOL_VERSION 0.6.0
+# gpg: key 0F386284C03A1162: public key "Philip Estes <estesp@gmail.com>" imported
+#ENV MANIFEST_TOOL_GPG_KEY 27F3EA268A97867EAF0BD05C0F386284C03A1162
+# TODO consume Phil's releases again (once he fixes https://github.com/estesp/manifest-tool/issues/47 properly)
+
+COPY manifest-tool.patch ./
+
+RUN set -euxo pipefail; \
+	\
+	mkdir -p bin; \
+	\
+	mkdir -p manifest-tool/src/github.com/estesp/manifest-tool; \
+	wget -qO- "https://github.com/estesp/manifest-tool/archive/v${MANIFEST_TOOL_VERSION}.tar.gz" \
+		| tar -xz --strip-components=1 -C manifest-tool/src/github.com/estesp/manifest-tool; \
+	( cd manifest-tool/src/github.com/estesp/manifest-tool && patch -p1 ) < manifest-tool.patch; \
+	for bashbrewArch in $BASHBREW_ARCHES; do \
+		( \
+			goEnv="$(.bashbrew-arch-to-goenv.sh "$bashbrewArch")"; eval "$goEnv"; \
+			[ "$GOOS" = 'windows' ] && ext='.exe' || ext=; \
+			GOPATH="$PWD/manifest-tool" \
+				go build \
+					-a -v \
+					-ldflags '-s -w' \
 # see https://github.com/golang/go/issues/9737#issuecomment-276817652 (and following comments) -- installsuffix is necessary (for now) to keep ARM
-# can remove "$osArch" from "installsuffix" in Go 1.10+ (https://github.com/golang/go/commit/1b53f15ebb00dd158af674df410c7941abb2b933)
-			-tags netgo -installsuffix "netgo-$osArch" \
-			-o "bin/bashbrew-$osArch$ext" \
-			./src/bashbrew; \
-		\
-		case "$GOARCH" in \
-# manifest-tool and GOARM aren't friends yet
-# ... and estesp is probably a big fat "lololol" on supporting i386 :D
-			arm|386) continue ;; \
-		esac; \
-		wget -O "bin/manifest-tool-$osArch$ext" "https://github.com/estesp/manifest-tool/releases/download/v${MANIFEST_TOOL_VERSION}/manifest-tool-$GOOS-$GOARCH$ext"; \
-		wget -O "bin/manifest-tool-$osArch$ext.asc" "https://github.com/estesp/manifest-tool/releases/download/v${MANIFEST_TOOL_VERSION}/manifest-tool-$GOOS-$GOARCH$ext.asc"; \
-		gpg --batch --verify "bin/manifest-tool-$osArch$ext.asc" "bin/manifest-tool-$osArch$ext"; \
+# can remove "$bashbrewArch" from "installsuffix" in Go 1.10+ (https://github.com/golang/go/commit/1b53f15ebb00dd158af674df410c7941abb2b933)
+					-tags netgo -installsuffix "netgo-$bashbrewArch" \
+					-o "$PWD/bin/manifest-tool-$bashbrewArch$ext" \
+					github.com/estesp/manifest-tool \
+			; \
+			ls -lAFh "bin/manifest-tool-$bashbrewArch$ext"; \
+			file "bin/manifest-tool-$bashbrewArch$ext"; \
+		) \
 	done; \
 	\
-	rm -rf "$GNUPGHOME"; \
+	ls -l bin; \
+	file bin/*
+
+COPY go .
+
+RUN set -euxo pipefail; \
+	\
+	mkdir -p bin; \
+	\
+	for bashbrewArch in $BASHBREW_ARCHES; do \
+		( \
+			goEnv="$(.bashbrew-arch-to-goenv.sh "$bashbrewArch")"; eval "$goEnv"; \
+			[ "$GOOS" = 'windows' ] && ext='.exe' || ext=; \
+			\
+			go build \
+				-a -v \
+				-ldflags '-s -w' \
+	# see https://github.com/golang/go/issues/9737#issuecomment-276817652 (and following comments) -- installsuffix is necessary (for now) to keep ARM
+	# can remove "$bashbrewArch" from "installsuffix" in Go 1.10+ (https://github.com/golang/go/commit/1b53f15ebb00dd158af674df410c7941abb2b933)
+				-tags netgo -installsuffix "netgo-$bashbrewArch" \
+				-o "bin/bashbrew-$bashbrewArch$ext" \
+				./src/bashbrew \
+			; \
+		) \
+	done; \
 	\
 	ls -l bin; \
 	file bin/*

--- a/bashbrew/manifest-tool.patch
+++ b/bashbrew/manifest-tool.patch
@@ -1,0 +1,56 @@
+https://github.com/estesp/manifest-tool/issues/47
+
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 52da523..3cf3d98 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -100,6 +100,13 @@ func (f *Field) UnmarshalText(p []byte) error {
+ 	return nil
+ }
+ 
++func remoteName(name string) string {
++	if !strings.ContainsRune(name, '/') {
++		return "library/" + name
++	}
++	return name
++}
++
+ // Named is an object with a full name
+ type Named interface {
+ 	Reference
+@@ -304,7 +311,7 @@ func (r reference) String() string {
+ }
+ 
+ func (r reference) Name() string {
+-	return r.name
++	return remoteName(r.name)
+ }
+ 
+ func (r reference) Tag() string {
+@@ -322,7 +329,7 @@ func (r repository) String() string {
+ }
+ 
+ func (r repository) Name() string {
+-	return string(r)
++	return remoteName(string(r))
+ }
+ 
+ type digestReference digest.Digest
+@@ -345,7 +352,7 @@ func (t taggedReference) String() string {
+ }
+ 
+ func (t taggedReference) Name() string {
+-	return t.name
++	return remoteName(t.name)
+ }
+ 
+ func (t taggedReference) Tag() string {
+@@ -362,7 +369,7 @@ func (c canonicalReference) String() string {
+ }
+ 
+ func (c canonicalReference) Name() string {
+-	return c.name
++	return remoteName(c.name)
+ }
+ 
+ func (c canonicalReference) Digest() digest.Digest {


### PR DESCRIPTION
This applies a minor patch to our `manifest-tool` builds so that they can push to `library/xxx` successfully! (see https://github.com/estesp/manifest-tool/issues/47)

Since it only affects our usage, we're applying this hanky little patch (which is rightly 100% unacceptable for upstream) so that @estesp can focus on making a proper fix on his own schedule. :+1: