### PR TITLE
Bump swipl to 7.5.15, set default lang to UTF-8.

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,6 +1,6 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
-Tags: latest, 7.5.14
-GitCommit: b76acfff26b916351287a562d98b29c199c188ab
-Directory: 7.5.14/stretch
+Tags: latest, 7.5.15
+GitCommit: 31e2158e7ba2bb2fa9ebff7c0717c476244506bb
+Directory: 7.5.15/stretch


### PR DESCRIPTION
This bumps to the newly released `swipl` 7.5.15 and also sets the default behavior to load prolog code at UTF-8 rather than ASCII.

REF: https://github.com/SWI-Prolog/docker-swipl/issues/5