### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.09.0-ce-rc1, 17.09.0-ce, 17.09.0, 17.09-rc, rc, test
 Architectures: amd64
-GitCommit: ce8784112e81f724c96dae8272dd7367d712f3e9
+GitCommit: a170903ea568fe5c6aa34d3af2bda7308e037fc1
 Directory: 17.09-rc
 
 Tags: 17.09.0-ce-rc1-dind, 17.09.0-ce-dind, 17.09.0-dind, 17.09-rc-dind, rc-dind, test-dind

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -26,6 +26,6 @@ s390x-Directory: s390x/hello-seattle
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hello-seattle/nanoserver
 Constraints: nanoserver

--- a/library/hello-world
+++ b/library/hello-world
@@ -26,6 +26,6 @@ s390x-Directory: s390x/hello-world
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hello-world/nanoserver
 Constraints: nanoserver

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -26,6 +26,6 @@ s390x-Directory: s390x/hola-mundo
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hola-mundo/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
- `docker`: add `ppc64le` support (still waiting on Alpine multiarch; https://github.com/gliderlabs/docker-alpine/issues/304)
- `hello-seattle`: update Windows example (docker-library/hello-world#36)
- `hello-world`: update Windows example (docker-library/hello-world#36)
- `hola-mundo`: update Windows example (docker-library/hello-world#36)