### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.09.0-ce-rc1, 17.09.0-ce, 17.09.0, 17.09-rc, rc, test
+Tags: 17.09.0-ce-rc2, 17.09.0-ce, 17.09.0, 17.09-rc, rc, test
 Architectures: amd64
-GitCommit: a170903ea568fe5c6aa34d3af2bda7308e037fc1
+GitCommit: e90d458a6147f66630e7ad9877d7aa3c6d541414
 Directory: 17.09-rc
 
-Tags: 17.09.0-ce-rc1-dind, 17.09.0-ce-dind, 17.09.0-dind, 17.09-rc-dind, rc-dind, test-dind
+Tags: 17.09.0-ce-rc2-dind, 17.09.0-ce-dind, 17.09.0-dind, 17.09-rc-dind, rc-dind, test-dind
 Architectures: amd64
 GitCommit: ce8784112e81f724c96dae8272dd7367d712f3e9
 Directory: 17.09-rc/dind
 
-Tags: 17.09.0-ce-rc1-git, 17.09.0-ce-git, 17.09.0-git, 17.09-rc-git, rc-git, test-git
+Tags: 17.09.0-ce-rc2-git, 17.09.0-ce-git, 17.09.0-git, 17.09-rc-git, rc-git, test-git
 Architectures: amd64
 GitCommit: ce8784112e81f724c96dae8272dd7367d712f3e9
 Directory: 17.09-rc/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.8.5, 1.8, 1, latest
+Tags: 1.8.6, 1.8, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 815762e5f83619e062cc8adda8e9133f096c258f
+GitCommit: 8a63e148794b0dc626a1b0abcfd28829230dbca1
 Directory: 1/debian
 
-Tags: 1.8.5-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.6-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 815762e5f83619e062cc8adda8e9133f096c258f
+GitCommit: 8a63e148794b0dc626a1b0abcfd28829230dbca1
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,7 +5,7 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.4-apache, 11.0-apache, 11-apache, 11.0.4, 11.0, 11
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d87b840646635ba5b8fb92f19f72fe9e6486251e
+GitCommit: fd0cc806c8fe779c3f26fc41b0386f1d4ca9a2af
 Directory: 11.0/apache
 
 Tags: 11.0.4-fpm, 11.0-fpm, 11-fpm
@@ -15,7 +15,7 @@ Directory: 11.0/fpm
 
 Tags: 12.0.2-apache, 12.0-apache, 12-apache, apache, 12.0.2, 12.0, 12, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d87b840646635ba5b8fb92f19f72fe9e6486251e
+GitCommit: fd0cc806c8fe779c3f26fc41b0386f1d4ca9a2af
 Directory: 12.0/apache
 
 Tags: 12.0.2-fpm, 12.0-fpm, 12-fpm, fpm


### PR DESCRIPTION
- `docker`: 17.09.0-ce-rc2
- `ghost`: 1.8.6
- `nextcloud`: pretty URLs for Apache (https://github.com/nextcloud/docker/pull/152)