### PR TITLE
Add Solr 6.6.1 with other improvements

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,38 +1,80 @@
-# maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)
-# maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/4315c7b9cb10080492b0b426e4a7441e43c145b1/generate-stackbrew-library.sh
 
-5.5.4: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 5.5
-5.5: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 5.5
-5: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 5.5
+Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
+             Shalin Mangar <shalin@apache.org> (@shalinmangar)
+GitRepo: https://github.com/docker-solr/docker-solr.git
 
-5.5.4-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
-5.5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
-5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 5.5/alpine
+Tags: 6.6.1, 6.6, 6, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.6
 
-6.3.0: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.3
-6.3: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.3
+Tags: 6.6.1-alpine, 6.6-alpine, 6-alpine, alpine
+Architectures: amd64
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.6/alpine
 
-6.3.0-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3/alpine
-6.3-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.3/alpine
+Tags: 6.6.1-slim, 6.6-slim, 6-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.6/slim
 
-6.4.2: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.4
-6.4: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.4
+Tags: 6.5.1, 6.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.5
 
-6.4.2-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4/alpine
-6.4-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.4/alpine
+Tags: 6.5.1-alpine, 6.5-alpine
+Architectures: amd64
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.5/alpine
 
-6.5.1: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.5
-6.5: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.5
+Tags: 6.5.1-slim, 6.5-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.5/slim
 
-6.5.1-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5/alpine
-6.5-alpine: git://github.com/docker-solr/docker-solr@f02cef1654e7c5cdd46411b6dbe351e7fcb6422c 6.5/alpine
+Tags: 6.4.2, 6.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.4
 
-6.6.0: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.6
-6.6: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.6
-6: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.6
-latest: git://github.com/docker-solr/docker-solr@600fd5c682b63cca400ef87fe7738d752f6ca0ed 6.6
+Tags: 6.4.2-alpine, 6.4-alpine
+Architectures: amd64
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.4/alpine
 
-6.6.0-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
-6.6-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
-6-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
-alpine: git://github.com/docker-solr/docker-solr@c61a0c9b012c7313c2b5d0d97ddc06693270b734 6.6/alpine
+Tags: 6.4.2-slim, 6.4-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.4/slim
+
+Tags: 6.3.0, 6.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.3
+
+Tags: 6.3.0-alpine, 6.3-alpine
+Architectures: amd64
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.3/alpine
+
+Tags: 6.3.0-slim, 6.3-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 6.3/slim
+
+Tags: 5.5.4, 5.5, 5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 5.5
+
+Tags: 5.5.4-alpine, 5.5-alpine, 5-alpine
+Architectures: amd64
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 5.5/alpine
+
+Tags: 5.5.4-slim, 5.5-slim, 5-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+Directory: 5.5/slim


### PR DESCRIPTION
- Add Solr 6.6.1. See [announcement](http://lucene.apache.org/solr/news.html#7-september-2017-apache-solrtm-661-available)
- change the manifest to support multiple architectures
- add 'slim' variants
- reduce in-container file creation to help with INIT_SOLR_HOME and --user
- rewrite wait-for-solr.sh and add ability to wait for a remote Solr
- increased shellcheck compliance
- reduce build steps

For local/CI builds:

- separate and expanded tests
- separate build scripts used for Travis and local builds
- Travis parallel builds
- improvements to help older versions of Solr

Full changes: https://github.com/docker-solr/docker-solr/compare/600fd5c682b63cca400ef87fe7738d752f6ca0ed...master