### PR TITLE
fedora image updates

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -6,7 +6,7 @@ Constraints: !aufs
 Tags: latest, 26
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitFetch: refs/heads/26
-GitCommit: 1cea10502253a1a5b913eb1e59a7dc7482cbc0fa
+GitCommit: 065231a8dbc04882df54afdd749be16931aecd5a
 amd64-Directory: x86_64/
 arm32v7-Directory: armhfp/
 arm64v8-Directory: aarch64/
@@ -19,17 +19,16 @@ GitCommit: d5dd6eb44f0651788edb6f81a5537c09b07022c4
 amd64-Directory: x86_64/
 
 Tags: 25
+Architectures: amd64, arm32v7
 GitFetch: refs/heads/25
-GitCommit: 0603cc1536e4f62b77d1c34e39df55908f56aa48
-
-Tags: 24
-GitFetch: refs/heads/24
-GitCommit: f3726622b5012c1f374bf9f596616eab3cd4988c
+GitCommit: 2dc7762f57aac299ea93a58eb386bf1a9b31356f
+amd64-Directory: x86_64/
+arm32v7-Directory: armhfp/
 
 Tags: rawhide
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitFetch: refs/heads/rawhide
-GitCommit: 068835147960bde07171f320e1d2a037d62c07eb
+GitCommit: 3a5e26b6df79c1c649d231cd745d9360ee308041
 amd64-Directory: x86_64/
 arm32v7-Directory: armhfp/
 arm64v8-Directory: aarch64/


### PR DESCRIPTION
Remove EOL Fedora 24, update current images

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>