### PR TITLE
Bump Traefik to v1.4.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,28 +1,25 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge),
-             Vincent Demeester <vincent@sbr.pm> (@vdemeester),
-             Ludovic Fernandez <ludovic@containo.us> (@ldez)
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.0-rc2, 1.4.0-rc2, v1.4, 1.4, roquefort
+Tags: v1.4.0-rc3, 1.4.0-rc3, v1.4, 1.4, roquefort
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 57f83af9d2719e5f25e6c769fd2640f973b519dc
+GitCommit: 167c6ac81bbf39bebfbe4fdfef0e931ab33e9cac
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.0-rc2-alpine, 1.4.0-rc2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-Architectures: amd64
-GitCommit: 57f83af9d2719e5f25e6c769fd2640f973b519dc
+Tags: v1.4.0-rc3-alpine, 1.4.0-rc3-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 167c6ac81bbf39bebfbe4fdfef0e931ab33e9cac
 Directory: alpine
 
 Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
-Architectures: amd64
 GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
 Directory: alpine

--- a/library/traefik
+++ b/library/traefik
@@ -9,7 +9,6 @@ arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.4.0-rc3-alpine, 1.4.0-rc3-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-Architectures: amd64, arm64v8, arm32v6
 GitCommit: 167c6ac81bbf39bebfbe4fdfef0e931ab33e9cac
 Directory: alpine
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.0-rc3.

/cc @vdemeester @emilevauge

Cheers
