### PR TITLE
Update Crate to newer RFC 2822-based manifest format and adjust tag ordering to list "most specific" first for each entry

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -1,21 +1,22 @@
-# maintainer: Bernd Dorn <bernddorn@gmail.com> (@dobe)
-# maintainer: Mathias Fußenegger <mathias@crate.io> (@mfussenegger)
-# maintainer: Matthias Wahl <matthias@crate.io> (@mfelsche)
-# maintainer: Michael Beer <michael.beer@crate.io> (@mikethebeer)
-# maintainer: Christian Haudum <christian.haudum@crate.io> (@chaudum)
-# maintainer: Ruslan Kovalov <ruslan@crate.io> (@kovrus)
-# maintainer: Claus Matzinger <claus@crate.io> (@celaus)
-# maintainer: Christian Bader <christian.bader@crate.io> (@christianbader)
-# maintainer: Mika Naylor <mika@crate.io> (@autophagy)
+Maintainers: Bernd Dorn <bernddorn@gmail.com> (@dobe),
+             Mathias Fußenegger <mathias@crate.io> (@mfussenegger),
+             Matthias Wahl <matthias@crate.io> (@mfelsche),
+             Michael Beer <michael.beer@crate.io> (@mikethebeer),
+             Christian Haudum <christian.haudum@crate.io> (@chaudum),
+             Ruslan Kovalov <ruslan@crate.io> (@kovrus),
+             Claus Matzinger <claus@crate.io> (@celaus),
+             Christian Bader <christian.bader@crate.io> (@christianbader),
+             Mika Naylor <mika@crate.io> (@autophagy)
+GitRepo: https://github.com/crate/docker-crate.git
 
-# see also https://crate.io
+Tags: 2.1.7, 2.1, latest
+GitCommit: 21b3ccb1b09845558fefc3a822132ecb1c8161e6
 
-latest: git://github.com/crate/docker-crate@21b3ccb1b09845558fefc3a822132ecb1c8161e6
-1.0: git://github.com/crate/docker-crate@89e1557944b257c9e56b0e93a458eb6f0238ece3
-1.0.6: git://github.com/crate/docker-crate@89e1557944b257c9e56b0e93a458eb6f0238ece3
-1.1: git://github.com/crate/docker-crate@019830ed59c4b110f8c93f30430d282818ad95ec
-1.1.6: git://github.com/crate/docker-crate@019830ed59c4b110f8c93f30430d282818ad95ec
-2.0: git://github.com/crate/docker-crate@79d51bb263104ccd2d3c57a5d74c16d6f0466d21
-2.0.7: git://github.com/crate/docker-crate@79d51bb263104ccd2d3c57a5d74c16d6f0466d21
-2.1: git://github.com/crate/docker-crate@21b3ccb1b09845558fefc3a822132ecb1c8161e6
-2.1.7: git://github.com/crate/docker-crate@21b3ccb1b09845558fefc3a822132ecb1c8161e6
+Tags: 2.0.7, 2.0
+GitCommit: 79d51bb263104ccd2d3c57a5d74c16d6f0466d21
+
+Tags: 1.1.6, 1.1
+GitCommit: 019830ed59c4b110f8c93f30430d282818ad95ec
+
+Tags: 1.0.6, 1.0
+GitCommit: 89e1557944b257c9e56b0e93a458eb6f0238ece3


### PR DESCRIPTION
Closes #3467 (I also got the build to succeed, and the updated manifest list on `docker.io/library/crate` should be going up faster than I can type this)

fyi @dobe @mfussenegger @mfelsche @mikethebeer @chaudum @kovrus @celaus @christianbader @autophagy