### PR TITLE
Update couchdb images, maintainer and source repo

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -1,10 +1,14 @@
-# maintainer: Clemens Stolle <klaemo@apache.org> (@klaemo)
+# maintainer: Joan Touzet <wohali@apache.org> (@wohali)
 
-latest: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1
-1.6.1: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1
-1.6: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1
-1: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1
+latest: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
+2.1.1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
+2.1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
+2: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
 
-1.6.1-couchperuser: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1-couchperuser
-1.6-couchperuser: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1-couchperuser
-1-couchperuser: git://github.com/klaemo/docker-couchdb@29ed69965ed616a9d0df9a6ffa081773d86c78bc 1.6.1-couchperuser
+1.7.0: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
+1.7: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
+1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
+
+1.7.0-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser
+1.7-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser
+1-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser


### PR DESCRIPTION
Hi there, I'm with the Apache CouchDB PMC and have taken over release engineering efforts as of about a year ago. Clemens Stolle (@klaemo) provided his work on Docker to the ASF, and it has become an official part of the CouchDB project: https://github.com/apache/couchdb-docker. This PR changes the pointers from Clemens' repo over to this new repo.

This PR also includes new semi-official* images for the 2.1.0 release, which has been long awaited by our users. All of these images are also being published on Docker Hub at `apache/couchdb`.

A follow-up PR will be coming shortly to update the documentation as well. Please let me know what else is required.

*The Apache Software Foundation, by policy, only releases official source code tarballs; any derived binary work is considered a "convenience binary." I'm calling these "semi-official" because they are built and tested directly by the Apache CouchDB committer team.