### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.0-rc1-apache, 8.4-rc-apache, rc-apache, 8.4.0-rc1, 8.4-rc, rc
+Tags: 8.4.0-rc2-apache, 8.4-rc-apache, rc-apache, 8.4.0-rc2, 8.4-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
+GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
 Directory: 8.4-rc/apache
 
-Tags: 8.4.0-rc1-fpm, 8.4-rc-fpm, rc-fpm
+Tags: 8.4.0-rc2-fpm, 8.4-rc-fpm, rc-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
+GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
 Directory: 8.4-rc/fpm
 
-Tags: 8.4.0-rc1-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.4.0-rc2-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: c561323f3add389efbb3826593f3a45fede5d14b
+GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
 Directory: 8.4-rc/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,22 +3,22 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 11.0.4-apache, 11.0-apache, 11-apache, 11.0.4, 11.0, 11
+Tags: 11.0.5-apache, 11.0-apache, 11-apache, 11.0.5, 11.0, 11
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fd0cc806c8fe779c3f26fc41b0386f1d4ca9a2af
+GitCommit: 650e4b324872e4813f1a1851da9448c06fdb0872
 Directory: 11.0/apache
 
-Tags: 11.0.4-fpm, 11.0-fpm, 11-fpm
+Tags: 11.0.5-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d87b840646635ba5b8fb92f19f72fe9e6486251e
+GitCommit: 650e4b324872e4813f1a1851da9448c06fdb0872
 Directory: 11.0/fpm
 
-Tags: 12.0.2-apache, 12.0-apache, 12-apache, apache, 12.0.2, 12.0, 12, latest
+Tags: 12.0.3-apache, 12.0-apache, 12-apache, apache, 12.0.3, 12.0, 12, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fd0cc806c8fe779c3f26fc41b0386f1d4ca9a2af
+GitCommit: 8ad5dbd5f3de836ca3faf3966f343c136db74c72
 Directory: 12.0/apache
 
-Tags: 12.0.2-fpm, 12.0-fpm, 12-fpm, fpm
+Tags: 12.0.3-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d87b840646635ba5b8fb92f19f72fe9e6486251e
+GitCommit: 8ad5dbd5f3de836ca3faf3966f343c136db74c72
 Directory: 12.0/fpm

--- a/library/php
+++ b/library/php
@@ -6,140 +6,140 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0RC2-cli, 7.2-rc-cli, rc-cli, 7.2.0RC2, 7.2-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc
 
 Tags: 7.2.0RC2-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/alpine
 
 Tags: 7.2.0RC2-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/apache
 
 Tags: 7.2.0RC2-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/fpm
 
 Tags: 7.2.0RC2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/fpm/alpine
 
 Tags: 7.2.0RC2-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/zts
 
 Tags: 7.2.0RC2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: d7bfdb589536f64318933a9cc082b01309c6c97d
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1
 
 Tags: 7.1.9-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/alpine
 
 Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/apache
 
 Tags: 7.1.9-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/fpm
 
 Tags: 7.1.9-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/zts
 
 Tags: 7.1.9-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: ae9d560db8b4a8fc4408da2b158e8594015c0fcb
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0
 
 Tags: 7.0.23-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/alpine
 
 Tags: 7.0.23-apache, 7.0-apache
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/apache
 
 Tags: 7.0.23-fpm, 7.0-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/fpm
 
 Tags: 7.0.23-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.23-zts, 7.0-zts
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/zts
 
 Tags: 7.0.23-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 502066405bd72cfa75d07ae10b97314a73891741
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6
 
 Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/apache
 
 Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/fpm
 
 Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/zts
 
 Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: ddc7084c8a78ea12f0cfdceff7d03c5a530b787e
+GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/zts/alpine

--- a/library/piwik
+++ b/library/piwik
@@ -2,10 +2,10 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.1.0-apache, 3.1-apache, 3-apache, apache, 3.1.0, 3.1, 3, latest
-GitCommit: 1f844a0de9e1ef018cdf8541a90620fd22a8c7a7
+Tags: 3.1.1-apache, 3.1-apache, 3-apache, apache, 3.1.1, 3.1, 3, latest
+GitCommit: dddf0af92dc1a1e5c6bfd4ac26b884aaaad56dd7
 Directory: apache
 
-Tags: 3.1.0-fpm, 3.1-fpm, 3-fpm, fpm
-GitCommit: 1f844a0de9e1ef018cdf8541a90620fd22a8c7a7
+Tags: 3.1.1-fpm, 3.1-fpm, 3-fpm, fpm
+GitCommit: dddf0af92dc1a1e5c6bfd4ac26b884aaaad56dd7
 Directory: fpm

--- a/library/python
+++ b/library/python
@@ -1,22 +1,46 @@
-# this file is generated via https://github.com/docker-library/python/blob/0f8a2f5985fad8a5e818b06b491678825380cf47/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/50d7c600f388fa02d0e25427eab0289e51f289b2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
+
+Tags: 3.7.0a1-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0a1, 3.7-rc, rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+Directory: 3.7-rc/stretch
+
+Tags: 3.7.0a1-slim, 3.7-rc-slim, rc-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+Directory: 3.7-rc/stretch/slim
+
+Tags: 3.7.0a1-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a1-alpine, 3.7-rc-alpine, rc-alpine
+Architectures: amd64
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+Directory: 3.7-rc/alpine3.6
+
+Tags: 3.7.0a1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore
+SharedTags: 3.7.0a1, 3.7-rc, rc
+Architectures: windows-amd64
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+Directory: 3.7-rc/windows/windowsservercore
+Constraints: windowsservercore
 
 Tags: 3.6.2-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c9954b06c8b178d7888bc1626bed5a14e43a9203
 Directory: 3.6/stretch
 
-Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie, 3.6.2, 3.6, 3, latest
+Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.2, 3.6, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
 Directory: 3.6/jessie
 
 Tags: 3.6.2-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -35,19 +59,21 @@ GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
 Directory: 3.6/alpine3.4
 
 Tags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
+SharedTags: 3.6.2, 3.6, 3, latest
 Architectures: windows-amd64
 GitCommit: 761d766baa0ff33754436c0a1fd9aedc68cf7947
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.5.4-jessie, 3.5-jessie, 3.5.4, 3.5
+Tags: 3.5.4-jessie, 3.5-jessie
+SharedTags: 3.5.4, 3.5
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/jessie
 
 Tags: 3.5.4-slim, 3.5-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.3-onbuild, 3.5-onbuild
@@ -61,19 +87,21 @@ GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/alpine3.4
 
 Tags: 3.5.4-windowsservercore, 3.5-windowsservercore
+SharedTags: 3.5.4, 3.5
 Architectures: windows-amd64
 GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.7-jessie, 3.4-jessie, 3.4.7, 3.4
+Tags: 3.4.7-jessie, 3.4-jessie
+SharedTags: 3.4.7, 3.4
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/jessie
 
 Tags: 3.4.7-slim, 3.4-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.6-onbuild, 3.4-onbuild
@@ -91,14 +119,15 @@ Architectures: amd64
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/alpine3.4
 
-Tags: 3.3.7-jessie, 3.3-jessie, 3.3.7, 3.3
+Tags: 3.3.7-jessie, 3.3-jessie
+SharedTags: 3.3.7, 3.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
 Directory: 3.3/jessie
 
 Tags: 3.3.7-slim, 3.3-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
+GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.3/jessie/slim
 
 Tags: 3.3.6-onbuild, 3.3-onbuild
@@ -121,7 +150,8 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/stretch
 
-Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie, 2.7.14, 2.7, 2
+Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie
+SharedTags: 2.7.14, 2.7, 2
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/jessie
@@ -152,6 +182,7 @@ GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/alpine3.4
 
 Tags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
+SharedTags: 2.7.14, 2.7, 2
 Architectures: windows-amd64
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/windows/windowsservercore

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,22 +44,22 @@ Architectures: amd64
 GitCommit: 03255da1fc6f0e3ab4a3507cb9e28d707fc921d0
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.20-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.20, 8.5, 8, latest
+Tags: 8.5.21-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.21, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec4d672211c919aad07ac7bebe7c6f26373ee467
+GitCommit: 98708820f99e6c58da0eddb3243a01282a64b3be
 Directory: 8.5/jre8
 
-Tags: 8.5.20-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.20-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.21-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.21-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 9040855496452d91d7b0d8abbfd70c60448a07a1
+GitCommit: de50f0009a7a3ca6929890241d0a0f5d5a071f23
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M26-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M26, 9.0.0, 9.0, 9
+Tags: 9.0.0.M27-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M27, 9.0.0, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 77323f32b92405944da026c68428e3180e6bc33a
+GitCommit: 9b1b4d00ed9b281e16de07f891b7b399c3457d5e
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M26-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M26-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.0.M27-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M27-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: dcadb55c324ad088e5e34b5bc6f1202e025ea848
+GitCommit: 749503f817a760ff76549305dc68c0abf42f4453
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.8.1-apache, 4.8-apache, 4-apache, apache, 4.8.1, 4.8, 4, latest, 4.8.1-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.1-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+Tags: 4.8.2-apache, 4.8-apache, 4-apache, apache, 4.8.2, 4.8, 4, latest, 4.8.2-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.2-php5.6, 4.8-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php5.6/apache
 
-Tags: 4.8.1-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.1-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.8.2-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.2-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php5.6/fpm
 
-Tags: 4.8.1-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.1-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.8.2-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.2-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php5.6/fpm-alpine
 
-Tags: 4.8.1-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.1-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+Tags: 4.8.2-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.2-php7.0, 4.8-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.0/apache
 
-Tags: 4.8.1-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.8.2-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.0/fpm
 
-Tags: 4.8.1-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.8.2-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.0/fpm-alpine
 
-Tags: 4.8.1-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.1-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+Tags: 4.8.2-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.2-php7.1, 4.8-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.1/apache
 
-Tags: 4.8.1-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.8.2-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.1/fpm
 
-Tags: 4.8.1-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.8.2-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 7902c5f856c7fbc20dd70762bef324158328dcff
+GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `drupal`: 8.4.0-rc2
- `nextcloud`: 11.0.5, 12.0.3
- `php`: extra info text (docker-library/php#497)
- `piwik`: 3.1.1
- `python`: 3.7.0a1 (docker-library/python#223), `SharedTags` (docker-library/python#224)
- `tomcat`: 8.5.21, 9.0.0.M27
- `wordpress`: 4.8.2