### PR TITLE
add EulerOS

### DIFF
--- a/library/euleros
+++ b/library/euleros
@@ -1,0 +1,7 @@
+Maintainers: Li Ruilin <liruilin4@huawei.com> (@Kazero0)
+GitRepo: https://github.com/euleros/euleros-docker-images.git
+GitFetch: refs/heads/master
+GitCommit: e1e5020fe9fd5030c9e5d34d5e86a74b379eff36
+
+Tags: 2.2, latest
+Directory: 2.2


### PR DESCRIPTION
# Summary 

This pull request adds the requested file for the [EulerOS](http://developer.huawei.com/ict/en/site-euleros). I also submitted a [pull request](https://github.com/docker-library/docs/pull/1013) in the docs repository.

EulerOS is used wildly inside Huawei and it is already on the [Azura market](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/huawei.euleros-v2?tab=Overview) and [AWS market](https://aws.amazon.com/marketplace/pp/B071P8DWPL)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/euleros
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - "base distribution"
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1013
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] ~~existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)~~
    - `FROM scratch`
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
    - yeah, on master -- need to make sure it stays with only one commit that contains tarballs during future image updates
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)