### PR TITLE
Update Swift to 4.0

### DIFF
--- a/library/swift
+++ b/library/swift
@@ -2,7 +2,7 @@ Maintainers: Haris Amin <aminharis7@gmail.com> (@hamin),
              Thomas Catterall <me@swizzlr.co> (@swizzlr)
 GitRepo: https://github.com/swiftdocker/docker-swift.git
 
-Tags: 4.0, latest
+Tags: 4.0, 4, latest
 GitCommit: 545b8629ffe1f9785298203cf1382711cc2ac302
 
 Tags: 3.1.0, 3.1, 3

--- a/library/swift
+++ b/library/swift
@@ -3,7 +3,7 @@ Maintainers: Haris Amin <aminharis7@gmail.com> (@hamin),
 GitRepo: https://github.com/swiftdocker/docker-swift.git
 
 Tags: 4.0, 4, latest
-GitCommit: 545b8629ffe1f9785298203cf1382711cc2ac302
+GitCommit: 84d2f69c035204bc2dc077f330deb7a393255a18
 
 Tags: 3.1.0, 3.1, 3
 GitCommit: ef9aa534705fc8ab4258c539f6304072ebae9613

--- a/library/swift
+++ b/library/swift
@@ -2,7 +2,10 @@ Maintainers: Haris Amin <aminharis7@gmail.com> (@hamin),
              Thomas Catterall <me@swizzlr.co> (@swizzlr)
 GitRepo: https://github.com/swiftdocker/docker-swift.git
 
-Tags: 3.1.0, 3.1, 3, latest
+Tags: 4.0, latest
+GitCommit: 545b8629ffe1f9785298203cf1382711cc2ac302
+
+Tags: 3.1.0, 3.1, 3
 GitCommit: ef9aa534705fc8ab4258c539f6304072ebae9613
 
 Tags: 3.0.2, 3.0


### PR DESCRIPTION
Updates the GitCommit for Swift 4.0 as tags 4.0, latest. Also removes the latest tag from Swift 3.

This would be my first attempt at updating an official image, feedback is welcome. 