### PR TITLE
Update Solr to 7.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,80 +1,95 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/4315c7b9cb10080492b0b426e4a7441e43c145b1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/66f9ed9663ce1d4782e9ad977259758ac7795e61/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 6.6.1, 6.6, 6, latest
+Tags: 7.0.0, 7.0, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+Directory: 7.0
+
+Tags: 7.0.0-alpine, 7.0-alpine, 7-alpine, alpine
+Architectures: amd64
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+Directory: 7.0/alpine
+
+Tags: 7.0.0-slim, 7.0-slim, 7-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+Directory: 7.0/slim
+
+Tags: 6.6.1, 6.6, 6
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.6
 
-Tags: 6.6.1-alpine, 6.6-alpine, 6-alpine, alpine
+Tags: 6.6.1-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.6/alpine
 
-Tags: 6.6.1-slim, 6.6-slim, 6-slim, slim
+Tags: 6.6.1-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.6/slim
 
 Tags: 6.5.1, 6.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.5
 
 Tags: 6.5.1-alpine, 6.5-alpine
 Architectures: amd64
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.5/alpine
 
 Tags: 6.5.1-slim, 6.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.5/slim
 
 Tags: 6.4.2, 6.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.4
 
 Tags: 6.4.2-alpine, 6.4-alpine
 Architectures: amd64
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.4/alpine
 
 Tags: 6.4.2-slim, 6.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.4/slim
 
 Tags: 6.3.0, 6.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.3
 
 Tags: 6.3.0-alpine, 6.3-alpine
 Architectures: amd64
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.3/alpine
 
 Tags: 6.3.0-slim, 6.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 6.3/slim
 
 Tags: 5.5.4, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 5.5
 
 Tags: 5.5.4-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 5.5/alpine
 
 Tags: 5.5.4-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a8e9311fbe5d40861f6d26293441c272a7878f8
+GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
 Directory: 5.5/slim


### PR DESCRIPTION
Add Solr 7

Announcement email: http://mail-archives.us.apache.org/mod_mbox/www-announce/201709.mbox/%3CCAKiERN4YkSkh0BSRn6Y1N8C1gweAWCLjoLTg8a2gJACmh94bVg@mail.gmail.com%3E
Changes: http://lucene.apache.org/solr/7_0_0/changes/Changes.html

Note that that in Solr 7, the `data_driven_schema_configs` configset has been removed in favour or the `_default` configset (see http://lucene.apache.org/solr/7_0_0/changes/Changes.html#v7.0.0.upgrading_from_solr_6.x points 27/28). The docker-solr scripts have been updated accordingly. There are behavioural differences between these configsets. For example, the docker-solr tests relied (inadvertently) on a `copyField` to `_text_` that is not present in the `_default` configset.