### PR TITLE
Update CrateDB 2.1.7 docker image with better defaults

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -10,7 +10,7 @@ Maintainers: Bernd Dorn <bernddorn@gmail.com> (@dobe),
 GitRepo: https://github.com/crate/docker-crate.git
 
 Tags: 2.1.7, 2.1, latest
-GitCommit: 21b3ccb1b09845558fefc3a822132ecb1c8161e6
+GitCommit: 1c775563b01e830f265f0210ce8a68c81903c8cc
 
 Tags: 2.0.7, 2.0
 GitCommit: 79d51bb263104ccd2d3c57a5d74c16d6f0466d21


### PR DESCRIPTION
This PR updates the Dockerfile with a default heap memory size and default network host for CrateDB, as the previous defaults (or lack thereof) were causing bootstrapping checks to fail and made it difficult to run the image without providing a bunch of settings.