### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.12, 4.4, 4, latest
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
-GitCommit: 75358344e900aa56e64722b2241a6bcd39ca67ee
+GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
 Directory: 3.0

--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.09.0-ce-rc3, 17.09.0-ce, 17.09.0, 17.09-rc, rc, test
 Architectures: amd64
-GitCommit: f7363cacd357b4bf6a550fb4abfa9faf911d1d71
+GitCommit: f42a21a7ae22d2ccf2797887c0555ff2f5a173a6
 Directory: 17.09-rc
 
 Tags: 17.09.0-ce-rc3-dind, 17.09.0-ce-dind, 17.09.0-dind, 17.09-rc-dind, rc-dind, test-dind

--- a/library/drupal
+++ b/library/drupal
@@ -16,7 +16,7 @@ Directory: 8.4-rc/fpm
 
 Tags: 8.4.0-rc2-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
+GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 8.4-rc/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest
@@ -31,7 +31,7 @@ Directory: 8.3/fpm
 
 Tags: 8.3.7-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
+GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7
@@ -46,5 +46,5 @@ Directory: 7/fpm
 
 Tags: 7.56-fpm-alpine, 7-fpm-alpine
 Architectures: amd64
-GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
+GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 7/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.8.7, 1.8, 1, latest
+Tags: 1.9.0, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4b5a3383906e72f645f3f68a8e8f9a20cd26338e
+GitCommit: 1249536b0b8135179230174fa8a89e68e92f8c25
 Directory: 1/debian
 
-Tags: 1.8.7-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.9.0-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 4b5a3383906e72f645f3f68a8e8f9a20cd26338e
+GitCommit: 1249536b0b8135179230174fa8a89e68e92f8c25
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/haproxy
+++ b/library/haproxy
@@ -11,7 +11,7 @@ Directory: 1.4
 
 Tags: 1.4.27-alpine, 1.4-alpine
 Architectures: amd64
-GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
+GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
 Directory: 1.4/alpine
 
 Tags: 1.5.19, 1.5
@@ -21,7 +21,7 @@ Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64
-GitCommit: dbf5702c136a1de7046a935b1d79516d6f82c861
+GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
 Directory: 1.5/alpine
 
 Tags: 1.6.13, 1.6
@@ -31,7 +31,7 @@ Directory: 1.6
 
 Tags: 1.6.13-alpine, 1.6-alpine
 Architectures: amd64
-GitCommit: 900676649347a83b314fd7b33e0a52265e168577
+GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
 Directory: 1.6/alpine
 
 Tags: 1.7.9, 1.7, 1, latest
@@ -41,5 +41,5 @@ Directory: 1.7
 
 Tags: 1.7.9-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 394255fbe76c57a9f2e0775e3e69df714e801b46
+GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
 Directory: 1.7/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -11,7 +11,7 @@ Directory: 2.2
 
 Tags: 2.2.34-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 01f18a3fa8ac5335a5621d80370d40149b8d78b2
+GitCommit: 3d5133cff766a1b6d734c9ac107613b7e53f2378
 Directory: 2.2/alpine
 
 Tags: 2.4.27, 2.4, 2, latest
@@ -21,5 +21,5 @@ Directory: 2.4
 
 Tags: 2.4.27-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: b86f02f7ac6f27a0915cbf17a35d978532eb839f
+GitCommit: 3d5133cff766a1b6d734c9ac107613b7e53f2378
 Directory: 2.4/alpine

--- a/library/irssi
+++ b/library/irssi
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.0.4-alpine, 1.0-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 95671eb7309e646addd82699ddaf6065ea57e271
+GitCommit: ecf3007a6598bc2e7783e24acd5c62dc57dc9f0a
 Directory: alpine

--- a/library/memcached
+++ b/library/memcached
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.5.1-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 47577ad04041d83146439243e35f809b88236466
+GitCommit: 7fbb158344e49c24f632256ef0f4455c7714c23d
 Directory: alpine

--- a/library/php
+++ b/library/php
@@ -11,7 +11,7 @@ Directory: 7.2-rc
 
 Tags: 7.2.0RC2-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.2-rc/alpine
 
 Tags: 7.2.0RC2-apache, 7.2-rc-apache, rc-apache
@@ -26,7 +26,7 @@ Directory: 7.2-rc/fpm
 
 Tags: 7.2.0RC2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.2-rc/fpm/alpine
 
 Tags: 7.2.0RC2-zts, 7.2-rc-zts, rc-zts
@@ -36,7 +36,7 @@ Directory: 7.2-rc/zts
 
 Tags: 7.2.0RC2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
@@ -46,7 +46,7 @@ Directory: 7.1
 
 Tags: 7.1.9-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.1/alpine
 
 Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
@@ -61,7 +61,7 @@ Directory: 7.1/fpm
 
 Tags: 7.1.9-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
@@ -71,7 +71,7 @@ Directory: 7.1/zts
 
 Tags: 7.1.9-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
@@ -81,7 +81,7 @@ Directory: 7.0
 
 Tags: 7.0.23-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.0/alpine
 
 Tags: 7.0.23-apache, 7.0-apache
@@ -96,7 +96,7 @@ Directory: 7.0/fpm
 
 Tags: 7.0.23-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.23-zts, 7.0-zts
@@ -106,7 +106,7 @@ Directory: 7.0/zts
 
 Tags: 7.0.23-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
@@ -116,7 +116,7 @@ Directory: 5.6
 
 Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
@@ -131,7 +131,7 @@ Directory: 5.6/fpm
 
 Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
@@ -141,5 +141,5 @@ Directory: 5.6/zts
 
 Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 7c45279501f958926e51779081bc083fbb412539
 Directory: 5.6/zts/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10-beta4, 10
+Tags: 10-rc1, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
+GitCommit: 2ba4ac1074bc592ffa40076e5de2f94f972afb84
 Directory: 10
 
-Tags: 10-beta4-alpine, 10-alpine
+Tags: 10-rc1-alpine, 10-alpine
 Architectures: amd64
-GitCommit: ee1bb1f51c9bae5be684a4797f934dbb943e3267
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 10/alpine
 
 Tags: 9.6.5, 9.6, 9, latest
@@ -21,7 +21,7 @@ Directory: 9.6
 
 Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64
-GitCommit: d1725ffa8ba29ed7649bd453065eb392f63a3113
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.6/alpine
 
 Tags: 9.5.9, 9.5
@@ -31,7 +31,7 @@ Directory: 9.5
 
 Tags: 9.5.9-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: 9e862fa9b1d510c618d51e5d2c63f439d15381ff
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.5/alpine
 
 Tags: 9.4.14, 9.4
@@ -41,7 +41,7 @@ Directory: 9.4
 
 Tags: 9.4.14-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: b2649f97aee8bca9f4e65a2c050f66fe255ec9f3
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.4/alpine
 
 Tags: 9.3.19, 9.3
@@ -51,7 +51,7 @@ Directory: 9.3
 
 Tags: 9.3.19-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: b1fc9b6f7506ea7357f48fb0125e8b7a3c1d96e9
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.3/alpine
 
 Tags: 9.2.23, 9.2
@@ -61,5 +61,5 @@ Directory: 9.2
 
 Tags: 9.2.23-alpine, 9.2-alpine
 Architectures: amd64
-GitCommit: b3cb99032a600a27dcb8f3c52f14c72fd22d477f
+GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.2/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.12, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b2eba70a1a31e11bfc644e626a34edf9920fbbcb
+GitCommit: ed9a656804f0f14a6b6b99fc7d71ba1a043854f5
 Directory: 3.6/debian
 
 Tags: 3.6.12-management, 3.6-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.12-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: ba7ea670b5c084417d1f03cb07012314ba51c57a
+GitCommit: ed9a656804f0f14a6b6b99fc7d71ba1a043854f5
 Directory: 3.6/alpine
 
 Tags: 3.6.12-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/ruby
+++ b/library/ruby
@@ -31,12 +31,12 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
+GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
+GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
@@ -56,7 +56,7 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 1ec8021cd6a22a1122d35ca68c395a85c093658c
+GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
@@ -76,5 +76,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: c1f97577cd4f73ae0968f417dd74a1fd7a6f0cce
+GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.2/alpine3.4

--- a/library/tomcat
+++ b/library/tomcat
@@ -11,7 +11,7 @@ Directory: 7/jre7
 
 Tags: 7.0.81-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.81-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: 0e9a915bf893faa9160ab1a144c7ba5049a4fe27
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 7/jre7-alpine
 
 Tags: 7.0.81-jre8, 7.0-jre8, 7-jre8
@@ -21,7 +21,7 @@ Directory: 7/jre8
 
 Tags: 7.0.81-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: 0e9a915bf893faa9160ab1a144c7ba5049a4fe27
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 7/jre8-alpine
 
 Tags: 8.0.46-jre7, 8.0-jre7, 8.0.46, 8.0
@@ -31,7 +31,7 @@ Directory: 8.0/jre7
 
 Tags: 8.0.46-jre7-alpine, 8.0-jre7-alpine, 8.0.46-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: 03255da1fc6f0e3ab4a3507cb9e28d707fc921d0
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.46-jre8, 8.0-jre8
@@ -41,7 +41,7 @@ Directory: 8.0/jre8
 
 Tags: 8.0.46-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: 03255da1fc6f0e3ab4a3507cb9e28d707fc921d0
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.21-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.21, 8.5, 8, latest
@@ -51,7 +51,7 @@ Directory: 8.5/jre8
 
 Tags: 8.5.21-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.21-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: de50f0009a7a3ca6929890241d0a0f5d5a071f23
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.0.M27-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M27, 9.0.0, 9.0, 9
@@ -61,5 +61,5 @@ Directory: 9.0/jre8
 
 Tags: 9.0.0.M27-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M27-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 749503f817a760ff76549305dc68c0abf42f4453
+GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -16,7 +16,7 @@ Directory: php5.6/fpm
 
 Tags: 4.8.2-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.2-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php5.6/fpm-alpine
 
 Tags: 4.8.2-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.2-php7.0, 4.8-php7.0, 4-php7.0, php7.0
@@ -31,7 +31,7 @@ Directory: php7.0/fpm
 
 Tags: 4.8.2-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php7.0/fpm-alpine
 
 Tags: 4.8.2-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.2-php7.1, 4.8-php7.1, 4-php7.1, php7.1
@@ -46,22 +46,22 @@ Directory: php7.1/fpm
 
 Tags: 4.8.2-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-1.3.0, cli-1.3, cli-1, cli, cli-1.3.0-php5.6, cli-1.3-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php5.6/cli
 
 Tags: cli-1.3.0-php7.0, cli-1.3-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php7.0/cli
 
 Tags: cli-1.3.0-php7.1, cli-1.3-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 93bc135b2fad658fe041447209c1a379a16dd302
+GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php7.1/cli


### PR DESCRIPTION
- `bash`: `scanelf` improvements (tianon/docker-bash#8)
- `docker`: update `Dockerfile` with `arm32v6` and `arm64v8` (still blocked on https://github.com/gliderlabs/docker-alpine/issues/304)
- `drupal`: `scanelf` improvements (docker-library/drupal#93)
- `ghost`: 1.9.0
- `haproxy`: `scanelf` improvements (docker-library/haproxy#45)
- `httpd`: `scanelf` improvements (docker-library/httpd#74)
- `irssi`: `scanelf` improvements (jessfraz/irssi#18)
- `memcached`: `scanelf` improvements (docker-library/memcached#27)
- `php`: `scanelf` improvements (docker-library/php#500), `libressl` in Alpine 3.6+/PHP 7.2+ (docker-library/php#499)
- `postgres`: `scanelf` improvements (docker-library/postgres#344)
- `rabbitmq`: update cookie file permissions (docker-library/rabbitmq#193), consume upstream artifacts from GitHub (docker-library/rabbitmq#195), set `total_memory_available_override_value` (docker-library/rabbitmq#196)
- `ruby`: `scanelf` improvements (docker-library/ruby#161)
- `tomcat`: `scanelf` improvements (docker-library/tomcat#85)
- `wordpress`: `scanelf` improvements (docker-library/wordpress#240)