### PR TITLE
Remove Crate 1.x versions

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -14,9 +14,3 @@ GitCommit: 1c775563b01e830f265f0210ce8a68c81903c8cc
 
 Tags: 2.0.7, 2.0
 GitCommit: 79d51bb263104ccd2d3c57a5d74c16d6f0466d21
-
-Tags: 1.1.6, 1.1
-GitCommit: 019830ed59c4b110f8c93f30430d282818ad95ec
-
-Tags: 1.0.6, 1.0
-GitCommit: 89e1557944b257c9e56b0e93a458eb6f0238ece3


### PR DESCRIPTION
This is per @chaudum's comment over in https://github.com/docker-library/official-images/pull/3469#discussion_r139889632: :heart:

> No, these 1.x versions do not get any updates any more. I guess it would be ok to remove them.