### PR TITLE
update to jetty-9.4.7

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -2,13 +2,13 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.4.6, 9.4, 9, 9.4.6-jre8, 9.4-jre8, 9-jre8, latest, jre8
+Tags: 9.4.7, 9.4, 9, 9.4.7-jre8, 9.4-jre8, 9-jre8, latest, jre8
 Directory: 9.4-jre8
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 74289191601774dc6c343435ab47f103e6740570
 
-Tags: 9.4.6-alpine, 9.4-alpine, 9-alpine, 9.4.6-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
+Tags: 9.4.7-alpine, 9.4-alpine, 9-alpine, 9.4.7-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.4-jre8/alpine
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 74289191601774dc6c343435ab47f103e6740570
 
 Tags: 9.3.20, 9.3, 9.3.20-jre8, 9.3-jre8
 Directory: 9.3-jre8


### PR DESCRIPTION
This PR updates the official jetty release to 9.4.7.
There have been some performance degradation reports against 9.4.7 for machines with more than 32 CPUs, but they have not been reproduced in testing.

The update also includes changes to the docker image to avoid using the native code setuid mechanism. Instead the jetty user is specified in the Dockerfile.

See https://github.com/appropriate/docker-jetty/pull/73