### PR TITLE
haxe: 3.4.2 -> 3.4.3

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,24 +1,24 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 3.4.2-stretch, 3.4-stretch, 3.4.2, 3.4, latest
+Tags: 3.4.3-stretch, 3.4-stretch, 3.4.3, 3.4, latest
 Architectures: amd64
-GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+GitCommit: 55b42a6d36178f4ffe3ff6240c7cf9d3d4bacb92
 Directory: 3.4/stretch
 
-Tags: 3.4.2-jessie, 3.4-jessie
+Tags: 3.4.3-jessie, 3.4-jessie
 Architectures: amd64
-GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
+GitCommit: 55b42a6d36178f4ffe3ff6240c7cf9d3d4bacb92
 Directory: 3.4/jessie
 
-Tags: 3.4.2-onbuild, 3.4-onbuild
+Tags: 3.4.3-onbuild, 3.4-onbuild
 Architectures: amd64
-GitCommit: 8e6c65a2d72c239e8ddaf5af9157bb146d71016d
+GitCommit: 55b42a6d36178f4ffe3ff6240c7cf9d3d4bacb92
 Directory: 3.4/onbuild
 
-Tags: 3.4.2-windowsservercore, 3.4-windowsservercore
+Tags: 3.4.3-windowsservercore, 3.4-windowsservercore
 Architectures: windows-amd64
-GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
+GitCommit: 55b42a6d36178f4ffe3ff6240c7cf9d3d4bacb92
 Directory: 3.4/windowsservercore
 Constraints: windowsservercore
 


### PR DESCRIPTION
Updated 3.4 image from 3.4.2 to [3.4.3](https://github.com/HaxeFoundation/haxe/blob/3.4.3/extra/CHANGES.txt#L1-L20), which is backward compatible to Haxe 3.4.2.