### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,50 +1,35 @@
-# this file is generated via https://github.com/docker-library/docker/blob/ce8784112e81f724c96dae8272dd7367d712f3e9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/a6b52c73daa8283cd861f41f55e53426008708ac/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.09.0-ce-rc3, 17.09.0-ce, 17.09.0, 17.09-rc, rc, test
+Tags: 17.09.0-ce, 17.09.0, 17.09, 17, stable, test, edge, latest
 Architectures: amd64
-GitCommit: f42a21a7ae22d2ccf2797887c0555ff2f5a173a6
-Directory: 17.09-rc
+GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
+Directory: 17.09
 
-Tags: 17.09.0-ce-rc3-dind, 17.09.0-ce-dind, 17.09.0-dind, 17.09-rc-dind, rc-dind, test-dind
+Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, 17-dind, stable-dind, test-dind, edge-dind, dind
 Architectures: amd64
-GitCommit: ce8784112e81f724c96dae8272dd7367d712f3e9
-Directory: 17.09-rc/dind
+GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
+Directory: 17.09/dind
 
-Tags: 17.09.0-ce-rc3-git, 17.09.0-ce-git, 17.09.0-git, 17.09-rc-git, rc-git, test-git
+Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, 17-git, stable-git, test-git, edge-git, git
 Architectures: amd64
-GitCommit: ce8784112e81f724c96dae8272dd7367d712f3e9
-Directory: 17.09-rc/git
+GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
+Directory: 17.09/git
 
-Tags: 17.07.0-ce, 17.07.0, 17.07, 17, edge, latest
+Tags: 17.07.0-ce, 17.07.0, 17.07
 Architectures: amd64
 GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
 Directory: 17.07
 
-Tags: 17.07.0-ce-dind, 17.07.0-dind, 17.07-dind, 17-dind, edge-dind, dind
+Tags: 17.07.0-ce-dind, 17.07.0-dind, 17.07-dind
 Architectures: amd64
 GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
 Directory: 17.07/dind
 
-Tags: 17.07.0-ce-git, 17.07.0-git, 17.07-git, 17-git, edge-git, git
+Tags: 17.07.0-ce-git, 17.07.0-git, 17.07-git
 Architectures: amd64
 GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
 Directory: 17.07/git
-
-Tags: 17.06.2-ce, 17.06.2, 17.06, stable
-Architectures: amd64
-GitCommit: b33b5bffb560d4e4148506860d7c6b393315e339
-Directory: 17.06
-
-Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind, stable-dind
-Architectures: amd64
-GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
-Directory: 17.06/dind
-
-Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git, stable-git
-Architectures: amd64
-GitCommit: e68e4e6ec06c055a95d441144b0e34d0872f2665
-Directory: 17.06/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.9.0, 1.9, 1, latest
+Tags: 1.9.1, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1249536b0b8135179230174fa8a89e68e92f8c25
+GitCommit: eabf5910eda9620817515d23a58c4fa6ebb265d9
 Directory: 1/debian
 
-Tags: 1.9.0-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 1249536b0b8135179230174fa8a89e68e92f8c25
+GitCommit: eabf5910eda9620817515d23a58c4fa6ebb265d9
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,12 +8,12 @@ Tags: 10.3.1, 10.3
 GitCommit: 8bbe483d5fc132b87063db9d22132b571a778fd4
 Directory: 10.3
 
-Tags: 10.2.8, 10.2, 10, latest
-GitCommit: e841926a0c09fb1d1d7dd79131f9d8e3a09619ec
+Tags: 10.2.9, 10.2, 10, latest
+GitCommit: 8d8f803e38b374fa7c5a524bdbf014365000d319
 Directory: 10.2
 
 Tags: 10.1.26, 10.1
-GitCommit: b43b9ec1eac3f8fc6ad6ad5ea85fb301b2a0c95b
+GitCommit: cb4c56b1c0d827f3acd82f9b74852d424682b7f2
 Directory: 10.1
 
 Tags: 10.0.32, 10.0

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.5-apache, 11.0-apache, 11-apache, 11.0.5, 11.0, 11
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 650e4b324872e4813f1a1851da9448c06fdb0872
+GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 11.0/apache
 
 Tags: 11.0.5-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 650e4b324872e4813f1a1851da9448c06fdb0872
+GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 11.0/fpm
 
 Tags: 12.0.3-apache, 12.0-apache, 12-apache, apache, 12.0.3, 12.0, 12, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ad5dbd5f3de836ca3faf3966f343c136db74c72
+GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 12.0/apache
 
 Tags: 12.0.3-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ad5dbd5f3de836ca3faf3966f343c136db74c72
+GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 12.0/fpm

--- a/library/php
+++ b/library/php
@@ -11,7 +11,7 @@ Directory: 7.2-rc
 
 Tags: 7.2.0RC2-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.2-rc/alpine
 
 Tags: 7.2.0RC2-apache, 7.2-rc-apache, rc-apache
@@ -26,7 +26,7 @@ Directory: 7.2-rc/fpm
 
 Tags: 7.2.0RC2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.2-rc/fpm/alpine
 
 Tags: 7.2.0RC2-zts, 7.2-rc-zts, rc-zts
@@ -36,7 +36,7 @@ Directory: 7.2-rc/zts
 
 Tags: 7.2.0RC2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
@@ -46,7 +46,7 @@ Directory: 7.1
 
 Tags: 7.1.9-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/alpine
 
 Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
@@ -61,7 +61,7 @@ Directory: 7.1/fpm
 
 Tags: 7.1.9-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
@@ -71,7 +71,7 @@ Directory: 7.1/zts
 
 Tags: 7.1.9-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
@@ -81,7 +81,7 @@ Directory: 7.0
 
 Tags: 7.0.23-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.0/alpine
 
 Tags: 7.0.23-apache, 7.0-apache
@@ -96,7 +96,7 @@ Directory: 7.0/fpm
 
 Tags: 7.0.23-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.0/fpm/alpine
 
 Tags: 7.0.23-zts, 7.0-zts
@@ -106,7 +106,7 @@ Directory: 7.0/zts
 
 Tags: 7.0.23-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
@@ -116,7 +116,7 @@ Directory: 5.6
 
 Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
@@ -131,7 +131,7 @@ Directory: 5.6/fpm
 
 Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
@@ -141,5 +141,5 @@ Directory: 5.6/zts
 
 Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 7c45279501f958926e51779081bc083fbb412539
+GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 5.6/zts/alpine

--- a/library/python
+++ b/library/python
@@ -45,7 +45,7 @@ Directory: 3.6/jessie/slim
 
 Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.2-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
@@ -76,9 +76,9 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.5/jessie/slim
 
-Tags: 3.5.3-onbuild, 3.5-onbuild
+Tags: 3.5.4-onbuild, 3.5-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.5/jessie/onbuild
 
 Tags: 3.5.4-alpine3.4, 3.5-alpine3.4, 3.5.4-alpine, 3.5-alpine
@@ -104,9 +104,9 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.4/jessie/slim
 
-Tags: 3.4.6-onbuild, 3.4-onbuild
+Tags: 3.4.7-onbuild, 3.4-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.4/jessie/onbuild
 
 Tags: 3.4.7-wheezy, 3.4-wheezy
@@ -130,9 +130,9 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.3/jessie/slim
 
-Tags: 3.3.6-onbuild, 3.3-onbuild
+Tags: 3.3.7-onbuild, 3.3-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.3/jessie/onbuild
 
 Tags: 3.3.7-wheezy, 3.3-wheezy
@@ -161,9 +161,9 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/jessie/slim
 
-Tags: 2.7.13-onbuild, 2.7-onbuild, 2-onbuild
+Tags: 2.7.14-onbuild, 2.7-onbuild, 2-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 2.7/jessie/onbuild
 
 Tags: 2.7.14-wheezy, 2.7-wheezy, 2-wheezy


### PR DESCRIPTION
- `docker`: 17.09.0-ce GA
- `ghost`: 1.9.1
- `mariadb`: 10.2.9
- `nextcloud`: `redis-3.1.4` (https://github.com/nextcloud/docker/pull/161)
- `php`: keep `libressl` installed (docker-library/php#502)
- `python`: fix onbuild `FROM`s (docker-library/python#226)