### PR TITLE
Upgrade to jetty-9.3.21 and update 9.2 setuid

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,5 +1,5 @@
 Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
-Greg Wilkins <gregw@webtide.com> (@gregw)
+             Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.4.7, 9.4, 9, 9.4.7-jre8, 9.4-jre8, 9-jre8, latest, jre8

--- a/library/jetty
+++ b/library/jetty
@@ -1,5 +1,5 @@
 Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
-             Greg Wilkins <gregw@webtide.com> (@gregw)
+Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.4.7, 9.4, 9, 9.4.7-jre8, 9.4-jre8, 9-jre8, latest, jre8
@@ -10,18 +10,18 @@ Tags: 9.4.7-alpine, 9.4-alpine, 9-alpine, 9.4.7-jre8-alpine, 9.4-jre8-alpine, 9-
 Directory: 9.4-jre8/alpine
 GitCommit: 74289191601774dc6c343435ab47f103e6740570
 
-Tags: 9.3.20, 9.3, 9.3.20-jre8, 9.3-jre8
+Tags: 9.3.21, 9.3, 9.3.21-jre8, 9.3-jre8
 Directory: 9.3-jre8
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 74289191601774dc6c343435ab47f103e6740570
 
-Tags: 9.3.20-alpine, 9.3-alpine, 9.3.20-jre8-alpine, 9.3-jre8-alpine
+Tags: 9.3.21-alpine, 9.3-alpine, 9.3.21-jre8-alpine, 9.3-jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 74289191601774dc6c343435ab47f103e6740570
 
 Tags: 9.2.22, 9.2, 9.2.22-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 769cc333c41ed5204f43a47d0ca2a4dfd75a1c85
 
 Tags: 9.2.22-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: 769cc333c41ed5204f43a47d0ca2a4dfd75a1c85


### PR DESCRIPTION
Updates the jetty 9.3 images to 9.3.21
Updates the jetty 9.2 images to use the entry point that avoids setuid and forking the start.jar JVM