### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/e21e2f607ba2623b0d8fc8a9a6bbfad8df1cf511/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,28 +6,28 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2016-08-03
 Tags: 4.9.4, 4.9, 4
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
 Directory: 4.9
 # Docker EOL: 2017-08-03
 
 # Last Modified: 2016-06-03
 Tags: 5.4.0, 5.4, 5
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3b33871fe9558262cb5ed6253d358f76710e9ccb
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
 Directory: 5
 # Docker EOL: 2017-06-03
 
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c1fe37de30fbe69e83f042b4a9426b11cb624bca
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
 Directory: 6
 # Docker EOL: 2018-07-04
 
 # Last Modified: 2017-08-14
 Tags: 7.2.0, 7.2, 7, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3ccb804e330766ba05abe7fe990512f152a08254
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
 Directory: 7
 # Docker EOL: 2018-08-14

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.9, 10.2, 10, latest
 GitCommit: 8d8f803e38b374fa7c5a524bdbf014365000d319
 Directory: 10.2
 
-Tags: 10.1.26, 10.1
-GitCommit: cb4c56b1c0d827f3acd82f9b74852d424682b7f2
+Tags: 10.1.28, 10.1
+GitCommit: 6d8fbc8e417ed8f50be812d1e941a164ec3e32f2
 Directory: 10.1
 
 Tags: 10.0.32, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -19,18 +19,18 @@ GitCommit: 40d62a73bbd4e20d90ec859a8af483f70b1e5fd4
 Directory: 3.0/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.16-jessie, 3.2-jessie
-SharedTags: 3.2.16, 3.2
+Tags: 3.2.17-jessie, 3.2-jessie
+SharedTags: 3.2.17, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 61aabfb537a1fbcae44f02ab515df54395b68400
+GitCommit: 3eb1f6df20e04ea8f03ce8ba5893e21bb63073f5
 Directory: 3.2
 
-Tags: 3.2.16-windowsservercore, 3.2-windowsservercore
-SharedTags: 3.2.16, 3.2
+Tags: 3.2.17-windowsservercore, 3.2-windowsservercore
+SharedTags: 3.2.17, 3.2
 Architectures: windows-amd64
-GitCommit: 61aabfb537a1fbcae44f02ab515df54395b68400
+GitCommit: 3eb1f6df20e04ea8f03ce8ba5893e21bb63073f5
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/php
+++ b/library/php
@@ -1,46 +1,46 @@
-# this file is generated via https://github.com/docker-library/php/blob/925ea64fe2661a4f9d9d3d20cdb305673fc3de6d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/9c17873f3a6e95170d1747b43958f44db3fcf9c4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0RC2-cli, 7.2-rc-cli, rc-cli, 7.2.0RC2, 7.2-rc, rc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.2.0RC3-cli, 7.2-rc-cli, rc-cli, 7.2.0RC3, 7.2-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc
 
-Tags: 7.2.0RC2-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0RC3-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/alpine
 
-Tags: 7.2.0RC2-apache, 7.2-rc-apache, rc-apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.2.0RC3-apache, 7.2-rc-apache, rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/apache
 
-Tags: 7.2.0RC2-fpm, 7.2-rc-fpm, rc-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.2.0RC3-fpm, 7.2-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/fpm
 
-Tags: 7.2.0RC2-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0RC3-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/fpm/alpine
 
-Tags: 7.2.0RC2-zts, 7.2-rc-zts, rc-zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.2.0RC3-zts, 7.2-rc-zts, rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/zts
 
-Tags: 7.2.0RC2-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0RC3-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/zts/alpine
 
 Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1
 
@@ -50,12 +50,12 @@ GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/alpine
 
 Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/apache
 
 Tags: 7.1.9-fpm, 7.1-fpm, 7-fpm, fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/fpm
 
@@ -65,7 +65,7 @@ GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/fpm/alpine
 
 Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 7.1/zts
 
@@ -74,43 +74,43 @@ Architectures: amd64
 GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 7.1/zts/alpine
 
-Tags: 7.0.23-cli, 7.0-cli, 7.0.23, 7.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.0.24-cli, 7.0-cli, 7.0.24, 7.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0
 
-Tags: 7.0.23-alpine, 7.0-alpine
+Tags: 7.0.24-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/alpine
 
-Tags: 7.0.23-apache, 7.0-apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.0.24-apache, 7.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/apache
 
-Tags: 7.0.23-fpm, 7.0-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.0.24-fpm, 7.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/fpm
 
-Tags: 7.0.23-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.24-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/fpm/alpine
 
-Tags: 7.0.23-zts, 7.0-zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+Tags: 7.0.24-zts, 7.0-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/zts
 
-Tags: 7.0.23-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.24-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
 Directory: 7.0/zts/alpine
 
 Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6
 
@@ -120,12 +120,12 @@ GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 5.6/alpine
 
 Tags: 5.6.31-apache, 5.6-apache, 5-apache
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/apache
 
 Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/fpm
 
@@ -135,7 +135,7 @@ GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
 Directory: 5.6/fpm/alpine
 
 Tags: 5.6.31-zts, 5.6-zts, 5-zts
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
 Directory: 5.6/zts
 

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/50d7c600f388fa02d0e25427eab0289e51f289b2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/4883cab7762edbb16d929e55cba5dbfccd6099e1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/python.git
 
 Tags: 3.7.0a1-stretch, 3.7-rc-stretch, rc-stretch
 SharedTags: 3.7.0a1, 3.7-rc, rc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.7-rc/stretch
 
 Tags: 3.7.0a1-slim, 3.7-rc-slim, rc-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.7-rc/stretch/slim
 
@@ -28,23 +28,23 @@ Directory: 3.7-rc/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 3.6.2-stretch, 3.6-stretch, 3-stretch, stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c9954b06c8b178d7888bc1626bed5a14e43a9203
 Directory: 3.6/stretch
 
 Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
 SharedTags: 3.6.2, 3.6, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
 Directory: 3.6/jessie
 
 Tags: 3.6.2-slim, 3.6-slim, 3-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
@@ -67,17 +67,17 @@ Constraints: windowsservercore
 
 Tags: 3.5.4-jessie, 3.5-jessie
 SharedTags: 3.5.4, 3.5
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/jessie
 
 Tags: 3.5.4-slim, 3.5-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.4-onbuild, 3.5-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.5/jessie/onbuild
 
@@ -95,22 +95,22 @@ Constraints: windowsservercore
 
 Tags: 3.4.7-jessie, 3.4-jessie
 SharedTags: 3.4.7, 3.4
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/jessie
 
 Tags: 3.4.7-slim, 3.4-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.7-onbuild, 3.4-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.4/jessie/onbuild
 
 Tags: 3.4.7-wheezy, 3.4-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/wheezy
 
@@ -121,22 +121,22 @@ Directory: 3.4/alpine3.4
 
 Tags: 3.3.7-jessie, 3.3-jessie
 SharedTags: 3.3.7, 3.3
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
 Directory: 3.3/jessie
 
 Tags: 3.3.7-slim, 3.3-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.3/jessie/slim
 
 Tags: 3.3.7-onbuild, 3.3-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.3/jessie/onbuild
 
 Tags: 3.3.7-wheezy, 3.3-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
 Directory: 3.3/wheezy
 
@@ -146,28 +146,28 @@ GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
 Directory: 3.3/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/stretch
 
 Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie
 SharedTags: 2.7.14, 2.7, 2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/jessie
 
 Tags: 2.7.14-slim, 2.7-slim, 2-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.14-onbuild, 2.7-onbuild, 2-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 2.7/jessie/onbuild
 
 Tags: 2.7.14-wheezy, 2.7-wheezy, 2-wheezy
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/wheezy
 

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.58.2, 0.58, 0, latest
-GitCommit: 29af83db6144476190ecdd29d0dea902167cd9f8
+Tags: 0.58.3, 0.58, 0, latest
+GitCommit: 20710b313fc4e39f8909322d3901e458a63848ad

--- a/library/ruby
+++ b/library/ruby
@@ -1,31 +1,31 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/076a28bbc35c37078e06636c0dfc8158130959bc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/35eccb65d277077e9589df5b6d1ac7253eefe4e3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
 Directory: 2.4/stretch
 
 Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
 Directory: 2.4/jessie
 
 Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: beb05c8c3c694e4527effe3e3623120486d0e5ed
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
@@ -40,17 +40,17 @@ GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ec8021cd6a22a1122d35ca68c395a85c093658c
 Directory: 2.3/jessie
 
 Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ec8021cd6a22a1122d35ca68c395a85c093658c
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.5-onbuild, 2.3-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.3/jessie/onbuild
 
@@ -60,17 +60,17 @@ GitCommit: c9838b69af941637d68bbbaff70fee4402b715cb
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c1f97577cd4f73ae0968f417dd74a1fd7a6f0cce
 Directory: 2.2/jessie
 
 Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c1f97577cd4f73ae0968f417dd74a1fd7a6f0cce
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.8-onbuild, 2.2-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.2/jessie/onbuild
 


### PR DESCRIPTION
- `gcc`: `arm32` again (docker-library/gcc#42)
- `mariadb`: 10.1.28
- `mongo`: 3.2.17
- `php`: 7.0.24, 7.2.0RC3, `arm32v5`
- `python`: `arm32v5`
- `rocket.chat`: 0.58.3
- `ruby`: `arm32v5`