### PR TITLE
Cascade arm32v5 re-additions down to drupal, hylang, owncloud, redmine, wordpress

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/drupal.git
 
 Tags: 8.4.0-rc2-apache, 8.4-rc-apache, rc-apache, 8.4.0-rc2, 8.4-rc, rc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
 Directory: 8.4-rc/apache
 
 Tags: 8.4.0-rc2-fpm, 8.4-rc-fpm, rc-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
 Directory: 8.4-rc/fpm
 
@@ -20,12 +20,12 @@ GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 8.4-rc/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/apache
 
 Tags: 8.3.7-fpm, 8.3-fpm, 8-fpm, fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm
 
@@ -35,12 +35,12 @@ GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 8.3/fpm-alpine
 
 Tags: 7.56-apache, 7-apache, 7.56, 7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/apache
 
 Tags: 7.56-fpm, 7-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a8e09f524b89b61534f376e45b885d433d867c88
 Directory: 7/fpm
 

--- a/library/hylang
+++ b/library/hylang
@@ -3,7 +3,7 @@ Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag)
 # https://github.com/hylang/hy/tree/0.13.0
 Tags: 0.13.0, 0.13, 0, latest
 # arches scraped from "python:3"
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/hylang/hy.git
 GitFetch: refs/tags/0.13.0
 GitCommit: 807b0b6d248fd341cbf87bf8bfa55caf5b83d655

--- a/library/owncloud
+++ b/library/owncloud
@@ -5,31 +5,31 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.3-apache, 10.0-apache, 10-apache, apache, 10.0.3, 10.0, 10, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c0f5a270e565410cc47046b29b04e4a5ec9e828
 Directory: 10.0/apache
 
 Tags: 10.0.3-fpm, 10.0-fpm, 10-fpm, fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c0f5a270e565410cc47046b29b04e4a5ec9e828
 Directory: 10.0/fpm
 
 Tags: 9.1.6-apache, 9.1-apache, 9-apache, 9.1.6, 9.1, 9
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.1/apache
 
 Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.1/fpm
 
 Tags: 9.0.10-apache, 9.0-apache, 9.0.10, 9.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.0/apache
 
 Tags: 9.0.10-fpm, 9.0-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
 Directory: 9.0/fpm

--- a/library/redmine
+++ b/library/redmine
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.2, 3.4, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.4
 
@@ -14,7 +14,7 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.3
 
@@ -23,7 +23,7 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.2
 
@@ -32,7 +32,7 @@ GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.2/passenger
 
 Tags: 3.1.7, 3.1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.1
 

--- a/library/wordpress
+++ b/library/wordpress
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.8.2-apache, 4.8-apache, 4-apache, apache, 4.8.2, 4.8, 4, latest, 4.8.2-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.2-php5.6, 4.8-php5.6, 4-php5.6, php5.6
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php5.6/apache
 
 Tags: 4.8.2-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.2-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php5.6/fpm
 
@@ -20,12 +20,12 @@ GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php5.6/fpm-alpine
 
 Tags: 4.8.2-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.2-php7.0, 4.8-php7.0, 4-php7.0, php7.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.0/apache
 
 Tags: 4.8.2-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.0/fpm
 
@@ -35,12 +35,12 @@ GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
 Directory: php7.0/fpm-alpine
 
 Tags: 4.8.2-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.2-php7.1, 4.8-php7.1, 4-php7.1, php7.1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.1/apache
 
 Tags: 4.8.2-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
 Directory: php7.1/fpm
 


### PR DESCRIPTION
See https://github.com/docker-library/official-images/pull/3510.