### PR TITLE
Fix handling of JAVA_OPTIONS for jetty, upgrade to 9.3.21

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,24 +4,24 @@ GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.4.7, 9.4, 9, 9.4.7-jre8, 9.4-jre8, 9-jre8, latest, jre8
 Directory: 9.4-jre8
-GitCommit: 74289191601774dc6c343435ab47f103e6740570
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
 
 Tags: 9.4.7-alpine, 9.4-alpine, 9-alpine, 9.4.7-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.4-jre8/alpine
-GitCommit: 74289191601774dc6c343435ab47f103e6740570
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
 
-Tags: 9.3.20, 9.3, 9.3.20-jre8, 9.3-jre8
+Tags: 9.3.21, 9.3, 9.3.21-jre8, 9.3-jre8
 Directory: 9.3-jre8
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
 
-Tags: 9.3.20-alpine, 9.3-alpine, 9.3.20-jre8-alpine, 9.3-jre8-alpine
+Tags: 9.3.21-alpine, 9.3-alpine, 9.3.21-jre8-alpine, 9.3-jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
 
 Tags: 9.2.22, 9.2, 9.2.22-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
 
 Tags: 9.2.22-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: cafead33ad5c46a0226bff9713719579828ace15
+GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976


### PR DESCRIPTION
This PR fixes the broken handling of `$JAVA_OPTIONS` in the `jetty:9.4.7` image. It also upgrades `jetty:9.3` to version 9.3.21 and rolls out the updated entrypoint from https://github.com/appropriate/docker-jetty/pull/66 and the changes to `setuid` handling from https://github.com/appropriate/docker-jetty/pull/72 to the 9.3 and 9.2 images.

Replaces #3508