### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -33,3 +33,18 @@ Tags: 17.07.0-ce-git, 17.07.0-git, 17.07-git
 Architectures: amd64
 GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
 Directory: 17.07/git
+
+Tags: 17.06.2-ce, 17.06.2, 17.06
+Architectures: amd64
+GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
+Directory: 17.06
+
+Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
+Architectures: amd64
+GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
+Directory: 17.06/dind
+
+Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git
+Architectures: amd64
+GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
+Directory: 17.06/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.9.1, 1.9, 1, latest
+Tags: 1.10.0, 1.10, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: eabf5910eda9620817515d23a58c4fa6ebb265d9
+GitCommit: 1c8478b44f7bb0175e1818b203d432cc246353ab
 Directory: 1/debian
 
-Tags: 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.10.0-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: eabf5910eda9620817515d23a58c4fa6ebb265d9
+GitCommit: 1c8478b44f7bb0175e1818b203d432cc246353ab
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/php
+++ b/library/php
@@ -39,39 +39,39 @@ Architectures: amd64
 GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
 Directory: 7.2-rc/zts/alpine
 
-Tags: 7.1.9-cli, 7.1-cli, 7-cli, cli, 7.1.9, 7.1, 7, latest
+Tags: 7.1.10-cli, 7.1-cli, 7-cli, cli, 7.1.10, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1
 
-Tags: 7.1.9-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.1.10-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/alpine
 
-Tags: 7.1.9-apache, 7.1-apache, 7-apache, apache
+Tags: 7.1.10-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/apache
 
-Tags: 7.1.9-fpm, 7.1-fpm, 7-fpm, fpm
+Tags: 7.1.10-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/fpm
 
-Tags: 7.1.9-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.1.10-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/fpm/alpine
 
-Tags: 7.1.9-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.10-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/zts
 
-Tags: 7.1.9-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.10-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
+GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
 Directory: 7.1/zts/alpine
 
 Tags: 7.0.24-cli, 7.0-cli, 7.0.24, 7.0


### PR DESCRIPTION
- `docker`: add back 17.06 (support overlap for one month; https://blog.docker.com/2017/03/docker-enterprise-edition/)
- `ghost`: 1.10.0
- `php`: 7.1.10