### PR TITLE
upgrade r-base to R 3.4.2 released last Thursday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.4.1: git://github.com/rocker-org/rocker@541002c788eff3ffce85c16072365bf2bc8bdf67 r-base
-latest: git://github.com/rocker-org/rocker@541002c788eff3ffce85c16072365bf2bc8bdf67 r-base
+3.4.2: git://github.com/rocker-org/rocker@eeeeac041f639377acb9320e6cb1c3154f160dfe r-base
+latest: git://github.com/rocker-org/rocker@eeeeac041f639377acb9320e6cb1c3154f160dfe r-base


### PR DESCRIPTION
Standard upgrade to R 3.4.2 which came out on Sep 28.  Its Debian package (which I maintain) is fine (though there is a transition around) and the rocker/r-base image built fine and runs fine. 

Please merge as usual.