### PR TITLE
Add 7.7.0 swipl

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,6 +1,10 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
-Tags: latest, 7.5.15
+Tags: latest, 7.7.0
+GitCommit: a90c231a9bc888705b72f0fca1f0774897dfba54
+Directory: 7.7.0/stretch
+
+Tags: 7.5.15
 GitCommit: 31e2158e7ba2bb2fa9ebff7c0717c476244506bb
 Directory: 7.5.15/stretch


### PR DESCRIPTION
Keeping last 7.5.x release to support applications that cannot immediately migrate to 7.7.x.