### PR TITLE
Bump Traefik to v1.4.0-rc4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.0-rc3, 1.4.0-rc3, v1.4, 1.4, roquefort
+Tags: v1.4.0-rc4, 1.4.0-rc4, v1.4, 1.4, roquefort
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 167c6ac81bbf39bebfbe4fdfef0e931ab33e9cac
+GitCommit: d807e0f3692209f960bb2567e7890453a190c899
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.0-rc3-alpine, 1.4.0-rc3-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-GitCommit: 167c6ac81bbf39bebfbe4fdfef0e931ab33e9cac
+Tags: v1.4.0-rc4-alpine, 1.4.0-rc4-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
+GitCommit: d807e0f3692209f960bb2567e7890453a190c899
 Directory: alpine
 
 Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.0-rc4.

/cc @vdemeester @emilevauge

Cheers
