### PR TITLE
Add new "archNamespace" template function for parsing "--arch-namespace" parameters

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-cat.go
+++ b/bashbrew/go/src/bashbrew/cmd-cat.go
@@ -45,6 +45,9 @@ func cmdCat(c *cli.Context) error {
 		"arch": func() string {
 			return arch
 		},
+		"archNamespace": func(arch string) string {
+			return archNamespaces[arch]
+		},
 	}).Parse(format)
 	if err != nil {
 		return cli.NewMultiError(tmplMultiErr, err)


### PR DESCRIPTION
Example usage: `{{ archNamespace "windows-amd64" }}` => `winamd64`

This is intended for use in https://github.com/docker-library/docs to help create a list of "Supported architectures" for each image which links to each supported architecture repository (and if supported by Bashbrew itself, allows us to keep https://github.com/docker-library/docs isolated from Jenkins assumptions while still allowing Jenkins to contain the single-source-of-truth for arch-to-namespace mappings).