### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,22 +1,8 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/497fdbb37dbfc0829b5821594b68ef24d9f4f72c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
-
-# Last Modified: 2016-08-03
-Tags: 4.9.4, 4.9, 4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
-Directory: 4.9
-# Docker EOL: 2017-08-03
-
-# Last Modified: 2016-06-03
-Tags: 5.4.0, 5.4, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
-Directory: 5
-# Docker EOL: 2017-06-03
 
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.1, 1.5, 1, latest
+Tags: 1.5.2, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47577ad04041d83146439243e35f809b88236466
+GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
 Directory: debian
 
-Tags: 1.5.1-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.2-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 7fbb158344e49c24f632256ef0f4455c7714c23d
+GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -30,7 +30,7 @@ Directory: 3.2
 Tags: 3.2.17-windowsservercore, 3.2-windowsservercore
 SharedTags: 3.2.17, 3.2
 Architectures: windows-amd64
-GitCommit: 3eb1f6df20e04ea8f03ce8ba5893e21bb63073f5
+GitCommit: 7b2fe2cd853161fdb6d28d318e9e7968e51d0ee3
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,24 +1,24 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/afc0d21a718dfc33a5565f92a7a7599dcc90fc82/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/e4315232e337b5a5d913e62c9d078a25e5d45e15/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.5-apache, 11.0-apache, 11-apache, 11.0.5, 11.0, 11
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 11.0/apache
 
 Tags: 11.0.5-fpm, 11.0-fpm, 11-fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 11.0/fpm
 
 Tags: 12.0.3-apache, 12.0-apache, 12-apache, apache, 12.0.3, 12.0, 12, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 12.0/apache
 
 Tags: 12.0.3-fpm, 12.0-fpm, 12-fpm, fpm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
 Directory: 12.0/fpm

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/4883cab7762edbb16d929e55cba5dbfccd6099e1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/9fa3365797933bf588ddc6c51befbcd30346c1ed/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -118,32 +118,6 @@ Tags: 3.4.7-alpine3.4, 3.4-alpine3.4, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/alpine3.4
-
-Tags: 3.3.7-jessie, 3.3-jessie
-SharedTags: 3.3.7, 3.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
-Directory: 3.3/jessie
-
-Tags: 3.3.7-slim, 3.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
-Directory: 3.3/jessie/slim
-
-Tags: 3.3.7-onbuild, 3.3-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
-Directory: 3.3/jessie/onbuild
-
-Tags: 3.3.7-wheezy, 3.3-wheezy
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
-Directory: 3.3/wheezy
-
-Tags: 3.3.7-alpine3.4, 3.3-alpine3.4, 3.3.7-alpine, 3.3-alpine
-Architectures: amd64
-GitCommit: eb5fcfeb040c4ecdb32fd79caa547943e18f9c97
-Directory: 3.3/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,22 +44,22 @@ Architectures: amd64
 GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.21-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.21, 8.5, 8, latest
+Tags: 8.5.23-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.23, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98708820f99e6c58da0eddb3243a01282a64b3be
+GitCommit: dcb6ba09fa6e8f396f38106ca1086a6078799393
 Directory: 8.5/jre8
 
-Tags: 8.5.21-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.21-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.23-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.23-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: 637e4b66a8b8b077f6aca548d369c9fbcbbfe522
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.0.M27-jre8, 9.0.0-jre8, 9.0-jre8, 9-jre8, 9.0.0.M27, 9.0.0, 9.0, 9
+Tags: 9.0.1-jre8, 9.0-jre8, 9-jre8, 9.0.1, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b1b4d00ed9b281e16de07f891b7b399c3457d5e
+GitCommit: 124c504d29896db286570ad835d7746e0d3ebca9
 Directory: 9.0/jre8
 
-Tags: 9.0.0.M27-jre8-alpine, 9.0.0-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.0.M27-alpine, 9.0.0-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.1-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.1-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: ba45c4da39f4705edefbf685d410eb6064f5f151
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `gcc`: remove "Docker EOL" 5 and 4.9
- `memcached`: 1.5.2
- `mongo`: updated Windows SHA256
- `nextcloud`: `arm32v5` (https://github.com/nextcloud/docker/pull/165)
- `python`: remove 3.3 (EOL; docker-library/python#227)
- `tomcat`: 9.0.1, 8.5.23