### PR TITLE
Remove PostgreSQL 9.2

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -53,13 +53,3 @@ Tags: 9.3.19-alpine, 9.3-alpine
 Architectures: amd64
 GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.3/alpine
-
-Tags: 9.2.23, 9.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
-Directory: 9.2
-
-Tags: 9.2.23-alpine, 9.2-alpine
-Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
-Directory: 9.2/alpine


### PR DESCRIPTION
EOL September 2017 per https://www.postgresql.org/support/versioning/