### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.10.0, 1.10, 1, latest
+Tags: 1.11.0, 1.11, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1c8478b44f7bb0175e1818b203d432cc246353ab
+GitCommit: d073430475106a306dbfaf433495a59c80c6760a
 Directory: 1/debian
 
-Tags: 1.10.0-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.11.0-alpine, 1.11-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 1c8478b44f7bb0175e1818b203d432cc246353ab
+GitCommit: d073430475106a306dbfaf433495a59c80c6760a
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/python
+++ b/library/python
@@ -27,20 +27,20 @@ GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
 Directory: 3.7-rc/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.6.2-stretch, 3.6-stretch, 3-stretch, stretch
+Tags: 3.6.3-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9954b06c8b178d7888bc1626bed5a14e43a9203
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/stretch
 
-Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.2, 3.6, 3, latest
+Tags: 3.6.3-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.3, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/jessie
 
-Tags: 3.6.2-slim, 3.6-slim, 3-slim, slim
+Tags: 3.6.3-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -48,20 +48,20 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
-Tags: 3.6.2-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
+Tags: 3.6.3-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: 5d86c858d58f84b8dd1274ac61ac1c9c9ebc7739
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/alpine3.6
 
-Tags: 3.6.2-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.2-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.3-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.3-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: d3c5f47b788adb96e69477dadfb0baca1d97f764
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/alpine3.4
 
-Tags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
-SharedTags: 3.6.2, 3.6, 3, latest
+Tags: 3.6.3-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
+SharedTags: 3.6.3, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: 761d766baa0ff33754436c0a1fd9aedc68cf7947
+GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/redmine
+++ b/library/redmine
@@ -30,12 +30,3 @@ Directory: 3.2
 Tags: 3.2.7-passenger, 3.2-passenger
 GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
 Directory: 3.2/passenger
-
-Tags: 3.1.7, 3.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
-Directory: 3.1
-
-Tags: 3.1.7-passenger, 3.1-passenger
-GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
-Directory: 3.1/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.81-jre7, 7.0-jre7, 7-jre7, 7.0.81, 7.0, 7
+Tags: 7.0.82-jre7, 7.0-jre7, 7-jre7, 7.0.82, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ab435d680d56084ebe0419adfb31cc58df3624dd
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 7/jre7
 
-Tags: 7.0.81-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.81-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.82-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.82-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 7/jre7-alpine
 
-Tags: 7.0.81-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.82-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ab435d680d56084ebe0419adfb31cc58df3624dd
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 7/jre8
 
-Tags: 7.0.81-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.82-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 7/jre8-alpine
 
-Tags: 8.0.46-jre7, 8.0-jre7, 8.0.46, 8.0
+Tags: 8.0.47-jre7, 8.0-jre7, 8.0.47, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c8b74e495a1b63116b524407941b15eef58a7fe
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.0/jre7
 
-Tags: 8.0.46-jre7-alpine, 8.0-jre7-alpine, 8.0.46-alpine, 8.0-alpine
+Tags: 8.0.47-jre7-alpine, 8.0-jre7-alpine, 8.0.47-alpine, 8.0-alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.46-jre8, 8.0-jre8
+Tags: 8.0.47-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c8b74e495a1b63116b524407941b15eef58a7fe
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.0/jre8
 
-Tags: 8.0.46-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.47-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64
-GitCommit: 9532e6813b3a64a058af3d21526a9c02b59ab2b7
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.23-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.23, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcb6ba09fa6e8f396f38106ca1086a6078799393
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.5/jre8
 
 Tags: 8.5.23-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.23-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 637e4b66a8b8b077f6aca548d369c9fbcbbfe522
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.5/jre8-alpine
 
 Tags: 9.0.1-jre8, 9.0-jre8, 9-jre8, 9.0.1, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 124c504d29896db286570ad835d7746e0d3ebca9
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 9.0/jre8
 
 Tags: 9.0.1-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.1-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64
-GitCommit: ba45c4da39f4705edefbf685d410eb6064f5f151
+GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 9.0/jre8-alpine


### PR DESCRIPTION
- `ghost`: 1.11.0
- `python`: 3.6.3
- `redmine`: remove 3.1 (docker-library/redmine#91)
- `tomcat`: 7.0.82, 8.0.47, SHA1s, more URLs (docker-library/tomcat#86)