### PR TITLE
Upgrades elixir to 1.5.2

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,18 +1,18 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/a57ae22bc9505ccdc7662f2556143e1048361d47/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-elixir/blob/50e579afdbacd31c2b9f77b1b4290e61331f8d95/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.5.1, 1.5, latest
-GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
+Tags: 1.5.2, 1.5, latest
+GitCommit: 50e579afdbacd31c2b9f77b1b4290e61331f8d95
 Directory: 1.5
 
-Tags: 1.5.1-slim, 1.5-slim, slim
-GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
+Tags: 1.5.2-slim, 1.5-slim, slim
+GitCommit: 50e579afdbacd31c2b9f77b1b4290e61331f8d95
 Directory: 1.5/slim
 
-Tags: 1.5.1-alpine, 1.5-alpine, alpine
-GitCommit: 162a4ccf85fa7ebcefdbf43903099b0907f6babd
+Tags: 1.5.2-alpine, 1.5-alpine, alpine
+GitCommit: 50e579afdbacd31c2b9f77b1b4290e61331f8d95
 Directory: 1.5/alpine
 
 Tags: 1.4.5, 1.4


### PR DESCRIPTION
Please hold on to this PR and only merge after https://github.com/docker-library/official-images/pull/3533 is merged and images are built, as @c0b requested in https://github.com/c0b/docker-elixir/pull/42#issuecomment-333973387.