### PR TITLE
Add ClefOS to the Official Repositories

### DIFF
--- a/library/clefos
+++ b/library/clefos
@@ -2,17 +2,7 @@ Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealef)
 GitRepo: https://github.com/nealef/clefos.git
 Constraints: !aufs
 
-Tags: master
-GitFetch: refs/heads/master
-GitCommit: fc04b8f47e1dddd2be967b1d49b2b6580fc63dc9
-Architectures: s390x
-
-Tags: 7.4.1708
-GitFetch: refs/tags/7.4.1708
-GitCommit: 396496dfd576b3a2650249b95acf93ebb30641b5 
-Architectures: s390x
-
-Tags: latest
-GitFetch: refs/tags/latest
-GitCommit: 1cdf33f8d90c48e5802a303a07f647c1c1bfd10b 
+Tags: 7, 7.4.1708, latest
+GitFetch: refs/heads/7.4.1708
+GitCommit: 002827d6daa02a1c26d53c2571cc9024968f21d2
 Architectures: s390x

--- a/library/clefos
+++ b/library/clefos
@@ -1,0 +1,18 @@
+Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealeferguson)
+GitRepo: https://github.com/nealef/clefos.git
+Constraints: !aufs
+
+Tags: master
+GitFetch: refs/heads/master
+GitCommit: fc04b8f47e1dddd2be967b1d49b2b6580fc63dc9
+Architectures: s390x
+
+Tags: 7.4.1708
+GitFetch: refs/tags/7.4.1708
+GitCommit: 396496dfd576b3a2650249b95acf93ebb30641b5 
+Architectures: s390x
+
+Tags: latest
+GitFetch: refs/tags/latest
+GitCommit: 1cdf33f8d90c48e5802a303a07f647c1c1bfd10b 
+Architectures: s390x

--- a/library/clefos
+++ b/library/clefos
@@ -1,4 +1,4 @@
-Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealeferguson)
+Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealef)
 GitRepo: https://github.com/nealef/clefos.git
 Constraints: !aufs
 


### PR DESCRIPTION
ClefOS is a distribution for IBM Z (aka "the mainframe") based on the CentOS (and thus RHEL) sources. This distribution has been around since 2012 and is used by many in the Z community. The current release is 7.4.1708. This distribution may be found at [ClefOS Download Site](http://download.sinenomine.net/clefos).

This PR has been generated to add a ClefOS base image to the official repository.

The base repo build recipe and files may be found in the [ClefOS Image Repository] (https://github.com/nealef/clefos). 

Checklist:
* _associated with or contacted upstream?_
I am not sure what this means

* _does it fit into one of the common categories? ("service", "language stack", "base distribution")_
Base distribution

* _is it reasonably popular, or does it solve a particular use case well?_
Around 60 [images](https://hub.docker.com/u/clefos) have been built on this image and its predecessors. The images in those predecessor repositories: [sinenomine](https://hub.docker.com/u/sinenomine) and [brunswickheads](https://hub.docker.com/u/brunswickheads) have been downloaded many hundreds of times.
  
* _does a documentation PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)_
A [PR](https://github.com/docker-library/docs/pull/1022) has been generated.

* _dockerization review for best practices and cache gotchas/improvements (ala the official review guidelines)?_
I believe this base image adheres to these guidelines. Updates will be made as new releases or important security fixes become available.

* _2+ dockerization review?_
Not yet

* _existing official images have been considered as a base? (ie, if foobar needs Node.js, has FROM node:... instead of grabbing node via other means been considered?). If FROM scratch, tarballs only exist in a single commit within the associated history?_
Based on scratch. Tarball clefos-7-docker.tar.xz is in the git repo.

*  _passes current tests? any simple new tests that might be appropriate to add?_
```
testing clefos:clefos7
	'utc' [1/4]...passed
	'cve-2014--shellshock' [2/4]...passed
	'no-hard-coded-passwords' [3/4]...passed
	'override-cmd' [4/4]...passed
```

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - http://www.sinenomine.net/news/ClefOS
    - > Recently Sine Nomine Associates engineer Neale Ferguson had the opportunity to introduce ClefOS (Commercial-grade Linux on Enterprise Foundations Operating System) to users of Linux on System z.
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - base image
-	[x] is it reasonably popular, or does it solve a particular use case well?
    - currently one of the only ways to run CentOS on s390x (https://botbot.me/freenode/docker-library/msg/91108292/ is relevant here)
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1022
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
    - need to make sure we check at each image update to ensure it stays with only a single commit containing a tarball
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)