### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.11.0, 1.11, 1, latest
+Tags: 1.11.1, 1.11, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d073430475106a306dbfaf433495a59c80c6760a
+GitCommit: 5325106dec7cecb53a928f1d114dbfcf8f0edfb3
 Directory: 1/debian
 
-Tags: 1.11.0-alpine, 1.11-alpine, 1-alpine, alpine
+Tags: 1.11.1-alpine, 1.11-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: d073430475106a306dbfaf433495a59c80c6760a
+GitCommit: 5325106dec7cecb53a928f1d114dbfcf8f0edfb3
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -5,61 +5,61 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9.0-stretch, 1.9-stretch, 1-stretch, stretch, 1.9.0, 1.9, 1, latest
+Tags: 1.9.1-stretch, 1.9-stretch, 1-stretch, stretch, 1.9.1, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/stretch
 
-Tags: 1.9.0-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.0-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.1-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.0-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
+Tags: 1.9.1-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: f34c645c8402bd8f6b70f530545ad7845dfefbcc
+GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.9.0-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.9.1-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: f34c645c8402bd8f6b70f530545ad7845dfefbcc
+GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8.3-stretch, 1.8-stretch
+Tags: 1.8.4-stretch, 1.8-stretch
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/stretch
 
-Tags: 1.8.3-jessie, 1.8-jessie, 1.8.3, 1.8
+Tags: 1.8.4-jessie, 1.8-jessie, 1.8.4, 1.8
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/jessie
 
-Tags: 1.8.3-alpine3.6, 1.8-alpine3.6
+Tags: 1.8.4-alpine3.6, 1.8-alpine3.6
 Architectures: amd64
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/alpine3.6
 
-Tags: 1.8.3-alpine3.5, 1.8-alpine3.5, 1.8.3-alpine, 1.8-alpine
+Tags: 1.8.4-alpine3.5, 1.8-alpine3.5, 1.8.4-alpine, 1.8-alpine
 Architectures: amd64
-GitCommit: 94e49ca93c5bbf172e462cea8872c77f9bc08c10
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/alpine3.5
 
-Tags: 1.8.3-onbuild, 1.8-onbuild
+Tags: 1.8.4-onbuild, 1.8-onbuild
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
-Tags: 1.8.3-windowsservercore, 1.8-windowsservercore
+Tags: 1.8.4-windowsservercore, 1.8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8.3-nanoserver, 1.8-nanoserver
+Tags: 1.8.4-nanoserver, 1.8-nanoserver
 Architectures: windows-amd64
-GitCommit: 64b88dc3e9d83e71eafc000fed1f0d5e289b3e65
+GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver

--- a/library/httpd
+++ b/library/httpd
@@ -14,12 +14,12 @@ Architectures: amd64
 GitCommit: 3d5133cff766a1b6d734c9ac107613b7e53f2378
 Directory: 2.2/alpine
 
-Tags: 2.4.27, 2.4, 2, latest
+Tags: 2.4.28, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 109e6332af1ac4176aefd7aad1c28e42f9e10644
+GitCommit: 5b3b87b10907617b0d69af4308ae1dfa21ccf703
 Directory: 2.4
 
-Tags: 2.4.27-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.28-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 3d5133cff766a1b6d734c9ac107613b7e53f2378
+GitCommit: 5b3b87b10907617b0d69af4308ae1dfa21ccf703
 Directory: 2.4/alpine


### PR DESCRIPTION
- `ghost`: 1.11.1
- `golang`: 1.9.1, 1.8.4 (security releases)
- `httpd`: 2.4.28 (docker-library/httpd#78)