### PR TITLE
Match the constraint used by Fedora and CentOS

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -2,6 +2,7 @@ Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/ol-container-images.git
 GitFetch: refs/heads/master
 GitCommit: a7e8a49c20bb2d717191ca1f6e022ddab0bcef43
+Constraints: !aufs
 
 Tags: 7-slim
 Directory: 7-slim


### PR DESCRIPTION
This constraint does apply to Oracle Linux too and should've been added years ago. Mea culpa.

Signed-off-by: Avi Miller <avi.miller@oracle.com>