### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.18, 2.1
+Tags: 2.1.19, 2.1
 Architectures: amd64, i386
-GitCommit: ca3c9df03cab318d34377bba0610c741253b0466
+GitCommit: 8fa6a2876a831c1bab6e846cb27af475ecafceb7
 Directory: 2.1
 
-Tags: 2.2.10, 2.2, 2
+Tags: 2.2.11, 2.2, 2
 Architectures: amd64, i386
-GitCommit: ca3c9df03cab318d34377bba0610c741253b0466
+GitCommit: e5698d3847ed4c4378b1171ae77b5c5ee0e58125
 Directory: 2.2
 
 Tags: 3.0.14, 3.0

--- a/library/docker
+++ b/library/docker
@@ -4,6 +4,21 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
+Tags: 17.10.0-ce-rc1, 17.10-rc, rc
+Architectures: amd64
+GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
+Directory: 17.10-rc
+
+Tags: 17.10.0-ce-rc1-dind, 17.10-rc-dind, rc-dind
+Architectures: amd64
+GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
+Directory: 17.10-rc/dind
+
+Tags: 17.10.0-ce-rc1-git, 17.10-rc-git, rc-git
+Architectures: amd64
+GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
+Directory: 17.10-rc/git
+
 Tags: 17.09.0-ce, 17.09.0, 17.09, 17, stable, test, edge, latest
 Architectures: amd64
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac

--- a/library/drupal
+++ b/library/drupal
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/4cabbdd883753a3b20d826cf5fed5e741291827b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/234e8c0a16d46a62aaaa8ffb139d0f9298880650/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.0-rc2-apache, 8.4-rc-apache, rc-apache, 8.4.0-rc2, 8.4-rc, rc
+Tags: 8.4.0-apache, 8.4-apache, 8-apache, apache, 8.4.0, 8.4, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
-Directory: 8.4-rc/apache
+GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+Directory: 8.4/apache
 
-Tags: 8.4.0-rc2-fpm, 8.4-rc-fpm, rc-fpm
+Tags: 8.4.0-fpm, 8.4-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a7c250fd9d562dcf166ae051f5b06de0461702c
-Directory: 8.4-rc/fpm
+GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+Directory: 8.4/fpm
 
-Tags: 8.4.0-rc2-fpm-alpine, 8.4-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.4.0-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
-Directory: 8.4-rc/fpm-alpine
+GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+Directory: 8.4/fpm-alpine
 
-Tags: 8.3.7-apache, 8.3-apache, 8-apache, apache, 8.3.7, 8.3, 8, latest
+Tags: 8.3.7-apache, 8.3-apache, 8.3.7, 8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/apache
 
-Tags: 8.3.7-fpm, 8.3-fpm, 8-fpm, fpm
+Tags: 8.3.7-fpm, 8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6eb80c71ff39e076633362adf0dc67dd252f1753
 Directory: 8.3/fpm
 
-Tags: 8.3.7-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.3.7-fpm-alpine, 8.3-fpm-alpine
 Architectures: amd64
 GitCommit: 30b3f40a64a8f128f0bff32f7e76eb9bc041cba5
 Directory: 8.3/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.11.1, 1.11, 1, latest
+Tags: 1.12.0, 1.12, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5325106dec7cecb53a928f1d114dbfcf8f0edfb3
+GitCommit: 2ef499bc13d24c2ec222bf2e8b0e6abadc81d211
 Directory: 1/debian
 
-Tags: 1.11.1-alpine, 1.11-alpine, 1-alpine, alpine
+Tags: 1.12.0-alpine, 1.12-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 5325106dec7cecb53a928f1d114dbfcf8f0edfb3
+GitCommit: 2ef499bc13d24c2ec222bf2e8b0e6abadc81d211
 Directory: 1/alpine
 
 Tags: 0.11.11, 0.11, 0

--- a/library/postgres
+++ b/library/postgres
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/cd3f3b1c483e17a0c174d2bfa80d61a5b0f72d2e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/32caee4c0be1529a58d42e873ffcb5504844191e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10-rc1, 10
+Tags: 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2ba4ac1074bc592ffa40076e5de2f94f972afb84
+GitCommit: f34b7cb79c4209a67b573f3bc4bc7827d69800e1
 Directory: 10
 
-Tags: 10-rc1-alpine, 10-alpine
+Tags: 10.0-alpine, 10-alpine, alpine
 Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
+GitCommit: 0b0ca18dda787003f567e7e1a51efaf2348d34d7
 Directory: 10/alpine
 
-Tags: 9.6.5, 9.6, 9, latest
+Tags: 9.6.5, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
 Directory: 9.6
 
-Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine, alpine
+Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64
 GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
 Directory: 9.6/alpine

--- a/library/pypy
+++ b/library/pypy
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.8.0, 2-5.8, 2-5, 2
+Tags: 2-5.9.0, 2-5.9, 2-5, 2
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
+GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
 Directory: 2
 
-Tags: 2-5.8.0-slim, 2-5.8-slim, 2-5-slim, 2-slim
+Tags: 2-5.9.0-slim, 2-5.9-slim, 2-5-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
+GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
 Directory: 2/slim
 
-Tags: 2-5.8.0-onbuild, 2-5.8-onbuild, 2-5-onbuild, 2-onbuild
+Tags: 2-5.9.0-onbuild, 2-5.9-onbuild, 2-5-onbuild, 2-onbuild
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-5.8.0, 3-5.8, 3-5, 3, latest
+Tags: 3-5.9.0, 3-5.9, 3-5, 3, latest
 Architectures: amd64
-GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
+GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
 Directory: 3
 
-Tags: 3-5.8.0-slim, 3-5.8-slim, 3-5-slim, 3-slim, slim
+Tags: 3-5.9.0-slim, 3-5.9-slim, 3-5-slim, 3-slim, slim
 Architectures: amd64
-GitCommit: ae4d6e7d038eb080a55fc3d8d91594505e0f4030
+GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
 Directory: 3/slim
 
-Tags: 3-5.8.0-onbuild, 3-5.8-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Tags: 3-5.9.0-onbuild, 3-5.9-onbuild, 3-5-onbuild, 3-onbuild, onbuild
 Architectures: amd64
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild


### PR DESCRIPTION
- `cassandra`: 2.2.11, 2.1.19
- `docker`: 17.10.0-ce-rc1
- `drupal`: 8.4.0 GA (docker-library/drupal#94)
- `ghost`: 1.12.0
- `postgres`: 10.0 GA
- `pypy`: 5.9.0