### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.1, 10.3
-GitCommit: 8bbe483d5fc132b87063db9d22132b571a778fd4
+Tags: 10.3.2, 10.3
+GitCommit: adb3a3a5d9e3a3a7da8f4676e577ccb621731159
 Directory: 10.3
 
 Tags: 10.2.9, 10.2, 10, latest

--- a/library/python
+++ b/library/python
@@ -23,7 +23,7 @@ Directory: 3.7-rc/alpine3.6
 Tags: 3.7.0a1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore
 SharedTags: 3.7.0a1, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
 Directory: 3.7-rc/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -61,7 +61,7 @@ Directory: 3.6/alpine3.4
 Tags: 3.6.3-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
 SharedTags: 3.6.3, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
+GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
 Directory: 3.6/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -89,7 +89,7 @@ Directory: 3.5/alpine3.4
 Tags: 3.5.4-windowsservercore, 3.5-windowsservercore
 SharedTags: 3.5.4, 3.5
 Architectures: windows-amd64
-GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
+GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
 Directory: 3.5/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -158,6 +158,6 @@ Directory: 2.7/alpine3.4
 Tags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
 SharedTags: 2.7.14, 2.7, 2
 Architectures: windows-amd64
-GitCommit: b1512ead24c6b111506a8d4229134a29da240597
+GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
 Directory: 2.7/windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
- `mariadb`: 10.3.2
- `python`: fix Windows builds (docker-library/python#228)