### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,12 +14,12 @@ Architectures: amd64, i386
 GitCommit: e5698d3847ed4c4378b1171ae77b5c5ee0e58125
 Directory: 2.2
 
-Tags: 3.0.14, 3.0
+Tags: 3.0.15, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: ca3c9df03cab318d34377bba0610c741253b0466
+GitCommit: 50fbd6b9fe453e80f045d3a84f55c77240369658
 Directory: 3.0
 
-Tags: 3.11.0, 3.11, 3, latest
+Tags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: ca3c9df03cab318d34377bba0610c741253b0466
+GitCommit: b77e932d6935318f599026cd1ccf0a2697b3224a
 Directory: 3.11

--- a/library/docker
+++ b/library/docker
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.10.0-ce-rc1, 17.10-rc, rc
+Tags: 17.10.0-ce-rc2, 17.10-rc, rc
 Architectures: amd64
-GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
+GitCommit: 5a539ed6ab5d91c5d8ccf0ccbc583500740199a2
 Directory: 17.10-rc
 
-Tags: 17.10.0-ce-rc1-dind, 17.10-rc-dind, rc-dind
+Tags: 17.10.0-ce-rc2-dind, 17.10-rc-dind, rc-dind
 Architectures: amd64
 GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
 Directory: 17.10-rc/dind
 
-Tags: 17.10.0-ce-rc1-git, 17.10-rc-git, rc-git
+Tags: 17.10.0-ce-rc2-git, 17.10-rc-git, rc-git
 Architectures: amd64
 GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
 Directory: 17.10-rc/git
 
 Tags: 17.09.0-ce, 17.09.0, 17.09, 17, stable, test, edge, latest
 Architectures: amd64
-GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
+GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, 17-dind, stable-dind, test-dind, edge-dind, dind
@@ -36,7 +36,7 @@ Directory: 17.09/git
 
 Tags: 17.07.0-ce, 17.07.0, 17.07
 Architectures: amd64
-GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
+GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.07
 
 Tags: 17.07.0-ce-dind, 17.07.0-dind, 17.07-dind
@@ -51,7 +51,7 @@ Directory: 17.07/git
 
 Tags: 17.06.2-ce, 17.06.2, 17.06
 Architectures: amd64
-GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
+GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind

--- a/library/httpd
+++ b/library/httpd
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.34, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53654452889ae3af537eef2dbb981ccac6fb907f
+GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
 Directory: 2.2
 
 Tags: 2.2.34-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 3d5133cff766a1b6d734c9ac107613b7e53f2378
+GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
 Directory: 2.2/alpine
 
 Tags: 2.4.28, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5b3b87b10907617b0d69af4308ae1dfa21ccf703
+GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
 Directory: 2.4
 
 Tags: 2.4.28-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 5b3b87b10907617b0d69af4308ae1dfa21ccf703
+GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
 Directory: 2.4/alpine

--- a/library/php
+++ b/library/php
@@ -1,145 +1,145 @@
-# this file is generated via https://github.com/docker-library/php/blob/9c17873f3a6e95170d1747b43958f44db3fcf9c4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/662067f7336bbf238fdffb3aeee4b084a0cf3de7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0RC3-cli, 7.2-rc-cli, rc-cli, 7.2.0RC3, 7.2-rc, rc
+Tags: 7.2.0RC4-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC4-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC4-cli, 7.2-rc-cli, rc-cli, 7.2.0RC4, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc
+GitCommit: 662067f7336bbf238fdffb3aeee4b084a0cf3de7
+Directory: 7.2-rc/stretch/cli
 
-Tags: 7.2.0RC3-alpine, 7.2-rc-alpine, rc-alpine
-Architectures: amd64
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/alpine
-
-Tags: 7.2.0RC3-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0RC4-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC4-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/apache
+GitCommit: 662067f7336bbf238fdffb3aeee4b084a0cf3de7
+Directory: 7.2-rc/stretch/apache
 
-Tags: 7.2.0RC3-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0RC4-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC4-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/fpm
+GitCommit: 662067f7336bbf238fdffb3aeee4b084a0cf3de7
+Directory: 7.2-rc/stretch/fpm
 
-Tags: 7.2.0RC3-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
-Architectures: amd64
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/fpm/alpine
-
-Tags: 7.2.0RC3-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0RC4-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC4-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/zts
+GitCommit: 662067f7336bbf238fdffb3aeee4b084a0cf3de7
+Directory: 7.2-rc/stretch/zts
 
-Tags: 7.2.0RC3-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0RC4-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC4-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC4-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC4-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 1e6f8ba4901a5f3f02f447fd70d4226193e4f24b
-Directory: 7.2-rc/zts/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.2-rc/alpine3.6/cli
 
-Tags: 7.1.10-cli, 7.1-cli, 7-cli, cli, 7.1.10, 7.1, 7, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1
-
-Tags: 7.1.10-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.2.0RC4-fpm-alpine3.6, 7.2-rc-fpm-alpine3.6, rc-fpm-alpine3.6, 7.2.0RC4-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.2-rc/alpine3.6/fpm
 
-Tags: 7.1.10-apache, 7.1-apache, 7-apache, apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/apache
-
-Tags: 7.1.10-fpm, 7.1-fpm, 7-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/fpm
-
-Tags: 7.1.10-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.0RC4-zts-alpine3.6, 7.2-rc-zts-alpine3.6, rc-zts-alpine3.6, 7.2.0RC4-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/fpm/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.2-rc/alpine3.6/zts
 
-Tags: 7.1.10-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.10-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.10-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.10-cli, 7.1-cli, 7-cli, cli, 7.1.10, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/zts
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/jessie/cli
 
-Tags: 7.1.10-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.10-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.10-apache, 7.1-apache, 7-apache, apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/jessie/apache
+
+Tags: 7.1.10-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.10-fpm, 7.1-fpm, 7-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/jessie/fpm
+
+Tags: 7.1.10-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.10-zts, 7.1-zts, 7-zts, zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/jessie/zts
+
+Tags: 7.1.10-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.10-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.10-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.10-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 4c0766729088fa5c37d46ccd837386f0e91a33ac
-Directory: 7.1/zts/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/alpine3.4/cli
 
-Tags: 7.0.24-cli, 7.0-cli, 7.0.24, 7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0
-
-Tags: 7.0.24-alpine, 7.0-alpine
+Tags: 7.1.10-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.10-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.0.24-apache, 7.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/apache
-
-Tags: 7.0.24-fpm, 7.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/fpm
-
-Tags: 7.0.24-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.1.10-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.10-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/fpm/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.1/alpine3.4/zts
 
-Tags: 7.0.24-zts, 7.0-zts
+Tags: 7.0.24-cli-jessie, 7.0-cli-jessie, 7.0.24-jessie, 7.0-jessie, 7.0.24-cli, 7.0-cli, 7.0.24, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/zts
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/jessie/cli
 
-Tags: 7.0.24-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.24-apache-jessie, 7.0-apache-jessie, 7.0.24-apache, 7.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/jessie/apache
+
+Tags: 7.0.24-fpm-jessie, 7.0-fpm-jessie, 7.0.24-fpm, 7.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/jessie/fpm
+
+Tags: 7.0.24-zts-jessie, 7.0-zts-jessie, 7.0.24-zts, 7.0-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/jessie/zts
+
+Tags: 7.0.24-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.24-alpine3.4, 7.0-alpine3.4, 7.0.24-cli-alpine, 7.0-cli-alpine, 7.0.24-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 290b7ed9a79dc311b048e3d8a5143ffc9b0d2606
-Directory: 7.0/zts/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/alpine3.4/cli
 
-Tags: 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
-Directory: 5.6
-
-Tags: 5.6.31-alpine, 5.6-alpine, 5-alpine
+Tags: 7.0.24-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.24-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
-Directory: 5.6/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/alpine3.4/fpm
 
-Tags: 5.6.31-apache, 5.6-apache, 5-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
-Directory: 5.6/apache
-
-Tags: 5.6.31-fpm, 5.6-fpm, 5-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
-Directory: 5.6/fpm
-
-Tags: 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 7.0.24-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.24-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
-Directory: 5.6/fpm/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 7.0/alpine3.4/zts
 
-Tags: 5.6.31-zts, 5.6-zts, 5-zts
+Tags: 5.6.31-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.31-jessie, 5.6-jessie, 5-jessie, 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 511db0eb59337abf2b105e83ce0f0f1401dbe68f
-Directory: 5.6/zts
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/jessie/cli
 
-Tags: 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.31-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.31-apache, 5.6-apache, 5-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/jessie/apache
+
+Tags: 5.6.31-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.31-fpm, 5.6-fpm, 5-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/jessie/fpm
+
+Tags: 5.6.31-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.31-zts, 5.6-zts, 5-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/jessie/zts
+
+Tags: 5.6.31-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.31-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.31-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.31-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: fc24121abdce6d74be6d4df6758230b2074d9066
-Directory: 5.6/zts/alpine
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/alpine3.4/cli
+
+Tags: 5.6.31-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Architectures: amd64
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/alpine3.4/fpm
+
+Tags: 5.6.31-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Architectures: amd64
+GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+Directory: 5.6/alpine3.4/zts

--- a/library/piwik
+++ b/library/piwik
@@ -2,10 +2,10 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.1.1-apache, 3.1-apache, 3-apache, apache, 3.1.1, 3.1, 3, latest
-GitCommit: dddf0af92dc1a1e5c6bfd4ac26b884aaaad56dd7
+Tags: 3.2.0-apache, 3.2-apache, 3-apache, apache, 3.2.0, 3.2, 3, latest
+GitCommit: b5782462cddfd5c5ff7da5e19bb83b901e079781
 Directory: apache
 
-Tags: 3.1.1-fpm, 3.1-fpm, 3-fpm, fpm
-GitCommit: dddf0af92dc1a1e5c6bfd4ac26b884aaaad56dd7
+Tags: 3.2.0-fpm, 3.2-fpm, 3-fpm, fpm
+GitCommit: b5782462cddfd5c5ff7da5e19bb83b901e079781
 Directory: fpm

--- a/library/postgres
+++ b/library/postgres
@@ -6,50 +6,50 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f34b7cb79c4209a67b573f3bc4bc7827d69800e1
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 10
 
 Tags: 10.0-alpine, 10-alpine, alpine
 Architectures: amd64
-GitCommit: 0b0ca18dda787003f567e7e1a51efaf2348d34d7
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 10/alpine
 
 Tags: 9.6.5, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7cb3c6eacea93be2259381033be3cc435649369
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.6
 
 Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.6/alpine
 
 Tags: 9.5.9, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.5
 
 Tags: 9.5.9-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.5/alpine
 
 Tags: 9.4.14, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.4
 
 Tags: 9.4.14-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.4/alpine
 
 Tags: 9.3.19, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bef8f02d1fe2bb4547280ba609f19abd20230180
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.3
 
 Tags: 9.3.19-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: 1089a8971b43a675109ad886bf1f3b327c067fa1
+GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 9.3/alpine


### PR DESCRIPTION
- `cassandra`: 3.11.1, 3.0.15
- `docker`: 17.10.0-ce-rc2, `/etc/nsswitch.conf` (docker-library/docker#84)
- `httpd`: apply any released patches, especially for CVEs (docker-library/httpd#79)
- `php`: 7.2.0RC4, more specific tags so a base image transition can be implemented over time (docker-library/php#507)
- `piwik`: 3.2.0
- `postgres`: fix `PATH`, especially for cyrillic characters in `psql` (docker-library/postgres#355)