### PR TITLE
Update Jetty images for latest entrypoint changes

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,24 +4,25 @@ GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.4.7, 9.4, 9, 9.4.7-jre8, 9.4-jre8, 9-jre8, latest, jre8
 Directory: 9.4-jre8
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
 
 Tags: 9.4.7-alpine, 9.4-alpine, 9-alpine, 9.4.7-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Directory: 9.4-jre8/alpine
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
 
 Tags: 9.3.21, 9.3, 9.3.21-jre8, 9.3-jre8
 Directory: 9.3-jre8
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
 
 Tags: 9.3.21-alpine, 9.3-alpine, 9.3.21-jre8-alpine, 9.3-jre8-alpine
 Directory: 9.3-jre8/alpine
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
 
 Tags: 9.2.22, 9.2, 9.2.22-jre8, 9.2-jre8
 Directory: 9.2-jre8
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
 
 Tags: 9.2.22-jre7, 9.2-jre7, 9-jre7, jre7
 Directory: 9.2-jre7
-GitCommit: bb1a968360166dec223b0eff1a979e1acad8b976
+GitCommit: 6938dbcf3c3f1e433fca63909400670a52f39dfe
+


### PR DESCRIPTION
improve the docker-entry-point.sh and generate-jetty-start.sh scripts to
be more consistent and to remove the need to switch back to root USER
for configuration generation.