### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/a6b52c73daa8283cd861f41f55e53426008708ac/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/2f6926c4fb37274b90fae3ba6c3320619a8d0289/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -19,6 +19,12 @@ Architectures: amd64
 GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
 Directory: 17.10-rc/git
 
+Tags: 17.10.0-ce-rc2-windowsservercore, 17.10-rc-windowsservercore, rc-windowsservercore
+Architectures: windows-amd64
+GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
+Directory: 17.10-rc/windows/windowsservercore
+Constraints: windowsservercore
+
 Tags: 17.09.0-ce, 17.09.0, 17.09, 17, stable, test, edge, latest
 Architectures: amd64
 GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
@@ -33,6 +39,12 @@ Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, 17-git, stable-git, test-git, edge
 Architectures: amd64
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git
+
+Tags: 17.09.0-ce-windowsservercore, 17.09.0-windowsservercore, 17.09-windowsservercore, 17-windowsservercore, stable-windowsservercore, test-windowsservercore, edge-windowsservercore, windowsservercore
+Architectures: windows-amd64
+GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
+Directory: 17.09/windows/windowsservercore
+Constraints: windowsservercore
 
 Tags: 17.07.0-ce, 17.07.0, 17.07
 Architectures: amd64
@@ -49,6 +61,12 @@ Architectures: amd64
 GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
 Directory: 17.07/git
 
+Tags: 17.07.0-ce-windowsservercore, 17.07.0-windowsservercore, 17.07-windowsservercore
+Architectures: windows-amd64
+GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
+Directory: 17.07/windows/windowsservercore
+Constraints: windowsservercore
+
 Tags: 17.06.2-ce, 17.06.2, 17.06
 Architectures: amd64
 GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
@@ -63,3 +81,9 @@ Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git
 Architectures: amd64
 GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
 Directory: 17.06/git
+
+Tags: 17.06.2-ce-windowsservercore, 17.06.2-windowsservercore, 17.06-windowsservercore
+Architectures: windows-amd64
+GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
+Directory: 17.06/windows/windowsservercore
+Constraints: windowsservercore

--- a/library/ghost
+++ b/library/ghost
@@ -14,12 +14,12 @@ Architectures: amd64
 GitCommit: 6ebc6712a201c82c039e81c55ca58b67aa1f2033
 Directory: 1/alpine
 
-Tags: 0.11.11, 0.11, 0
+Tags: 0.11.12, 0.11, 0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a3f9385d624bc3511b4f702671dcc27ae96de66
+GitCommit: 44dc27d05debece6a738ccbddd85d2ed4adc2eac
 Directory: 0/debian
 
-Tags: 0.11.11-alpine, 0.11-alpine, 0-alpine
+Tags: 0.11.12-alpine, 0.11-alpine, 0-alpine
 Architectures: amd64
-GitCommit: fabb247507dc8b2d20c5795d688c4167b98caf4a
+GitCommit: 44dc27d05debece6a738ccbddd85d2ed4adc2eac
 Directory: 0/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.12, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed9a656804f0f14a6b6b99fc7d71ba1a043854f5
+GitCommit: 7872457525eb343df072a50c89189406436fbfa5
 Directory: 3.6/debian
 
 Tags: 3.6.12-management, 3.6-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.12-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: ed9a656804f0f14a6b6b99fc7d71ba1a043854f5
+GitCommit: 7872457525eb343df072a50c89189406436fbfa5
 Directory: 3.6/alpine
 
 Tags: 3.6.12-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.4
 
 Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
+GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.4/passenger
 
 Tags: 3.3.4, 3.3
@@ -19,7 +19,7 @@ GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.3
 
 Tags: 3.3.4-passenger, 3.3-passenger
-GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
+GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.3/passenger
 
 Tags: 3.2.7, 3.2
@@ -28,5 +28,5 @@ GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
 Directory: 3.2
 
 Tags: 3.2.7-passenger, 3.2-passenger
-GitCommit: 0bb559650d42409350dba74c9ee982049a61117a
+GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.2/passenger


### PR DESCRIPTION
- `docker`: add client-only Windows variants (docker-library/docker#75)
- `ghost`: 0.11.12
- `rabbitmq`: escape special characters in config (docker-library/rabbitmq#201)
- `redmine`: passenger 5.1.10