### PR TITLE
Adding 7.6.0 stable release for swipl

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -5,6 +5,10 @@ Tags: latest, 7.7.0
 GitCommit: a90c231a9bc888705b72f0fca1f0774897dfba54
 Directory: 7.7.0/stretch
 
+Tags: stable, 7.6.0
+GitCommit: 96f1963cd93da79eecd6fc7442ab301135a982f5
+Directory: 7.6.0/stretch
+
 Tags: 7.5.15
 GitCommit: 31e2158e7ba2bb2fa9ebff7c0717c476244506bb
 Directory: 7.5.15/stretch


### PR DESCRIPTION
7.6.x represents more of an LTS release cycle, so adding a `stable` label that will float to the latest 7.6.x version.