### PR TITLE
haxe: add alpine variant

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -22,6 +22,11 @@ GitCommit: 4d1efc06f99732c3530a9550adaef330e4896eda
 Directory: 3.4/windowsservercore
 Constraints: windowsservercore
 
+Tags: 3.4.4-alpine3.6, 3.4-alpine3.6, 3.4.4-alpine, 3.4-alpine
+Architectures: amd64
+GitCommit: 417db03257ac556fffd130003c80be7dbe89ef1c
+Directory: 3.4/alpine3.6
+
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
@@ -43,6 +48,11 @@ GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.3/windowsservercore
 Constraints: windowsservercore
 
+Tags: 3.3.0-rc.1-alpine3.6, 3.3.0-rc.1-alpine, 3.3.0-alpine3.6, 3.3-alpine3.6, 3.3.0-alpine, 3.3-alpine
+Architectures: amd64
+GitCommit: 417db03257ac556fffd130003c80be7dbe89ef1c
+Directory: 3.3/alpine3.6
+
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
 Architectures: amd64
 GitCommit: 718e80d01e38b9e40b4f221c2ed54d7d134d80f7
@@ -63,6 +73,11 @@ Architectures: windows-amd64
 GitCommit: ba6ec51ec4db8248066b9a294b22bcbfd83a20f4
 Directory: 3.2/windowsservercore
 Constraints: windowsservercore
+
+Tags: 3.2.1-alpine3.6, 3.2-alpine3.6, 3.2.1-alpine, 3.2-alpine
+Architectures: amd64
+GitCommit: 417db03257ac556fffd130003c80be7dbe89ef1c
+Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
 Architectures: amd64


### PR DESCRIPTION
Note that there is no `3.1-alpine` just because haxe 3.1 doesn't build there.