### PR TITLE
Bump swipl to 7.7.1, include typical addins

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -2,7 +2,7 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
 Tags: latest, 7.7.1
-GitCommit: dd512b505241beed243c306c4488ad35b836b253
+GitCommit: 96c86a17801437c3424834721a171a6521cc8d30
 Directory: 7.7.1/stretch
 
 Tags: stable, 7.6.0

--- a/library/swipl
+++ b/library/swipl
@@ -1,14 +1,10 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 
-Tags: latest, 7.7.0
-GitCommit: a90c231a9bc888705b72f0fca1f0774897dfba54
-Directory: 7.7.0/stretch
+Tags: latest, 7.7.1
+GitCommit: dd512b505241beed243c306c4488ad35b836b253
+Directory: 7.7.1/stretch
 
 Tags: stable, 7.6.0
 GitCommit: 96f1963cd93da79eecd6fc7442ab301135a982f5
 Directory: 7.6.0/stretch
-
-Tags: 7.5.15
-GitCommit: 31e2158e7ba2bb2fa9ebff7c0717c476244506bb
-Directory: 7.5.15/stretch


### PR DESCRIPTION
- Increment to SWI-Prolog 7.7.1
- Including space, prosqlite, rocksdb, hdt, and rserve addins by default in the image.