### PR TITLE
Bump Traefik to v1.4.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,24 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.0-rc5, 1.4.0-rc5, v1.4, 1.4, roquefort
+Tags: v1.4.0, 1.4.0, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f77e470fe4e3e4135aeaeeac49ba5c21846fb04a
+GitCommit: f24cd6a1a31933c76ab397868b5da84d43f5d2ff
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.0-rc5-alpine, 1.4.0-rc5-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine
-GitCommit: f77e470fe4e3e4135aeaeeac49ba5c21846fb04a
-Directory: alpine
-
-Tags: v1.3.8, 1.3.8, v1.3, 1.3, raclette, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
-amd64-Directory: scratch/amd64
-arm32v6-Directory: scratch/arm
-arm64v8-Directory: scratch/arm64
-
-Tags: v1.3.8-alpine, 1.3.8-alpine, v1.3-alpine, 1.3-alpine, raclette-alpine, alpine
-GitCommit: cfa3fa48bed342b86b143006e61d9bdf7db07901
+Tags: v1.4.0-alpine, 1.4.0-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+GitCommit: f24cd6a1a31933c76ab397868b5da84d43f5d2ff
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.0.

/cc @vdemeester @emilevauge

Cheers
