### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,7 +4,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.12, 4.4, 4, latest
-GitCommit: 246ce07202932c5385c76122c5a4ca2dd1328b08
+GitCommit: 239d768d3010aaa5875917e44498446ef430485f
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.13.0, 1.13, 1, latest
+Tags: 1.14.0, 1.14, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6ebc6712a201c82c039e81c55ca58b67aa1f2033
+GitCommit: 6081c3a28855d42fd7050767f0a88133865cdee2
 Directory: 1/debian
 
-Tags: 1.13.0-alpine, 1.13-alpine, 1-alpine, alpine
+Tags: 1.14.0-alpine, 1.14-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 6ebc6712a201c82c039e81c55ca58b67aa1f2033
+GitCommit: 6081c3a28855d42fd7050767f0a88133865cdee2
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -1,11 +1,12 @@
-# this file is generated via https://github.com/docker-library/golang/blob/e0ac3d629dc06dcf25ba6724f7126a79723a74af/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/9898665371e4d61803313ff59c838a66a4a39b29/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9.1-stretch, 1.9-stretch, 1-stretch, stretch, 1.9.1, 1.9, 1, latest
+Tags: 1.9.1-stretch, 1.9-stretch, 1-stretch, stretch
+SharedTags: 1.9.1, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/stretch
@@ -16,6 +17,7 @@ GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/alpine3.6
 
 Tags: 1.9.1-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
+SharedTags: 1.9.1, 1.9, 1, latest
 Architectures: windows-amd64
 GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/windows/windowsservercore
@@ -32,7 +34,8 @@ Architectures: amd64, arm32v7, i386, ppc64le, s390x
 GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/stretch
 
-Tags: 1.8.4-jessie, 1.8-jessie, 1.8.4, 1.8
+Tags: 1.8.4-jessie, 1.8-jessie
+SharedTags: 1.8.4, 1.8
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
 GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/jessie
@@ -53,6 +56,7 @@ GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
 Tags: 1.8.4-windowsservercore, 1.8-windowsservercore
+SharedTags: 1.8.4, 1.8
 Architectures: windows-amd64
 GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/windows/windowsservercore

--- a/library/mysql
+++ b/library/mysql
@@ -8,14 +8,14 @@ Tags: 8.0.3, 8.0, 8
 GitCommit: 86431f073b3d2f963d21e33cb8943f0bdcdf143d
 Directory: 8.0
 
-Tags: 5.7.19, 5.7, 5, latest
-GitCommit: 0590e4efd2b31ec794383f084d419dea9bc752c4
+Tags: 5.7.20, 5.7, 5, latest
+GitCommit: 429047ac5e28d59d40a2ac84a189c9d25310f060
 Directory: 5.7
 
-Tags: 5.6.37, 5.6
-GitCommit: 7ee927986b8c0cbfa6cdbb073a0e662bdb62c18a
+Tags: 5.6.38, 5.6
+GitCommit: d8e7c8b6c0ba854fd5ea8257b79a2b3377f668ae
 Directory: 5.6
 
-Tags: 5.5.57, 5.5
-GitCommit: 08b08d88066bc27f82212631e1d3415b61097afe
+Tags: 5.5.58, 5.5
+GitCommit: 41cfbdd89323a1230342038757b5b8f7f2f36b74
 Directory: 5.5

--- a/library/redmine
+++ b/library/redmine
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.4.2, 3.4, 3, latest
+Tags: 3.4.3, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
+GitCommit: 1c73da6ae5eebe714a26dbda520cf6a3daf5ac61
 Directory: 3.4
 
-Tags: 3.4.2-passenger, 3.4-passenger, 3-passenger, passenger
+Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
 GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.4/passenger
 
-Tags: 3.3.4, 3.3
+Tags: 3.3.5, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
+GitCommit: 6105eb941f6b2529d706667202686e8eba58cbe4
 Directory: 3.3
 
-Tags: 3.3.4-passenger, 3.3-passenger
+Tags: 3.3.5-passenger, 3.3-passenger
 GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.3/passenger
 
-Tags: 3.2.7, 3.2
+Tags: 3.2.8, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 288c332e8e13d8fad52d37133dcd29421b369d17
+GitCommit: 35ac30dc2616ab2eb284051ee79fe444ec28abd0
 Directory: 3.2
 
-Tags: 3.2.7-passenger, 3.2-passenger
+Tags: 3.2.8-passenger, 3.2-passenger
 GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
 Directory: 3.2/passenger


### PR DESCRIPTION
- `bash`: update to 4.4.12 patch-rollup
- `ghost`: 1.14.0
- `golang`: `SharedTags` (docker-library/golang#180)
- `mysql`: 5.6.38, 5.7.20, 5.5.58
- `redmine`: 3.2.8, 3.3.5, 3.4.3