### PR TITLE
Rapidoid v5.4.5

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -1,5 +1,5 @@
 Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski)
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
-Tags: 5.4.4, 5.4, 5, latest
-GitCommit: 21292dfd8933021b1e8be562f428d031cf3a1f31
+Tags: 5.4.5, 5.4, 5, latest
+GitCommit: d3740cbc3dcabd7f9c3c396dc20f2210760ad0de

--- a/library/rapidoid
+++ b/library/rapidoid
@@ -2,4 +2,4 @@ Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.4.5, 5.4, 5, latest
-GitCommit: d3740cbc3dcabd7f9c3c396dc20f2210760ad0de
+GitCommit: 5f6abe4bc7ce310ff559a9704b348b9e518e47be


### PR DESCRIPTION
Also switching from `openjdk:8-jdk` to `openjdk:8-jre-slim`.