### PR TITLE
Update Solr to 7.1.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,6 +4,21 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
+Tags: 7.1.0, 7.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+Directory: 7.1
+
+Tags: 7.1.0-alpine, 7.1-alpine
+Architectures: amd64
+GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+Directory: 7.1/alpine
+
+Tags: 7.1.0-slim, 7.1-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+Directory: 7.1/slim
+
 Tags: 7.0.1, 7.0, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e459dbee3bedba0535f3c1b3be97f14dbabaf3bb


### PR DESCRIPTION
Solr 7.1.0. This includes a Critical Security Update for [CVE-2017-12629](https://nvd.nist.gov/vuln/detail/CVE-2017-12629).  See the [disclosure email](http://mail-archives.apache.org/mod_mbox/lucene-general/201710.mbox/%3CCAOOKt500C-0JZVg-zWq5T4%2BwamXwEGr3qKcKLQMQBve8y=26tw@mail.gmail.com%3E) for details.

Announcement emails: [lucene](http://mail-archives.apache.org/mod_mbox/lucene-general/201710.mbox/%3CCAOOKt51vVxSP9Kn8rxm2RykxU6vfvJ3TLFuvBSE3PpCkvR3RKQ@mail.gmail.com%3E), [solr](http://mail-archives.apache.org/mod_mbox/lucene-general/201710.mbox/%3CCAOOKt500C-0JZVg-zWq5T4%2BwamXwEGr3qKcKLQMQBve8y=26tw@mail.gmail.com%3E)