### PR TITLE
Update Solr to 6.6.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -34,19 +34,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e459dbee3bedba0535f3c1b3be97f14dbabaf3bb
 Directory: 7.0/slim
 
-Tags: 6.6.1, 6.6, 6
+Tags: 6.6.2, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
 Directory: 6.6
 
-Tags: 6.6.1-alpine, 6.6-alpine, 6-alpine
+Tags: 6.6.2-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
 Directory: 6.6/alpine
 
-Tags: 6.6.1-slim, 6.6-slim, 6-slim
+Tags: 6.6.2-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
 Directory: 6.6/slim
 
 Tags: 6.5.1, 6.5


### PR DESCRIPTION
Solr 6.6.2. This includes a Critical Security Update for [CVE-2017-12629](https://nvd.nist.gov/vuln/detail/CVE-2017-12629).  See the [disclosure email](http://mail-archives.apache.org/mod_mbox/lucene-general/201710.mbox/%3CCAOOKt500C-0JZVg-zWq5T4%2BwamXwEGr3qKcKLQMQBve8y=26tw@mail.gmail.com%3E) for details.

Changes: [Lucene](https://lucene.apache.org/core/6_6_2/changes/Changes.html), [Solr](https://lucene.apache.org/solr/6_6_2/changes/Changes.html).