### PR TITLE
Fixing build failure for Rapidoid v5.4.5

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -2,4 +2,4 @@ Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.4.5, 5.4, 5, latest
-GitCommit: 5f6abe4bc7ce310ff559a9704b348b9e518e47be
+GitCommit: 079ea9dc69b966493e33eccbf0c06a5605d4f8ec


### PR DESCRIPTION
There was a build error and the latest image (5.4.5) wasn't built:

```
+ rm -r /tmp/tmp.C5UUmwgWst
rm: cannot remove '/tmp/tmp.C5UUmwgWst/S.gpg-agent.ssh': No such file or directory
rm: cannot remove '/tmp/tmp.C5UUmwgWst/S.gpg-agent.browser': No such file or directory
```