### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,70 +1,49 @@
-# this file is generated via https://github.com/docker-library/docker/blob/2f6926c4fb37274b90fae3ba6c3320619a8d0289/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/62a456489acfe7443d426cd502ccf22130d1ccf9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.10.0-ce-rc2, 17.10-rc, rc
+Tags: 17.10.0-ce, 17.10.0, 17.10, 17, edge, test, latest
 Architectures: amd64
-GitCommit: 5a539ed6ab5d91c5d8ccf0ccbc583500740199a2
-Directory: 17.10-rc
+GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+Directory: 17.10
 
-Tags: 17.10.0-ce-rc2-dind, 17.10-rc-dind, rc-dind
+Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, test-dind, dind
 Architectures: amd64
-GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
-Directory: 17.10-rc/dind
+GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+Directory: 17.10/dind
 
-Tags: 17.10.0-ce-rc2-git, 17.10-rc-git, rc-git
+Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, test-git, git
 Architectures: amd64
-GitCommit: 8ada62f762b30d09fd54664710c0ef3b64038f07
-Directory: 17.10-rc/git
+GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+Directory: 17.10/git
 
-Tags: 17.10.0-ce-rc2-windowsservercore, 17.10-rc-windowsservercore, rc-windowsservercore
+Tags: 17.10.0-ce-windowsservercore, 17.10.0-windowsservercore, 17.10-windowsservercore, 17-windowsservercore, edge-windowsservercore, test-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
-Directory: 17.10-rc/windows/windowsservercore
+GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+Directory: 17.10/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 17.09.0-ce, 17.09.0, 17.09, 17, stable, test, edge, latest
+Tags: 17.09.0-ce, 17.09.0, 17.09, stable
 Architectures: amd64
 GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.09
 
-Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, 17-dind, stable-dind, test-dind, edge-dind, dind
+Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
 Architectures: amd64
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/dind
 
-Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, 17-git, stable-git, test-git, edge-git, git
+Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
 Architectures: amd64
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git
 
-Tags: 17.09.0-ce-windowsservercore, 17.09.0-windowsservercore, 17.09-windowsservercore, 17-windowsservercore, stable-windowsservercore, test-windowsservercore, edge-windowsservercore, windowsservercore
+Tags: 17.09.0-ce-windowsservercore, 17.09.0-windowsservercore, 17.09-windowsservercore, stable-windowsservercore
 Architectures: windows-amd64
 GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
 Directory: 17.09/windows/windowsservercore
-Constraints: windowsservercore
-
-Tags: 17.07.0-ce, 17.07.0, 17.07
-Architectures: amd64
-GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
-Directory: 17.07
-
-Tags: 17.07.0-ce-dind, 17.07.0-dind, 17.07-dind
-Architectures: amd64
-GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
-Directory: 17.07/dind
-
-Tags: 17.07.0-ce-git, 17.07.0-git, 17.07-git
-Architectures: amd64
-GitCommit: a8f8fa1b57349cc22c80e7d6cbbdb512ffee2bd2
-Directory: 17.07/git
-
-Tags: 17.07.0-ce-windowsservercore, 17.07.0-windowsservercore, 17.07-windowsservercore
-Architectures: windows-amd64
-GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
-Directory: 17.07/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 17.06.2-ce, 17.06.2, 17.06

--- a/library/gcc
+++ b/library/gcc
@@ -4,6 +4,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
+# Last Modified: 2017-10-10
+Tags: 5.5.0, 5.5, 5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: b6ad93a00a6d2fea84b578506712247217294200
+Directory: 5
+# Docker EOL: 2018-10-10
+
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.14.0, 1.14, 1, latest
+Tags: 1.14.1, 1.14, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6081c3a28855d42fd7050767f0a88133865cdee2
+GitCommit: 7c8b79ec58d1d1bf0a0c5bf2479e50675594909b
 Directory: 1/debian
 
-Tags: 1.14.0-alpine, 1.14-alpine, 1-alpine, alpine
+Tags: 1.14.1-alpine, 1.14-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 6081c3a28855d42fd7050767f0a88133865cdee2
+GitCommit: 7c8b79ec58d1d1bf0a0c5bf2479e50675594909b
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -20,6 +20,6 @@ Tags: 10.0.32, 10.0
 GitCommit: 48182d4da0a078eb05c118a39c28b8b832c1f60b
 Directory: 10.0
 
-Tags: 5.5.57, 5.5, 5
-GitCommit: 198f04b24ca6f668357106355b03d38d1f3234bc
+Tags: 5.5.58, 5.5, 5
+GitCommit: 9ea1296c9855bb11e5b1b59781872e85dad9d898
 Directory: 5.5

--- a/library/python
+++ b/library/python
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0a1-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0a1, 3.7-rc, rc
+Tags: 3.7.0a2-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0a2, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0a1-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0a2-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0a1-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a1-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0a2-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a2-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/alpine3.6
 
-Tags: 3.7.0a1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore
-SharedTags: 3.7.0a1, 3.7-rc, rc
+Tags: 3.7.0a2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore
+SharedTags: 3.7.0a2, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
+GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/windows/windowsservercore
 Constraints: windowsservercore
 
@@ -50,12 +50,12 @@ Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.3-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.3-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.3-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.6/alpine3.4
 
 Tags: 3.6.3-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
@@ -83,7 +83,7 @@ Directory: 3.5/jessie/onbuild
 
 Tags: 3.5.4-alpine3.4, 3.5-alpine3.4, 3.5.4-alpine, 3.5-alpine
 Architectures: amd64
-GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.5/alpine3.4
 
 Tags: 3.5.4-windowsservercore, 3.5-windowsservercore
@@ -116,7 +116,7 @@ Directory: 3.4/wheezy
 
 Tags: 3.4.7-alpine3.4, 3.4-alpine3.4, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.4/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch
@@ -147,12 +147,12 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.14-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64
-GitCommit: b1512ead24c6b111506a8d4229134a29da240597
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.14-alpine3.4, 2.7-alpine3.4, 2-alpine3.4, 2.7.14-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64
-GitCommit: b1512ead24c6b111506a8d4229134a29da240597
+GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 2.7/alpine3.4
 
 Tags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 1c73da6ae5eebe714a26dbda520cf6a3daf5ac61
 Directory: 3.4
 
 Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
+GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
 Directory: 3.4/passenger
 
 Tags: 3.3.5, 3.3
@@ -19,7 +19,7 @@ GitCommit: 6105eb941f6b2529d706667202686e8eba58cbe4
 Directory: 3.3
 
 Tags: 3.3.5-passenger, 3.3-passenger
-GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
+GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
 Directory: 3.3/passenger
 
 Tags: 3.2.8, 3.2
@@ -28,5 +28,5 @@ GitCommit: 35ac30dc2616ab2eb284051ee79fe444ec28abd0
 Directory: 3.2
 
 Tags: 3.2.8-passenger, 3.2-passenger
-GitCommit: b0b0f745e4dec3cd7a5db64f50adcd19b53e7ac9
+GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
 Directory: 3.2/passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.3.0, cli-1.3, cli-1, cli, cli-1.3.0-php5.6, cli-1.3-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.4.0, cli-1.4, cli-1, cli, cli-1.4.0-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
 Directory: php5.6/cli
 
-Tags: cli-1.3.0-php7.0, cli-1.3-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.4.0-php7.0, cli-1.4-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
 Directory: php7.0/cli
 
-Tags: cli-1.3.0-php7.1, cli-1.3-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.4.0-php7.1, cli-1.4-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
 Directory: php7.1/cli


### PR DESCRIPTION
- `docker`: 17.10.0 GA
- `gcc`: 5.5.0
- `ghost`: 1.14.1
- `mariadb`: 5.5.58
- `python`: 3.7.0a2, updated `scanelf` logic (docker-library/python#229)
- `redmine`: passenger 5.1.11
- `wordpress`: cli 1.4.0