### PR TITLE
Update Clear Linux Project.

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@1856b9f9d8340774f4a77171bac9e1476fc0b8c1
-base: git://github.com/clearlinux/docker-brew-clearlinux@1856b9f9d8340774f4a77171bac9e1476fc0b8c1
+latest: git://github.com/clearlinux/docker-brew-clearlinux@67fc950799a38873a74c42b68bbb2c35d7e9596f
+base: git://github.com/clearlinux/docker-brew-clearlinux@67fc950799a38873a74c42b68bbb2c35d7e9596f


### PR DESCRIPTION
Update Clear Linux base+latest images to release 18520.