### PR TITLE
Fix Clear Linux Project certificate store

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@67fc950799a38873a74c42b68bbb2c35d7e9596f
-base: git://github.com/clearlinux/docker-brew-clearlinux@67fc950799a38873a74c42b68bbb2c35d7e9596f
+latest: git://github.com/clearlinux/docker-brew-clearlinux@e44dea8fea6cf1b6e8633fa402a33b239f1dff5b
+base: git://github.com/clearlinux/docker-brew-clearlinux@e44dea8fea6cf1b6e8633fa402a33b239f1dff5b


### PR DESCRIPTION
Update image to populate the certificate store in /var. This is a
break to stateless but better as a temporary work around than having
users need to run the trust store generation themselves before being
able to use any system certificates.