### PR TITLE
Fix condition to detect jruby

### DIFF
--- a/test/tests/ruby-standard-libs/container.rb
+++ b/test/tests/ruby-standard-libs/container.rb
@@ -96,7 +96,7 @@ stdlib = [
 	'zlib',
 ]
 
-if defined? RUBY_ENGINE && RUBY_ENGINE == 'jruby'
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 	# these libraries don't work or don't exist on JRuby ATM
 	stdlib.delete('dbm')
 	stdlib.delete('gdbm')


### PR DESCRIPTION
`defined? RUBY_ENGINE && RUBY_ENGINE == 'jruby'` is always truthy
because it's parsed as `defined?(RUBY_ENGINE && RUBY_ENGINE == 'jruby')`

```
$ docker run --rm ruby:2.4-alpine ruby -e "p (defined? RUBY_ENGINE && RUBY_ENGINE == 'jruby')"
"expression"
```

```
$ docker run --rm ruby:2.4-alpine ruby -e "p (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')"
false
```