### PR TITLE
Fix std libs test for Ruby 2.5

### DIFF
--- a/test/tests/ruby-standard-libs/container.rb
+++ b/test/tests/ruby-standard-libs/container.rb
@@ -96,7 +96,7 @@ stdlib = [
 	'zlib',
 ]
 
-if defined? RUBY_ENGINE && RUBY_ENGINE == 'jruby'
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 	# these libraries don't work or don't exist on JRuby ATM
 	stdlib.delete('dbm')
 	stdlib.delete('gdbm')

--- a/test/tests/ruby-standard-libs/container.rb
+++ b/test/tests/ruby-standard-libs/container.rb
@@ -103,6 +103,11 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 	stdlib.delete('mkmf')
 	stdlib.delete('objspace')
 	stdlib.delete('sdbm')
+else
+	require 'rubygems/version'
+	if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.5')
+		stdlib.delete('mathn')
+	end
 end
 
 result = 'ok'


### PR DESCRIPTION
mathn.rb is removed from stdlib since 2.5.

https://github.com/ruby/ruby/blob/v2_5_0_preview1/NEWS#stdlib-compatibility-issues-excluding-feature-bug-fixes

----------

I split my PR just in case.

https://github.com/docker-library/official-images/pull/3605

Please feel free to close #3605 or ask me rebasing this PR after merging #3605