### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.14.1, 1.14, 1, latest
+Tags: 1.15.0, 1.15, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7c8b79ec58d1d1bf0a0c5bf2479e50675594909b
+GitCommit: 75b0977d8d9588037ea1a0f32cde0a855e2c6822
 Directory: 1/debian
 
-Tags: 1.14.1-alpine, 1.14-alpine, 1-alpine, alpine
+Tags: 1.15.0-alpine, 1.15-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 7c8b79ec58d1d1bf0a0c5bf2479e50675594909b
+GitCommit: 75b0977d8d9588037ea1a0f32cde0a855e2c6822
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/httpd
+++ b/library/httpd
@@ -14,12 +14,12 @@ Architectures: amd64
 GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
 Directory: 2.2/alpine
 
-Tags: 2.4.28, 2.4, 2, latest
+Tags: 2.4.29, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
+GitCommit: 6d50d7f89f4d8bc6a6a3f86d892e254f4d6bfd8b
 Directory: 2.4
 
-Tags: 2.4.28-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.29-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
+GitCommit: 7976cabe162268bd5ad2d233d61e340447bfc371
 Directory: 2.4/alpine

--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.0.4, 1.0, 1, latest
+Tags: 1.0.5, 1.0, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95671eb7309e646addd82699ddaf6065ea57e271
+GitCommit: baf8c9887dcbe070d522ebd50e8cfd272e0618fd
 Directory: debian
 
-Tags: 1.0.4-alpine, 1.0-alpine, 1-alpine, alpine
+Tags: 1.0.5-alpine, 1.0-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: ecf3007a6598bc2e7783e24acd5c62dc57dc9f0a
+GitCommit: baf8c9887dcbe070d522ebd50e8cfd272e0618fd
 Directory: alpine

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/9fa3365797933bf588ddc6c51befbcd30346c1ed/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/7891fcc63609dfd43ae2e8de13a40e838b5e7608/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -10,9 +10,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0a2-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0a2-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0a2-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f12f511910098f45951111aa5642fd935133afc
+GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
 Directory: 3.7-rc/stretch/slim
 
 Tags: 3.7.0a2-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a2-alpine, 3.7-rc-alpine, rc-alpine
@@ -32,18 +32,23 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/stretch
 
+Tags: 3.6.3-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
+Directory: 3.6/stretch/slim
+
 Tags: 3.6.3-jessie, 3.6-jessie, 3-jessie, jessie
 SharedTags: 3.6.3, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
 Directory: 3.6/jessie
 
-Tags: 3.6.3-slim, 3.6-slim, 3-slim, slim
+Tags: 3.6.3-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.3-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf179e4a7b442b29d85f521c2b172b89ef04beef
+GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.2-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Tags: 3.6.3-onbuild, 3.6-onbuild, 3-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
@@ -71,9 +76,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
 Directory: 3.5/jessie
 
-Tags: 3.5.4-slim, 3.5-slim
+Tags: 3.5.4-slim-jessie, 3.5-slim-jessie, 3.5.4-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.4-onbuild, 3.5-onbuild
@@ -99,9 +104,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
 Directory: 3.4/jessie
 
-Tags: 3.4.7-slim, 3.4-slim
+Tags: 3.4.7-slim-jessie, 3.4-slim-jessie, 3.4.7-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45685613e1189227b91affba86dfcb2c764d7fa4
+GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.7-onbuild, 3.4-onbuild
@@ -124,15 +129,20 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/stretch
 
+Tags: 2.7.14-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
+Directory: 2.7/stretch/slim
+
 Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie
 SharedTags: 2.7.14, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/jessie
 
-Tags: 2.7.14-slim, 2.7-slim, 2-slim
+Tags: 2.7.14-slim-jessie, 2.7-slim-jessie, 2-slim-jessie, 2.7.14-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b1512ead24c6b111506a8d4229134a29da240597
+GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.14-onbuild, 2.7-onbuild, 2-onbuild


### PR DESCRIPTION
- `ghost`: 1.15.0
- `httpd`: 2.4.29
- `irssi`: 1.0.5
- `python`: update `slim` variants to use Debian `slim` variants and add explicit `slim-stretch` variants (docker-library/python#233)