### PR TITLE
Upgrade Couchbase Server to 5.0.0

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,15 +1,14 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/4.6.3
-enterprise: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/4.6.3
-4.6.3: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/4.6.3
-enterprise-4.6.3: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/4.6.3
+latest: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/5.0.0
+enterprise: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/5.0.0
+5.0.0: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/5.0.0
+enterprise-5.0.0: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/5.0.0
 
-community: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f community/couchbase-server/4.5.1
-community-4.5.1: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f community/couchbase-server/4.5.1
+4.6.3: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/4.6.3
+enterprise-4.6.3: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 enterprise/couchbase-server/4.6.3
 
-3.1.6: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/3.1.6
-enterprise-3.1.6: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f enterprise/couchbase-server/3.1.6
+community: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 community/couchbase-server/5.0.0
+community-5.0.0: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 community/couchbase-server/5.0.0
 
-community-3.1.3: git://github.com/couchbase/docker@abdfa74c6281d57974b356731a60b5fa68e14f9f community/couchbase-server/3.1.3
-
+community-4.5.1: git://github.com/couchbase/docker@d8cf107f607ca857105d37da6dce9eb7f0e4cbc0 community/couchbase-server/4.5.1


### PR DESCRIPTION
Bump Couchbase EE and CE to 5.0.0. Leave previous EE 4.6.3 and CE 4.5.1 releases. Drops earlier 3.x releases.

If at all possible, we would like this image live no later than Wednesday 8:00 AM PDT, but no earlier than Tuesday evening PDT. However early would be much better than late, so if it need to go live during working hours on Tuesday that's fine. Thanks!