### PR TITLE
Add LICENSE environment variable

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: David Currie <david_currie@uk.ibm.com> (@davidcurrie),
              Jamie Coleman <jlcoleman@uk.ibm.com> (@jamiecoleman92),
              Duane Appleby <applebyd@uk.ibm.com> (@dibbles)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: e6a1e1bc6a9afd206ca361a13c22b25219c7e9b1
+GitCommit: 39e2271ea2b0d104195e9694345faaae1dccb6d2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Add the ability to specify a LICENSE=accept environment variable at runtime to suppress the license message in the output logs (a requirement from one of our stack products). Note that this variable is not required: the image will continue to start without the variable. Also adds some product labels used by IBM's Product Insights offering to identify container content.