### PR TITLE
Update lein to 2.8.0 for clojure image

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,19 +2,19 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 54d3dcd9756fb53c489eb9cb8debd80a1a5f6430
+GitCommit: 73c081d41e28d6366704537204a120f5e577d7c9
 
-Tags: lein-2.7.1, lein, latest
+Tags: lein-2.8.0, lein, latest
 Directory: debian/lein
 
-Tags: lein-2.7.1-onbuild, lein-onbuild, onbuild
+Tags: lein-2.8.0-onbuild, lein-onbuild, onbuild
 Directory: debian/lein/onbuild
 
-Tags: lein-2.7.1-alpine, lein-alpine, alpine
+Tags: lein-2.8.0-alpine, lein-alpine, alpine
 Architectures: amd64
 Directory: alpine/lein
 
-Tags: lein-2.7.1-alpine-onbuild, lein-alpine-onbuild, alpine-onbuild
+Tags: lein-2.8.0-alpine-onbuild, lein-alpine-onbuild, alpine-onbuild
 Architectures: amd64
 Directory: alpine/lein/onbuild
 


### PR DESCRIPTION
Leiningen 2.8.0 has been released, and this updates the `lein` variants of the clojure image to use it.