### PR TITLE
Also tag SharedTags (and include them in dependency calculations, etc)

### DIFF
--- a/bashbrew/go/src/bashbrew/repo.go
+++ b/bashbrew/go/src/bashbrew/repo.go
@@ -147,7 +147,9 @@ func (r Repo) Entries() []manifest.Manifest2822Entry {
 func (r Repo) Tags(namespace string, uniq bool, entry manifest.Manifest2822Entry) []string {
 	tagRepo := path.Join(namespace, r.RepoName)
 	ret := []string{}
-	for i, tag := range entry.Tags {
+	tags := append([]string{}, entry.Tags...)
+	tags = append(tags, entry.SharedTags...)
+	for i, tag := range tags {
 		if uniq && i > 0 {
 			break
 		}


### PR DESCRIPTION
This will include SharedTags directly in "bashbrew list", etc, but explicitly does _not_ include them during "bashbrew push".  This allows for other images to be "FROM" a SharedTags value, and should be reasonably safe since any given SharedTag should only be applicable for a given architecture at most once.