### PR TITLE
Bump Traefik to v1.4.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.0, 1.4.0, v1.4, 1.4, roquefort, latest
+Tags: v1.4.1, 1.4.1, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f24cd6a1a31933c76ab397868b5da84d43f5d2ff
+GitCommit: df4c1a51c1f7b935fce84d7d9589c6824daa16ce
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.0-alpine, 1.4.0-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-GitCommit: f24cd6a1a31933c76ab397868b5da84d43f5d2ff
+Tags: v1.4.1-alpine, 1.4.1-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+GitCommit: df4c1a51c1f7b935fce84d7d9589c6824daa16ce
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.1.

/cc @vdemeester @emilevauge

Cheers
