### PR TITLE
Add Solr 5.5.5

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,105 +6,105 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+GitCommit: cbb8cbc39d29773f2418557c50b255c7bafbf697
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c47a6d6a1796706aaea6ff75358aa5ab691f5a5
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 7.1/slim
 
 Tags: 7.0.1, 7.0, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e459dbee3bedba0535f3c1b3be97f14dbabaf3bb
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 7.0
 
 Tags: 7.0.1-alpine, 7.0-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: e459dbee3bedba0535f3c1b3be97f14dbabaf3bb
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 7.0/alpine
 
 Tags: 7.0.1-slim, 7.0-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e459dbee3bedba0535f3c1b3be97f14dbabaf3bb
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 7.0/slim
 
 Tags: 6.6.2, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.6
 
 Tags: 6.6.2-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64
-GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.6/alpine
 
 Tags: 6.6.2-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9fc02620e0d2cd4eaa4586271a730a5ea3ceba7b
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.6/slim
 
 Tags: 6.5.1, 6.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.5
 
 Tags: 6.5.1-alpine, 6.5-alpine
 Architectures: amd64
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.5/alpine
 
 Tags: 6.5.1-slim, 6.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.5/slim
 
 Tags: 6.4.2, 6.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: cbb8cbc39d29773f2418557c50b255c7bafbf697
 Directory: 6.4
 
 Tags: 6.4.2-alpine, 6.4-alpine
 Architectures: amd64
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.4/alpine
 
 Tags: 6.4.2-slim, 6.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 22e4a81546f4763b102beab7833a342beff34cea
 Directory: 6.4/slim
 
 Tags: 6.3.0, 6.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: cbb8cbc39d29773f2418557c50b255c7bafbf697
 Directory: 6.3
 
 Tags: 6.3.0-alpine, 6.3-alpine
 Architectures: amd64
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: cbb8cbc39d29773f2418557c50b255c7bafbf697
 Directory: 6.3/alpine
 
 Tags: 6.3.0-slim, 6.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: cbb8cbc39d29773f2418557c50b255c7bafbf697
 Directory: 6.3/slim
 
-Tags: 5.5.4, 5.5, 5
+Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 4ed56419308ecee62149a65db8b4b9ef7fab05c1
 Directory: 5.5
 
-Tags: 5.5.4-alpine, 5.5-alpine, 5-alpine
+Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 4ed56419308ecee62149a65db8b4b9ef7fab05c1
 Directory: 5.5/alpine
 
-Tags: 5.5.4-slim, 5.5-slim, 5-slim
+Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b577d7f761f34db1aeec4264d447bb69803b6c8
+GitCommit: 4ed56419308ecee62149a65db8b4b9ef7fab05c1
 Directory: 5.5/slim


### PR DESCRIPTION
Solr 5.5.5, with one critical and one important security fix (CVE-2017-12629, CVE-2017-7660).

Changes: https://lucene.apache.org/solr/5_5_5/changes/Changes.html