### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.15.0, 1.15, 1, latest
+Tags: 1.15.1, 1.15, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 75b0977d8d9588037ea1a0f32cde0a855e2c6822
+GitCommit: 36484438bd30329bceccd3e5536be3a013d04966
 Directory: 1/debian
 
-Tags: 1.15.0-alpine, 1.15-alpine, 1-alpine, alpine
+Tags: 1.15.1-alpine, 1.15-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 75b0977d8d9588037ea1a0f32cde0a855e2c6822
+GitCommit: 36484438bd30329bceccd3e5536be3a013d04966
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.0, 5.6, 5, latest
-GitCommit: 2137f27f7c73233a80ac2a34e591ff2685e37d76
+Tags: 5.6.3, 5.6, 5, latest
+GitCommit: 8a791a6db074dec988aad1e1f6ac645b50ee6702
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.1, 5.6, 5, latest
-GitCommit: f4da9f064268de461db0c6e1c1ed0ed2cb7b0c94
+Tags: 5.6.3, 5.6, 5, latest
+GitCommit: c257f0d648cd01631657a39e005911fc4c7c5aeb
 Directory: 5
 
-Tags: 5.6.1-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: f4da9f064268de461db0c6e1c1ed0ed2cb7b0c94
+Tags: 5.6.3-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: c257f0d648cd01631657a39e005911fc4c7c5aeb
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.2, 10.3
-GitCommit: adb3a3a5d9e3a3a7da8f4676e577ccb621731159
+GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.3
 
 Tags: 10.2.9, 10.2, 10, latest
-GitCommit: 8d8f803e38b374fa7c5a524bdbf014365000d319
+GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.2
 
 Tags: 10.1.28, 10.1
-GitCommit: 6d8fbc8e417ed8f50be812d1e941a164ec3e32f2
+GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.1
 
 Tags: 10.0.32, 10.0
-GitCommit: 48182d4da0a078eb05c118a39c28b8b832c1f60b
+GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.0
 
 Tags: 5.5.58, 5.5, 5
-GitCommit: 9ea1296c9855bb11e5b1b59781872e85dad9d898
+GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 5.5

--- a/library/mysql
+++ b/library/mysql
@@ -9,11 +9,11 @@ GitCommit: 86431f073b3d2f963d21e33cb8943f0bdcdf143d
 Directory: 8.0
 
 Tags: 5.7.20, 5.7, 5, latest
-GitCommit: 429047ac5e28d59d40a2ac84a189c9d25310f060
+GitCommit: 883703dfb30d9c197e0059a669c4bb64d55f6e0d
 Directory: 5.7
 
 Tags: 5.6.38, 5.6
-GitCommit: d8e7c8b6c0ba854fd5ea8257b79a2b3377f668ae
+GitCommit: 883703dfb30d9c197e0059a669c4bb64d55f6e0d
 Directory: 5.6
 
 Tags: 5.5.58, 5.5

--- a/library/percona
+++ b/library/percona
@@ -5,13 +5,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.19, 5.7, 5, latest
-GitCommit: bded1be561f9480c248058840644be09d3282e44
+GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
 Directory: 5.7
 
 Tags: 5.6.37, 5.6
-GitCommit: a49009485acc80aee9be0837eef49f0808cd8ac7
+GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
 Directory: 5.6
 
 Tags: 5.5.57, 5.5
-GitCommit: c9d10f11d7b363a322c9b4337e7a0ed6020f928a
+GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
 Directory: 5.5

--- a/library/ruby
+++ b/library/ruby
@@ -1,27 +1,42 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/35eccb65d277077e9589df5b6d1ac7253eefe4e3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/6bd09a6694ddd921b06cc21d829b6affefa96307/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
+Tags: 2.5.0-preview1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-preview1, 2.5-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+Directory: 2.5-rc/stretch
+
+Tags: 2.5.0-preview1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-preview1-slim, 2.5-rc-slim, rc-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+Directory: 2.5-rc/stretch/slim
+
+Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
+Architectures: amd64
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+Directory: 2.5-rc/alpine3.6
+
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/stretch
 
 Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/jessie
 
 Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -31,22 +46,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 9390129c08cc19668fc482edfd7d7c5a890a80eb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104e3aeadd3c2ea1597be3cd407551faab802ecb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.3/jessie
 
 Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104e3aeadd3c2ea1597be3cd407551faab802ecb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.5-onbuild, 2.3-onbuild
@@ -56,17 +71,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 104e3aeadd3c2ea1597be3cd407551faab802ecb
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59abfdf2c6aaeab159aeb46c762c178e76900c0f
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.2/jessie
 
 Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59abfdf2c6aaeab159aeb46c762c178e76900c0f
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.8-onbuild, 2.2-onbuild
@@ -76,5 +91,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 59abfdf2c6aaeab159aeb46c762c178e76900c0f
+GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `ghost`: 1.15.1
- `kibana`: 5.6.3 (oops)
- `logstash`: 5.6.3 (oops)
- `mariadb`: resync config fixes (docker-library/mariadb#133)
- `mysql`: fix config issues (docker-library/mysql#336)
- `percona`: resync config fixes, `MYSQL_ROOT_HOST` (docker-library/percona#51)
- `ruby`: 2.5.0-preview1 (docker-library/ruby#165)