### PR TITLE
[Security update] Update node 4, 6 and 8

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,95 +1,95 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/15d780e932fc8cd4a145a36cff405610c8c71b0c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/7701eea6fe125530894b3e83f1e9d385e9ee509f/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.7.0, 8.7, 8, latest
+Tags: 8.8.0, 8.8, 8, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8
 
-Tags: 8.7.0-alpine, 8.7-alpine, 8-alpine, alpine
+Tags: 8.8.0-alpine, 8.8-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7/alpine
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8/alpine
 
-Tags: 8.7.0-onbuild, 8.7-onbuild, 8-onbuild, onbuild
+Tags: 8.8.0-onbuild, 8.8-onbuild, 8-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7/onbuild
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8/onbuild
 
-Tags: 8.7.0-slim, 8.7-slim, 8-slim, slim
+Tags: 8.8.0-slim, 8.8-slim, 8-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7/slim
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8/slim
 
-Tags: 8.7.0-stretch, 8.7-stretch, 8-stretch, stretch
+Tags: 8.8.0-stretch, 8.8-stretch, 8-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7/stretch
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8/stretch
 
-Tags: 8.7.0-wheezy, 8.7-wheezy, 8-wheezy, wheezy
+Tags: 8.8.0-wheezy, 8.8-wheezy, 8-wheezy, wheezy
 Architectures: amd64
-GitCommit: 15d780e932fc8cd4a145a36cff405610c8c71b0c
-Directory: 8.7/wheezy
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
+Directory: 8.8/wheezy
 
-Tags: 6.11.4, 6.11, 6, boron
+Tags: 6.11.5, 6.11, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11
 
-Tags: 6.11.4-alpine, 6.11-alpine, 6-alpine, boron-alpine
+Tags: 6.11.5-alpine, 6.11-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/alpine
 
-Tags: 6.11.4-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.11.5-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/onbuild
 
-Tags: 6.11.4-slim, 6.11-slim, 6-slim, boron-slim
+Tags: 6.11.5-slim, 6.11-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/slim
 
-Tags: 6.11.4-stretch, 6.11-stretch, 6-stretch, boron-stretch
+Tags: 6.11.5-stretch, 6.11-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/stretch
 
-Tags: 6.11.4-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
+Tags: 6.11.5-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: 36585913a2776f7f72afcdbf0d39d54625716916
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/wheezy
 
-Tags: 4.8.4, 4.8, 4, argon
+Tags: 4.8.5, 4.8, 4, argon
 Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8
 
-Tags: 4.8.4-alpine, 4.8-alpine, 4-alpine, argon-alpine
+Tags: 4.8.5-alpine, 4.8-alpine, 4-alpine, argon-alpine
 Architectures: amd64
-GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/alpine
 
-Tags: 4.8.4-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+Tags: 4.8.5-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
 Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: 3ffba881ad5a78d33b8edf888d5406222b60686e
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/onbuild
 
-Tags: 4.8.4-slim, 4.8-slim, 4-slim, argon-slim
+Tags: 4.8.5-slim, 4.8-slim, 4-slim, argon-slim
 Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/slim
 
-Tags: 4.8.4-stretch, 4.8-stretch, 4-stretch, argon-stretch
+Tags: 4.8.5-stretch, 4.8-stretch, 4-stretch, argon-stretch
 Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: b502aa016335c81a586b430328d8fee4897ee440
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/stretch
 
-Tags: 4.8.4-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+Tags: 4.8.5-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
 Architectures: amd64
-GitCommit: 9c25cbe93f9108fd1e506d14228afe4a3d04108f
+GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/wheezy
 


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/oct-2017-dos/
https://github.com/nodejs/docker-node/pull/555