### PR TITLE
More arches for alpine based images (and a bump)!

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.10.0-ce, 17.10.0, 17.10, 17, edge, test, latest
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
 Directory: 17.10
 
 Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, test-dind, dind
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
 Directory: 17.10/dind
 
 Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, test-git, git
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
 Directory: 17.10/git
 
@@ -26,17 +26,17 @@ Directory: 17.10/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 17.09.0-ce, 17.09.0, 17.09, stable
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/dind
 
 Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git
 
@@ -47,17 +47,17 @@ Directory: 17.09/windows/windowsservercore
 Constraints: windowsservercore
 
 Tags: 17.06.2-ce, 17.06.2, 17.06
-Architectures: amd64
+Architectures: amd64, s390x
 GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
 Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
-Architectures: amd64
+Architectures: amd64, s390x
 GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
 Directory: 17.06/dind
 
 Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git
-Architectures: amd64
+Architectures: amd64, s390x
 GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
 Directory: 17.06/git
 

--- a/library/golang
+++ b/library/golang
@@ -12,8 +12,8 @@ GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
 Directory: 1.9/stretch
 
 Tags: 1.9.1-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
-Architectures: amd64
-GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a69e233ce841ae9cf8986c103f58b877e294dcd0
 Directory: 1.9/alpine3.6
 
 Tags: 1.9.1-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
@@ -41,8 +41,8 @@ GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
 Directory: 1.8/jessie
 
 Tags: 1.8.4-alpine3.6, 1.8-alpine3.6
-Architectures: amd64
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: ada74f34261f8142b826961b4d0521c1c97b3371
 Directory: 1.8/alpine3.6
 
 Tags: 1.8.4-alpine3.5, 1.8-alpine3.5, 1.8.4-alpine, 1.8-alpine

--- a/library/httpd
+++ b/library/httpd
@@ -20,6 +20,6 @@ GitCommit: 6d50d7f89f4d8bc6a6a3f86d892e254f4d6bfd8b
 Directory: 2.4
 
 Tags: 2.4.29-alpine, 2.4-alpine, 2-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 7976cabe162268bd5ad2d233d61e340447bfc371
 Directory: 2.4/alpine

--- a/library/memcached
+++ b/library/memcached
@@ -10,6 +10,6 @@ GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
 Directory: debian
 
 Tags: 1.5.2-alpine, 1.5-alpine, 1-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -34,18 +34,18 @@ GitCommit: 7b2fe2cd853161fdb6d28d318e9e7968e51d0ee3
 Directory: 3.2/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.9-jessie, 3.4-jessie, 3-jessie, jessie
-SharedTags: 3.4.9, 3.4, 3, latest
+Tags: 3.4.10-jessie, 3.4-jessie, 3-jessie, jessie
+SharedTags: 3.4.10, 3.4, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 18081c4daf5ecf72beee4a77343e961e6cf38ecd
+GitCommit: c501968a9c330a773a2bc2c9b67dcd4ebbb58651
 Directory: 3.4
 
-Tags: 3.4.9-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
-SharedTags: 3.4.9, 3.4, 3, latest
+Tags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
+SharedTags: 3.4.10, 3.4, 3, latest
 Architectures: windows-amd64
-GitCommit: 18081c4daf5ecf72beee4a77343e961e6cf38ecd
+GitCommit: c501968a9c330a773a2bc2c9b67dcd4ebbb58651
 Directory: 3.4/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -35,7 +35,7 @@ GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
 Directory: 7-jdk/slim
 
 Tags: 7u131-jdk-alpine, 7u131-alpine, 7-jdk-alpine, 7-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 7-jdk/alpine
 
@@ -50,7 +50,7 @@ GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
 Directory: 7-jre/slim
 
 Tags: 7u131-jre-alpine, 7-jre-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 7-jre/alpine
 
@@ -65,7 +65,7 @@ GitCommit: 8a23a228bda7d2edeb4132fffd2d08c1e1fcf4ac
 Directory: 8-jdk/slim
 
 Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 8-jdk/alpine
 
@@ -92,7 +92,7 @@ GitCommit: 8a23a228bda7d2edeb4132fffd2d08c1e1fcf4ac
 Directory: 8-jre/slim
 
 Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 8-jre/alpine
 

--- a/library/php
+++ b/library/php
@@ -25,17 +25,17 @@ GitCommit: 662067f7336bbf238fdffb3aeee4b084a0cf3de7
 Directory: 7.2-rc/stretch/zts
 
 Tags: 7.2.0RC4-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC4-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC4-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC4-alpine, 7.2-rc-alpine, rc-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
 Directory: 7.2-rc/alpine3.6/cli
 
 Tags: 7.2.0RC4-fpm-alpine3.6, 7.2-rc-fpm-alpine3.6, rc-fpm-alpine3.6, 7.2.0RC4-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
 Directory: 7.2-rc/alpine3.6/fpm
 
 Tags: 7.2.0RC4-zts-alpine3.6, 7.2-rc-zts-alpine3.6, rc-zts-alpine3.6, 7.2.0RC4-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
 Directory: 7.2-rc/alpine3.6/zts
 

--- a/library/postgres
+++ b/library/postgres
@@ -10,7 +10,7 @@ GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 10
 
 Tags: 10.0-alpine, 10-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
 Directory: 10/alpine
 

--- a/library/python
+++ b/library/python
@@ -16,7 +16,7 @@ GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
 Directory: 3.7-rc/stretch/slim
 
 Tags: 3.7.0a2-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a2-alpine, 3.7-rc-alpine, rc-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/alpine3.6
 
@@ -54,7 +54,7 @@ GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.3-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.6/alpine3.6
 
@@ -156,7 +156,7 @@ GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/wheezy
 
 Tags: 2.7.14-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 2.7/alpine3.6
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -15,11 +15,11 @@ GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
 Tags: 3.6.12-alpine, 3.6-alpine, 3-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 7872457525eb343df072a50c89189406436fbfa5
 Directory: 3.6/alpine
 
 Tags: 3.6.12-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/alpine/management

--- a/library/redis
+++ b/library/redis
@@ -15,7 +15,7 @@ GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
 Directory: 3.2/32bit
 
 Tags: 3.2.11-alpine, 3.2-alpine, 3-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
 Directory: 3.2/alpine
 
@@ -30,6 +30,6 @@ GitCommit: 29b44c477011c5450dd89fd41af4c04e0c71e5b2
 Directory: 4.0/32bit
 
 Tags: 4.0.2-alpine, 4.0-alpine, 4-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 29b44c477011c5450dd89fd41af4c04e0c71e5b2
 Directory: 4.0/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -15,7 +15,7 @@ GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.5-rc/stretch/slim
 
 Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.5-rc/alpine3.6
 
@@ -45,7 +45,7 @@ GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
 Directory: 2.4/alpine3.6
 


### PR DESCRIPTION
 - `golang` arches and https://github.com/docker-library/golang/pull/181
 - `mongo` just a bump to `3.4.10`

With https://github.com/docker-library/official-images/pull/3623 we can have more arches for alpine based images.