### PR TITLE
Update Go to 1.9.2 and 1.8.5

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,65 +5,65 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.9.1-stretch, 1.9-stretch, 1-stretch, stretch
-SharedTags: 1.9.1, 1.9, 1, latest
+Tags: 1.9.2-stretch, 1.9-stretch, 1-stretch, stretch
+SharedTags: 1.9.2, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.9/stretch
 
-Tags: 1.9.1-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.2-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a69e233ce841ae9cf8986c103f58b877e294dcd0
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.1-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
-SharedTags: 1.9.1, 1.9, 1, latest
+Tags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
+SharedTags: 1.9.2, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.9/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.9.1-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.9.2-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 221ee92559f2963c1fe55646d3516f5b8f4c91a4
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.9/windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.8.4-stretch, 1.8-stretch
+Tags: 1.8.5-stretch, 1.8-stretch
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/stretch
 
-Tags: 1.8.4-jessie, 1.8-jessie
-SharedTags: 1.8.4, 1.8
+Tags: 1.8.5-jessie, 1.8-jessie
+SharedTags: 1.8.5, 1.8
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/jessie
 
-Tags: 1.8.4-alpine3.6, 1.8-alpine3.6
+Tags: 1.8.5-alpine3.6, 1.8-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ada74f34261f8142b826961b4d0521c1c97b3371
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/alpine3.6
 
-Tags: 1.8.4-alpine3.5, 1.8-alpine3.5, 1.8.4-alpine, 1.8-alpine
+Tags: 1.8.5-alpine3.5, 1.8-alpine3.5, 1.8.5-alpine, 1.8-alpine
 Architectures: amd64
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/alpine3.5
 
-Tags: 1.8.4-onbuild, 1.8-onbuild
+Tags: 1.8.5-onbuild, 1.8-onbuild
 Architectures: amd64, arm32v7, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
-Tags: 1.8.4-windowsservercore, 1.8-windowsservercore
-SharedTags: 1.8.4, 1.8
+Tags: 1.8.5-windowsservercore, 1.8-windowsservercore
+SharedTags: 1.8.5, 1.8
 Architectures: windows-amd64
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/windows/windowsservercore
 Constraints: windowsservercore
 
-Tags: 1.8.4-nanoserver, 1.8-nanoserver
+Tags: 1.8.5-nanoserver, 1.8-nanoserver
 Architectures: windows-amd64
-GitCommit: 1116b4262228428be20d7e9413ad277c716adb16
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/windows/nanoserver
 Constraints: nanoserver


### PR DESCRIPTION
Adds
- https://github.com/docker-library/golang/pull/182