### PR TITLE
jruby multi-arch

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -4,25 +4,33 @@ GitFetch: refs/heads/master
 GitCommit: 4a733532d5cdffdbafd96be19e2e9862bfe61056
 
 Tags: latest, 9, 9.1, 9.1-jre, 9.1.13, 9.1.13-jre, 9.1.13.0, 9.1.13.0-jre
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 9000/jre
 
 Tags: 9-alpine, 9.1-alpine, 9.1-jre-alpine, 9.1.13-alpine, 9.1.13-jre-alpine, 9.1.13.0-alpine, 9.1.13.0-jre-alpine
+Architectures: amd64, arm32v5, arm32v7
 Directory: 9000/alpine-jre
 
 Tags: 9.1-jdk, 9.1.13-jdk, 9.1.13.0-jdk
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 9000/jdk
 
 Tags: 9.1-jdk-alpine, 9.1.13-jdk-alpine, 9.1.13.0-jdk-alpine
+Architectures: amd64, arm32v5, arm32v7
 Directory: 9000/alpine-jdk
 
 Tags: 9-onbuild, 9.1-onbuild, 9.1.13-onbuild, 9.1.13.0-onbuild
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 9000/onbuild
 
 Tags: 1.7, 1.7.27, 1.7-jre, 1.7.27-jre
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 1.7/jre
 
 Tags: 1.7-jdk, 1.7.27-jdk
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 1.7/jdk
 
 Tags: 1.7-onbuild, 1.7.27-onbuild
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: 1.7/onbuild


### PR DESCRIPTION
Not supporting i386+alpine yet since there seems to be an issue when
installing bundler: related to https://github.com/jruby/jruby/issues/3409