### PR TITLE
Add jupyter-base-notebook

### DIFF
--- a/library/jupyter-base-notebook
+++ b/library/jupyter-base-notebook
@@ -1,4 +1,4 @@
-Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com>
+Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com> (@vaibhavsood)
 GitRepo: https://github.com/jupyter/docker-stacks.git
 
 Tags: 5.2.0, latest

--- a/library/jupyter-base-notebook
+++ b/library/jupyter-base-notebook
@@ -1,0 +1,14 @@
+Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com>
+GitRepo: https://github.com/jupyter/docker-stacks.git
+
+Tags: 5.2.0, latest
+GitCommit: 40a2791b73c59186d2af2dc1f02df91f6086b53c
+Directory: base-notebook
+
+Tags: 5.1.0, latest
+GitCommit: 01c9e6c66b15391a71b8aa70f68f01fcf09c7ebd
+Directory: base-notebook
+
+Tags: 5.0.0, latest
+GitCommit: 9e320520460be2dbfd78b7fcbb7656d177c45084
+Directory: base-notebook

--- a/library/jupyter-base-notebook
+++ b/library/jupyter-base-notebook
@@ -5,10 +5,10 @@ Tags: 5.2.0, latest
 GitCommit: 40a2791b73c59186d2af2dc1f02df91f6086b53c
 Directory: base-notebook
 
-Tags: 5.1.0, latest
+Tags: 5.1.0
 GitCommit: 01c9e6c66b15391a71b8aa70f68f01fcf09c7ebd
 Directory: base-notebook
 
-Tags: 5.0.0, latest
+Tags: 5.0.0
 GitCommit: 9e320520460be2dbfd78b7fcbb7656d177c45084
 Directory: base-notebook

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,6 +1,8 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
+Architectures: amd64, ppc64le
+
 Tags: 3.3.6, 3.3
 GitCommit: 9f00dd78dcd67baa9b57449329fcbd4744948326
 Directory: 3.3.6

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,8 +1,6 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
-Architectures: amd64, ppc64le
-
 Tags: 3.3.6, 3.3
 GitCommit: 9f00dd78dcd67baa9b57449329fcbd4744948326
 Directory: 3.3.6


### PR DESCRIPTION
This is to create a official image request for jupyter-base-notebook, dockerfiles hosted here: https://github.com/jupyter/docker-stacks

Initiated a conversation with upstream https://github.com/jupyter/docker-stacks/issues/472

The doc PR is here: https://github.com/docker-library/docs/pull/1055

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1055
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)