### PR TITLE
Bump Kong LTS release

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -11,9 +11,10 @@ GitCommit: 9f5e82fc6fa947ddb282d5d58242566ee17eb4d0
 Constraints: !aufs
 Directory: centos
 
-Tags: 0.10, 0.10.3
-GitCommit: a209825a9a74f9921c71c13ecb6e39a1b8e18aef
+Tags: 0.10, 0.10.4
+GitCommit: 12f9731151bbdf2c24d033c86c3cd6d5c196f117
 Constraints: !aufs
+Directory: lts
 
 Tags: 0.9, 0.9.9
 GitCommit: b512fa58a9c5a085b21bc5ffb90299cbc4e48eba


### PR DESCRIPTION
We introduce a new directory 'lts' that supports an older version of our Dockerfile used prior to the 0.11.x series of releases.