### PR TITLE
Bump Kong legacy release

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -11,9 +11,10 @@ GitCommit: 9f5e82fc6fa947ddb282d5d58242566ee17eb4d0
 Constraints: !aufs
 Directory: centos
 
-Tags: 0.10, 0.10.3
-GitCommit: a209825a9a74f9921c71c13ecb6e39a1b8e18aef
+Tags: 0.10, 0.10.4
+GitCommit: 206d0a077068e191454c260ee772d2e5bbb4d050
 Constraints: !aufs
+Directory: legacy
 
 Tags: 0.9, 0.9.9
 GitCommit: b512fa58a9c5a085b21bc5ffb90299cbc4e48eba


### PR DESCRIPTION
We introduce a new directory 'legacy' that supports an older version of our Dockerfile used prior to the 0.11.x series of releases.