### PR TITLE
Maven 3.5.2

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -1,62 +1,62 @@
 Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
 GitRepo: https://github.com/carlossg/docker-maven.git
 
-Tags: 3.5.0-jdk-7, 3.5-jdk-7, 3-jdk-7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b6cf057428dec330e39af811b54a6abd000402a
-Directory: jdk-7
-
-Tags: 3.5.0-jdk-7-alpine, 3.5-jdk-7-alpine, 3-jdk-7-alpine
-Architectures: amd64
-GitCommit: bdcedecba28295e7fc91256c9e58b0cc1f69ed57
+Tags: 3.5.2-jdk-7-alpine, 3.5-jdk-7-alpine, 3-jdk-7-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: jdk-7-alpine
 
-Tags: 3.5.0-jdk-7-slim, 3.5-jdk-7-slim, 3-jdk-7-slim
+Tags: 3.5.2-jdk-7-slim, 3.5-jdk-7-slim, 3-jdk-7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afebe58fedee70782887d8bce0fdf808851593fd
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: jdk-7-slim
 
-Tags: 3.5.0-jdk-8, 3.5.0, 3.5-jdk-8, 3.5, 3-jdk-8, 3, latest
+Tags: 3.5.2-jdk-7, 3.5-jdk-7, 3-jdk-7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7fe1595b23769f777515ae3beca30003349a5ebb
-Directory: jdk-8
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+Directory: jdk-7
 
-Tags: 3.5.0-jdk-8-alpine, 3.5.0-alpine, 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
-Architectures: amd64
-GitCommit: bdcedecba28295e7fc91256c9e58b0cc1f69ed57
+Tags: 3.5.2-jdk-8-alpine, 3.5.2-alpine, 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: jdk-8-alpine
 
-Tags: 3.5.0-jdk-8-slim, 3.5.0-slim, 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim
+Tags: 3.5.2-jdk-8-slim, 3.5.2-slim, 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afebe58fedee70782887d8bce0fdf808851593fd
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: jdk-8-slim
 
-Tags: 3.5.0-jdk-9, 3.5-jdk-9, 3-jdk-9
+Tags: 3.5.2-jdk-8, 3.5.2, 3.5-jdk-8, 3.5, 3-jdk-8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc6d3b87457570ccf1310cc70fba3d3c8fc46139
-Directory: jdk-9
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+Directory: jdk-8
 
-Tags: 3.5.0-jdk-9-slim, 3.5-jdk-9-slim, 3-jdk-9-slim
+Tags: 3.5.2-jdk-9-slim, 3.5-jdk-9-slim, 3-jdk-9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc6d3b87457570ccf1310cc70fba3d3c8fc46139
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: jdk-9-slim
 
-Tags: 3.5.0-ibmjava-8, 3.5.0-ibmjava, 3.5-ibmjava-8, 3.5-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 4b6cf057428dec330e39af811b54a6abd000402a
-Directory: ibmjava-8
+Tags: 3.5.2-jdk-9, 3.5-jdk-9, 3-jdk-9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+Directory: jdk-9
 
-Tags: 3.5.0-ibmjava-8-alpine, 3.5.0-ibmjava-alpine, 3.5-ibmjava-8-alpine, 3.5-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
+Tags: 3.5.2-ibmjava-8-alpine, 3.5.2-ibmjava-alpine, 3.5-ibmjava-8-alpine, 3.5-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
 Architectures: amd64
-GitCommit: bdcedecba28295e7fc91256c9e58b0cc1f69ed57
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: ibmjava-8-alpine
 
-Tags: 3.5.0-ibmjava-9, 3.5-ibmjava-9, 3-ibmjava-9
+Tags: 3.5.2-ibmjava-8, 3.5.2-ibmjava, 3.5-ibmjava-8, 3.5-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 4b6cf057428dec330e39af811b54a6abd000402a
-Directory: ibmjava-9
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+Directory: ibmjava-8
 
-Tags: 3.5.0-ibmjava-9-alpine, 3.5-ibmjava-9-alpine, 3-ibmjava-9-alpine
+Tags: 3.5.2-ibmjava-9-alpine, 3.5-ibmjava-9-alpine, 3-ibmjava-9-alpine
 Architectures: amd64
-GitCommit: bdcedecba28295e7fc91256c9e58b0cc1f69ed57
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
 Directory: ibmjava-9-alpine
+
+Tags: 3.5.2-ibmjava-9, 3.5-ibmjava-9, 3-ibmjava-9
+Architectures: amd64, i386, ppc64le, s390x
+GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+Directory: ibmjava-9


### PR DESCRIPTION
I'm getting an error with `bashbrew` but I worked around it changing the Dockerfile manually for the generation, not sure if the generated file is ok.

```
Tags: 3.5.2-jdk-7, 3.5-jdk-7, 3-jdk-7
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
Directory: jdk-7
error: failed fetching repo "openjdk:8u121-jre-alpine"
tag not found in manifest for "openjdk": "8u121-jre-alpine"
```

Using 8u121-jre-alpine because latest alpine jdks have a bug

https://github.com/carlossg/docker-maven/blob/master/jdk-8-alpine/Dockerfile#L1

