### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.16.0, 1.16, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c4d49c0e0957bb653dff565a43096099049c9454
+GitCommit: fbe680f241404781784559da23e226f9966ae53b
 Directory: 1/debian
 
 Tags: 1.16.0-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: c4d49c0e0957bb653dff565a43096099049c9454
+GitCommit: fbe680f241404781784559da23e226f9966ae53b
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -16,8 +16,8 @@ Tags: 10.1.28, 10.1
 GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.1
 
-Tags: 10.0.32, 10.0
-GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
+Tags: 10.0.33, 10.0
+GitCommit: 1d69a91e641da4a77b3a5868c8a78e36b2fbfbb4
 Directory: 10.0
 
 Tags: 5.5.58, 5.5, 5

--- a/library/php
+++ b/library/php
@@ -39,39 +39,39 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
 Directory: 7.2-rc/alpine3.6/zts
 
-Tags: 7.1.10-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.10-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.10-cli, 7.1-cli, 7-cli, cli, 7.1.10, 7.1, 7, latest
+Tags: 7.1.11-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.11-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.11-cli, 7.1-cli, 7-cli, cli, 7.1.11, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.10-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.10-apache, 7.1-apache, 7-apache, apache
+Tags: 7.1.11-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.11-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.10-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.10-fpm, 7.1-fpm, 7-fpm, fpm
+Tags: 7.1.11-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.11-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.10-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.10-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.11-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.11-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.10-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.10-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.10-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.10-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.1.11-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.11-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.11-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.11-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.10-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.10-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.1.11-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.11-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.10-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.10-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.11-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.11-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.25-cli-jessie, 7.0-cli-jessie, 7.0.25-jessie, 7.0-jessie, 7.0.25-cli, 7.0-cli, 7.0.25, 7.0
@@ -109,37 +109,37 @@ Architectures: amd64
 GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
 Directory: 7.0/alpine3.4/zts
 
-Tags: 5.6.31-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.31-jessie, 5.6-jessie, 5-jessie, 5.6.31-cli, 5.6-cli, 5-cli, 5.6.31, 5.6, 5
+Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.31-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.31-apache, 5.6-apache, 5-apache
+Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.31-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.31-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.31-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.31-zts, 5.6-zts, 5-zts
+Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.31-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.31-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.31-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.31-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/alpine3.4/cli
 
-Tags: 5.6.31-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.31-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.32-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.32-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/alpine3.4/fpm
 
-Tags: 5.6.31-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.31-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.32-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.32-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 0bb4068bd639ba98631bc2999e0d20cae583ec00
+GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
 Directory: 5.6/alpine3.4/zts


### PR DESCRIPTION
- `ghost`: ghost-cli 1.2.0, support `NODE_ENV=development` (docker-library/ghost#100)
- `mariadb`: 10.0.33
- `php`: 5.6.32, 7.1.11