### PR TITLE
Odoo: Remove 8.0 and update 9.0-11.0 to release 20171030

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,14 +1,11 @@
 # maintainer: Christophe Monniez <moc@odoo.com> (@d-fence)
 
-8.0: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 8.0
-8: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 8.0
+9.0: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 9.0
+9: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 9.0
 
-9.0: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 9.0
-9: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 9.0
+10.0: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 10.0
+10: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 10.0
 
-10.0: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 10.0
-10: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 10.0
-
-11.0: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 11.0
-11: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 11.0
-latest: git://github.com/odoo/docker@60b3f82cf1ccb05878b6ce7b470ea5ce80753745 11.0
+11.0: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 11.0
+11: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 11.0
+latest: git://github.com/odoo/docker@16d5988408434e4678f3bf6318aabad542dec4ee 11.0


### PR DESCRIPTION
Hello,

This PR is an update for the supported versions of Odoo.
Also, I removed the version 8.0 since this version has reached end of life since October 6, 2017.

I'm not sure if something else is needed to remove an official image properly ?

Thanks and happy Halloween