### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/62a456489acfe7443d426cd502ccf22130d1ccf9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/bca413739d33629db28b0ef6f51a7468451b8654/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -11,7 +11,7 @@ Directory: 17.10
 
 Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
 Directory: 17.10/dind
 
 Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, test-git, git
@@ -32,7 +32,7 @@ Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
+GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
 Directory: 17.09/dind
 
 Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
@@ -53,7 +53,7 @@ Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
 Architectures: amd64, s390x
-GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
+GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
 Directory: 17.06/dind
 
 Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.16.0, 1.16, 1, latest
+Tags: 1.16.1, 1.16, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fbe680f241404781784559da23e226f9966ae53b
+GitCommit: f73d0a971eef8da86811e532c37ebfa4bf0a8524
 Directory: 1/debian
 
-Tags: 1.16.0-alpine, 1.16-alpine, 1-alpine, alpine
+Tags: 1.16.1-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: fbe680f241404781784559da23e226f9966ae53b
+GitCommit: f73d0a971eef8da86811e532c37ebfa4bf0a8524
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -30,14 +30,14 @@ Directory: 1.9/windows/nanoserver
 Constraints: nanoserver
 
 Tags: 1.8.5-stretch, 1.8-stretch
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
 Directory: 1.8/stretch
 
 Tags: 1.8.5-jessie, 1.8-jessie
 SharedTags: 1.8.5, 1.8
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
 Directory: 1.8/jessie
 
 Tags: 1.8.5-alpine3.6, 1.8-alpine3.6
@@ -51,7 +51,7 @@ GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.8/alpine3.5
 
 Tags: 1.8.5-onbuild, 1.8-onbuild
-Architectures: amd64, arm32v7, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.3, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c73da6ae5eebe714a26dbda520cf6a3daf5ac61
+GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.4
 
 Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.5, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6105eb941f6b2529d706667202686e8eba58cbe4
+GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.3
 
 Tags: 3.3.5-passenger, 3.3-passenger
@@ -24,7 +24,7 @@ Directory: 3.3/passenger
 
 Tags: 3.2.8, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35ac30dc2616ab2eb284051ee79fe444ec28abd0
+GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.2
 
 Tags: 3.2.8-passenger, 3.2-passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.8.2-apache, 4.8-apache, 4-apache, apache, 4.8.2, 4.8, 4, latest, 4.8.2-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.2-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+Tags: 4.8.3-apache, 4.8-apache, 4-apache, apache, 4.8.3, 4.8, 4, latest, 4.8.3-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.3-php5.6, 4.8-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php5.6/apache
 
-Tags: 4.8.2-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.2-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.8.3-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.3-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php5.6/fpm
 
-Tags: 4.8.2-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.2-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.8.3-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.3-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php5.6/fpm-alpine
 
-Tags: 4.8.2-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.2-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+Tags: 4.8.3-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.3-php7.0, 4.8-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.0/apache
 
-Tags: 4.8.2-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.8.3-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.0/fpm
 
-Tags: 4.8.2-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.8.3-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.0/fpm-alpine
 
-Tags: 4.8.2-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.2-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+Tags: 4.8.3-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.3-php7.1, 4.8-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.1/apache
 
-Tags: 4.8.2-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.8.3-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 666c5c06d7bc9d02c71fd48a74911248be6f5a5b
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.1/fpm
 
-Tags: 4.8.2-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.8.3-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: e4672ea456ab6abbdbf58fed9d0bd7a6729f63b1
+GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker`: remove `vfs` as default `--storage-driver` (docker-library/docker#89), add `zfs` utils (docker-library/docker#87)
- `ghost`: 1.16.1
- `golang`: `arm64v8` for 1.8 (new in 1.8.5)
- `redmine`: skip `bundle exec` for getting the database adapter (docker-library/redmine#92)
- `wordpress`: 4.8.3