### PR TITLE
Upgrade node v8.x to 8.9.0 LTS Carbon

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,35 +3,35 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.8.1, 8.8, 8, latest
+Tags: 8.9.0, 8.9, 8, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9
 
-Tags: 8.8.1-alpine, 8.8-alpine, 8-alpine, alpine
+Tags: 8.9.0-alpine, 8.9-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8/alpine
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9/alpine
 
-Tags: 8.8.1-onbuild, 8.8-onbuild, 8-onbuild, onbuild
+Tags: 8.9.0-onbuild, 8.9-onbuild, 8-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8/onbuild
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9/onbuild
 
-Tags: 8.8.1-slim, 8.8-slim, 8-slim, slim
+Tags: 8.9.0-slim, 8.9-slim, 8-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8/slim
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9/slim
 
-Tags: 8.8.1-stretch, 8.8-stretch, 8-stretch, stretch
+Tags: 8.9.0-stretch, 8.9-stretch, 8-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8/stretch
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9/stretch
 
-Tags: 8.8.1-wheezy, 8.8-wheezy, 8-wheezy, wheezy
+Tags: 8.9.0-wheezy, 8.9-wheezy, 8-wheezy, wheezy
 Architectures: amd64
-GitCommit: 9eedeaba3b58f15b9ad2eb8035d48c502e868be6
-Directory: 8.8/wheezy
+GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Directory: 8.9/wheezy
 
 Tags: 6.11.5, 6.11, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7


### PR DESCRIPTION
This PR upgrade node to it's latest version 8.9.0 which has been announced as the current LTS version.

https://github.com/nodejs/docker-node/pull/563
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.9.0