### PR TITLE
update bonita to use curl and https

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -4,5 +4,5 @@
 # maintainer: Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur)
 
 7.4.3: git://github.com/Bonitasoft-Community/docker_bonita@5e4d4c6d86a90b2f7639215e4098097200a8751a 7.4
-7.5.4: git://github.com/Bonitasoft-Community/docker_bonita@6ca5b601c0d23080ebd8ed3b59de2ddc4dd1d4a0 7.5
-latest: git://github.com/Bonitasoft-Community/docker_bonita@6ca5b601c0d23080ebd8ed3b59de2ddc4dd1d4a0 7.5
+7.5.4: git://github.com/Bonitasoft-Community/docker_bonita@715b7b807ff1f7411702a158c0596db08baf1159 7.5
+latest: git://github.com/Bonitasoft-Community/docker_bonita@715b7b807ff1f7411702a158c0596db08baf1159 7.5

--- a/library/bonita
+++ b/library/bonita
@@ -4,5 +4,5 @@
 # maintainer: Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur)
 
 7.4.3: git://github.com/Bonitasoft-Community/docker_bonita@5e4d4c6d86a90b2f7639215e4098097200a8751a 7.4
-7.5.4: git://github.com/Bonitasoft-Community/docker_bonita@3d28a037ecf87d6b710b1debe43ccf7fc31282e2 7.5
-latest: git://github.com/Bonitasoft-Community/docker_bonita@3d28a037ecf87d6b710b1debe43ccf7fc31282e2 7.5
+7.5.4: git://github.com/Bonitasoft-Community/docker_bonita@6ca5b601c0d23080ebd8ed3b59de2ddc4dd1d4a0 7.5
+latest: git://github.com/Bonitasoft-Community/docker_bonita@6ca5b601c0d23080ebd8ed3b59de2ddc4dd1d4a0 7.5


### PR DESCRIPTION
* switch ow2 url in https (thanks to fix of https://jira.ow2.org/browse/SERVICEDESK-481)
* replace wget with curl to support shorter auth syntax while using docker build with --build-arg BONITA_URL="-u login:password https://..."