### PR TITLE
Add multi-arch support for node-alpine

### DIFF
--- a/library/node
+++ b/library/node
@@ -9,7 +9,7 @@ GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0
 
 Tags: 9.0.0-alpine, 9.0-alpine, 9-alpine, alpine
-Architectures: amd64
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
 GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0/alpine
 
@@ -39,7 +39,7 @@ GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9
 
 Tags: 8.9.0-alpine, 8.9-alpine, 8-alpine, carbon-alpine
-Architectures: amd64
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
 GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9/alpine
 
@@ -65,7 +65,7 @@ Directory: 8.9/wheezy
 
 Tags: 6.11.5, 6.11, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+GitCommit: 222c645bfa57e415d57fc4ac2088262c8c3cef70
 Directory: 6.11
 
 Tags: 6.11.5-alpine, 6.11-alpine, 6-alpine, boron-alpine


### PR DESCRIPTION
https://github.com/nodejs/docker-node/pull/569

Will rebase after https://github.com/docker-library/official-images/pull/3655 is merged

In the meantime, diff vs #3655 is

```diff
diff --git i/library/node w/library/node
index 092306f..6b8ad1f 100644
--- i/library/node
+++ w/library/node
@@ -10,7 +10,7 @@ GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0
 
 Tags: 9.0.0-alpine, 9.0-alpine, 9-alpine, alpine
-Architectures: amd64
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
 GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0/alpine
 
@@ -40,7 +40,7 @@ GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9
 
 Tags: 8.9.0-alpine, 8.9-alpine, 8-alpine, carbon-alpine
-Architectures: amd64
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
 GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9/alpine
 
@@ -66,7 +66,7 @@ Directory: 8.9/wheezy
 
 Tags: 6.11.5, 6.11, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+GitCommit: d5fae1082f7d7d46f04a156e45ba8cb809c915da
 Directory: 6.11
 
 Tags: 6.11.5-alpine, 6.11-alpine, 6-alpine, boron-alpine
@@ -96,7 +96,7 @@ Directory: 6.11/wheezy
 
 Tags: 4.8.5, 4.8, 4, argon
 Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+GitCommit: d5fae1082f7d7d46f04a156e45ba8cb809c915da
 Directory: 4.8
 
 Tags: 4.8.5-alpine, 4.8-alpine, 4-alpine, argon-alpine
```