### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,7 +16,7 @@ Directory: artful/scm
 
 Tags: artful
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: artful
 
 Tags: buster-curl
@@ -31,7 +31,7 @@ Directory: buster/scm
 
 Tags: buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: buster
 
 Tags: jessie-curl
@@ -46,7 +46,7 @@ Directory: jessie/scm
 
 Tags: jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: jessie
 
 Tags: sid-curl
@@ -61,7 +61,7 @@ Directory: sid/scm
 
 Tags: sid
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: sid
 
 Tags: stretch-curl, curl
@@ -76,7 +76,7 @@ Directory: stretch/scm
 
 Tags: stretch, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: stretch
 
 Tags: trusty-curl
@@ -91,7 +91,7 @@ Directory: trusty/scm
 
 Tags: trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: trusty
 
 Tags: wheezy-curl
@@ -106,7 +106,7 @@ Directory: wheezy/scm
 
 Tags: wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: wheezy
 
 Tags: xenial-curl
@@ -121,7 +121,7 @@ Directory: xenial/scm
 
 Tags: xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: xenial
 
 Tags: zesty-curl
@@ -136,5 +136,5 @@ Directory: zesty/scm
 
 Tags: zesty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d86449454958f224035b5b200bfd3be9c088ff3
+GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: zesty

--- a/library/docker
+++ b/library/docker
@@ -11,7 +11,7 @@ Directory: 17.10
 
 Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
+GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
 Directory: 17.10/dind
 
 Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, test-git, git
@@ -32,7 +32,7 @@ Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
+GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
 Directory: 17.09/dind
 
 Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
@@ -53,7 +53,7 @@ Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
 Architectures: amd64, s390x
-GitCommit: 598fcbbf506b6ccecf53746c14950b7016d98312
+GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
 Directory: 17.06/dind
 
 Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/e7ae2cf479db53d3110a0b5a609a32641a39467c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: e7ae2cf479db53d3110a0b5a609a32641a39467c
+GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 
 Tags: linux
 SharedTags: latest
@@ -29,3 +29,10 @@ Architectures: windows-amd64
 windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hello-seattle/nanoserver
 Constraints: nanoserver
+
+Tags: nanoserver1709
+SharedTags: latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-Directory: amd64/hello-seattle/nanoserver1709
+Constraints: nanoserver1709

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/e7ae2cf479db53d3110a0b5a609a32641a39467c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: e7ae2cf479db53d3110a0b5a609a32641a39467c
+GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 
 Tags: linux
 SharedTags: latest
@@ -29,3 +29,10 @@ Architectures: windows-amd64
 windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hello-world/nanoserver
 Constraints: nanoserver
+
+Tags: nanoserver1709
+SharedTags: latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-Directory: amd64/hello-world/nanoserver1709
+Constraints: nanoserver1709

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/e7ae2cf479db53d3110a0b5a609a32641a39467c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: e7ae2cf479db53d3110a0b5a609a32641a39467c
+GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 
 Tags: linux
 SharedTags: latest
@@ -29,3 +29,10 @@ Architectures: windows-amd64
 windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
 windows-amd64-Directory: amd64/hola-mundo/nanoserver
 Constraints: nanoserver
+
+Tags: nanoserver1709
+SharedTags: latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-Directory: amd64/hola-mundo/nanoserver1709
+Constraints: nanoserver1709

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.3.2, 10.3
 GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
 Directory: 10.3
 
-Tags: 10.2.9, 10.2, 10, latest
-GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
+Tags: 10.2.10, 10.2, 10, latest
+GitCommit: f50d0a8218602a64806a4eb907b3b5dcc5916981
 Directory: 10.2
 
 Tags: 10.1.28, 10.1

--- a/library/python
+++ b/library/python
@@ -12,7 +12,7 @@ Directory: 3.7-rc/stretch
 
 Tags: 3.7.0a2-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0a2-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 3.7-rc/stretch/slim
 
 Tags: 3.7.0a2-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a2-alpine, 3.7-rc-alpine, rc-alpine
@@ -34,7 +34,7 @@ Directory: 3.6/stretch
 
 Tags: 3.6.3-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.3-jessie, 3.6-jessie, 3-jessie, jessie
@@ -45,7 +45,7 @@ Directory: 3.6/jessie
 
 Tags: 3.6.3-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.3-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.3-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -78,7 +78,7 @@ Directory: 3.5/jessie
 
 Tags: 3.5.4-slim-jessie, 3.5-slim-jessie, 3.5.4-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.4-onbuild, 3.5-onbuild
@@ -106,7 +106,7 @@ Directory: 3.4/jessie
 
 Tags: 3.4.7-slim-jessie, 3.4-slim-jessie, 3.4.7-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28490a60c628a76a2e5a35b986d687a9dcf3ae0e
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.7-onbuild, 3.4-onbuild
@@ -131,7 +131,7 @@ Directory: 2.7/stretch
 
 Tags: 2.7.14-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie
@@ -142,7 +142,7 @@ Directory: 2.7/jessie
 
 Tags: 2.7.14-slim-jessie, 2.7-slim-jessie, 2-slim-jessie, 2.7.14-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7891fcc63609dfd43ae2e8de13a40e838b5e7608
+GitCommit: 5ad82ca56a6ba42c56665c7e25f15d1ba1aa1c90
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.14-onbuild, 2.7-onbuild, 2-onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-preview1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-preview1, 2.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: ed50dfb679ca43ef3ece8224da9f29a081cda082
 Directory: 2.5-rc/stretch
 
 Tags: 2.5.0-preview1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-preview1-slim, 2.5-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: ed50dfb679ca43ef3ece8224da9f29a081cda082
 Directory: 2.5-rc/stretch/slim
 
 Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: ed50dfb679ca43ef3ece8224da9f29a081cda082
 Directory: 2.5-rc/alpine3.6
 
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/stretch
 
 Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/jessie
 
 Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -46,22 +46,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 8a4631f3750e594f394e4bda97d71999d9439179
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 7e1c5ff8efecf8991f8fb8298d6fb8f9e992bf4a
 Directory: 2.3/jessie
 
 Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 7e1c5ff8efecf8991f8fb8298d6fb8f9e992bf4a
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.5-onbuild, 2.3-onbuild
@@ -71,17 +71,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 7e1c5ff8efecf8991f8fb8298d6fb8f9e992bf4a
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 54c32e9b3cb131f9bb3e1aed455410669abeda81
 Directory: 2.2/jessie
 
 Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 54c32e9b3cb131f9bb3e1aed455410669abeda81
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.8-onbuild, 2.2-onbuild
@@ -91,5 +91,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 6959194971f4f84e9bef2976ae6b8a469fa58dae
+GitCommit: 54c32e9b3cb131f9bb3e1aed455410669abeda81
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `buildpack-deps`: add `libncursesw5-dev` (docker-library/buildpack-deps#69)
- `docker`: exclude `zfs` package when unavailable (docker-library/docker#91)
- `hello-seattle`: add `microsoft/nanoserver:1709` variant (docker-library/hello-world#38)
- `hello-world`: add `microsoft/nanoserver:1709` variant (docker-library/hello-world#38)
- `hola-mundo`: add `microsoft/nanoserver:1709` variant (docker-library/hello-world#38)
- `mariadb`: 10.2.10
- `python`: build against `libncursesw5-dev` (docker-library/python#238)
- `ruby`: bundler 1.16.0