### PR TITLE
Maven 3-jdk-8-alpine was using jre

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -18,7 +18,7 @@ Directory: jdk-7
 
 Tags: 3.5.2-jdk-8-alpine, 3.5.2-alpine, 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
+GitCommit: 798decbb2f987a14f345c017f8fa3725c2467758
 Directory: jdk-8-alpine
 
 Tags: 3.5.2-jdk-8-slim, 3.5.2-slim, 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim


### PR DESCRIPTION
There was an issue in #3649 and the 3-jdk-8-alpine tags were using jre

I guess this change is enough