### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/buildpack-deps.git
 
 Tags: artful-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: artful/curl
 
 Tags: artful-scm
@@ -21,7 +21,7 @@ Directory: artful
 
 Tags: buster-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72021102be2a05177d2c01e466495ba1c9d0b4f5
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: buster/curl
 
 Tags: buster-scm
@@ -36,7 +36,7 @@ Directory: buster
 
 Tags: jessie-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: jessie/curl
 
 Tags: jessie-scm
@@ -51,7 +51,7 @@ Directory: jessie
 
 Tags: sid-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: sid/curl
 
 Tags: sid-scm
@@ -66,7 +66,7 @@ Directory: sid
 
 Tags: stretch-curl, curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: stretch/curl
 
 Tags: stretch-scm, scm
@@ -81,7 +81,7 @@ Directory: stretch
 
 Tags: trusty-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: trusty/curl
 
 Tags: trusty-scm
@@ -96,7 +96,7 @@ Directory: trusty
 
 Tags: wheezy-curl
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: wheezy/curl
 
 Tags: wheezy-scm
@@ -111,7 +111,7 @@ Directory: wheezy
 
 Tags: xenial-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: xenial/curl
 
 Tags: xenial-scm
@@ -126,7 +126,7 @@ Directory: xenial
 
 Tags: zesty-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f60e19008458220114f1a0b6cd3710f1015d402
+GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: zesty/curl
 
 Tags: zesty-scm

--- a/library/docker
+++ b/library/docker
@@ -11,7 +11,7 @@ Directory: 17.10
 
 Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
+GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.10/dind
 
 Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, test-git, git
@@ -32,7 +32,7 @@ Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
+GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.09/dind
 
 Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
@@ -53,7 +53,7 @@ Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
 Architectures: amd64, s390x
-GitCommit: 67a8b4525f03bf3b7228c9f4b7e506825c9ecbf0
+GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.06/dind
 
 Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git

--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.0-apache, 8.4-apache, 8-apache, apache, 8.4.0, 8.4, 8, latest
+Tags: 8.4.1-apache, 8.4-apache, 8-apache, apache, 8.4.1, 8.4, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
 Directory: 8.4/apache
 
-Tags: 8.4.0-fpm, 8.4-fpm, 8-fpm, fpm
+Tags: 8.4.1-fpm, 8.4-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
 Directory: 8.4/fpm
 
-Tags: 8.4.0-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.4.1-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 4adc72d34dc250cde5329dff32989b5aa8090324
+GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
 Directory: 8.4/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8.3.7, 8.3

--- a/library/gcc
+++ b/library/gcc
@@ -7,20 +7,20 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b6ad93a00a6d2fea84b578506712247217294200
+GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
 Directory: 5
 # Docker EOL: 2018-10-10
 
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
+GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
 Directory: 6
 # Docker EOL: 2018-07-04
 
 # Last Modified: 2017-08-14
 Tags: 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1539ed62d45cbd1e2a4d0c3e94c07ca2acdb914a
+GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
 Directory: 7
 # Docker EOL: 2018-08-14

--- a/library/php
+++ b/library/php
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0RC5-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC5-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC5-cli, 7.2-rc-cli, rc-cli, 7.2.0RC5, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.2-rc/stretch/cli
 
 Tags: 7.2.0RC5-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC5-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.2-rc/stretch/apache
 
 Tags: 7.2.0RC5-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC5-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.2-rc/stretch/fpm
 
 Tags: 7.2.0RC5-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC5-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.2-rc/stretch/zts
 
 Tags: 7.2.0RC5-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC5-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC5-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC5-alpine, 7.2-rc-alpine, rc-alpine
@@ -41,22 +41,22 @@ Directory: 7.2-rc/alpine3.6/zts
 
 Tags: 7.1.11-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.11-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.11-cli, 7.1-cli, 7-cli, cli, 7.1.11, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.11-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.11-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.11-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.11-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.11-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.11-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.11-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.11-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.11-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.11-alpine, 7.1-alpine, 7-alpine, alpine
@@ -76,22 +76,22 @@ Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.25-cli-jessie, 7.0-cli-jessie, 7.0.25-jessie, 7.0-jessie, 7.0.25-cli, 7.0-cli, 7.0.25, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.25-apache-jessie, 7.0-apache-jessie, 7.0.25-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.25-fpm-jessie, 7.0-fpm-jessie, 7.0.25-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.25-zts-jessie, 7.0-zts-jessie, 7.0.25-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.25-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.25-alpine3.4, 7.0-alpine3.4, 7.0.25-cli-alpine, 7.0-cli-alpine, 7.0.25-alpine, 7.0-alpine
@@ -111,22 +111,22 @@ Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: bfe27759103fa6050601060165409b5b3be06395
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3b022607bec233463a3d055731fb710837978747
 Directory: 10
 
 Tags: 10.0-alpine, 10-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 10/alpine
 
 Tags: 9.6.5, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3b022607bec233463a3d055731fb710837978747
 Directory: 9.6
 
 Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine
@@ -26,7 +26,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.9, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3b022607bec233463a3d055731fb710837978747
 Directory: 9.5
 
 Tags: 9.5.9-alpine, 9.5-alpine
@@ -36,7 +36,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.14, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3b022607bec233463a3d055731fb710837978747
 Directory: 9.4
 
 Tags: 9.4.14-alpine, 9.4-alpine
@@ -46,7 +46,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.19, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3b022607bec233463a3d055731fb710837978747
 Directory: 9.3
 
 Tags: 9.3.19-alpine, 9.3-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.12, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7872457525eb343df072a50c89189406436fbfa5
+GitCommit: 57baaf4a1a4a20a710b24800739652d29e94e7c9
 Directory: 3.6/debian
 
 Tags: 3.6.12-management, 3.6-management, 3-management, management


### PR DESCRIPTION
- `buildpack-deps`: `s/gnupg2/gnupg/g` (docker-library/buildpack-deps#70)
- `docker`: fix `zfs` arch exclusion (docker-library/docker#92)
- `drupal`: 8.4.1
- `gcc`: `s/gnupg2/gnupg/g` (docker-library/gcc#44)
- `php`: `s/gnupg2/gnupg/g` (docker-library/php#514)
- `postgres`: `s/gnupg2/gnupg/g` (docker-library/postgres#364)
- `rabbitmq`: `s/gnupg2/gnupg/g` (docker-library/rabbitmq#204)