### PR TITLE
Bump Traefik to v1.4.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.1, 1.4.1, v1.4, 1.4, roquefort, latest
+Tags: v1.4.2, 1.4.2, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: df4c1a51c1f7b935fce84d7d9589c6824daa16ce
+GitCommit: 1d5fa099fa6ff0c510ca76a400e0b5596d1d58c5
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.1-alpine, 1.4.1-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-GitCommit: df4c1a51c1f7b935fce84d7d9589c6824daa16ce
+Tags: v1.4.2-alpine, 1.4.2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+GitCommit: 1d5fa099fa6ff0c510ca76a400e0b5596d1d58c5
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.2.

/cc @vdemeester @emilevauge

Cheers
