### PR TITLE
 Add multi-arch support to Zookeeper

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -2,13 +2,16 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
 Tags: 3.3.6, 3.3
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: e69f3889112bac11a39be680b284eb50b1bb44dc
 Directory: 3.3.6
 
 Tags: 3.4.10, 3.4, latest
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: e69f3889112bac11a39be680b284eb50b1bb44dc
 Directory: 3.4.10
 
 Tags: 3.5.3-beta, 3.5
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: e69f3889112bac11a39be680b284eb50b1bb44dc
 Directory: 3.5.3-beta

--- a/test/config.sh
+++ b/test/config.sh
@@ -210,6 +210,10 @@ imageTests+=(
 	[wordpress:fpm]='
 		wordpress-fpm-run
 	'
+
+	[zookeeper]='
+		zookeeper-basics
+	'
 # example onbuild
 #	[python:onbuild]='
 #		py-onbuild

--- a/test/tests/zookeeper-basics/run.sh
+++ b/test/tests/zookeeper-basics/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+ZOOKEEPER_TEST_SLEEP=3
+ZOOKEEPER_TEST_TRIES=5
+
+cname="zookeeper-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" "$image")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+zkCli() {
+	docker run --rm -i \
+		--link "$cname":zookeeper \
+		"$image" \
+		zkCli.sh \
+		-server zookeeper \
+		"$@"
+}
+
+. "$dir/../../retry.sh" --tries "$ZOOKEEPER_TEST_TRIES" --sleep "$ZOOKEEPER_TEST_SLEEP" zkCli ls /
+
+# List Zokeeper root
+[[ "$(zkCli ls / | tail -n1)" == "[zookeeper]" ]]


### PR DESCRIPTION
@tianon I have no idea how to test these architectures. Will the test I added be run on the listed architectures? Or it's only testing against `amd64`?