### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.4.1-apache, 8.4-apache, 8-apache, apache, 8.4.1, 8.4, 8, latest
+Tags: 8.4.2-apache, 8.4-apache, 8-apache, apache, 8.4.2, 8.4, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
+GitCommit: 2de47f70667e6c3c710b8307ddc4e7a371ef440f
 Directory: 8.4/apache
 
-Tags: 8.4.1-fpm, 8.4-fpm, 8-fpm, fpm
+Tags: 8.4.2-fpm, 8.4-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
+GitCommit: 2de47f70667e6c3c710b8307ddc4e7a371ef440f
 Directory: 8.4/fpm
 
-Tags: 8.4.1-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.4.2-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 7813bc048a45c0b61409f89ee977247195b0b216
+GitCommit: 2de47f70667e6c3c710b8307ddc4e7a371ef440f
 Directory: 8.4/fpm-alpine
 
 Tags: 8.3.7-apache, 8.3-apache, 8.3.7, 8.3

--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.16.2, 1.16, 1, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 777cb093549e81d57ee2323d5c36cf58a5fa2f45
+GitCommit: a5c9dd0d5872eaa1fd7ae7d4d486852489f0a586
 Directory: 1/debian
 
 Tags: 1.16.2-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 777cb093549e81d57ee2323d5c36cf58a5fa2f45
+GitCommit: a5c9dd0d5872eaa1fd7ae7d4d486852489f0a586
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0


### PR DESCRIPTION
- `drupal`: 8.4.2
- `ghost`: fix `sqlite3` for non-amd64 arches (docker-library/ghost#101)