### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -27,7 +27,7 @@ Constraints: windowsservercore
 
 Tags: 17.10.0-ce, 17.10.0, 17.10, 17, edge, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
+GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
 Directory: 17.10
 
 Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, dind
@@ -48,7 +48,7 @@ Constraints: windowsservercore
 
 Tags: 17.09.0-ce, 17.09.0, 17.09, stable
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
+GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
 Directory: 17.09
 
 Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
@@ -69,7 +69,7 @@ Constraints: windowsservercore
 
 Tags: 17.06.2-ce, 17.06.2, 17.06
 Architectures: amd64, s390x
-GitCommit: 454a0ff9e99d4fde7112b25d64d25f940ab28a99
+GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
 Directory: 17.06
 
 Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.3, 5.6, 5, latest
-GitCommit: e3b9b5c27ce4ea5fbdbfac57280a98e54bf7528f
+Tags: 5.6.4, 5.6, 5, latest
+GitCommit: 0e42c8b41dbbbf4158f03f2af61812729c52662b
 Directory: 5
 
-Tags: 5.6.3-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: e3b9b5c27ce4ea5fbdbfac57280a98e54bf7528f
+Tags: 5.6.4-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 0e42c8b41dbbbf4158f03f2af61812729c52662b
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.16.2, 1.16, 1, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5c9dd0d5872eaa1fd7ae7d4d486852489f0a586
+Tags: 1.17.0, 1.17, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f434a4b02c2d92ab3a8f801f5f4e6d879862af35
 Directory: 1/debian
 
-Tags: 1.16.2-alpine, 1.16-alpine, 1-alpine, alpine
+Tags: 1.17.0-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: a5c9dd0d5872eaa1fd7ae7d4d486852489f0a586
+GitCommit: f434a4b02c2d92ab3a8f801f5f4e6d879862af35
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 44dc27d05debece6a738ccbddd85d2ed4adc2eac
 Directory: 0/debian
 

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.3, 5.6, 5, latest
-GitCommit: 8a791a6db074dec988aad1e1f6ac645b50ee6702
+Tags: 5.6.4, 5.6, 5, latest
+GitCommit: 8951190befd71bc72c11eb13e6b7e778de38c950
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.3, 5.6, 5, latest
-GitCommit: c257f0d648cd01631657a39e005911fc4c7c5aeb
+Tags: 5.6.4, 5.6, 5, latest
+GitCommit: 5a25e180a82989857ee4ef036686523be210f619
 Directory: 5
 
-Tags: 5.6.3-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: c257f0d648cd01631657a39e005911fc4c7c5aeb
+Tags: 5.6.4-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 5a25e180a82989857ee4ef036686523be210f619
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.2, 1.5, 1, latest
+Tags: 1.5.3, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
+GitCommit: 39fb13c73f938d2eb12633be4dea548f4ea2971f
 Directory: debian
 
-Tags: 1.5.2-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.3-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4054fdd2b7e0744078806abec9aa507d0df0815c
+GitCommit: 39fb13c73f938d2eb12633be4dea548f4ea2971f
 Directory: alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.12, 3.6, 3, latest
+Tags: 3.6.14, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57baaf4a1a4a20a710b24800739652d29e94e7c9
+GitCommit: 28001b529f28ed0d8e8297f8b603a4cc93a846a3
 Directory: 3.6/debian
 
-Tags: 3.6.12-management, 3.6-management, 3-management, management
+Tags: 3.6.14-management, 3.6-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
 
-Tags: 3.6.12-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.14-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7872457525eb343df072a50c89189406436fbfa5
+GitCommit: 2558d958a0ab9c38f58ad616e387063b33bb229c
 Directory: 3.6/alpine
 
-Tags: 3.6.12-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.6.14-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/alpine/management


### PR DESCRIPTION
- `docker`: `ip link show`-based `modprobe` tricks (docker-library/docker#90)
- `elasticsearch`: 5.6.4
- `ghost`: 1.17.0
- `kibana`: 5.6.4
- `logstash`: 5.6.4
- `memcached`: 1.5.3
- `rabbitmq`: 3.6.14