### PR TITLE
Propose Apache Geode as an official image

### DIFF
--- a/library/geode
+++ b/library/geode
@@ -1,0 +1,6 @@
+Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com> (@vaibhavsood)
+GitRepo: https://github.com/apache/geode.git
+
+Tags: 1.3.0, latest
+GitCommit: 3b70ee615b585c07fbd177011cfe71ab457cf5bb
+Directory: docker

--- a/library/geode
+++ b/library/geode
@@ -1,5 +1,6 @@
 Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com> (@vaibhavsood)
 GitRepo: https://github.com/apache/geode.git
+GitFetch: refs/heads/develop
 
 Tags: 1.3.0, latest
 GitCommit: 3b70ee615b585c07fbd177011cfe71ab457cf5bb


### PR DESCRIPTION
Have created a doc PR https://github.com/docker-library/docs/pull/1062
Have contacted upstream, they are willing to do the official image https://issues.apache.org/jira/browse/GEODE-3921

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://issues.apache.org/jira/browse/GEODE-3921 (looks like we need to link this PR back there)
    - https://github.com/apache/geode
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - > Apache Geode is a distributed, in-memory database with strong data consistency, built to support transactional applications with low latency and high concurrency needs.
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1062
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
    - no :disappointed: -- installs `openjdk-8` from CentOS repos instead of using `FROM openjdk` :confused:
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
  