### PR TITLE
[ROS] Adding arm32v7 back to trusty based images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -8,22 +8,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 # Distro: ubuntu:trusty
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/perception
 
@@ -35,22 +35,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 # Distro: ubuntu:trusty
 
 Tags: jade-ros-core, jade-ros-core-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-core
 
 Tags: jade-ros-base, jade-ros-base-trusty, jade
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-base
 
 Tags: jade-robot, jade-robot-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/robot
 
 Tags: jade-perception, jade-perception-trusty
-Architectures: amd64
+Architectures: amd64, arm32v7
 GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/perception
 


### PR DESCRIPTION
In anticipation for fixed arm32v7 ubuntu cloud images for trusty to propagate into the Docker Hub library image for ubuntu.
Related:
 * https://github.com/tianon/docker-brew-ubuntu-core/issues/94
 * https://bugs.launchpad.net/cloud-images/+bug/1711735