### PR TITLE
Update Swift 3.1 and Swift 4, removing Swift 3.0.

### DIFF
--- a/library/swift
+++ b/library/swift
@@ -2,11 +2,10 @@ Maintainers: Haris Amin <aminharis7@gmail.com> (@hamin),
              Thomas Catterall <me@swizzlr.co> (@swizzlr)
 GitRepo: https://github.com/swiftdocker/docker-swift.git
 
-Tags: 4.0, 4, latest
-GitCommit: 84d2f69c035204bc2dc077f330deb7a393255a18
+Tags: 4.0.2, 4.0, 4, latest
+GitCommit: 5c83628d4696bca62aec3136a4ee9b854e8d548e
+Directory: 4.0
 
-Tags: 3.1.0, 3.1, 3
-GitCommit: ef9aa534705fc8ab4258c539f6304072ebae9613
-
-Tags: 3.0.2, 3.0
-GitCommit: 94a43272fe6411c12045414cfc797d3c0bcf2823
+Tags: 3.1.1, 3.1, 3
+GitCommit: 5c83628d4696bca62aec3136a4ee9b854e8d548e
+Directory: 3.1


### PR DESCRIPTION
🎉