### PR TITLE
New CouchDB 1.7.1 release

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -5,10 +5,10 @@ latest: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d
 2.1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
 2: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
 
-1.7.0: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
-1.7: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
-1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0
+1.7.1: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
+1.7: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
+1: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
 
-1.7.0-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser
-1.7-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser
-1-couchperuser: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 1.7.0-couchperuser
+1.7.1-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser
+1.7-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser
+1-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser


### PR DESCRIPTION
Only change is our new 1.7.1 release to address a regression in 1.7.0:

https://github.com/apache/couchdb-docker/commit/029760550b8af66f49bf439ddbabfbd040e9727c

Since 2.1.1 didn't change I haven't updated the commit for it to prevent unnecessary churn.