### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.11.0-ce-rc2, 17.11-rc, rc, test
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
+GitCommit: 146b0d04de69f9aaace6a5a3c22ac4e8e9744fd3
 Directory: 17.11-rc
 
 Tags: 17.11.0-ce-rc2-dind, 17.11-rc-dind, rc-dind, test-dind
@@ -65,25 +65,4 @@ Tags: 17.09.0-ce-windowsservercore, 17.09.0-windowsservercore, 17.09-windowsserv
 Architectures: windows-amd64
 GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
 Directory: 17.09/windows/windowsservercore
-Constraints: windowsservercore
-
-Tags: 17.06.2-ce, 17.06.2, 17.06
-Architectures: amd64, s390x
-GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
-Directory: 17.06
-
-Tags: 17.06.2-ce-dind, 17.06.2-dind, 17.06-dind
-Architectures: amd64, s390x
-GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
-Directory: 17.06/dind
-
-Tags: 17.06.2-ce-git, 17.06.2-git, 17.06-git
-Architectures: amd64, s390x
-GitCommit: 168a6d227d021c6d38c3986b7c668702ec172fa7
-Directory: 17.06/git
-
-Tags: 17.06.2-ce-windowsservercore, 17.06.2-windowsservercore, 17.06-windowsservercore
-Architectures: windows-amd64
-GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
-Directory: 17.06/windows/windowsservercore
 Constraints: windowsservercore

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.17.0, 1.17, 1, latest
+Tags: 1.17.1, 1.17, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f434a4b02c2d92ab3a8f801f5f4e6d879862af35
+GitCommit: 933884147645ff393aac112ace13329057a8dd4e
 Directory: 1/debian
 
-Tags: 1.17.0-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.1-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: f434a4b02c2d92ab3a8f801f5f4e6d879862af35
+GitCommit: 933884147645ff393aac112ace13329057a8dd4e
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/php
+++ b/library/php
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0RC5-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC5-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC5-cli, 7.2-rc-cli, rc-cli, 7.2.0RC5, 7.2-rc, rc
+Tags: 7.2.0RC6-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC6-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC6-cli, 7.2-rc-cli, rc-cli, 7.2.0RC6, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/stretch/cli
 
-Tags: 7.2.0RC5-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC5-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0RC6-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC6-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/stretch/apache
 
-Tags: 7.2.0RC5-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC5-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0RC6-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC6-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/stretch/fpm
 
-Tags: 7.2.0RC5-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC5-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0RC6-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC6-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/stretch/zts
 
-Tags: 7.2.0RC5-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC5-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC5-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC5-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0RC6-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC6-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC6-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC6-alpine, 7.2-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/alpine3.6/cli
 
-Tags: 7.2.0RC5-fpm-alpine3.6, 7.2-rc-fpm-alpine3.6, rc-fpm-alpine3.6, 7.2.0RC5-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0RC6-fpm-alpine3.6, 7.2-rc-fpm-alpine3.6, rc-fpm-alpine3.6, 7.2.0RC6-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/alpine3.6/fpm
 
-Tags: 7.2.0RC5-zts-alpine3.6, 7.2-rc-zts-alpine3.6, rc-zts-alpine3.6, 7.2.0RC5-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0RC6-zts-alpine3.6, 7.2-rc-zts-alpine3.6, rc-zts-alpine3.6, 7.2.0RC6-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 47041839085c4feaa7f7e6b2732a993a98471a20
+GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/alpine3.6/zts
 
 Tags: 7.1.11-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.11-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.11-cli, 7.1-cli, 7-cli, cli, 7.1.11, 7.1, 7, latest

--- a/library/postgres
+++ b/library/postgres
@@ -4,52 +4,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10.0, 10, latest
+Tags: 10.1, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b022607bec233463a3d055731fb710837978747
+GitCommit: 3d0487a6caf77a2f0a66262158ff2719d1c22c94
 Directory: 10
 
-Tags: 10.0-alpine, 10-alpine, alpine
+Tags: 10.1-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 60db3b9da9c3a83057daee618d47864ac271bebf
 Directory: 10/alpine
 
-Tags: 9.6.5, 9.6, 9
+Tags: 9.6.6, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b022607bec233463a3d055731fb710837978747
+GitCommit: 82e8101ff612b492507f4efc2120963b29f4188d
 Directory: 9.6
 
-Tags: 9.6.5-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.6-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 3d152d1a0d08cf52a1392b58243ff3c423588ccc
 Directory: 9.6/alpine
 
-Tags: 9.5.9, 9.5
+Tags: 9.5.10, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b022607bec233463a3d055731fb710837978747
+GitCommit: b84ddd1619ee3a7f6e318bb9ac33f39818b3b548
 Directory: 9.5
 
-Tags: 9.5.9-alpine, 9.5-alpine
+Tags: 9.5.10-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 5a690fbbe0f256b916a01afee293e8b2dfd3ad8d
 Directory: 9.5/alpine
 
-Tags: 9.4.14, 9.4
+Tags: 9.4.15, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b022607bec233463a3d055731fb710837978747
+GitCommit: 3001d13fcac68cf9f8b0217eafdad8e83c41907c
 Directory: 9.4
 
-Tags: 9.4.14-alpine, 9.4-alpine
+Tags: 9.4.15-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: cd2cafec4e998847fd2b10f08cc3444a2116e6d5
 Directory: 9.4/alpine
 
-Tags: 9.3.19, 9.3
+Tags: 9.3.20, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b022607bec233463a3d055731fb710837978747
+GitCommit: 4af033ebfe50d33214c32be78c52f2693769fb14
 Directory: 9.3
 
-Tags: 9.3.19-alpine, 9.3-alpine
+Tags: 9.3.20-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: f7dc5727b1d6b6a636350e11648845ae33477579
+GitCommit: 881448bf624ca3f461f7ddd234c198ba23aea1fe
 Directory: 9.3/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-preview1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-preview1, 2.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f528306dffdc55fd082c3ec0d483777a9c046ef0
+GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
 Directory: 2.5-rc/stretch
 
 Tags: 2.5.0-preview1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-preview1-slim, 2.5-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f528306dffdc55fd082c3ec0d483777a9c046ef0
+GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
 Directory: 2.5-rc/stretch/slim
 
 Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f528306dffdc55fd082c3ec0d483777a9c046ef0
+GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
 Directory: 2.5-rc/alpine3.6
 
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/stretch
 
 Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/jessie
 
 Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -46,22 +46,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 9984daa9247c76a292614d6cd752d513ac1309d9
+GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58d779d22b18c4a5daad0fb0f11cf81f12a00cba
+GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
 Directory: 2.3/jessie
 
 Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58d779d22b18c4a5daad0fb0f11cf81f12a00cba
+GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.5-onbuild, 2.3-onbuild
@@ -71,17 +71,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 58d779d22b18c4a5daad0fb0f11cf81f12a00cba
+GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f0d425c10d680eecb9845db709005eb276bb1860
+GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
 Directory: 2.2/jessie
 
 Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f0d425c10d680eecb9845db709005eb276bb1860
+GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.8-onbuild, 2.2-onbuild
@@ -91,5 +91,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: f0d425c10d680eecb9845db709005eb276bb1860
+GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `docker`: remove EOL 17.06
- `ghost`: 1.17.1
- `php`: 7.2.0RC6
- `postgres`: 10.1, 9.3.20, 9.4.15, 9.5.10, 9.6.6
- `ruby`: rubygems 2.7.2