### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.11.0-ce-rc2, 17.11-rc, rc, test
+Tags: 17.11.0-ce-rc3, 17.11-rc, rc, test
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 146b0d04de69f9aaace6a5a3c22ac4e8e9744fd3
+GitCommit: 4e1f14f433ef9b800a19fe1907a54b09d8f42a15
 Directory: 17.11-rc
 
-Tags: 17.11.0-ce-rc2-dind, 17.11-rc-dind, rc-dind, test-dind
+Tags: 17.11.0-ce-rc3-dind, 17.11-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
 Directory: 17.11-rc/dind
 
-Tags: 17.11.0-ce-rc2-git, 17.11-rc-git, rc-git, test-git
+Tags: 17.11.0-ce-rc3-git, 17.11-rc-git, rc-git, test-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
 Directory: 17.11-rc/git
 
-Tags: 17.11.0-ce-rc2-windowsservercore, 17.11-rc-windowsservercore, rc-windowsservercore, test-windowsservercore
+Tags: 17.11.0-ce-rc3-windowsservercore, 17.11-rc-windowsservercore, rc-windowsservercore, test-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
+GitCommit: 4e1f14f433ef9b800a19fe1907a54b09d8f42a15
 Directory: 17.11-rc/windows/windowsservercore
 Constraints: windowsservercore
 

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.82-jre7, 7.0-jre7, 7-jre7, 7.0.82, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 5802aa060091bb2b18aee4f98a83a155540b978a
 Directory: 7/jre7
 
 Tags: 7.0.82-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.82-alpine, 7.0-alpine, 7-alpine
@@ -16,7 +16,7 @@ Directory: 7/jre7-alpine
 
 Tags: 7.0.82-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 5802aa060091bb2b18aee4f98a83a155540b978a
 Directory: 7/jre8
 
 Tags: 7.0.82-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -26,7 +26,7 @@ Directory: 7/jre8-alpine
 
 Tags: 8.0.47-jre7, 8.0-jre7, 8.0.47, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 1b5b0791e065d9bfdfe84235faf7f77c157ff70d
 Directory: 8.0/jre7
 
 Tags: 8.0.47-jre7-alpine, 8.0-jre7-alpine, 8.0.47-alpine, 8.0-alpine
@@ -36,7 +36,7 @@ Directory: 8.0/jre7-alpine
 
 Tags: 8.0.47-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 1b5b0791e065d9bfdfe84235faf7f77c157ff70d
 Directory: 8.0/jre8
 
 Tags: 8.0.47-jre8-alpine, 8.0-jre8-alpine
@@ -46,7 +46,7 @@ Directory: 8.0/jre8-alpine
 
 Tags: 8.5.23-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.23, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 68f75ec81727e398a223ed55fe50f9a3ff78d83f
 Directory: 8.5/jre8
 
 Tags: 8.5.23-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.23-alpine, 8.5-alpine, 8-alpine, alpine
@@ -56,7 +56,7 @@ Directory: 8.5/jre8-alpine
 
 Tags: 9.0.1-jre8, 9.0-jre8, 9-jre8, 9.0.1, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 4fddd4bc6c1656e34b0da3b374ca0f036b689adb
 Directory: 9.0/jre8
 
 Tags: 9.0.1-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.1-alpine, 9.0-alpine, 9-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.4.0, cli-1.4, cli-1, cli, cli-1.4.0-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.4.1, cli-1.4, cli-1, cli, cli-1.4.1-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
+GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
 Directory: php5.6/cli
 
-Tags: cli-1.4.0-php7.0, cli-1.4-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.4.1-php7.0, cli-1.4-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
+GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
 Directory: php7.0/cli
 
-Tags: cli-1.4.0-php7.1, cli-1.4-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.4.1-php7.1, cli-1.4-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 10f3c09d94d8e8d147f5ab76c538dc2356032d46
+GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
 Directory: php7.1/cli


### PR DESCRIPTION
- `docker`: 17.11.0-ce-rc3
- `tomcat`: openssl `1.1.0f-3+deb9u1`
- `wordpress`: cli 1.4.1