### PR TITLE
Bump Traefik to v1.4.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.2, 1.4.2, v1.4, 1.4, roquefort, latest
+Tags: v1.4.3, 1.4.3, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 1d5fa099fa6ff0c510ca76a400e0b5596d1d58c5
+GitCommit: 9070c532cf6e3b8b00f8fef573636f2b163aa23a
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.2-alpine, 1.4.2-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-GitCommit: 1d5fa099fa6ff0c510ca76a400e0b5596d1d58c5
+Tags: v1.4.3-alpine, 1.4.3-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 9070c532cf6e3b8b00f8fef573636f2b163aa23a
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.3.

/cc @vdemeester @emilevauge

Cheers
