### PR TITLE
Bump jruby

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -1,25 +1,25 @@
 Maintainers: Brian Goff <cpuguy83@gmail.com> (@cpuguy83)
 GitRepo: https://github.com/cpuguy83/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: 4a733532d5cdffdbafd96be19e2e9862bfe61056
+GitCommit: 9716f7a302976bcc0a326100a50733b69b6fb0cf
 
-Tags: latest, 9, 9.1, 9.1-jre, 9.1.13, 9.1.13-jre, 9.1.13.0, 9.1.13.0-jre
+Tags: latest, 9, 9.1, 9.1.14, 9.1-jre, 9.1.14-jre, 9.1.14.0, 9.1.14.0-jre
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/jre
 
-Tags: 9-alpine, 9.1-alpine, 9.1-jre-alpine, 9.1.13-alpine, 9.1.13-jre-alpine, 9.1.13.0-alpine, 9.1.13.0-jre-alpine
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Tags: 9-alpine, 9.1-alpine, 9.1.14-alpine, 9.1-jre-alpine, 9.1.14-jre-alpine, 9.1.14.0-alpine, 9.1.14.0-jre-alpine
+Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 9000/alpine-jre
 
-Tags: 9.1-jdk, 9.1.13-jdk, 9.1.13.0-jdk
+Tags: 9-jdk, 9.1-jdk, 9.1.14-jdk, 9.1.14.0-jdk
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/jdk
 
-Tags: 9.1-jdk-alpine, 9.1.13-jdk-alpine, 9.1.13.0-jdk-alpine
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Tags: 9-jdk-alpine, 9.1-jdk-alpine, 9.1.14-jdk-alpine, 9.1.14.0-jdk-alpine
+Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 9000/alpine-jdk
 
-Tags: 9-onbuild, 9.1-onbuild, 9.1.13-onbuild, 9.1.13.0-onbuild
+Tags: 9-onbuild, 9.1-onbuild, 9.1.14-onbuild, 9.1.14.0-onbuild
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/onbuild
 

--- a/library/jruby
+++ b/library/jruby
@@ -22,15 +22,3 @@ Directory: 9000/alpine-jdk
 Tags: 9-onbuild, 9.1-onbuild, 9.1.14-onbuild, 9.1.14.0-onbuild
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/onbuild
-
-Tags: 1.7, 1.7.27, 1.7-jre, 1.7.27-jre
-Architectures: amd64, i386, arm32v6, arm64v8, ppc64le, s390x
-Directory: 1.7/jre
-
-Tags: 1.7-jdk, 1.7.27-jdk
-Architectures: amd64, i386, arm32v6, arm64v8, ppc64le, s390x
-Directory: 1.7/jdk
-
-Tags: 1.7-onbuild, 1.7.27-onbuild
-Architectures: amd64, i386, arm32v6, arm64v8, ppc64le, s390x
-Directory: 1.7/onbuild


### PR DESCRIPTION
Also removes arm32-alpine builds which are failing due to issues in jruby.