### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.17.1, 1.17, 1, latest
+Tags: 1.17.2, 1.17, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933884147645ff393aac112ace13329057a8dd4e
+GitCommit: f7fe8c847bce4ebcfde5bea23a8c45c7a242e243
 Directory: 1/debian
 
-Tags: 1.17.1-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.2-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 933884147645ff393aac112ace13329057a8dd4e
+GitCommit: f7fe8c847bce4ebcfde5bea23a8c45c7a242e243
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.2, 10.3
-GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
+GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 10.3
 
 Tags: 10.2.10, 10.2, 10, latest
-GitCommit: f50d0a8218602a64806a4eb907b3b5dcc5916981
+GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 10.2
 
-Tags: 10.1.28, 10.1
-GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
+Tags: 10.1.29, 10.1
+GitCommit: 4e117ad92a4a7c53a582b2db4a743d218ce76f36
 Directory: 10.1
 
 Tags: 10.0.33, 10.0
-GitCommit: 1d69a91e641da4a77b3a5868c8a78e36b2fbfbb4
+GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 10.0
 
 Tags: 5.5.58, 5.5, 5
-GitCommit: 754b3987acb85150eae0e0bc92e6dd2edce0cb3d
+GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0RC6-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC6-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC6-cli, 7.2-rc-cli, rc-cli, 7.2.0RC6, 7.2-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
+GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
 Directory: 7.2-rc/stretch/cli
 
 Tags: 7.2.0RC6-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC6-apache, 7.2-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
+GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
 Directory: 7.2-rc/stretch/apache
 
 Tags: 7.2.0RC6-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC6-fpm, 7.2-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
+GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
 Directory: 7.2-rc/stretch/fpm
 
 Tags: 7.2.0RC6-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC6-zts, 7.2-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
+GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
 Directory: 7.2-rc/stretch/zts
 
 Tags: 7.2.0RC6-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC6-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC6-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC6-alpine, 7.2-rc-alpine, rc-alpine

--- a/library/postgres
+++ b/library/postgres
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.1, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d0487a6caf77a2f0a66262158ff2719d1c22c94
+GitCommit: 1805adb0693d9602bfb19b6bf2583b311c43b749
 Directory: 10
 
 Tags: 10.1-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 60db3b9da9c3a83057daee618d47864ac271bebf
+GitCommit: 1805adb0693d9602bfb19b6bf2583b311c43b749
 Directory: 10/alpine
 
 Tags: 9.6.6, 9.6, 9


### PR DESCRIPTION
- `ghost`: 1.17.2, `knex-migrator` direct in `PATH` (docker-library/ghost#105)
- `mariadb`: 10.1.29, `gosu` 1.10 (docker-library/mariadb#139)
- `php`: argon2 password hashing in 7.2+ (docker-library/php#521)
- `postgres`: `--xlogdir` -> `--waldir` in 10+ (docker-library/postgres#374)