### PR TITLE
added new CrateDB version 2.2.3/2.2/latest

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -9,7 +9,10 @@ Maintainers: Bernd Dorn <bernddorn@gmail.com> (@dobe),
              Mika Naylor <mika@crate.io> (@autophagy)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 2.1.10, 2.1, latest
+Tags: 2.2.3, 2.2, latest
+GitCommit: bd8b2dbf14ffebe2991ff5fd4e10ac9462e8ba81
+
+Tags: 2.1.10, 2.1
 GitCommit: ed8cda8b567628dd733716dc5c8f507512587783
 
 Tags: 2.0.7, 2.0


### PR DESCRIPTION
CrateDB release notes: https://crate.io/docs/crate/reference/en/2.2/release_notes/2.2.3.html