### PR TITLE
Create a new official image for fluentd

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -1,0 +1,34 @@
+Maintainers: Vaibhav Sood <vaibhavs@us.ibm.com> (@vaibhavsood)
+GitRepo: https://github.com/fluent/fluentd-docker-image.git
+
+Tags: v0.14-alpine, latest
+GitCommit: 16dea2e9941315e039a68f3d9f098f9c13ea0f14
+Directory: v0.14/alpine
+
+Tags: v0.14-alpine-onbuild
+GitCommit: 16dea2e9941315e039a68f3d9f098f9c13ea0f14
+Directory: v0.14/alpine-onbuild
+
+Tags: v0.14-debian
+GitCommit: 16dea2e9941315e039a68f3d9f098f9c13ea0f14
+Directory: v0.14/debian
+
+Tags: v0.14-debian-onbuild
+GitCommit: 16dea2e9941315e039a68f3d9f098f9c13ea0f14
+Directory: v0.14/debian-onbuild
+
+Tags: v0.12-alpine, latest
+GitCommit: 59ffaec3156be9a0b01fffb6935bd41d4efb4055
+Directory: v0.12/alpine
+
+Tags: v0.12-alpine-onbuild
+GitCommit: 59ffaec3156be9a0b01fffb6935bd41d4efb4055
+Directory: v0.12/alpine-onbuild
+
+Tags: v0.12-debian
+GitCommit: 59ffaec3156be9a0b01fffb6935bd41d4efb4055
+Directory: v0.12/debian
+
+Tags: v0.12-debian-onbuild
+GitCommit: 59ffaec3156be9a0b01fffb6935bd41d4efb4055
+Directory: v0.12/debian-onbuild


### PR DESCRIPTION
This is a proposal to create a new official image for https://www.fluentd.org/

Have checked with the community as per here: https://github.com/fluent/fluentd-docker-image/issues/98