### PR TITLE
Update Clear Linux Project.

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@e44dea8fea6cf1b6e8633fa402a33b239f1dff5b
-base: git://github.com/clearlinux/docker-brew-clearlinux@e44dea8fea6cf1b6e8633fa402a33b239f1dff5b
+latest: git://github.com/clearlinux/docker-brew-clearlinux@e3cb727ce7ff02f80f8952ea89766ae092081ed7
+base: git://github.com/clearlinux/docker-brew-clearlinux@e3cb727ce7ff02f80f8952ea89766ae092081ed7


### PR DESCRIPTION
Update Clear Linux base+latest images to release 19150. This also
removes the temporary certificate work around added to the 18520
image.