### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,26 +4,20 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.11.0-ce-rc3, 17.11-rc, rc, test
+Tags: 17.11.0-ce-rc4, 17.11-rc, rc, test
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 4e1f14f433ef9b800a19fe1907a54b09d8f42a15
+GitCommit: 51a40fb6eed136282edaf32f45d469ac2c5fb6e4
 Directory: 17.11-rc
 
-Tags: 17.11.0-ce-rc3-dind, 17.11-rc-dind, rc-dind, test-dind
+Tags: 17.11.0-ce-rc4-dind, 17.11-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
 Directory: 17.11-rc/dind
 
-Tags: 17.11.0-ce-rc3-git, 17.11-rc-git, rc-git, test-git
+Tags: 17.11.0-ce-rc4-git, 17.11-rc-git, rc-git, test-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
 Directory: 17.11-rc/git
-
-Tags: 17.11.0-ce-rc3-windowsservercore, 17.11-rc-windowsservercore, rc-windowsservercore, test-windowsservercore
-Architectures: windows-amd64
-GitCommit: 4e1f14f433ef9b800a19fe1907a54b09d8f42a15
-Directory: 17.11-rc/windows/windowsservercore
-Constraints: windowsservercore
 
 Tags: 17.10.0-ce, 17.10.0, 17.10, 17, edge, latest
 Architectures: amd64, arm64v8, ppc64le, s390x

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -8,31 +8,31 @@ GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 amd64-Directory: amd64/hello-seattle
-arm32v5-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v5-Directory: arm32v5/hello-seattle
-arm32v7-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v7-Directory: arm32v7/hello-seattle
-arm64v8-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm64v8-Directory: arm64v8/hello-seattle
-i386-GitCommit: c0f93c30814d7a2487648efc712dc031a89bac79
+i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 i386-Directory: i386/hello-seattle
-ppc64le-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 ppc64le-Directory: ppc64le/hello-seattle
-s390x-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hello-seattle
 
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hello-seattle/nanoserver
 Constraints: nanoserver
 
 Tags: nanoserver1709
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hello-seattle/nanoserver1709
 Constraints: nanoserver1709

--- a/library/hello-world
+++ b/library/hello-world
@@ -8,31 +8,31 @@ GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 amd64-Directory: amd64/hello-world
-arm32v5-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v5-Directory: arm32v5/hello-world
-arm32v7-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v7-Directory: arm32v7/hello-world
-arm64v8-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm64v8-Directory: arm64v8/hello-world
-i386-GitCommit: c0f93c30814d7a2487648efc712dc031a89bac79
+i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 i386-Directory: i386/hello-world
-ppc64le-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 ppc64le-Directory: ppc64le/hello-world
-s390x-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hello-world
 
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hello-world/nanoserver
 Constraints: nanoserver
 
 Tags: nanoserver1709
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hello-world/nanoserver1709
 Constraints: nanoserver1709

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -8,31 +8,31 @@ GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 amd64-Directory: amd64/hola-mundo
-arm32v5-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v5-Directory: arm32v5/hola-mundo
-arm32v7-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm32v7-Directory: arm32v7/hola-mundo
-arm64v8-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 arm64v8-Directory: arm64v8/hola-mundo
-i386-GitCommit: c0f93c30814d7a2487648efc712dc031a89bac79
+i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 i386-Directory: i386/hola-mundo
-ppc64le-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 ppc64le-Directory: ppc64le/hola-mundo
-s390x-GitCommit: 7d0ee592e4ed60e2da9d59331e16ecdcadc1ed87
+s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hola-mundo
 
 Tags: nanoserver
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b63893caa6ec64d8159f8bd45b3745ed4f12f605
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hola-mundo/nanoserver
 Constraints: nanoserver
 
 Tags: nanoserver1709
 SharedTags: latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 windows-amd64-Directory: amd64/hola-mundo/nanoserver1709
 Constraints: nanoserver1709

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -11,7 +11,7 @@ Directory: 3.6/debian
 
 Tags: 3.6.14-management, 3.6-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
+GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/debian/management
 
 Tags: 3.6.14-alpine, 3.6-alpine, 3-alpine, alpine
@@ -21,5 +21,5 @@ Directory: 3.6/alpine
 
 Tags: 3.6.14-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
+GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/alpine/management

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.8.3-apache, 4.8-apache, 4-apache, apache, 4.8.3, 4.8, 4, latest, 4.8.3-php5.6-apache, 4.8-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.8.3-php5.6, 4.8-php5.6, 4-php5.6, php5.6
+Tags: 4.9.0-apache, 4.9-apache, 4-apache, apache, 4.9.0, 4.9, 4, latest, 4.9.0-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.0-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php5.6/apache
 
-Tags: 4.8.3-fpm, 4.8-fpm, 4-fpm, fpm, 4.8.3-php5.6-fpm, 4.8-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.0-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.0-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php5.6/fpm
 
-Tags: 4.8.3-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.8.3-php5.6-fpm-alpine, 4.8-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.0-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.0-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php5.6/fpm-alpine
 
-Tags: 4.8.3-php7.0-apache, 4.8-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.8.3-php7.0, 4.8-php7.0, 4-php7.0, php7.0
+Tags: 4.9.0-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.0-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.0/apache
 
-Tags: 4.8.3-php7.0-fpm, 4.8-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.0-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.0/fpm
 
-Tags: 4.8.3-php7.0-fpm-alpine, 4.8-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.0-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.0/fpm-alpine
 
-Tags: 4.8.3-php7.1-apache, 4.8-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.8.3-php7.1, 4.8-php7.1, 4-php7.1, php7.1
+Tags: 4.9.0-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.0-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.1/apache
 
-Tags: 4.8.3-php7.1-fpm, 4.8-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.0-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.1/fpm
 
-Tags: 4.8.3-php7.1-fpm-alpine, 4.8-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.0-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: f7acf35a2b49b7a45d71b4c5fc8797042f34d4bd
+GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker`: 17.11.0-ce-rc4 (removes 17.11-rc windows variant; https://github.com/docker-library/docker/commit/85c10e110faeb56a8b7ce51908cf58562195d795)
- `hello-seattle`: add `arch` to output (docker-library/hello-world#40)
- `hello-world`: add `arch` to output (docker-library/hello-world#40)
- `hola-mundo`: add `arch` to output (docker-library/hello-world#40)
- `rabbitmq`: `rabbitmqadmin` in `management` variant (docker-library/rabbitmq#208)
- `wordpress`: 4.9