### PR TITLE
Update images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,44 +1,23 @@
-# this file is generated via https://github.com/docker-library/docker/blob/bca413739d33629db28b0ef6f51a7468451b8654/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/2aa6d388f205fc20ad22402bfed4ece715c7cb48/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.11.0-ce-rc4, 17.11-rc, rc, test
+Tags: 17.11.0-ce, 17.11.0, 17.11, 17, edge, test, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51a40fb6eed136282edaf32f45d469ac2c5fb6e4
-Directory: 17.11-rc
+GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
+Directory: 17.11
 
-Tags: 17.11.0-ce-rc4-dind, 17.11-rc-dind, rc-dind, test-dind
+Tags: 17.11.0-ce-dind, 17.11.0-dind, 17.11-dind, 17-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
-Directory: 17.11-rc/dind
+GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
+Directory: 17.11/dind
 
-Tags: 17.11.0-ce-rc4-git, 17.11-rc-git, rc-git, test-git
+Tags: 17.11.0-ce-git, 17.11.0-git, 17.11-git, 17-git, edge-git, test-git, git
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e7677bec19c214ef5445c0d2b96c56e42098ca1
-Directory: 17.11-rc/git
-
-Tags: 17.10.0-ce, 17.10.0, 17.10, 17, edge, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
-Directory: 17.10
-
-Tags: 17.10.0-ce-dind, 17.10.0-dind, 17.10-dind, 17-dind, edge-dind, dind
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
-Directory: 17.10/dind
-
-Tags: 17.10.0-ce-git, 17.10.0-git, 17.10-git, 17-git, edge-git, git
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
-Directory: 17.10/git
-
-Tags: 17.10.0-ce-windowsservercore, 17.10.0-windowsservercore, 17.10-windowsservercore, 17-windowsservercore, edge-windowsservercore, windowsservercore
-Architectures: windows-amd64
-GitCommit: 62a456489acfe7443d426cd502ccf22130d1ccf9
-Directory: 17.10/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
+Directory: 17.11/git
 
 Tags: 17.09.0-ce, 17.09.0, 17.09, stable
 Architectures: amd64, arm64v8, ppc64le, s390x
@@ -55,8 +34,16 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git
 
-Tags: 17.09.0-ce-windowsservercore, 17.09.0-windowsservercore, 17.09-windowsservercore, stable-windowsservercore
+Tags: 17.09.0-ce-windowsservercore-ltsc2016, 17.09.0-windowsservercore-ltsc2016, 17.09-windowsservercore-ltsc2016, stable-windowsservercore-ltsc2016
+SharedTags: windowsservercore
 Architectures: windows-amd64
-GitCommit: 2f6926c4fb37274b90fae3ba6c3320619a8d0289
-Directory: 17.09/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 2aa6d388f205fc20ad22402bfed4ece715c7cb48
+Directory: 17.09/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 17.09.0-ce-windowsservercore-1709, 17.09.0-windowsservercore-1709, 17.09-windowsservercore-1709, stable-windowsservercore-1709
+SharedTags: windowsservercore
+Architectures: windows-amd64
+GitCommit: 2aa6d388f205fc20ad22402bfed4ece715c7cb48
+Directory: 17.09/windows/windowsservercore-1709
+Constraints: windowsservercore-1709

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.17.3, 1.17, 1, latest
+Tags: 1.18.0, 1.18, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ddece4dde5727e3324198d86ae565511ec2fbef
+GitCommit: ab26d8e463d708c406ccd05ffc67c63215b71d1d
 Directory: 1/debian
 
-Tags: 1.17.3-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.18.0-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 8ddece4dde5727e3324198d86ae565511ec2fbef
+GitCommit: ab26d8e463d708c406ccd05ffc67c63215b71d1d
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/9898665371e4d61803313ff59c838a66a4a39b29/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -16,18 +16,26 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: bb5a9205c84b1af7daea647e144f2517497cc7ef
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
-SharedTags: 1.9.2, 1.9, 1, latest
+Tags: 1.9.2-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: windowsservercore, 1.9.2, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
-Directory: 1.9/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.2-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.9.2-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: windowsservercore, 1.9.2, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
-Directory: 1.9/windows/nanoserver
-Constraints: nanoserver
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.9.2-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: nanoserver
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 1.8.5-stretch, 1.8-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -55,15 +63,23 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
-Tags: 1.8.5-windowsservercore, 1.8-windowsservercore
-SharedTags: 1.8.5, 1.8
+Tags: 1.8.5-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 1.8.5, 1.8
 Architectures: windows-amd64
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
-Directory: 1.8/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
 
-Tags: 1.8.5-nanoserver, 1.8-nanoserver
+Tags: 1.8.5-windowsservercore-1709, 1.8-windowsservercore-1709
+SharedTags: windowsservercore, 1.8.5, 1.8
 Architectures: windows-amd64
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
-Directory: 1.8/windows/nanoserver
-Constraints: nanoserver
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.8.5-nanoserver-sac2016, 1.8-nanoserver-sac2016
+SharedTags: nanoserver
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016

--- a/library/haproxy
+++ b/library/haproxy
@@ -46,10 +46,10 @@ Directory: 1.7/alpine
 
 Tags: 1.8-rc4, 1.8-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4beed6d596162e52e555500b2aa24ee5e7b6473f
+GitCommit: 0c9c27713bfca8505331e0da2664a9454755c7b9
 Directory: 1.8-rc
 
 Tags: 1.8-rc4-alpine, 1.8-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
+GitCommit: 0c9c27713bfca8505331e0da2664a9454755c7b9
 Directory: 1.8-rc/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/f99e17d0be49185244ed1c5deb941e1ec867d998/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/1b618816c7c3cc20f48a28e891b674a353283e6f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,40 +6,50 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.4.27, 1.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a11db1597f9be5365028673df4d05b2ea854b3ed
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.4
 
 Tags: 1.4.27-alpine, 1.4-alpine
 Architectures: amd64
-GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.4/alpine
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67667912113013d9dfd14b503c14e120ceab9899
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64
-GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.5/alpine
 
 Tags: 1.6.13, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 900676649347a83b314fd7b33e0a52265e168577
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.6
 
 Tags: 1.6.13-alpine, 1.6-alpine
 Architectures: amd64
-GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
+GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
 Directory: 1.6/alpine
 
 Tags: 1.7.9, 1.7, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 394255fbe76c57a9f2e0775e3e69df714e801b46
+GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.7
 
 Tags: 1.7.9-alpine, 1.7-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 2d393f2b59824bf5c7f692a503c18e2dac43fae7
+GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
 Directory: 1.7/alpine
+
+Tags: 1.8-rc4, 1.8-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4beed6d596162e52e555500b2aa24ee5e7b6473f
+Directory: 1.8-rc
+
+Tags: 1.8-rc4-alpine, 1.8-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
+Directory: 1.8-rc/alpine

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+GitCommit: d206a435163e171e629490b2803b2615b3831906
 
 Tags: linux
 SharedTags: latest
@@ -23,16 +23,16 @@ ppc64le-Directory: ppc64le/hello-world
 s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hello-world
 
-Tags: nanoserver
-SharedTags: latest
+Tags: nanoserver-sac2016
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hello-world/nanoserver
-Constraints: nanoserver
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
-Tags: nanoserver1709
-SharedTags: latest
+Tags: nanoserver-1709
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hello-world/nanoserver1709
-Constraints: nanoserver1709
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hello-world/nanoserver-1709
+Constraints: nanoserver-1709

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/92d9bb881b350e87ec8419ce2632361847591be5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/daeeeccd0edd110e6341ba3ee2d699caf885fbce/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -12,12 +12,19 @@ Architectures: amd64
 GitCommit: 00a8519463e776e797c227681a595986d8f9dbe1
 Directory: 3.0
 
-Tags: 3.0.15-windowsservercore, 3.0-windowsservercore
-SharedTags: 3.0.15, 3.0
+Tags: 3.0.15-windowsservercore-ltsc2016, 3.0-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.0.15, 3.0
 Architectures: windows-amd64
-GitCommit: 40d62a73bbd4e20d90ec859a8af483f70b1e5fd4
-Directory: 3.0/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.0/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.0.15-windowsservercore-1709, 3.0-windowsservercore-1709
+SharedTags: windowsservercore, 3.0.15, 3.0
+Architectures: windows-amd64
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.0/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.2.17-jessie, 3.2-jessie
 SharedTags: 3.2.17, 3.2
@@ -27,12 +34,19 @@ Architectures: amd64
 GitCommit: 3eb1f6df20e04ea8f03ce8ba5893e21bb63073f5
 Directory: 3.2
 
-Tags: 3.2.17-windowsservercore, 3.2-windowsservercore
-SharedTags: 3.2.17, 3.2
+Tags: 3.2.17-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.2.17, 3.2
 Architectures: windows-amd64
-GitCommit: 7b2fe2cd853161fdb6d28d318e9e7968e51d0ee3
-Directory: 3.2/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.2/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.2.17-windowsservercore-1709, 3.2-windowsservercore-1709
+SharedTags: windowsservercore, 3.2.17, 3.2
+Architectures: windows-amd64
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.2/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.4.10-jessie, 3.4-jessie, 3-jessie, jessie
 SharedTags: 3.4.10, 3.4, 3, latest
@@ -42,12 +56,19 @@ Architectures: amd64
 GitCommit: c501968a9c330a773a2bc2c9b67dcd4ebbb58651
 Directory: 3.4
 
-Tags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3-windowsservercore, windowsservercore
-SharedTags: 3.4.10, 3.4, 3, latest
+Tags: 3.4.10-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.4.10, 3.4, 3, latest
 Architectures: windows-amd64
-GitCommit: c501968a9c330a773a2bc2c9b67dcd4ebbb58651
-Directory: 3.4/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.4/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.4.10-windowsservercore-1709, 3.4-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: windowsservercore, 3.4.10, 3.4, 3, latest
+Architectures: windows-amd64
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.4/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.5.13-jessie, 3.5-jessie, unstable-jessie
 SharedTags: 3.5.13, 3.5, unstable
@@ -57,9 +78,16 @@ Architectures: amd64
 GitCommit: 532f0dce1488540fb486d58407aff00301203e47
 Directory: 3.5
 
-Tags: 3.5.13-windowsservercore, 3.5-windowsservercore, unstable-windowsservercore
-SharedTags: 3.5.13, 3.5, unstable
+Tags: 3.5.13-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.5.13, 3.5, unstable
 Architectures: windows-amd64
-GitCommit: 532f0dce1488540fb486d58407aff00301203e47
-Directory: 3.5/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.5/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.5.13-windowsservercore-1709, 3.5-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: windowsservercore, 3.5.13, 3.5, unstable
+Architectures: windows-amd64
+GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+Directory: 3.5/windows/windowsservercore-1709
+Constraints: windowsservercore-1709

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/a893fe3cd82757e7bccc0948c88bfee09bd916c3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/873fb56728befef8ecaf8436c3a27fd239cba301/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -69,17 +69,26 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 8-jdk/alpine
 
-Tags: 8u151-jdk-windowsservercore, 8u151-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 8u151-jdk-windowsservercore-ltsc2016, 8u151-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: windowsservercore
 Architectures: windows-amd64
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 8-jdk/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 8-jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
 
-Tags: 8u151-jdk-nanoserver, 8u151-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
+Tags: 8u151-jdk-windowsservercore-1709, 8u151-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: windowsservercore
 Architectures: windows-amd64
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 8-jdk/windows/nanoserver
-Constraints: nanoserver
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 8-jdk/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 8u151-jdk-nanoserver-sac2016, 8u151-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: nanoserver
+Architectures: windows-amd64
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 8-jdk/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 8u151-jre, 8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -106,17 +115,26 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jdk/slim
 
-Tags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Tags: 9.0.1-jdk-windowsservercore-ltsc2016, 9.0.1-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
+SharedTags: windowsservercore
 Architectures: windows-amd64
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jdk/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
 
-Tags: 9.0.1-jdk-nanoserver, 9.0.1-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
+Tags: 9.0.1-jdk-windowsservercore-1709, 9.0.1-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
+SharedTags: windowsservercore
 Architectures: windows-amd64
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jdk/windows/nanoserver
-Constraints: nanoserver
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 9.0.1-jdk-nanoserver-sac2016, 9.0.1-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
+SharedTags: nanoserver
+Architectures: windows-amd64
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/7891fcc63609dfd43ae2e8de13a40e838b5e7608/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/ce648832b041293fa3542af884ac5a44a67354d3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -20,12 +20,19 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f12f511910098f45951111aa5642fd935133afc
 Directory: 3.7-rc/alpine3.6
 
-Tags: 3.7.0a2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore
-SharedTags: 3.7.0a2, 3.7-rc, rc
+Tags: 3.7.0a2-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.7.0a2, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 3f12f511910098f45951111aa5642fd935133afc
-Directory: 3.7-rc/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.7-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.7.0a2-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.7.0a2, 3.7-rc, rc
+Architectures: windows-amd64
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.7-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.6.3-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -63,12 +70,19 @@ Architectures: amd64
 GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.6/alpine3.4
 
-Tags: 3.6.3-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore
-SharedTags: 3.6.3, 3.6, 3, latest
+Tags: 3.6.3-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.3, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: e01eb54f3c70555cf661dd756d529c85fd2cc04f
-Directory: 3.6/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.6/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.6.3-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: windowsservercore, 3.6.3, 3.6, 3, latest
+Architectures: windows-amd64
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.6/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.5.4-jessie, 3.5-jessie
 SharedTags: 3.5.4, 3.5
@@ -91,12 +105,19 @@ Architectures: amd64
 GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 3.5/alpine3.4
 
-Tags: 3.5.4-windowsservercore, 3.5-windowsservercore
-SharedTags: 3.5.4, 3.5
+Tags: 3.5.4-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.5.4, 3.5
 Architectures: windows-amd64
-GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
-Directory: 3.5/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.5/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.5.4-windowsservercore-1709, 3.5-windowsservercore-1709
+SharedTags: windowsservercore, 3.5.4, 3.5
+Architectures: windows-amd64
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 3.5/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.4.7-jessie, 3.4-jessie
 SharedTags: 3.4.7, 3.4
@@ -165,9 +186,16 @@ Architectures: amd64
 GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
 Directory: 2.7/alpine3.4
 
-Tags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore
-SharedTags: 2.7.14, 2.7, 2
+Tags: 2.7.14-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 2.7.14, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 9524a26b67ebc8ea48ceaaf6750f5f6caf89478e
-Directory: 2.7/windows/windowsservercore
-Constraints: windowsservercore
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 2.7/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 2.7.14-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
+SharedTags: windowsservercore, 2.7.14, 2.7, 2
+Architectures: windows-amd64
+GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+Directory: 2.7/windows/windowsservercore-1709
+Constraints: windowsservercore-1709


### PR DESCRIPTION
 - docker: 17.11 GA
 - docker, golang, hello-world, mongo, openjdk, python use new microsoft/windowsservercore tags
 - ghost `1.18.0` bump
 - haproxy lua bump: https://github.com/docker-library/haproxy/pull/52, 1.8-rc https://github.com/docker-library/haproxy/pull/49, `-db` https://github.com/docker-library/haproxy/pull/51