### PR TITLE
Bump Traefik to v1.4.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.3, 1.4.3, v1.4, 1.4, roquefort, latest
+Tags: v1.4.4, 1.4.4, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 9070c532cf6e3b8b00f8fef573636f2b163aa23a
+GitCommit: ab1c388b991daeced863419d65c04528a4166010
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.3-alpine, 1.4.3-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+Tags: v1.4.4-alpine, 1.4.4-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 9070c532cf6e3b8b00f8fef573636f2b163aa23a
+GitCommit: ab1c388b991daeced863419d65c04528a4166010
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.4.4.

/cc @vdemeester @emilevauge

Cheers
