### PR TITLE
Reference the 7.4.7 release.

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -1,10 +1,10 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/docker
 
-Tags: 7.4.6, 7.4, latest
-GitCommit: fb5ac90d57ebb78b00fe1bdb306bef7ad268cce5
-Directory: 7.4/7.4.6
+Tags: 7.4.7, 7.4, latest
+GitCommit: 895a6f71871b5e4747931f9acbaca91b83351070
+Directory: 7.4/7.4.7
 
-Tags: web-connector-7.4.6, web-connector-7.4, web-connector
-GitCommit: fb5ac90d57ebb78b00fe1bdb306bef7ad268cce5
-Directory: 7.4/7.4.6/web-connector
+Tags: web-connector-7.4.7, web-connector-7.4, web-connector
+GitCommit: 895a6f71871b5e4747931f9acbaca91b83351070
+Directory: 7.4/7.4.7/web-connector

--- a/library/convertigo
+++ b/library/convertigo
@@ -2,9 +2,9 @@ Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier
 GitRepo: https://github.com/convertigo/docker
 
 Tags: 7.4.7, 7.4, latest
-GitCommit: 895a6f71871b5e4747931f9acbaca91b83351070
+GitCommit: dc3d5543b5de1813bf05c5abc937164a662bb491
 Directory: 7.4/7.4.7
 
 Tags: web-connector-7.4.7, web-connector-7.4, web-connector
-GitCommit: 895a6f71871b5e4747931f9acbaca91b83351070
+GitCommit: dc3d5543b5de1813bf05c5abc937164a662bb491
 Directory: 7.4/7.4.7/web-connector


### PR DESCRIPTION
I just reference the new version.
The build is now based on the official tomcat image (instead of java).

Also, I have already asked but, can we have our logo on our page ?
https://hub.docker.com/_/convertigo/

![convertigo_128x128_32](https://cloud.githubusercontent.com/assets/225279/24517632/538354c0-157f-11e7-8345-67929b41cbfe.png)

Or how can I join the UI team for this ?

Thank you very much !