### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -13,7 +13,7 @@ Directory: 1.9/stretch
 
 Tags: 1.9.2-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bb5a9205c84b1af7daea647e144f2517497cc7ef
+GitCommit: 0f5ee2149d00dcdbf48fca05acf582e45d8fa9a5
 Directory: 1.9/alpine3.6
 
 Tags: 1.9.2-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -50,12 +50,12 @@ Directory: 1.8/jessie
 
 Tags: 1.8.5-alpine3.6, 1.8-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+GitCommit: 0f5ee2149d00dcdbf48fca05acf582e45d8fa9a5
 Directory: 1.8/alpine3.6
 
 Tags: 1.8.5-alpine3.5, 1.8-alpine3.5, 1.8.5-alpine, 1.8-alpine
 Architectures: amd64
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+GitCommit: 0f5ee2149d00dcdbf48fca05acf582e45d8fa9a5
 Directory: 1.8/alpine3.5
 
 Tags: 1.8.5-onbuild, 1.8-onbuild

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/1b618816c7c3cc20f48a28e891b674a353283e6f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/1fa9d01682376087032e856c0a8c319f97c2ebec/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -34,22 +34,22 @@ Architectures: amd64
 GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
 Directory: 1.6/alpine
 
-Tags: 1.7.9, 1.7, 1, latest
+Tags: 1.7.9, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.7
 
-Tags: 1.7.9-alpine, 1.7-alpine, 1-alpine, alpine
+Tags: 1.7.9-alpine, 1.7-alpine
 Architectures: amd64
 GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
 Directory: 1.7/alpine
 
-Tags: 1.8-rc4, 1.8-rc, rc
+Tags: 1.8.0, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c9c27713bfca8505331e0da2664a9454755c7b9
-Directory: 1.8-rc
+GitCommit: c2cf8a6c5b9dfcb0008cf5546fc86d89fc1d633e
+Directory: 1.8
 
-Tags: 1.8-rc4-alpine, 1.8-rc-alpine, rc-alpine
+Tags: 1.8.0-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c9c27713bfca8505331e0da2664a9454755c7b9
-Directory: 1.8-rc/alpine
+GitCommit: c2cf8a6c5b9dfcb0008cf5546fc86d89fc1d633e
+Directory: 1.8/alpine

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+GitCommit: d206a435163e171e629490b2803b2615b3831906
 
 Tags: linux
 SharedTags: latest
@@ -23,16 +23,16 @@ ppc64le-Directory: ppc64le/hello-seattle
 s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hello-seattle
 
-Tags: nanoserver
-SharedTags: latest
+Tags: nanoserver-sac2016
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hello-seattle/nanoserver
-Constraints: nanoserver
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hello-seattle/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
-Tags: nanoserver1709
-SharedTags: latest
+Tags: nanoserver-1709
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hello-seattle/nanoserver1709
-Constraints: nanoserver1709
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hello-seattle/nanoserver-1709
+Constraints: nanoserver-1709

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/b9c8214f529b04e37683fddba4a4244308f046e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: b9c8214f529b04e37683fddba4a4244308f046e8
+GitCommit: d206a435163e171e629490b2803b2615b3831906
 
 Tags: linux
 SharedTags: latest
@@ -23,16 +23,16 @@ ppc64le-Directory: ppc64le/hola-mundo
 s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
 s390x-Directory: s390x/hola-mundo
 
-Tags: nanoserver
-SharedTags: latest
+Tags: nanoserver-sac2016
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hola-mundo/nanoserver
-Constraints: nanoserver
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hola-mundo/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
-Tags: nanoserver1709
-SharedTags: latest
+Tags: nanoserver-1709
+SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
-windows-amd64-Directory: amd64/hola-mundo/nanoserver1709
-Constraints: nanoserver1709
+windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-Directory: amd64/hola-mundo/nanoserver-1709
+Constraints: nanoserver-1709

--- a/library/mongo
+++ b/library/mongo
@@ -91,3 +91,25 @@ Architectures: windows-amd64
 GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.5/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 3.6.0-rc5-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
+SharedTags: 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6-rc/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
+GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+Directory: 3.6-rc
+
+Tags: 3.6.0-rc5-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+Architectures: windows-amd64
+GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+Directory: 3.6-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.6.0-rc5-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+Architectures: windows-amd64
+GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+Directory: 3.6-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.5-apache, 11.0-apache, 11-apache, 11.0.5, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
+GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
 Directory: 11.0/apache
 
 Tags: 11.0.5-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
+GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
 Directory: 11.0/fpm
 
 Tags: 12.0.3-apache, 12.0-apache, 12-apache, apache, 12.0.3, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
+GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
 Directory: 12.0/apache
 
 Tags: 12.0.3-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57edb879dc79524a8df9f48ee553abb6117054e1
+GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
 Directory: 12.0/fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -26,12 +26,12 @@ Directory: 6-jre/slim
 
 Tags: 7u151-jdk, 7u151, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jdk
 
 Tags: 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jdk/slim
 
 Tags: 7u131-jdk-alpine, 7u131-alpine, 7-jdk-alpine, 7-alpine
@@ -41,12 +41,12 @@ Directory: 7-jdk/alpine
 
 Tags: 7u151-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jre
 
 Tags: 7u151-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c68ebcca06c8740939866575cfe39ee4ad84c782
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jre/slim
 
 Tags: 7u131-jre-alpine, 7-jre-alpine

--- a/library/php
+++ b/library/php
@@ -39,74 +39,74 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
 Directory: 7.2-rc/alpine3.6/zts
 
-Tags: 7.1.11-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.11-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.11-cli, 7.1-cli, 7-cli, cli, 7.1.11, 7.1, 7, latest
+Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.12-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.12-cli, 7.1-cli, 7-cli, cli, 7.1.12, 7.1, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.11-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.11-apache, 7.1-apache, 7-apache, apache
+Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.12-apache, 7.1-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.11-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.11-fpm, 7.1-fpm, 7-fpm, fpm
+Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.12-fpm, 7.1-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.11-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.11-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.12-zts, 7.1-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.11-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.11-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.11-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.11-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.12-alpine, 7.1-alpine, 7-alpine, alpine
 Architectures: amd64
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.11-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.11-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.11-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.11-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64
-GitCommit: 05fe6f9eb601984e5f95057578ce830a21d11716
+GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
 Directory: 7.1/alpine3.4/zts
 
-Tags: 7.0.25-cli-jessie, 7.0-cli-jessie, 7.0.25-jessie, 7.0-jessie, 7.0.25-cli, 7.0-cli, 7.0.25, 7.0
+Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.25-apache-jessie, 7.0-apache-jessie, 7.0.25-apache, 7.0-apache
+Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.25-fpm-jessie, 7.0-fpm-jessie, 7.0.25-fpm, 7.0-fpm
+Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.25-zts-jessie, 7.0-zts-jessie, 7.0.25-zts, 7.0-zts
+Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.25-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.25-alpine3.4, 7.0-alpine3.4, 7.0.25-cli-alpine, 7.0-cli-alpine, 7.0.25-alpine, 7.0-alpine
+Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/alpine3.4/cli
 
-Tags: 7.0.25-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.25-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.26-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.26-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/alpine3.4/fpm
 
-Tags: 7.0.25-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.25-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.26-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.26-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 89894ff2da4da406d52931f1acebf9a2f349a898
+GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
 Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.4
 
 Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
+GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
 Directory: 3.4/passenger
 
 Tags: 3.3.5, 3.3
@@ -19,7 +19,7 @@ GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.3
 
 Tags: 3.3.5-passenger, 3.3-passenger
-GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
+GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
 Directory: 3.3/passenger
 
 Tags: 3.2.8, 3.2
@@ -28,5 +28,5 @@ GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
 Directory: 3.2
 
 Tags: 3.2.8-passenger, 3.2-passenger
-GitCommit: 3ddc488fe71bf80e3b760e9028fd06785b7db9fb
+GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
 Directory: 3.2/passenger


### PR DESCRIPTION
- `golang`: `GOARM`/`GOARCH` (docker-library/golang#187)
- `haproxy`: 1.8.0 GA! (docker-library/haproxy#53)
- `hello-seattle`: the missing bits from https://github.com/docker-library/official-images/pull/3737 (new Windows tags)
- `hola-mundo`: the missing bits from https://github.com/docker-library/official-images/pull/3737 (new Windows tags)
- `mongo`: 3.6.0-rc5 (docker-library/mongo#215)
- `nextcloud`: `memcached-3.0.4` (nextcloud/docker#187)
- `openjdk`: debian `7u151-2.6.11-2~deb8u1`
- `php`: 7.1.12, 7.0.26
- `redmine`: passenger 5.1.12