### PR TITLE
Bump Traefik to v1.5.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,26 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.4.4, 1.4.4, v1.4, 1.4, roquefort, latest
+Tags: v1.5.0-rc1, 1.5.0-rc1, v1.5, 1.5, cancoillotte
 Architectures: amd64, arm64v8, arm32v6
+GitCommit: 14a1d1d5727338efd0a90a33024360e3e8926daa
+amd64-Directory: scratch/amd64
+arm32v6-Directory: scratch/arm
+arm64v8-Directory: scratch/arm64
+
+Tags: v1.5.0-rc1-alpine, 1.5.0-rc1-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 14a1d1d5727338efd0a90a33024360e3e8926daa
+Directory: alpine
+
+Tags: v1.4.4, 1.4.4, v1.4, 1.4, roquefort, latest
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: ab1c388b991daeced863419d65c04528a4166010
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.4.4-alpine, 1.4.4-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: ab1c388b991daeced863419d65c04528a4166010
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.0-rc1.

/cc @vdemeester @emilevauge

Cheers
