### PR TITLE
Updating Oracle Linux 7.4 and 7-slim images to resolve CVE-2017-1000257

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/ol-container-images.git
 GitFetch: refs/heads/master
-GitCommit: a7e8a49c20bb2d717191ca1f6e022ddab0bcef43
+GitCommit: d9ef39427435f87702beae3067c3d114c7581751 
 Constraints: !aufs
 
 Tags: 7-slim


### PR DESCRIPTION
https://linux.oracle.com/errata/ELSA-2017-3263.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>