### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.3.2, 10.3
 GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 10.3
 
-Tags: 10.2.10, 10.2, 10, latest
-GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
+Tags: 10.2.11, 10.2, 10, latest
+GitCommit: 502ed2d6772c87fb0be3db73e6de019ea605a279
 Directory: 10.2
 
 Tags: 10.1.29, 10.1

--- a/library/mongo
+++ b/library/mongo
@@ -26,25 +26,25 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.2.17-jessie, 3.2-jessie
-SharedTags: 3.2.17, 3.2
+Tags: 3.2.18-jessie, 3.2-jessie
+SharedTags: 3.2.18, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 3eb1f6df20e04ea8f03ce8ba5893e21bb63073f5
+GitCommit: f3f3059a1582b3bde0a116dcc5e5ff4106927cad
 Directory: 3.2
 
-Tags: 3.2.17-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.2.17, 3.2
+Tags: 3.2.18-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.2.18, 3.2
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 1af403f9d70fed1da9502b6f486a5f68f384eef7
 Directory: 3.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.2.17-windowsservercore-1709, 3.2-windowsservercore-1709
-SharedTags: windowsservercore, 3.2.17, 3.2
+Tags: 3.2.18-windowsservercore-1709, 3.2-windowsservercore-1709
+SharedTags: windowsservercore, 3.2.18, 3.2
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 1af403f9d70fed1da9502b6f486a5f68f384eef7
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -92,24 +92,24 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.5/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.0-rc5-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
-SharedTags: 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc6-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
+SharedTags: 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6-rc/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+GitCommit: e2d583551cca18d491eda945fe122ba328ba542f
 Directory: 3.6-rc
 
-Tags: 3.6.0-rc5-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc6-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+GitCommit: 20ca4aa92bc6308737c203c4cbe33a13dc3166f5
 Directory: 3.6-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.0-rc5-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: windowsservercore, 3.6.0-rc5, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc6-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 375c4226fe653262306de9539bb2d3fc985dc3b4
+GitCommit: 20ca4aa92bc6308737c203c4cbe33a13dc3166f5
 Directory: 3.6-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-preview1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-preview1, 2.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
+GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
 Directory: 2.5-rc/stretch
 
 Tags: 2.5.0-preview1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-preview1-slim, 2.5-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
+GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
 Directory: 2.5-rc/stretch/slim
 
 Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 06027e388354d5c61c2a0301a2d31c0301594c9b
+GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
 Directory: 2.5-rc/alpine3.6
 
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/stretch
 
 Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/jessie
 
 Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -46,22 +46,22 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 73d3ed6b06738a7457a24fba9024cad303829c0a
+GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
+GitCommit: e23879898862f2426e6714324c912d14db1067b5
 Directory: 2.3/jessie
 
 Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
+GitCommit: e23879898862f2426e6714324c912d14db1067b5
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.5-onbuild, 2.3-onbuild
@@ -71,17 +71,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: d3dc5a87e233dd19497cb6a0ce3933cd0340ce32
+GitCommit: e23879898862f2426e6714324c912d14db1067b5
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
+GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
 Directory: 2.2/jessie
 
 Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
+GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.8-onbuild, 2.2-onbuild
@@ -91,5 +91,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 9d6c3fe1348a23bb9903fc1e8ed73b800808dbfe
+GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `mariadb`: 10.2.11
- `mongo`: 3.2.18, 3.6.0-rc6
- `ruby`: rubygems 2.7.3