### PR TITLE
Add official container for YOURLS

### DIFF
--- a/library/yourls
+++ b/library/yourls
@@ -1,0 +1,17 @@
+# this file is generated via https://github.com/YOURLS/docker-yourls/blob/c21e47c222cdfbacbb8c40e1bf3e8ea92d20cd88/generate-stackbrew-library.sh
+
+Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
+             Léo Colombaro <git@colombaro.fr> (@LeoColomb)
+GitRepo: https://github.com/YOURLS/docker-yourls.git
+
+Tags: 1.7.2-apache, 1.7-apache, 1-apache, apache, 1.7.2, 1.7, 1, latest
+GitCommit: d95df637a2b47dd34d93f0716229f86f8fc1bb09
+Directory: 1.7.2/apache
+
+Tags: 1.7.2-fpm, 1.7-fpm, 1-fpm, fpm
+GitCommit: d95df637a2b47dd34d93f0716229f86f8fc1bb09
+Directory: 1.7.2/fpm
+
+Tags: 1.7.2-fpm-alpine, 1.7-fpm-alpine, 1-fpm-alpine, fpm-alpine
+GitCommit: d95df637a2b47dd34d93f0716229f86f8fc1bb09
+Directory: 1.7.2/fpm-alpine


### PR DESCRIPTION
# Summary

This pull request adds the requested file for the YOURLS container. I also submitted a pull request in the docs repository.

Repo: https://github.com/YOURLS/docker-yourls
Project: https://github.com/YOURLS/YOURLS

# Checklist for Review

-	[x] associated with or contacted upstream?
     * @YOURLS
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
	* Should be `service`
-	[x] is it reasonably popular, or does it solve a particular use case well?
	* See https://github.com/YOURLS/YOURLS
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
	* See docker-library/docs#1078
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
	* From php5.6 (with official variants)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
	* Locally: https://travis-ci.org/YOURLS/docker-yourls

💌 