### PR TITLE
Update ghost, mongo, php, redis, tomcat, and wordpress

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.18.0, 1.18, 1, latest
+Tags: 1.18.2, 1.18, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ab26d8e463d708c406ccd05ffc67c63215b71d1d
+GitCommit: 979e837a8381dbc9ab4d3f8c6a9afbd6a786bebd
 Directory: 1/debian
 
-Tags: 1.18.0-alpine, 1.18-alpine, 1-alpine, alpine
+Tags: 1.18.2-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: ab26d8e463d708c406ccd05ffc67c63215b71d1d
+GitCommit: 979e837a8381dbc9ab4d3f8c6a9afbd6a786bebd
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/mongo
+++ b/library/mongo
@@ -92,24 +92,24 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.5/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.0-rc6-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
-SharedTags: 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc7-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
+SharedTags: 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6-rc/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: e2d583551cca18d491eda945fe122ba328ba542f
+GitCommit: 060a2889ba425fd498839ddeb562140e1899f216
 Directory: 3.6-rc
 
-Tags: 3.6.0-rc6-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc7-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 20ca4aa92bc6308737c203c4cbe33a13dc3166f5
+GitCommit: 06c92111d8f3ea13dff1401dd41077a314fcb95d
 Directory: 3.6-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.0-rc6-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: windowsservercore, 3.6.0-rc6, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc7-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 20ca4aa92bc6308737c203c4cbe33a13dc3166f5
+GitCommit: 06c92111d8f3ea13dff1401dd41077a314fcb95d
 Directory: 3.6-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/php
+++ b/library/php
@@ -1,145 +1,145 @@
-# this file is generated via https://github.com/docker-library/php/blob/662067f7336bbf238fdffb3aeee4b084a0cf3de7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/6fc9a08356ef76bcd52797bdad818ecf76d95b23/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0RC6-cli-stretch, 7.2-rc-cli-stretch, rc-cli-stretch, 7.2.0RC6-stretch, 7.2-rc-stretch, rc-stretch, 7.2.0RC6-cli, 7.2-rc-cli, rc-cli, 7.2.0RC6, 7.2-rc, rc
+Tags: 7.2.0-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.0-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.0-cli, 7.2-cli, 7-cli, cli, 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
-Directory: 7.2-rc/stretch/cli
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/stretch/cli
 
-Tags: 7.2.0RC6-apache-stretch, 7.2-rc-apache-stretch, rc-apache-stretch, 7.2.0RC6-apache, 7.2-rc-apache, rc-apache
+Tags: 7.2.0-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.0-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
-Directory: 7.2-rc/stretch/apache
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/stretch/apache
 
-Tags: 7.2.0RC6-fpm-stretch, 7.2-rc-fpm-stretch, rc-fpm-stretch, 7.2.0RC6-fpm, 7.2-rc-fpm, rc-fpm
+Tags: 7.2.0-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.0-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
-Directory: 7.2-rc/stretch/fpm
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/stretch/fpm
 
-Tags: 7.2.0RC6-zts-stretch, 7.2-rc-zts-stretch, rc-zts-stretch, 7.2.0RC6-zts, 7.2-rc-zts, rc-zts
+Tags: 7.2.0-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.0-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2577f1147b323633d64501f1a085ce8c580ab863
-Directory: 7.2-rc/stretch/zts
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/stretch/zts
 
-Tags: 7.2.0RC6-cli-alpine3.6, 7.2-rc-cli-alpine3.6, rc-cli-alpine3.6, 7.2.0RC6-alpine3.6, 7.2-rc-alpine3.6, rc-alpine3.6, 7.2.0RC6-cli-alpine, 7.2-rc-cli-alpine, rc-cli-alpine, 7.2.0RC6-alpine, 7.2-rc-alpine, rc-alpine
+Tags: 7.2.0-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.0-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.0-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
-Directory: 7.2-rc/alpine3.6/cli
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.0RC6-fpm-alpine3.6, 7.2-rc-fpm-alpine3.6, rc-fpm-alpine3.6, 7.2.0RC6-fpm-alpine, 7.2-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.2.0-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.0-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
-Directory: 7.2-rc/alpine3.6/fpm
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.0RC6-zts-alpine3.6, 7.2-rc-zts-alpine3.6, rc-zts-alpine3.6, 7.2.0RC6-zts-alpine, 7.2-rc-zts-alpine, rc-zts-alpine
+Tags: 7.2.0-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.0-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d8d798be28c49ced47d772aa899c0a1febabdba3
-Directory: 7.2-rc/alpine3.6/zts
+GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7-cli-jessie, cli-jessie, 7.1.12-jessie, 7.1-jessie, 7-jessie, jessie, 7.1.12-cli, 7.1-cli, 7-cli, cli, 7.1.12, 7.1, 7, latest
+Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7.1.12-jessie, 7.1-jessie, 7.1.12-cli, 7.1-cli, 7.1.12, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7-apache-jessie, apache-jessie, 7.1.12-apache, 7.1-apache, 7-apache, apache
+Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7.1.12-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7-fpm-jessie, fpm-jessie, 7.1.12-fpm, 7.1-fpm, 7-fpm, fpm
+Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7.1.12-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7-zts-jessie, zts-jessie, 7.1.12-zts, 7.1-zts, 7-zts, zts
+Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7.1.12-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7-cli-alpine3.4, cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7-alpine3.4, alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7-cli-alpine, cli-alpine, 7.1.12-alpine, 7.1-alpine, 7-alpine, alpine
+Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7.1.12-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7-fpm-alpine3.4, fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7-zts-alpine3.4, zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 287a157544a8e43032ecb2879ff778d10c0d0e37
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/alpine3.4/cli
 
 Tags: 7.0.26-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.26-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/alpine3.4/fpm
 
 Tags: 7.0.26-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.26-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: e5a6cb72428ff467674e44f60378a7a4a1d22464
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfe27759103fa6050601060165409b5b3be06395
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/alpine3.4/cli
 
 Tags: 5.6.32-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.32-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/alpine3.4/fpm
 
 Tags: 5.6.32-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.32-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: ec6b6e60b42c283d48775596f722f5250c1f5ca5
+GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
 Directory: 5.6/alpine3.4/zts

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
 Directory: 3.2/alpine
 
-Tags: 4.0.2, 4.0, 4, latest
+Tags: 4.0.4, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29b44c477011c5450dd89fd41af4c04e0c71e5b2
+GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
 Directory: 4.0
 
-Tags: 4.0.2-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.4-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: 29b44c477011c5450dd89fd41af4c04e0c71e5b2
+GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
 Directory: 4.0/32bit
 
-Tags: 4.0.2-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.4-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 29b44c477011c5450dd89fd41af4c04e0c71e5b2
+GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
 Directory: 4.0/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -44,22 +44,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.23-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.23, 8.5, 8, latest
+Tags: 8.5.24-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.24, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68f75ec81727e398a223ed55fe50f9a3ff78d83f
+GitCommit: d9a438155caff88fad8114297954e2347b534ce3
 Directory: 8.5/jre8
 
-Tags: 8.5.23-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.23-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.24-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.24-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: efab5942d355f9bac6f6e2a99d82a40a564bef3c
 Directory: 8.5/jre8-alpine
 
-Tags: 9.0.1-jre8, 9.0-jre8, 9-jre8, 9.0.1, 9.0, 9
+Tags: 9.0.2-jre8, 9.0-jre8, 9-jre8, 9.0.2, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fddd4bc6c1656e34b0da3b374ca0f036b689adb
+GitCommit: 8c3a43c1c4f400ab9dfe6c5fe638b9c5264392c5
 Directory: 9.0/jre8
 
-Tags: 9.0.1-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.1-alpine, 9.0-alpine, 9-alpine
+Tags: 9.0.2-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine, 9.0.2-alpine, 9.0-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: b6a8794a995e0f482a3832b7c7041eec9a804f2a
 Directory: 9.0/jre8-alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.0-apache, 4.9-apache, 4-apache, apache, 4.9.0, 4.9, 4, latest, 4.9.0-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.0-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/apache
 
-Tags: 4.9.0-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.0-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/fpm
 
-Tags: 4.9.0-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.0-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.0-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.0-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.1-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.1-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.0/apache
 
-Tags: 4.9.0-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.1-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.0/fpm
 
-Tags: 4.9.0-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.1-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.0-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.0-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.1-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.1-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.1/apache
 
-Tags: 4.9.0-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.1-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.1/fpm
 
-Tags: 4.9.0-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.1-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 050652ba972ba46d24cb1b2174a2c4c9fbbbcd80
+GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.1/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost` bump to `1.18.2`
- `mongo` bump to `3.6.0-rc7`
- `php` `7.2` GA and pcre-jit fixes https://github.com/docker-library/php/pull/526
- `redis` bump to `4.0.4`
- `tomcat` bumps to `8.5.24` and `9.0.2`
- `wordpress` bump to `4.9.1`