### PR TITLE
Update ghost, mongo, redis

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.18.2, 1.18, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 979e837a8381dbc9ab4d3f8c6a9afbd6a786bebd
+GitCommit: cc2f464de32577f31f99e8f18dcbfa8d1d5d26e8
 Directory: 1/debian
 
 Tags: 1.18.2-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 979e837a8381dbc9ab4d3f8c6a9afbd6a786bebd
+GitCommit: cc2f464de32577f31f99e8f18dcbfa8d1d5d26e8
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/mongo
+++ b/library/mongo
@@ -92,24 +92,24 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.5/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.0-rc7-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
-SharedTags: 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc8-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
+SharedTags: 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6-rc/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 060a2889ba425fd498839ddeb562140e1899f216
+GitCommit: 93f0595616e4d0a0eaabe74b58404da9648456d1
 Directory: 3.6-rc
 
-Tags: 3.6.0-rc7-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc8-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 06c92111d8f3ea13dff1401dd41077a314fcb95d
+GitCommit: add0a061a66ebe3530050b4f74a5fdccfe5ba0e2
 Directory: 3.6-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.0-rc7-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: windowsservercore, 3.6.0-rc7, 3.6.0, 3.6, 3.6-rc, rc
+Tags: 3.6.0-rc8-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
 Architectures: windows-amd64
-GitCommit: 06c92111d8f3ea13dff1401dd41077a314fcb95d
+GitCommit: add0a061a66ebe3530050b4f74a5fdccfe5ba0e2
 Directory: 3.6-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/6fc9a08356ef76bcd52797bdad818ecf76d95b23/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/3f132379556d132a6a416cbf34c31901d8eb1afd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
 Directory: 3.2/alpine
 
-Tags: 4.0.4, 4.0, 4, latest
+Tags: 4.0.5, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
+GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
 Directory: 4.0
 
-Tags: 4.0.4-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.5-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
+GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
 Directory: 4.0/32bit
 
-Tags: 4.0.4-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.5-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e8030f878c023ac62e6928780707b723a31a9c3
+GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
 Directory: 4.0/alpine


### PR DESCRIPTION
- `ghost` cli bump `1.4.0`
- `mongo` bump to `3.6.0-rc8`
- `php` comment change in `generate-stackbrew-library.sh`
- `redis` bump to `4.0.5`