### PR TITLE
Update fsharp to 4.1.29, trim old versions

### DIFF
--- a/library/fsharp
+++ b/library/fsharp
@@ -2,22 +2,10 @@ Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
 
-Tags: latest, 4, 4.1, 4.1.28
-GitCommit: 58be3b5a99a5170b8277c60c77cf163ce66a733f
-Directory: 4.1.28/mono
-
-Tags: 4.1.18
-GitCommit: ad4c4d67a1975b2b0ff0acc49dc46b3271836831
-Directory: 4.1.18/mono
-
-Tags: 4.1.0.1
-GitCommit: a28196740e38035beea04c41d5862136413281e3
-Directory: 4.1.0.1/mono
+Tags: latest, 4, 4.1, 4.1.29
+GitCommit: a58f8a05cd4995b1daf1a41692a84d3a003b160b
+Directory: 4.1.29/mono
 
 Tags: 4.0, 4.0.1, 4.0.1.1
 GitCommit: a28196740e38035beea04c41d5862136413281e3
 Directory: 4.0.1.1
-
-Tags: 4.0.0.4
-GitCommit: a28196740e38035beea04c41d5862136413281e3
-Directory: 4.0.0.4


### PR DESCRIPTION
Bumping to 4.1.29 and trimming the build for official images to only the 4.0 and 4.1 most recent.