### PR TITLE
Update perl image for 5.24.3/5.26.1 and more architectures

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,19 +1,19 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini), Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 8044d4ba7627712b6fbed84e544d2d78ca805f96
-Architectures: amd64, arm64v8
+GitCommit: a5c2d6c896807e9c1beec4ebac01c7f30c075bf0
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.26, 5.26.0
-Directory: 5.026.000-64bit
+Tags: latest, 5, 5.26, 5.26.1
+Directory: 5.026.001-64bit
 
-Tags: threaded, 5-threaded, 5.26-threaded, 5.26.0-threaded
-Directory: 5.026.000-64bit,threaded
+Tags: threaded, 5-threaded, 5.26-threaded, 5.26.1-threaded
+Directory: 5.026.001-64bit,threaded
 
-Tags: 5.24, 5.24.2
-Directory: 5.024.002-64bit
+Tags: 5.24, 5.24.3
+Directory: 5.024.003-64bit
 
-Tags: 5.24-threaded, 5.24.2-threaded
-Directory: 5.024.002-64bit,threaded
+Tags: 5.24-threaded, 5.24.3-threaded
+Directory: 5.024.003-64bit,threaded
 
 Tags: 5.22, 5.22.4
 Directory: 5.022.004-64bit


### PR DESCRIPTION
- Update to Perl 5.24.3 and 5.26.1
- Build Perl for more architectures (https://github.com/Perl/docker-perl/pull/43)