### PR TITLE
Request to create an official image for Open Liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,0 +1,10 @@
+Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
+GitRepo: https://github.com/OpenLiberty/ci.docker.git
+GitCommit: a9576a73b3a554c6b27345c2dcd4ca77c394e953
+Architectures: amd64, i386, ppc64le, s390x
+
+Tags: kernel, kernel-java8-ibm
+Directory: release/kernel/java8/ibmjava
+
+Tags: kernel-java8-ibmsfj
+Directory: release/kernel/java8/ibmsfj

--- a/test/config.sh
+++ b/test/config.sh
@@ -132,6 +132,9 @@ imageTests+=(
 		java-hello-world
 		java-uimanager-font
 	'
+	[open-liberty]='
+		open-liberty-hello-world
+	'
 	[percona]='
 	'
 	[perl]='

--- a/test/tests/open-liberty-hello-world/run.sh
+++ b/test/tests/open-liberty-hello-world/run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# since we have curl in the liberty image, we'll use that
+clientImage="$1"
+
+serverImage="$1"
+
+# Create an instance of the container-under-test
+cid="$(docker run -d "$serverImage")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+_request() {
+	local url="${1#/}"
+	shift
+
+	docker run --rm --link "$cid":open-liberty "$clientImage" \
+		wget -q -O - "$@" "http://open-liberty:9080/$url"
+}
+
+# Make sure that Open Liberty is listening
+. "$dir/../../retry.sh" '_request / &> /dev/null'
+
+# Check that we can request /
+[ -n "$(_request '/')" ]
+
+# Check that the version.js file can be retrieved.
+helloWorld="$(_request '/version.js')"
+[[ "$helloWorld" == *'var current'* ]]


### PR DESCRIPTION
IBM open sourced WebSphere Liberty in September this year. There is an official image for websphere-liberty, so this is a PR to create an official image for the Open Source project.

I've attempted to create a test for this image, but the test wouldn't run on my mac, readlink -f isn't valid and neither is declare -A. I think the test should be good (I copied the tomcat one), but I can't be sure.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/OpenLiberty
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1083
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
    - `FROM ibmjava`
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
  