### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -19,6 +19,21 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
 Directory: 17.11/git
 
+Tags: 17.09.1-ce-rc1, 17.09-rc, rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
+Directory: 17.09-rc
+
+Tags: 17.09.1-ce-rc1-dind, 17.09-rc-dind, rc-dind
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
+Directory: 17.09-rc/dind
+
+Tags: 17.09.1-ce-rc1-git, 17.09-rc-git, rc-git
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
+Directory: 17.09-rc/git
+
 Tags: 17.09.0-ce, 17.09.0, 17.09, stable
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d

--- a/library/gcc
+++ b/library/gcc
@@ -21,6 +21,6 @@ Directory: 6
 # Last Modified: 2017-08-14
 Tags: 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
+GitCommit: 9bf9204098e91914c02bc07d1fb44e33555276ed
 Directory: 7
 # Docker EOL: 2018-08-14

--- a/library/haproxy
+++ b/library/haproxy
@@ -44,12 +44,12 @@ Architectures: amd64
 GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
 Directory: 1.7/alpine
 
-Tags: 1.8.0, 1.8, 1, latest
+Tags: 1.8.1, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cf8a6c5b9dfcb0008cf5546fc86d89fc1d633e
+GitCommit: ef3051452ae81117911633535a9cdb0575aa2cf1
 Directory: 1.8
 
-Tags: 1.8.0-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.1-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cf8a6c5b9dfcb0008cf5546fc86d89fc1d633e
+GitCommit: ef3051452ae81117911633535a9cdb0575aa2cf1
 Directory: 1.8/alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,22 +3,22 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 11.0.5-apache, 11.0-apache, 11-apache, 11.0.5, 11.0, 11
+Tags: 11.0.6-apache, 11.0-apache, 11-apache, 11.0.6, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
+GitCommit: 074ca53482043fea8268eba83546815db0f7c4ad
 Directory: 11.0/apache
 
-Tags: 11.0.5-fpm, 11.0-fpm, 11-fpm
+Tags: 11.0.6-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
+GitCommit: 074ca53482043fea8268eba83546815db0f7c4ad
 Directory: 11.0/fpm
 
-Tags: 12.0.3-apache, 12.0-apache, 12-apache, apache, 12.0.3, 12.0, 12, latest
+Tags: 12.0.4-apache, 12.0-apache, 12-apache, apache, 12.0.4, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
+GitCommit: 0319dd0a84eb8a74ca65245c5781cbf6a7d54763
 Directory: 12.0/apache
 
-Tags: 12.0.3-fpm, 12.0-fpm, 12-fpm, fpm
+Tags: 12.0.4-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90f83fe0bbbafd3bf5a836765a82703c82ca08eb
+GitCommit: 0319dd0a84eb8a74ca65245c5781cbf6a7d54763
 Directory: 12.0/fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -34,9 +34,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jdk/slim
 
-Tags: 7u131-jdk-alpine, 7u131-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jdk/alpine
 
 Tags: 7u151-jre, 7-jre
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jre/slim
 
-Tags: 7u131-jre-alpine, 7-jre-alpine
+Tags: 7u151-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jre/alpine
 
 Tags: 8u151-jdk, 8u151, 8-jdk, 8, jdk, latest
@@ -64,9 +64,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jdk/slim
 
-Tags: 8u131-jdk-alpine, 8u131-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+Tags: 8u151-jdk-alpine, 8u151-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
 Directory: 8-jdk/alpine
 
 Tags: 8u151-jdk-windowsservercore-ltsc2016, 8u151-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -100,9 +100,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jre/slim
 
-Tags: 8u131-jre-alpine, 8-jre-alpine, jre-alpine
+Tags: 8u151-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
 Directory: 8-jre/alpine
 
 Tags: 9.0.1-11-jdk, 9.0.1-11, 9.0.1-jdk, 9.0.1, 9.0-jdk, 9.0, 9-jdk, 9

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
 Directory: 3.2/alpine
 
-Tags: 4.0.5, 4.0, 4, latest
+Tags: 4.0.6, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
+GitCommit: 9c63bd5fc7b52cc3d8f3441a660a593028a0ed15
 Directory: 4.0
 
-Tags: 4.0.5-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.6-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
+GitCommit: 9c63bd5fc7b52cc3d8f3441a660a593028a0ed15
 Directory: 4.0/32bit
 
-Tags: 4.0.5-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.6-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c7e67d8f47b12755f58f3f26282de31a46f16130
+GitCommit: 9c63bd5fc7b52cc3d8f3441a660a593028a0ed15
 Directory: 4.0/alpine


### PR DESCRIPTION
- `docker`: 17.09.1-ce-rc1
- `gcc`: mirror hiccups...
- `haproxy`: 1.8.1
- `nextcloud`: 12.0.4, 11.0.6
- `openjdk`: Alpine 3.7 + 8u151 (docker-library/openjdk#155)
- `redis`: 4.0.6