### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.4, 5.6, 5, latest
-GitCommit: 0e42c8b41dbbbf4158f03f2af61812729c52662b
+Tags: 5.6.5, 5.6, 5, latest
+GitCommit: 71454903d8d33c7050d7725b825fb8c6a65007e4
 Directory: 5
 
-Tags: 5.6.4-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 0e42c8b41dbbbf4158f03f2af61812729c52662b
+Tags: 5.6.5-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 71454903d8d33c7050d7725b825fb8c6a65007e4
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.18.2, 1.18, 1, latest
+Tags: 1.18.3, 1.18, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2f464de32577f31f99e8f18dcbfa8d1d5d26e8
+GitCommit: 1e75029f8fa29ab93d22a7921536c80bacf664e8
 Directory: 1/debian
 
-Tags: 1.18.2-alpine, 1.18-alpine, 1-alpine, alpine
+Tags: 1.18.3-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: cc2f464de32577f31f99e8f18dcbfa8d1d5d26e8
+GitCommit: 1e75029f8fa29ab93d22a7921536c80bacf664e8
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.4, 5.6, 5, latest
-GitCommit: 8951190befd71bc72c11eb13e6b7e778de38c950
+Tags: 5.6.5, 5.6, 5, latest
+GitCommit: c7f35a7103f04d289ae93427eafb24a6fa28aa78
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.4, 5.6, 5, latest
-GitCommit: 5a25e180a82989857ee4ef036686523be210f619
+Tags: 5.6.5, 5.6, 5, latest
+GitCommit: eccd95622eebf46a20cb8fb6484d1a7854fb44b6
 Directory: 5
 
-Tags: 5.6.4-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 5a25e180a82989857ee4ef036686523be210f619
+Tags: 5.6.5-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: eccd95622eebf46a20cb8fb6484d1a7854fb44b6
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/daeeeccd0edd110e6341ba3ee2d699caf885fbce/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/6cc8a96aaf38dec1525ecbb026488d8e817f6ef2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -48,68 +48,46 @@ GitCommit: 1af403f9d70fed1da9502b6f486a5f68f384eef7
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.4.10-jessie, 3.4-jessie, 3-jessie, jessie
-SharedTags: 3.4.10, 3.4, 3, latest
+Tags: 3.4.10-jessie, 3.4-jessie
+SharedTags: 3.4.10, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
 GitCommit: c501968a9c330a773a2bc2c9b67dcd4ebbb58651
 Directory: 3.4
 
-Tags: 3.4.10-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.4.10, 3.4, 3, latest
+Tags: 3.4.10-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.4.10, 3.4
 Architectures: windows-amd64
 GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.10-windowsservercore-1709, 3.4-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: windowsservercore, 3.4.10, 3.4, 3, latest
+Tags: 3.4.10-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: windowsservercore, 3.4.10, 3.4
 Architectures: windows-amd64
 GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.5.13-jessie, 3.5-jessie, unstable-jessie
-SharedTags: 3.5.13, 3.5, unstable
-# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.5/main/
+Tags: 3.6.0-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.0, 3.6, 3, latest
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 532f0dce1488540fb486d58407aff00301203e47
-Directory: 3.5
+GitCommit: 5dff8cfe204a3d5e7b98d83be5d7e5eaf114596e
+Directory: 3.6
 
-Tags: 3.5.13-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.5.13, 3.5, unstable
+Tags: 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.6.0, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
-Directory: 3.5/windows/windowsservercore-ltsc2016
+GitCommit: 5dff8cfe204a3d5e7b98d83be5d7e5eaf114596e
+Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.5.13-windowsservercore-1709, 3.5-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: windowsservercore, 3.5.13, 3.5, unstable
+Tags: 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: windowsservercore, 3.6.0, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
-Directory: 3.5/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
-Tags: 3.6.0-rc8-jessie, 3.6.0-jessie, 3.6-jessie, 3.6-rc-jessie, rc-jessie
-SharedTags: 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
-# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6-rc/main/
-# (i386 is empty, as is ppc64el)
-Architectures: amd64
-GitCommit: 93f0595616e4d0a0eaabe74b58404da9648456d1
-Directory: 3.6-rc
-
-Tags: 3.6.0-rc8-windowsservercore-ltsc2016, 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3.6-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
-Architectures: windows-amd64
-GitCommit: add0a061a66ebe3530050b4f74a5fdccfe5ba0e2
-Directory: 3.6-rc/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.6.0-rc8-windowsservercore-1709, 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3.6-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: windowsservercore, 3.6.0-rc8, 3.6.0, 3.6, 3.6-rc, rc
-Architectures: windows-amd64
-GitCommit: add0a061a66ebe3530050b4f74a5fdccfe5ba0e2
-Directory: 3.6-rc/windows/windowsservercore-1709
+GitCommit: 5dff8cfe204a3d5e7b98d83be5d7e5eaf114596e
+Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/mysql
+++ b/library/mysql
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.3, 8.0, 8
-GitCommit: 86431f073b3d2f963d21e33cb8943f0bdcdf143d
+GitCommit: 6c414e7f38c2079c7193beae5dc7c34ee46cd6e7
 Directory: 8.0
 
 Tags: 5.7.20, 5.7, 5, latest
-GitCommit: 883703dfb30d9c197e0059a669c4bb64d55f6e0d
+GitCommit: 6c414e7f38c2079c7193beae5dc7c34ee46cd6e7
 Directory: 5.7
 
 Tags: 5.6.38, 5.6

--- a/library/owncloud
+++ b/library/owncloud
@@ -14,22 +14,22 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c0f5a270e565410cc47046b29b04e4a5ec9e828
 Directory: 10.0/fpm
 
-Tags: 9.1.6-apache, 9.1-apache, 9-apache, 9.1.6, 9.1, 9
+Tags: 9.1.7-apache, 9.1-apache, 9-apache, 9.1.7, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
+GitCommit: b916cdc2840cb63d6b4ede93e88826863b150b06
 Directory: 9.1/apache
 
-Tags: 9.1.6-fpm, 9.1-fpm, 9-fpm
+Tags: 9.1.7-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
+GitCommit: b916cdc2840cb63d6b4ede93e88826863b150b06
 Directory: 9.1/fpm
 
-Tags: 9.0.10-apache, 9.0-apache, 9.0.10, 9.0
+Tags: 9.0.11-apache, 9.0-apache, 9.0.11, 9.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
+GitCommit: c98a6030224193c1fae590a3f1c1c27f6a6ed6bc
 Directory: 9.0/apache
 
-Tags: 9.0.10-fpm, 9.0-fpm
+Tags: 9.0.11-fpm, 9.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aad7b27a8d2dab3e417a94071d1acf6a795a2aed
+GitCommit: c98a6030224193c1fae590a3f1c1c27f6a6ed6bc
 Directory: 9.0/fpm

--- a/library/piwik
+++ b/library/piwik
@@ -2,10 +2,10 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.2.0-apache, 3.2-apache, 3-apache, apache, 3.2.0, 3.2, 3, latest
-GitCommit: b5782462cddfd5c5ff7da5e19bb83b901e079781
+Tags: 3.2.1-apache, 3.2-apache, 3-apache, apache, 3.2.1, 3.2, 3, latest
+GitCommit: 334185afd9977d3896c02e942d093eebe11d79c9
 Directory: apache
 
-Tags: 3.2.0-fpm, 3.2-fpm, 3-fpm, fpm
-GitCommit: b5782462cddfd5c5ff7da5e19bb83b901e079781
+Tags: 3.2.1-fpm, 3.2-fpm, 3-fpm, fpm
+GitCommit: 334185afd9977d3896c02e942d093eebe11d79c9
 Directory: fpm

--- a/library/python
+++ b/library/python
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0a2-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0a2, 3.7-rc, rc
+Tags: 3.7.0a3-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0a3, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f12f511910098f45951111aa5642fd935133afc
+GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0a2-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0a2-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0a3-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0a3-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4ce69de053337ec22d7f322cd997398eeba2350
+GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0a2-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a2-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0a3-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a3-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f12f511910098f45951111aa5642fd935133afc
+GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/alpine3.6
 
-Tags: 3.7.0a2-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: windowsservercore, 3.7.0a2, 3.7-rc, rc
+Tags: 3.7.0a3-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: windowsservercore, 3.7.0a3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0a2-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: windowsservercore, 3.7.0a2, 3.7-rc, rc
+Tags: 3.7.0a3-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: windowsservercore, 3.7.0a3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 


### PR DESCRIPTION
- `elasticsearch`: 5.6.5
- `ghost`: 1.18.3
- `kibana`: 5.6.5
- `logstash`: 5.6.5
- `mongo`: 3.6.0 GA
- `mysql`: adjust `mysql.session` user deletion (docker-library/mysql#347)
- `owncloud`: 9.1.7, 9.0.11
- `piwik`: 3.2.1
- `python`: 3.7.0a3