### PR TITLE
Bump jruby to 9.1.15.0

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -1,24 +1,24 @@
 Maintainers: Brian Goff <cpuguy83@gmail.com> (@cpuguy83)
 GitRepo: https://github.com/cpuguy83/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: 9716f7a302976bcc0a326100a50733b69b6fb0cf
+GitCommit: a2071f9c3f429753111ddd40e2a0cf5a89582675
 
-Tags: latest, 9, 9.1, 9.1.14, 9.1-jre, 9.1.14-jre, 9.1.14.0, 9.1.14.0-jre
+Tags: latest, 9, 9.1, 9.1.15, 9.1-jre, 9.1.15-jre, 9.1.15.0, 9.1.15.0-jre
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/jre
 
-Tags: 9-alpine, 9.1-alpine, 9.1.14-alpine, 9.1-jre-alpine, 9.1.14-jre-alpine, 9.1.14.0-alpine, 9.1.14.0-jre-alpine
+Tags: 9-alpine, 9.1-alpine, 9.1.15-alpine, 9.1-jre-alpine, 9.1.15-jre-alpine, 9.1.15.0-alpine, 9.1.15.0-jre-alpine
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 9000/alpine-jre
 
-Tags: 9-jdk, 9.1-jdk, 9.1.14-jdk, 9.1.14.0-jdk
+Tags: 9-jdk, 9.1-jdk, 9.1.15-jdk, 9.1.15.0-jdk
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/jdk
 
-Tags: 9-jdk-alpine, 9.1-jdk-alpine, 9.1.14-jdk-alpine, 9.1.14.0-jdk-alpine
+Tags: 9-jdk-alpine, 9.1-jdk-alpine, 9.1.15-jdk-alpine, 9.1.15.0-jdk-alpine
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 9000/alpine-jdk
 
-Tags: 9-onbuild, 9.1-onbuild, 9.1.14-onbuild, 9.1.14.0-onbuild
+Tags: 9-onbuild, 9.1-onbuild, 9.1.15-onbuild, 9.1.15.0-onbuild
 Architectures: amd64, i386, arm32v5, arm64v8, ppc64le, s390x
 Directory: 9000/onbuild


### PR DESCRIPTION
```diff
diff --git a/9000/VERSION b/9000/VERSION
index 853a173..1dbc36c 100644
--- a/9000/VERSION
+++ b/9000/VERSION
@@ -1 +1 @@
-9.1.14.0
+9.1.15.0
diff --git a/9000/alpine-jdk/Dockerfile b/9000/alpine-jdk/Dockerfile
index 5e66b85..e52683b 100644
--- a/9000/alpine-jdk/Dockerfile
+++ b/9000/alpine-jdk/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache \
       bash \
       libc6-compat
 
-ENV JRUBY_VERSION 9.1.14.0
-ENV JRUBY_SHA256 074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651
+ENV JRUBY_VERSION 9.1.15.0
+ENV JRUBY_SHA256 4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e
 
 RUN apk add --no-cache --virtual .build-deps \
       curl \
diff --git a/9000/alpine-jre/Dockerfile b/9000/alpine-jre/Dockerfile
index 788430c..651ab4c 100644
--- a/9000/alpine-jre/Dockerfile
+++ b/9000/alpine-jre/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache \
       bash \
       libc6-compat
 
-ENV JRUBY_VERSION 9.1.14.0
-ENV JRUBY_SHA256 074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651
+ENV JRUBY_VERSION 9.1.15.0
+ENV JRUBY_SHA256 4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e
 
 RUN apk add --no-cache --virtual .build-deps \
       curl \
diff --git a/9000/jdk/Dockerfile b/9000/jdk/Dockerfile
index 797b929..184f90a 100644
--- a/9000/jdk/Dockerfile
+++ b/9000/jdk/Dockerfile
@@ -2,8 +2,8 @@ FROM openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV JRUBY_VERSION 9.1.14.0
-ENV JRUBY_SHA256 074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651
+ENV JRUBY_VERSION 9.1.15.0
+ENV JRUBY_SHA256 4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e
 RUN mkdir /opt/jruby \
   && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
   && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
diff --git a/9000/jre/Dockerfile b/9000/jre/Dockerfile
index 0f7147e..a19e664 100644
--- a/9000/jre/Dockerfile
+++ b/9000/jre/Dockerfile
@@ -2,8 +2,8 @@ FROM openjdk:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV JRUBY_VERSION 9.1.14.0
-ENV JRUBY_SHA256 074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651
+ENV JRUBY_VERSION 9.1.15.0
+ENV JRUBY_SHA256 4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e
 RUN mkdir /opt/jruby \
   && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
   && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
```