### PR TITLE
[Security update] Update all release lines of node

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,123 +3,123 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.2.0, 9.2, 9, latest
+Tags: 9.2.1, 9.2, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9
 
-Tags: 9.2.0-alpine, 9.2-alpine, 9-alpine, alpine
+Tags: 9.2.1-alpine, 9.2-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9/alpine
 
-Tags: 9.2.0-onbuild, 9.2-onbuild, 9-onbuild, onbuild
+Tags: 9.2.1-onbuild, 9.2-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9/onbuild
 
-Tags: 9.2.0-slim, 9.2-slim, 9-slim, slim
+Tags: 9.2.1-slim, 9.2-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9/slim
 
-Tags: 9.2.0-stretch, 9.2-stretch, 9-stretch, stretch
+Tags: 9.2.1-stretch, 9.2-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9/stretch
 
-Tags: 9.2.0-wheezy, 9.2-wheezy, 9-wheezy, wheezy
+Tags: 9.2.1-wheezy, 9.2-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: c75cc560e2642755c6fbb2a53b8716063c0b3806
+GitCommit: 3779ff3b516feb666742cc391f5a36de2ed6bf4d
 Directory: 9/wheezy
 
-Tags: 8.9.2, 8.9, 8, carbon
+Tags: 8.9.3, 8.9, 8, carbon
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8
 
-Tags: 8.9.2-alpine, 8.9-alpine, 8-alpine, carbon-alpine
+Tags: 8.9.3-alpine, 8.9-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8/alpine
 
-Tags: 8.9.2-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.9.3-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8/onbuild
 
-Tags: 8.9.2-slim, 8.9-slim, 8-slim, carbon-slim
+Tags: 8.9.3-slim, 8.9-slim, 8-slim, carbon-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8/slim
 
-Tags: 8.9.2-stretch, 8.9-stretch, 8-stretch, carbon-stretch
+Tags: 8.9.3-stretch, 8.9-stretch, 8-stretch, carbon-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8/stretch
 
-Tags: 8.9.2-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
+Tags: 8.9.3-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
 Architectures: amd64
-GitCommit: 95506b2a681ca3d0b1df168a85f12b0ee7d27e5f
+GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
 Directory: 8/wheezy
 
-Tags: 6.12.1, 6.12, 6, boron
+Tags: 6.12.2, 6.12, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6
 
-Tags: 6.12.1-alpine, 6.12-alpine, 6-alpine, boron-alpine
+Tags: 6.12.2-alpine, 6.12-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6/alpine
 
-Tags: 6.12.1-onbuild, 6.12-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.12.2-onbuild, 6.12-onbuild, 6-onbuild, boron-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6/onbuild
 
-Tags: 6.12.1-slim, 6.12-slim, 6-slim, boron-slim
+Tags: 6.12.2-slim, 6.12-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6/slim
 
-Tags: 6.12.1-stretch, 6.12-stretch, 6-stretch, boron-stretch
+Tags: 6.12.2-stretch, 6.12-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6/stretch
 
-Tags: 6.12.1-wheezy, 6.12-wheezy, 6-wheezy, boron-wheezy
+Tags: 6.12.2-wheezy, 6.12-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: 698232de1e0a7bcdc52958b6bd6bf2816a31648b
+GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
 Directory: 6/wheezy
 
-Tags: 4.8.6, 4.8, 4, argon
+Tags: 4.8.7, 4.8, 4, argon
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4
 
-Tags: 4.8.6-alpine, 4.8-alpine, 4-alpine, argon-alpine
+Tags: 4.8.7-alpine, 4.8-alpine, 4-alpine, argon-alpine
 Architectures: amd64
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4/alpine
 
-Tags: 4.8.6-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
+Tags: 4.8.7-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4/onbuild
 
-Tags: 4.8.6-slim, 4.8-slim, 4-slim, argon-slim
+Tags: 4.8.7-slim, 4.8-slim, 4-slim, argon-slim
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4/slim
 
-Tags: 4.8.6-stretch, 4.8-stretch, 4-stretch, argon-stretch
+Tags: 4.8.7-stretch, 4.8-stretch, 4-stretch, argon-stretch
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4/stretch
 
-Tags: 4.8.6-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
+Tags: 4.8.7-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
 Architectures: amd64
-GitCommit: f941101d4d706cea27fab3b628c19e870a78d194
+GitCommit: 2dfcf38dafc79c0e163293b8a84f4daf7c0d6898
 Directory: 4/wheezy
 


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/december-2017-security-releases/

https://nodejs.org/en/blog/release/v4.8.7/
https://nodejs.org/en/blog/release/v6.12.2/
https://nodejs.org/en/blog/release/v8.9.3/
https://nodejs.org/en/blog/release/v9.2.1/

https://github.com/nodejs/docker-node/pull/594