### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -19,6 +19,21 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: artful
 
+Tags: bionic-curl
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
+Directory: bionic/curl
+
+Tags: bionic-scm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
+Directory: bionic/scm
+
+Tags: bionic
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
+Directory: bionic
+
 Tags: buster-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c

--- a/library/docker
+++ b/library/docker
@@ -4,61 +4,47 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.11.0-ce, 17.11.0, 17.11, 17, edge, test, latest
+Tags: 17.12.0-ce-rc1, 17.12-rc, rc, test
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
+Directory: 17.12-rc
+
+Tags: 17.12.0-ce-rc1-dind, 17.12-rc-dind, rc-dind, test-dind
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
+Directory: 17.12-rc/dind
+
+Tags: 17.12.0-ce-rc1-git, 17.12-rc-git, rc-git, test-git
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
+Directory: 17.12-rc/git
+
+Tags: 17.11.0-ce, 17.11.0, 17.11, 17, edge, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
 Directory: 17.11
 
-Tags: 17.11.0-ce-dind, 17.11.0-dind, 17.11-dind, 17-dind, edge-dind, test-dind, dind
+Tags: 17.11.0-ce-dind, 17.11.0-dind, 17.11-dind, 17-dind, edge-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
 Directory: 17.11/dind
 
-Tags: 17.11.0-ce-git, 17.11.0-git, 17.11-git, 17-git, edge-git, test-git, git
+Tags: 17.11.0-ce-git, 17.11.0-git, 17.11-git, 17-git, edge-git, git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
 Directory: 17.11/git
 
-Tags: 17.09.1-ce-rc1, 17.09-rc, rc
+Tags: 17.09.1-ce, 17.09.1, 17.09, stable
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
-Directory: 17.09-rc
-
-Tags: 17.09.1-ce-rc1-dind, 17.09-rc-dind, rc-dind
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
-Directory: 17.09-rc/dind
-
-Tags: 17.09.1-ce-rc1-git, 17.09-rc-git, rc-git
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f522868d85d70569fb3e90bd913efa1c3394a264
-Directory: 17.09-rc/git
-
-Tags: 17.09.0-ce, 17.09.0, 17.09, stable
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: af5b6cd45b8d1aeb534589d99f92b5a4dc886f5d
+GitCommit: 4e80fad160cf70fac2ad8920528b43870426a00c
 Directory: 17.09
 
-Tags: 17.09.0-ce-dind, 17.09.0-dind, 17.09-dind, stable-dind
+Tags: 17.09.1-ce-dind, 17.09.1-dind, 17.09-dind, stable-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.09/dind
 
-Tags: 17.09.0-ce-git, 17.09.0-git, 17.09-git, stable-git
+Tags: 17.09.1-ce-git, 17.09.1-git, 17.09-git, stable-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git
-
-Tags: 17.09.0-ce-windowsservercore-ltsc2016, 17.09.0-windowsservercore-ltsc2016, 17.09-windowsservercore-ltsc2016, stable-windowsservercore-ltsc2016
-SharedTags: windowsservercore
-Architectures: windows-amd64
-GitCommit: 2aa6d388f205fc20ad22402bfed4ece715c7cb48
-Directory: 17.09/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 17.09.0-ce-windowsservercore-1709, 17.09.0-windowsservercore-1709, 17.09-windowsservercore-1709, stable-windowsservercore-1709
-SharedTags: windowsservercore
-Architectures: windows-amd64
-GitCommit: 2aa6d388f205fc20ad22402bfed4ece715c7cb48
-Directory: 17.09/windows/windowsservercore-1709
-Constraints: windowsservercore-1709

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 10.0.3-apache, 10.0-apache, 10-apache, apache, 10.0.3, 10.0, 10, latest
+Tags: 10.0.4-apache, 10.0-apache, 10-apache, apache, 10.0.4, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c0f5a270e565410cc47046b29b04e4a5ec9e828
+GitCommit: 146a37ed55bb70778feef7f4ce5a8b56b8a4b3ce
 Directory: 10.0/apache
 
-Tags: 10.0.3-fpm, 10.0-fpm, 10-fpm, fpm
+Tags: 10.0.4-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c0f5a270e565410cc47046b29b04e4a5ec9e828
+GitCommit: 146a37ed55bb70778feef7f4ce5a8b56b8a4b3ce
 Directory: 10.0/fpm
 
 Tags: 9.1.7-apache, 9.1-apache, 9-apache, 9.1.7, 9.1, 9

--- a/library/percona
+++ b/library/percona
@@ -8,8 +8,8 @@ Tags: 5.7.19, 5.7, 5, latest
 GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
 Directory: 5.7
 
-Tags: 5.6.37, 5.6
-GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
+Tags: 5.6.38, 5.6
+GitCommit: d05195d80f65146ba72189947097fefd1bcf694c
 Directory: 5.6
 
 Tags: 5.5.58, 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -3,9 +3,9 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 3.2.1-apache, 3.2-apache, 3-apache, apache, 3.2.1, 3.2, 3, latest
-GitCommit: 334185afd9977d3896c02e942d093eebe11d79c9
+GitCommit: baf563abb7b48d9cb852c37713080f3e979097c3
 Directory: apache
 
 Tags: 3.2.1-fpm, 3.2-fpm, 3-fpm, fpm
-GitCommit: 334185afd9977d3896c02e942d093eebe11d79c9
+GitCommit: baf563abb7b48d9cb852c37713080f3e979097c3
 Directory: fpm

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/6bd09a6694ddd921b06cc21d829b6affefa96307/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/cd25076d7045f6f4d01544a95d8008ad0a1dbbd4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -14,7 +14,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
 Directory: 2.5-rc/stretch/slim
 
-Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
+Tags: 2.5.0-preview1-alpine3.7, 2.5-rc-alpine3.7, rc-alpine3.7, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: ee2df55c3abd3d0eccea5733f7041b733f8a5a62
+Directory: 2.5-rc/alpine3.7
+
+Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
 Directory: 2.5-rc/alpine3.6
@@ -43,6 +48,11 @@ Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
+
+Tags: 2.4.2-alpine3.7, 2.4-alpine3.7, 2-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: ee2df55c3abd3d0eccea5733f7041b733f8a5a62
+Directory: 2.4/alpine3.7
 
 Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/f5ccd855ad76431bad039d592ea63a4a9db498ff/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/96a8124c468049e097beec9aa4008bda26671d7e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/apache
 
-Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/fpm
 
-Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
 GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php5.6/fpm-alpine
@@ -49,19 +49,39 @@ Architectures: amd64
 GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
 Directory: php7.1/fpm-alpine
 
+Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.1-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 591388696848f29bfa627ab38f78678135096f15
+Directory: php7.2/apache
+
+Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 591388696848f29bfa627ab38f78678135096f15
+Directory: php7.2/fpm
+
+Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 591388696848f29bfa627ab38f78678135096f15
+Directory: php7.2/fpm-alpine
+
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.4.1, cli-1.4, cli-1, cli, cli-1.4.1-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.4.1-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
+GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
 Directory: php5.6/cli
 
 Tags: cli-1.4.1-php7.0, cli-1.4-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
+GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
 Directory: php7.0/cli
 
 Tags: cli-1.4.1-php7.1, cli-1.4-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: e3c8cccbe1bec9e59fc82f7e743e4c1665a9e22d
+GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
 Directory: php7.1/cli
+
+Tags: cli-1.4.1, cli-1.4, cli-1, cli, cli-1.4.1-php7.2, cli-1.4-php7.2, cli-1-php7.2, cli-php7.2
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
+Directory: php7.2/cli


### PR DESCRIPTION
- `buildpack-deps`: add bionic (docker-library/buildpack-deps#71)
- `docker`: 17.09.1-ce, 17.12.0-ce-rc1
- `owncloud`: 10.0.4
- `percona`: 5.6.38
- `piwik`: add `redis` support (piwik/docker-piwik#75)
- `ruby`: Alpine 3.7 (docker-library/ruby#174)
- `wordpress`: add `php7.2` variants and make them default (docker-library/wordpress#259)