### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -5,7 +5,7 @@ GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.12, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 239d768d3010aaa5875917e44498446ef430485f
+GitCommit: 63052402ddc3427912d780eaf9caf71bd03f8b2d
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/golang
+++ b/library/golang
@@ -43,6 +43,11 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
 Directory: 1.9/stretch
 
+Tags: 1.9.2-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 1e2ddb8ec8c9f59a56ddfb343e1bd8e65440b6db
+Directory: 1.9/alpine3.7
+
 Tags: 1.9.2-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,25 +1,45 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/b3f8989253d8c92e8462015eecd90f39d932c051/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/0283b756f739400cb3b25d0ad97fcbbad05a109e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.6.14, 3.6, 3, latest
+Tags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28001b529f28ed0d8e8297f8b603a4cc93a846a3
+GitCommit: 946a6d268ceb27e21b6658442e0f39e2e1af7649
+Directory: 3.7/debian
+
+Tags: 3.7.0-management, 3.7-management, 3-management, management
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
+Directory: 3.7/debian/management
+
+Tags: 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 946a6d268ceb27e21b6658442e0f39e2e1af7649
+Directory: 3.7/alpine
+
+Tags: 3.7.0-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
+Directory: 3.7/alpine/management
+
+Tags: 3.6.14, 3.6
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
 Directory: 3.6/debian
 
-Tags: 3.6.14-management, 3.6-management, 3-management, management
+Tags: 3.6.14-management, 3.6-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/debian/management
 
-Tags: 3.6.14-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.14-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2558d958a0ab9c38f58ad616e387063b33bb229c
 Directory: 3.6/alpine
 
-Tags: 3.6.14-management-alpine, 3.6-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.6.14-management-alpine, 3.6-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/alpine/management

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -11,7 +11,7 @@ Directory: 3.7/debian
 
 Tags: 3.7.0-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
+GitCommit: 301c52ad6d75075aa8b42b0977e4f54866c0af96
 Directory: 3.7/debian/management
 
 Tags: 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
@@ -21,7 +21,7 @@ Directory: 3.7/alpine
 
 Tags: 3.7.0-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
+GitCommit: 301c52ad6d75075aa8b42b0977e4f54866c0af96
 Directory: 3.7/alpine/management
 
 Tags: 3.6.14, 3.6

--- a/library/ruby
+++ b/library/ruby
@@ -19,11 +19,6 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: ee2df55c3abd3d0eccea5733f7041b733f8a5a62
 Directory: 2.5-rc/alpine3.7
 
-Tags: 2.5.0-preview1-alpine3.6, 2.5-rc-alpine3.6, rc-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
-Directory: 2.5-rc/alpine3.6
-
 Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c


### PR DESCRIPTION
- `bash`: apply Alpine patch to 4.4 for process substitution hang (tianon/docker-bash#4)
- `golang`: add `alpine3.7` variant of 1.9 (docker-library/golang#192)
- `rabbitmq`: add 3.7, which includes a new configuration file format (docker-library/rabbitmq#197)
- `ruby`: remove `2.5-rc-alpine3.6` variant (superseded by `2.5-rc-alpine3.7`)