### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.12.0-ce-rc1, 17.12-rc, rc, test
+Tags: 17.12.0-ce-rc2, 17.12-rc, rc, test
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
+GitCommit: f4d3f30de26100deddd4afdc37dd04bb6d018b26
 Directory: 17.12-rc
 
-Tags: 17.12.0-ce-rc1-dind, 17.12-rc-dind, rc-dind, test-dind
+Tags: 17.12.0-ce-rc2-dind, 17.12-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
 Directory: 17.12-rc/dind
 
-Tags: 17.12.0-ce-rc1-git, 17.12-rc-git, rc-git, test-git
+Tags: 17.12.0-ce-rc2-git, 17.12-rc-git, rc-git, test-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
 Directory: 17.12-rc/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.18.4, 1.18, 1, latest
+Tags: 1.19.0, 1.19, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b68444d5ed8057be842e99e93e7b98c4e8c9389
+GitCommit: 1e506751c29fb0be921eed1eff856ba93c6f67d2
 Directory: 1/debian
 
-Tags: 1.18.4-alpine, 1.18-alpine, 1-alpine, alpine
+Tags: 1.19.0-alpine, 1.19-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 6b68444d5ed8057be842e99e93e7b98c4e8c9389
+GitCommit: 1e506751c29fb0be921eed1eff856ba93c6f67d2
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/3f132379556d132a6a416cbf34c31901d8eb1afd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/df1c388d3a8732bac85d25583880e915aaa47395/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,140 +6,155 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.0-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.0-cli, 7.2-cli, 7-cli, cli, 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.0-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.0-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.0-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.0-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.0-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.0-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/stretch/zts
+
+Tags: 7.2.0-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.0-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+Directory: 7.2/alpine3.7/cli
+
+Tags: 7.2.0-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+Directory: 7.2/alpine3.7/fpm
+
+Tags: 7.2.0-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.0-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.0-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.0-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.0-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.0-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.0-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.0-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f795769559d9ce740e57ebd32f60f8a4569ee5b6
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7.1.12-jessie, 7.1-jessie, 7.1.12-cli, 7.1-cli, 7.1.12, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7.1.12-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7.1.12-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7.1.12-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7.1.12-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/alpine3.4/cli
 
 Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/alpine3.4/fpm
 
 Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/alpine3.4/cli
 
 Tags: 7.0.26-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.26-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/alpine3.4/fpm
 
 Tags: 7.0.26-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.26-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/alpine3.4/cli
 
 Tags: 5.6.32-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.32-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/alpine3.4/fpm
 
 Tags: 5.6.32-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.32-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 25e8a9268e5308b127ef1e07e62ed346c9776490
+GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
 Directory: 5.6/alpine3.4/zts

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,27 +6,27 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 946a6d268ceb27e21b6658442e0f39e2e1af7649
+GitCommit: f57f88450660d1daaf195e30d05d746279faab40
 Directory: 3.7/debian
 
 Tags: 3.7.0-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 301c52ad6d75075aa8b42b0977e4f54866c0af96
+GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/debian/management
 
 Tags: 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 946a6d268ceb27e21b6658442e0f39e2e1af7649
+GitCommit: f57f88450660d1daaf195e30d05d746279faab40
 Directory: 3.7/alpine
 
 Tags: 3.7.0-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 301c52ad6d75075aa8b42b0977e4f54866c0af96
+GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
 
 Tags: 3.6.14, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8baad22e34295f17fb09e6bcc5ed322e511628f
+GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.6/debian
 
 Tags: 3.6.14-management, 3.6-management

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.58.4, 0.58, 0, latest
-GitCommit: 5b8ac5413b368022ea3a3fc455fefa875941058e
+Tags: 0.59.6, 0.59, 0, latest
+GitCommit: b739ee434840288e2c0ef8b1c689950c3a309542

--- a/library/tomcat
+++ b/library/tomcat
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
 Directory: 7/jre8-alpine
 
-Tags: 8.0.47-jre7, 8.0-jre7, 8.0.47, 8.0
+Tags: 8.0.48-jre7, 8.0-jre7, 8.0.48, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b5b0791e065d9bfdfe84235faf7f77c157ff70d
+GitCommit: be9bb25a8bec9027dc11a05531ecd1f4171c8411
 Directory: 8.0/jre7
 
-Tags: 8.0.47-jre7-alpine, 8.0-jre7-alpine, 8.0.47-alpine, 8.0-alpine
+Tags: 8.0.48-jre7-alpine, 8.0-jre7-alpine, 8.0.48-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 0e8cf7367b4e3f3d77e8bc98fcec509bb7a8d7be
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.47-jre8, 8.0-jre8
+Tags: 8.0.48-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b5b0791e065d9bfdfe84235faf7f77c157ff70d
+GitCommit: be9bb25a8bec9027dc11a05531ecd1f4171c8411
 Directory: 8.0/jre8
 
-Tags: 8.0.47-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.48-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 0e8cf7367b4e3f3d77e8bc98fcec509bb7a8d7be
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.24-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.24, 8.5, 8, latest


### PR DESCRIPTION
- `docker`: 17.12.0-ce-rc2
- `ghost`: 1.19.0, ghost-cli 1.4.1
- `php`: add `alpine3.7` variant for 7.2 (docker-library/php#535)
- `rabbitmq`: fix entrypoint typo (docker-library/rabbitmq#215)
- `rocket.chat`: 0.59.6, fix download path (RocketChat/Docker.Official.Image#36)
- `tomcat`: 8.0.48