### PR TITLE
Amazon Linux 2: add 2017.12.0.20171212.2

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,14 +1,22 @@
-Maintainers: Amazon Linux Team <amazon-linux-ami@amazon.com> (@aws),
+Maintainers: Amazon Linux Team <amazon-linux@amazon.com> (@aws),
              Iliana Weller (@ilianaw),
              Praveen K Paladugu (@praveen-pk),
              Eric Warehime (@Eric-Warehime)
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
 
-Tags: 2017.09.0.20170930, 2017.09, latest
+Tags: 2017.12.0.20171212.2, 2017.12, 2
+GitFetch: refs/heads/2017.12
+GitCommit: 10641478ad16c6f44b691dc41acfc221c7a7594f
+
+Tags: 2017.12.0.20171212.2-with-sources, 2017.12-with-sources, 2-with-sources
+GitFetch: refs/heads/2017.12-with-sources
+GitCommit: 25ee203e5625961ed6c0b8baad3e7b8bda829b52
+
+Tags: 2017.09.0.20170930, 2017.09, 1, latest
 GitFetch: refs/heads/2017.09
 GitCommit: eb819d6b91ada2f0304d2a24ab9ce2ced0f166ea
 
-Tags: 2017.09.0.20170930-with-sources, 2017.09-with-sources, with-sources
+Tags: 2017.09.0.20170930-with-sources, 2017.09-with-sources, 1-with-sources, with-sources
 GitFetch: refs/heads/2017.09-with-sources
 GitCommit: f13ce885778e5cf48275986b7cf8c321a60b6693
 


### PR DESCRIPTION
This is the Amazon Linux 2 LTS Candidate.

Two new tags, `1`, and `2`, refer to Amazon Linux 1 (2017.09) and Amazon Linux 2, respectively.

`latest` does not yet point to `2` -- this is a deliberate choice we're making. When we drop the "Candidate" string from the release name, we'll move `latest` to `2`.

Let me know if you have any questions.