### PR TITLE
Update influxdata images

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -1,23 +1,24 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdb.com> (@jsternberg)
+GitRepo: git://github.com/influxdata/influxdata-docker
+GitCommit: ae56003075c8f39b6c265294ca8235c2c5235cc6
 
 Tags: 1.3, 1.3.5
 Architectures: amd64, arm32v7, arm64v8
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: a4d3ba497d902919317f6cf2269384f0dbdafc61
 Directory: telegraf/1.3
 
 Tags: 1.3-alpine, 1.3.5-alpine
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: a4d3ba497d902919317f6cf2269384f0dbdafc61
 Directory: telegraf/1.3/alpine
 
-Tags: 1.4, 1.4.5, latest
+Tags: 1.4, 1.4.5
 Architectures: amd64, arm32v7, arm64v8
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: da66c359d112b8d2d71ee7feb04d563c58428f27
 Directory: telegraf/1.4
 
-Tags: 1.4-alpine, 1.4.5-alpine, alpine
-GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: da66c359d112b8d2d71ee7feb04d563c58428f27
+Tags: 1.4-alpine, 1.4.5-alpine
 Directory: telegraf/1.4/alpine
+
+Tags: 1.5, 1.5.0, latest
+Architectures: amd64, arm32v7, arm64v8
+Directory: telegraf/1.5
+
+Tags: 1.5-alpine, 1.5.0-alpine, alpine
+Directory: telegraf/1.5/alpine


### PR DESCRIPTION
Add a new influxdb-meta image for enterprise clusters and an enterprise
variant for influxdb so the clustering software can be used in docker.

Documentation change for influxdb-meta is included here: docker-library/docs#1097.