### PR TITLE
Update Ruby images

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,97 +4,97 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.5.0-preview1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-preview1, 2.5-rc, rc
+Tags: 2.5.0-rc1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-rc1, 2.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
+GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
 Directory: 2.5-rc/stretch
 
-Tags: 2.5.0-preview1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-preview1-slim, 2.5-rc-slim, rc-slim
+Tags: 2.5.0-rc1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-rc1-slim, 2.5-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f6af01cc2f8b8d39ea5f2c7e9fb3c413edb93d6
+GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
 Directory: 2.5-rc/stretch/slim
 
-Tags: 2.5.0-preview1-alpine3.7, 2.5-rc-alpine3.7, rc-alpine3.7, 2.5.0-preview1-alpine, 2.5-rc-alpine, rc-alpine
+Tags: 2.5.0-rc1-alpine3.7, 2.5-rc-alpine3.7, rc-alpine3.7, 2.5.0-rc1-alpine, 2.5-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ee2df55c3abd3d0eccea5733f7041b733f8a5a62
+GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
 Directory: 2.5-rc/alpine3.7
 
-Tags: 2.4.2-stretch, 2.4-stretch, 2-stretch, stretch
+Tags: 2.4.3-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/stretch
 
-Tags: 2.4.2-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
+Tags: 2.4.3-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.2-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.2, 2.4, 2, latest
+Tags: 2.4.3-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.3, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/jessie
 
-Tags: 2.4.2-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.2-slim, 2.4-slim, 2-slim, slim
+Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.3-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.2-onbuild, 2.4-onbuild, 2-onbuild, onbuild
+Tags: 2.4.3-onbuild, 2.4-onbuild, 2-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
-Tags: 2.4.2-alpine3.7, 2.4-alpine3.7, 2-alpine3.7, alpine3.7
+Tags: 2.4.3-alpine3.7, 2.4-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ee2df55c3abd3d0eccea5733f7041b733f8a5a62
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/alpine3.7
 
-Tags: 2.4.2-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
+Tags: 2.4.3-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/alpine3.6
 
-Tags: 2.4.2-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.2-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.3-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 9ecd8dcd7c5303b1c5772446d8fea938f3cd233c
+GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
 Directory: 2.4/alpine3.4
 
-Tags: 2.3.5-jessie, 2.3-jessie, 2.3.5, 2.3
+Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e23879898862f2426e6714324c912d14db1067b5
+GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
 Directory: 2.3/jessie
 
-Tags: 2.3.5-slim-jessie, 2.3-slim-jessie, 2.3.5-slim, 2.3-slim
+Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e23879898862f2426e6714324c912d14db1067b5
+GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
 Directory: 2.3/jessie/slim
 
-Tags: 2.3.5-onbuild, 2.3-onbuild
+Tags: 2.3.6-onbuild, 2.3-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.3/jessie/onbuild
 
-Tags: 2.3.5-alpine3.4, 2.3-alpine3.4, 2.3.5-alpine, 2.3-alpine
+Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: e23879898862f2426e6714324c912d14db1067b5
+GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
 Directory: 2.3/alpine3.4
 
-Tags: 2.2.8-jessie, 2.2-jessie, 2.2.8, 2.2
+Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
+GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
 Directory: 2.2/jessie
 
-Tags: 2.2.8-slim-jessie, 2.2-slim-jessie, 2.2.8-slim, 2.2-slim
+Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
+GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
 Directory: 2.2/jessie/slim
 
-Tags: 2.2.8-onbuild, 2.2-onbuild
+Tags: 2.2.9-onbuild, 2.2-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.2/jessie/onbuild
 
-Tags: 2.2.8-alpine3.4, 2.2-alpine3.4, 2.2.8-alpine, 2.2-alpine
+Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 1d57c363d6b25099cac5472c30632e2f92ddab61
+GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
Ruby v2.4.3, v2.3.6 and v2.2.9 is includes [security fix](https://www.ruby-lang.org/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/).