### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.12.0-ce-rc2, 17.12-rc, rc, test
+Tags: 17.12.0-ce-rc3, 17.12-rc, rc, test
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f4d3f30de26100deddd4afdc37dd04bb6d018b26
+GitCommit: 29a9a02e3dbbc77cbd4783fc87c73f762fb8ac90
 Directory: 17.12-rc
 
-Tags: 17.12.0-ce-rc2-dind, 17.12-rc-dind, rc-dind, test-dind
+Tags: 17.12.0-ce-rc3-dind, 17.12-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
 Directory: 17.12-rc/dind
 
-Tags: 17.12.0-ce-rc2-git, 17.12-rc-git, rc-git, test-git
+Tags: 17.12.0-ce-rc3-git, 17.12-rc-git, rc-git, test-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
 Directory: 17.12-rc/git

--- a/library/julia
+++ b/library/julia
@@ -4,6 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.6.1, 0.6, 0, latest
+Tags: 0.6.2, 0.6, 0, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06148bd09222645c2996f50094d76aeeb9ed4556
+GitCommit: 7dc8567964481b8ff4370671ca57b79f1bab7bb4

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.19, 5.7, 5, latest
-GitCommit: 52abf70205354001f24432c0c677be4a0264ef47
+Tags: 5.7.20, 5.7, 5, latest
+GitCommit: 3b791041e48c8a764a7a6266fd58172277dca6a6
 Directory: 5.7
 
 Tags: 5.6.38, 5.6

--- a/library/php
+++ b/library/php
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.0-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.0-cli, 7.2-cli, 7-cli, cli, 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.0-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.0-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.0-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.0-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.0-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.0-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.0-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.0-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
@@ -56,22 +56,22 @@ Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7.1.12-jessie, 7.1-jessie, 7.1.12-cli, 7.1-cli, 7.1.12, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7.1.12-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7.1.12-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7.1.12-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7.1.12-alpine, 7.1-alpine
@@ -91,22 +91,22 @@ Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
@@ -126,22 +126,22 @@ Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/ce648832b041293fa3542af884ac5a44a67354d3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/54dd4418eea0768fd30ad3c2aefcaab97d3df0ea/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -15,10 +15,10 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0a3-alpine3.6, 3.7-rc-alpine3.6, rc-alpine3.6, 3.7.0a3-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0a3-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0a3-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ba34cdcf7860a9fb6a272f8e1b13b753b11d912b
-Directory: 3.7-rc/alpine3.6
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
+Directory: 3.7-rc/alpine3.7
 
 Tags: 3.7.0a3-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: windowsservercore, 3.7.0a3, 3.7-rc, rc
@@ -60,14 +60,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
+Tags: 3.6.3-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: f45e1fb3d57ccce5042d22f4fb618c4dc56d1819
+Directory: 3.6/alpine3.7
+
 Tags: 3.6.3-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.3-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.3-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 3.6/alpine3.4
 
 Tags: 3.6.3-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -102,7 +107,7 @@ Directory: 3.5/jessie/onbuild
 
 Tags: 3.5.4-alpine3.4, 3.5-alpine3.4, 3.5.4-alpine, 3.5-alpine
 Architectures: amd64
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 3.5/alpine3.4
 
 Tags: 3.5.4-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016
@@ -142,7 +147,7 @@ Directory: 3.4/wheezy
 
 Tags: 3.4.7-alpine3.4, 3.4-alpine3.4, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 3.4/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch
@@ -176,14 +181,19 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b1512ead24c6b111506a8d4229134a29da240597
 Directory: 2.7/wheezy
 
+Tags: 2.7.14-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: f45e1fb3d57ccce5042d22f4fb618c4dc56d1819
+Directory: 2.7/alpine3.7
+
 Tags: 2.7.14-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.14-alpine3.4, 2.7-alpine3.4, 2-alpine3.4, 2.7.14-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64
-GitCommit: 1d59eb2dd813c64891bf554a8ea01754aba25816
+GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
 Directory: 2.7/alpine3.4
 
 Tags: 2.7.14-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.3, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
+GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
 Directory: 3.4
 
 Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.5, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
+GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
 Directory: 3.3
 
 Tags: 3.3.5-passenger, 3.3-passenger
@@ -24,7 +24,7 @@ Directory: 3.3/passenger
 
 Tags: 3.2.8, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16b22cf462b639577c55b7086fe7529278d00a94
+GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
 Directory: 3.2
 
 Tags: 3.2.8-passenger, 3.2-passenger


### PR DESCRIPTION
- `docker`: 17.12.0-ce-rc3
- `julia`: 0.6.2
- `percona`: 5.7.20
- `php`: block install of Debian `php` (docker-library/php#542)
- `python`: add Alpine 3.7 variants (docker-library/python#249), update Alpine thread stack size (docker-library/python#248)
- `redmine`: fix over-aggressive `chmod` (docker-library/redmine#98)