### PR TITLE
[nats-streaming] Release v0.7.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,26 +1,26 @@
 Maintainers: Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 2f9abaf0830c64e40d22e3a8d4da47b96c666aef
+GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 
-Tags: 0.6.0-linux, linux
-SharedTags: 0.6.0, latest
+Tags: 0.7.0-linux, linux
+SharedTags: 0.7.0, latest
 Architectures: amd64, arm32v7, arm64v8
-amd64-GitCommit: 2f9abaf0830c64e40d22e3a8d4da47b96c666aef
+amd64-GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 amd64-Directory: amd64
-arm32v7-GitCommit: 2f9abaf0830c64e40d22e3a8d4da47b96c666aef
+arm32v7-GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 2f9abaf0830c64e40d22e3a8d4da47b96c666aef
+arm64v8-GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 arm64v8-Directory: arm64v8
 
-Tags: 0.6.0-nanoserver, nanoserver
-SharedTags: 0.6.0, latest
+Tags: 0.7.0-nanoserver, nanoserver
+SharedTags: 0.7.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 9596dfac61688686a6f4955624c559cf101301a9
+windows-amd64-GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.6.0-windowsservercore, windowsservercore
+Tags: 0.7.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 9596dfac61688686a6f4955624c559cf101301a9
+windows-amd64-GitCommit: 212a8f50575d4178722b869025ac7164d2da976f
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.7.0)