### PR TITLE
Bump Traefik to v1.5.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,26 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.5.0-rc2, 1.5.0-rc2, v1.5, 1.5, cancoillotte
+Tags: v1.5.0-rc3, 1.5.0-rc3, v1.5, 1.5, cancoillotte
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: da850273777e5a6013b7938836c6da4568622a04
+GitCommit: ce0d7acb0c306af5508c2af153d3fca5bac51f38
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.5.0-rc2-alpine, 1.5.0-rc2-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
+Tags: v1.5.0-rc3-alpine, 1.5.0-rc3-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: da850273777e5a6013b7938836c6da4568622a04
+GitCommit: ce0d7acb0c306af5508c2af153d3fca5bac51f38
 Directory: alpine
 
 Tags: v1.4.5, 1.4.5, v1.4, 1.4, roquefort, latest
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: e09f862b4974e0ded50e42d134b9439c1802aa3c
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.4.5-alpine, 1.4.5-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: e09f862b4974e0ded50e42d134b9439c1802aa3c
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.0-rc3.

/cc @vdemeester @emilevauge

Cheers
