### PR TITLE
Move websphere-liberty beta to 2017.12.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,7 +1,7 @@
 Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: f88b9f585cf2cfdb59f36101d4afe9cf3f309b7b
+GitCommit: 9dc5c2e942d20ddc2f913ae0a0dbcc9d174afc00
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Update to WebSphere Liberty 2017.12.0.0 beta driver.