### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.11, 10.2, 10, latest
 GitCommit: 502ed2d6772c87fb0be3db73e6de019ea605a279
 Directory: 10.2
 
-Tags: 10.1.29, 10.1
-GitCommit: 4e117ad92a4a7c53a582b2db4a743d218ce76f36
+Tags: 10.1.30, 10.1
+GitCommit: 04e2b9adcccd3cc634d8ef92f10b2f92e2c76076
 Directory: 10.1
 
 Tags: 10.0.33, 10.0

--- a/library/mysql
+++ b/library/mysql
@@ -13,9 +13,9 @@ GitCommit: 6c414e7f38c2079c7193beae5dc7c34ee46cd6e7
 Directory: 5.7
 
 Tags: 5.6.38, 5.6
-GitCommit: 883703dfb30d9c197e0059a669c4bb64d55f6e0d
+GitCommit: 36f2030de879bea73e808183302d27c3b670ce7a
 Directory: 5.6
 
 Tags: 5.5.58, 5.5
-GitCommit: 41cfbdd89323a1230342038757b5b8f7f2f36b74
+GitCommit: 36f2030de879bea73e808183302d27c3b670ce7a
 Directory: 5.5

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.6-apache, 11.0-apache, 11-apache, 11.0.6, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 074ca53482043fea8268eba83546815db0f7c4ad
+GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
 Directory: 11.0/apache
 
 Tags: 11.0.6-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 074ca53482043fea8268eba83546815db0f7c4ad
+GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
 Directory: 11.0/fpm
 
 Tags: 12.0.4-apache, 12.0-apache, 12-apache, apache, 12.0.4, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0319dd0a84eb8a74ca65245c5781cbf6a7d54763
+GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
 Directory: 12.0/apache
 
 Tags: 12.0.4-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0319dd0a84eb8a74ca65245c5781cbf6a7d54763
+GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
 Directory: 12.0/fpm

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-rc1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-rc1, 2.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
+GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
 Directory: 2.5-rc/stretch
 
 Tags: 2.5.0-rc1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-rc1-slim, 2.5-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
+GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
 Directory: 2.5-rc/stretch/slim
 
 Tags: 2.5.0-rc1-alpine3.7, 2.5-rc-alpine3.7, rc-alpine3.7, 2.5.0-rc1-alpine, 2.5-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e6441b9c34d6429e03695095543de11a80ea76e4
+GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
 Directory: 2.5-rc/alpine3.7
 
 Tags: 2.4.3-stretch, 2.4-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/stretch
 
 Tags: 2.4.3-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.3-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.3, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/jessie
 
 Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.3-slim, 2.4-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.3-onbuild, 2.4-onbuild, 2-onbuild, onbuild
@@ -46,27 +46,27 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.3-alpine3.7, 2.4-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.3-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.3-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64
-GitCommit: 8388fb66f2df5b269c8a1fa1d50beb635bfe5129
+GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
+GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
 Directory: 2.3/jessie
 
 Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
+GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.6-onbuild, 2.3-onbuild
@@ -76,17 +76,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 15e585cbe131a3506daf25710e87433e90c3cbd1
+GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
+GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
 Directory: 2.2/jessie
 
 Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
+GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.9-onbuild, 2.2-onbuild
@@ -96,5 +96,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: c7145524ca5294bca43e12648e817ec4d8e7927f
+GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
 Directory: 2.2/alpine3.4

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php5.6/apache
 
 Tags: 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php5.6/fpm
 
 Tags: 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.1-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.1-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.0/apache
 
 Tags: 4.9.1-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.0/fpm
 
 Tags: 4.9.1-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.1-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.1-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.1/apache
 
 Tags: 4.9.1-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.1/fpm
 
 Tags: 4.9.1-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 88b4aa3b5ec2a837e1ab9e0a67f73f699d2b84e4
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.1-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 591388696848f29bfa627ab38f78678135096f15
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.2/apache
 
 Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 591388696848f29bfa627ab38f78678135096f15
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.2/fpm
 
 Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 591388696848f29bfa627ab38f78678135096f15
+GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `mariadb`: 10.1.30
- `mysql`: pass extra `mysqld` flags to `mysql_install_db` (docker-library/mysql#358)
- `nextcloud`: redis 3.1.5 (nextcloud/docker#205)
- `ruby`: bundler 1.16.1
- `wordpress`: adjust hard-coded `www-data` to allow for arbitrary user support (docker-library/wordpress#249)