### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.2, 10.3
-GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
+Tags: 10.3.3, 10.3
+GitCommit: 506cd7c6b9d6c53d7b514a2c94db5d3daee832fd
 Directory: 10.3
 
 Tags: 10.2.11, 10.2, 10, latest

--- a/library/pypy
+++ b/library/pypy
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-5.9.0, 2-5.9, 2-5, 2
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
+Tags: 2-5.10.0, 2-5.10, 2-5, 2
+Architectures: amd64, arm32v5, i386
+GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
 Directory: 2
 
-Tags: 2-5.9.0-slim, 2-5.9-slim, 2-5-slim, 2-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
+Tags: 2-5.10.0-slim, 2-5.10-slim, 2-5-slim, 2-slim
+Architectures: amd64, arm32v5, i386
+GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
 Directory: 2/slim
 
-Tags: 2-5.9.0-onbuild, 2-5.9-onbuild, 2-5-onbuild, 2-onbuild
-Architectures: amd64, arm32v5, arm32v7, i386
+Tags: 2-5.10.0-onbuild, 2-5.10-onbuild, 2-5-onbuild, 2-onbuild
+Architectures: amd64, arm32v5, i386
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 2/onbuild
 
-Tags: 3-5.9.0, 3-5.9, 3-5, 3, latest
-Architectures: amd64
-GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
+Tags: 3-5.10.0, 3-5.10, 3-5, 3, latest
+Architectures: amd64, arm32v5, i386
+GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
 Directory: 3
 
-Tags: 3-5.9.0-slim, 3-5.9-slim, 3-5-slim, 3-slim, slim
-Architectures: amd64
-GitCommit: 1959d8cab4eb9d7e6970298bc5a3ef8417ad4251
+Tags: 3-5.10.0-slim, 3-5.10-slim, 3-5-slim, 3-slim, slim
+Architectures: amd64, arm32v5, i386
+GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
 Directory: 3/slim
 
-Tags: 3-5.9.0-onbuild, 3-5.9-onbuild, 3-5-onbuild, 3-onbuild, onbuild
-Architectures: amd64
+Tags: 3-5.10.0-onbuild, 3-5.10-onbuild, 3-5-onbuild, 3-onbuild, onbuild
+Architectures: amd64, arm32v5, i386
 GitCommit: b48e8489ab794a2bacfd396c2f8e1a5b06d6ae48
 Directory: 3/onbuild

--- a/library/ruby
+++ b/library/ruby
@@ -1,72 +1,72 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/cd25076d7045f6f4d01544a95d8008ad0a1dbbd4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/bf3b9e755c36c25dde89c832c293abe87292e482/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.5.0-rc1-stretch, 2.5-rc-stretch, rc-stretch, 2.5.0-rc1, 2.5-rc, rc
+Tags: 2.5.0-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.0, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
-Directory: 2.5-rc/stretch
+GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+Directory: 2.5/stretch
 
-Tags: 2.5.0-rc1-slim-stretch, 2.5-rc-slim-stretch, rc-slim-stretch, 2.5.0-rc1-slim, 2.5-rc-slim, rc-slim
+Tags: 2.5.0-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.0-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
-Directory: 2.5-rc/stretch/slim
+GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+Directory: 2.5/stretch/slim
 
-Tags: 2.5.0-rc1-alpine3.7, 2.5-rc-alpine3.7, rc-alpine3.7, 2.5.0-rc1-alpine, 2.5-rc-alpine, rc-alpine
+Tags: 2.5.0-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f4d5c084fab6c9a2bc55bf25257887d53e4eff87
-Directory: 2.5-rc/alpine3.7
+GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+Directory: 2.5/alpine3.7
 
-Tags: 2.4.3-stretch, 2.4-stretch, 2-stretch, stretch
+Tags: 2.4.3-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/stretch
 
-Tags: 2.4.3-slim-stretch, 2.4-slim-stretch, 2-slim-stretch, slim-stretch
+Tags: 2.4.3-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.3-jessie, 2.4-jessie, 2-jessie, jessie, 2.4.3, 2.4, 2, latest
+Tags: 2.4.3-jessie, 2.4-jessie, 2.4.3, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/jessie
 
-Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2-slim-jessie, slim-jessie, 2.4.3-slim, 2.4-slim, 2-slim, slim
+Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2.4.3-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.3-onbuild, 2.4-onbuild, 2-onbuild, onbuild
+Tags: 2.4.3-onbuild, 2.4-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
-Tags: 2.4.3-alpine3.7, 2.4-alpine3.7, 2-alpine3.7, alpine3.7
+Tags: 2.4.3-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/alpine3.7
 
-Tags: 2.4.3-alpine3.6, 2.4-alpine3.6, 2-alpine3.6, alpine3.6
+Tags: 2.4.3-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/alpine3.6
 
-Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2-alpine3.4, alpine3.4, 2.4.3-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2.4.3-alpine, 2.4-alpine
 Architectures: amd64
-GitCommit: 342c5bc6f7a6d5cdfb90e8dd0197a55a18cebe54
+GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
+GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
 Directory: 2.3/jessie
 
 Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
+GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.6-onbuild, 2.3-onbuild
@@ -76,17 +76,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: ace04afbea62e23792fcf7c2fa2c1883ca625db4
+GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
+GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
 Directory: 2.2/jessie
 
 Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
+GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.9-onbuild, 2.2-onbuild
@@ -96,5 +96,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 4208b2eb070e6e6b5b1ec26029aac81d573cb276
+GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `mariadb`: 10.3.3
- `pypy`: 5.10.0
- `ruby`: 2.5.0 GA (docker-library/ruby#178), rubygems 2.7.4