### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable, test, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
+GitCommit: 51ba3bdf3e104e8af01150daec9122c4fbeaa41e
 Directory: 17.12
 
 Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind, test-dind, dind

--- a/library/docker
+++ b/library/docker
@@ -4,47 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.12.0-ce-rc4, 17.12-rc, rc, test
+Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable, test, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1f5c55a69955147c50bd9c6ace5ccbc63772ccdc
-Directory: 17.12-rc
+GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
+Directory: 17.12
 
-Tags: 17.12.0-ce-rc4-dind, 17.12-rc-dind, rc-dind, test-dind
+Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
-Directory: 17.12-rc/dind
+GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
+Directory: 17.12/dind
 
-Tags: 17.12.0-ce-rc4-git, 17.12-rc-git, rc-git, test-git
+Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git, test-git, git
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bbfb50a21b358554c1621cfe19378158d9155694
-Directory: 17.12-rc/git
+GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
+Directory: 17.12/git
 
-Tags: 17.11.0-ce, 17.11.0, 17.11, 17, edge, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
-Directory: 17.11
-
-Tags: 17.11.0-ce-dind, 17.11.0-dind, 17.11-dind, 17-dind, edge-dind, dind
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
-Directory: 17.11/dind
-
-Tags: 17.11.0-ce-git, 17.11.0-git, 17.11-git, 17-git, edge-git, git
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64f6d5eba928dd79b9ca1e7e879021a2baf4c705
-Directory: 17.11/git
-
-Tags: 17.09.1-ce, 17.09.1, 17.09, stable
+Tags: 17.09.1-ce, 17.09.1, 17.09
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 4e80fad160cf70fac2ad8920528b43870426a00c
 Directory: 17.09
 
-Tags: 17.09.1-ce-dind, 17.09.1-dind, 17.09-dind, stable-dind
+Tags: 17.09.1-ce-dind, 17.09.1-dind, 17.09-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.09/dind
 
-Tags: 17.09.1-ce-git, 17.09.1-git, 17.09-git, stable-git
+Tags: 17.09.1-ce-git, 17.09.1-git, 17.09-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git

--- a/library/docker
+++ b/library/docker
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/docker-library/docker/blob/c5a0cf36146723c9ef1d7117774d256741c10fc2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/cb8d918e103504ee5b9106aa254177bcb7889a03/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable, test, latest
+Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable, edge, test, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 51ba3bdf3e104e8af01150daec9122c4fbeaa41e
 Directory: 17.12
 
-Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind, test-dind, dind
+Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/dind
 
-Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git, test-git, git
+Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git, edge-git, test-git, git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/git

--- a/library/mongo
+++ b/library/mongo
@@ -70,24 +70,24 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.0-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.0, 3.6, 3, latest
+Tags: 3.6.1-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.1, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
+GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
 Directory: 3.6
 
-Tags: 3.6.0-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.6.0-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.0, 3.6, 3, latest
+Tags: 3.6.1-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.1, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: 5dff8cfe204a3d5e7b98d83be5d7e5eaf114596e
+GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.0-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.6.0-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.0, 3.6, 3, latest
+Tags: 3.6.1-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.1, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: 5dff8cfe204a3d5e7b98d83be5d7e5eaf114596e
+GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.59.6, 0.59, 0, latest
-GitCommit: b739ee434840288e2c0ef8b1c689950c3a309542
+Tags: 0.60.0, 0.60, 0, latest
+GitCommit: 432748dc09e64d4f8212f8bc0772064d35eb9c6c


### PR DESCRIPTION
- `docker`: 17.12.0-ce GA
- `mongo`: 3.6.1
- `rocket.chat`: 0.60.0