### PR TITLE
Add arm32v7 and i386 architectures for the couchdb official image.

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -1,7 +1,7 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker.git
 
-Tags: latest, 2.1.1, 2.1, 2
+Tags: 2.1.1, 2.1, 2, latest
 Architectures: amd64, arm32v7, i386
 GitCommit: 1a7c4254c158a194ff195da6ebfed910d24a95b7
 Directory: 2.1.1

--- a/library/couchdb
+++ b/library/couchdb
@@ -1,14 +1,18 @@
-# maintainer: Joan Touzet <wohali@apache.org> (@wohali)
+Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 
-latest: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
-2.1.1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
-2.1: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
-2: git://github.com/apache/couchdb-docker@1a7c4254c158a194ff195da6ebfed910d24a95b7 2.1.1
+GitRepo: https://github.com/apache/couchdb-docker.git
 
-1.7.1: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
-1.7: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
-1: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1
+Tags: latest, 2.1.1, 2.1, 2
+Architectures: amd64, arm32v7, i386
+GitCommit: 1a7c4254c158a194ff195da6ebfed910d24a95b7
+Directory: 2.1.1
 
-1.7.1-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser
-1.7-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser
-1-couchperuser: git://github.com/apache/couchdb-docker@029760550b8af66f49bf439ddbabfbd040e9727c 1.7.1-couchperuser
+Tags: 1.7.1, 1.7, 1
+Architectures: amd64, arm32v7, i386
+GitCommit: 029760550b8af66f49bf439ddbabfbd040e9727c
+Directory: 1.7.1
+
+Tags: 1.7.1-couchperuser, 1.7-couchperuser, 1-couchperuser
+Architectures: amd64, arm32v7, i386
+GitCommit: 029760550b8af66f49bf439ddbabfbd040e9727c
+Directory: 1.7.1-couchperuser

--- a/library/couchdb
+++ b/library/couchdb
@@ -1,5 +1,4 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
-
 GitRepo: https://github.com/apache/couchdb-docker.git
 
 Tags: latest, 2.1.1, 2.1, 2


### PR DESCRIPTION
I have successfully tested a arm32v7 build on a Raspberry Pi 3 for
couchdb 1.7.1 and 2.1.1.