### PR TITLE
Bump Traefik to v1.4.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,14 +13,14 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: ce0d7acb0c306af5508c2af153d3fca5bac51f38
 Directory: alpine
 
-Tags: v1.4.5, 1.4.5, v1.4, 1.4, roquefort, latest
+Tags: v1.4.6, 1.4.6, v1.4, 1.4, roquefort, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e09f862b4974e0ded50e42d134b9439c1802aa3c
+GitCommit: 11fb07f3be330bece4875ced219372c6bda16868
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.4.5-alpine, 1.4.5-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
+Tags: v1.4.6-alpine, 1.4.6-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e09f862b4974e0ded50e42d134b9439c1802aa3c
+GitCommit: 11fb07f3be330bece4875ced219372c6bda16868
 Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.4.6.

/cc @vdemeester @emilevauge

Cheers