### PR TITLE
Update for Node.js v6.12.3 and v8.9.4

### DIFF
--- a/library/node
+++ b/library/node
@@ -33,64 +33,64 @@ Architectures: amd64
 GitCommit: a7e88f1dd2102689180f485c51133212f45fa064
 Directory: 9/wheezy
 
-Tags: 8.9.3, 8.9, 8, carbon
+Tags: 8.9.4, 8.9, 8, carbon
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8
 
-Tags: 8.9.3-alpine, 8.9-alpine, 8-alpine, carbon-alpine
+Tags: 8.9.4-alpine, 8.9-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8/alpine
 
-Tags: 8.9.3-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.9.4-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8/onbuild
 
-Tags: 8.9.3-slim, 8.9-slim, 8-slim, carbon-slim
+Tags: 8.9.4-slim, 8.9-slim, 8-slim, carbon-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8/slim
 
-Tags: 8.9.3-stretch, 8.9-stretch, 8-stretch, carbon-stretch
+Tags: 8.9.4-stretch, 8.9-stretch, 8-stretch, carbon-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8/stretch
 
-Tags: 8.9.3-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
+Tags: 8.9.4-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
 Architectures: amd64
-GitCommit: 6b8d86d6ad59e0d1e7a94cec2e909cad137a028f
+GitCommit: 994f8286cb0efc92578902d5fd11182f63a59869
 Directory: 8/wheezy
 
-Tags: 6.12.2, 6.12, 6, boron
+Tags: 6.12.3, 6.12, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6
 
-Tags: 6.12.2-alpine, 6.12-alpine, 6-alpine, boron-alpine
+Tags: 6.12.3-alpine, 6.12-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6/alpine
 
-Tags: 6.12.2-onbuild, 6.12-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.12.3-onbuild, 6.12-onbuild, 6-onbuild, boron-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6/onbuild
 
-Tags: 6.12.2-slim, 6.12-slim, 6-slim, boron-slim
+Tags: 6.12.3-slim, 6.12-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6/slim
 
-Tags: 6.12.2-stretch, 6.12-stretch, 6-stretch, boron-stretch
+Tags: 6.12.3-stretch, 6.12-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6/stretch
 
-Tags: 6.12.2-wheezy, 6.12-wheezy, 6-wheezy, boron-wheezy
+Tags: 6.12.3-wheezy, 6.12-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: 632df638ab53acc1e4608cc9c9dd6cac539cbb23
+GitCommit: 29b421ce1fcd412432ee139dca842b40d6e28cce
 Directory: 6/wheezy
 
 Tags: 4.8.7, 4.8, 4, argon


### PR DESCRIPTION
See:

- https://nodejs.org/en/blog/release/v6.12.3/
- https://nodejs.org/en/blog/release/v8.9.4/
- https://github.com/nodejs/docker-node/pull/604
- https://github.com/nodejs/docker-node/pull/605