### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.19, 2.1
 Architectures: amd64, i386
-GitCommit: 8fa6a2876a831c1bab6e846cb27af475ecafceb7
+GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
 Directory: 2.1
 
 Tags: 2.2.11, 2.2, 2
 Architectures: amd64, i386
-GitCommit: e5698d3847ed4c4378b1171ae77b5c5ee0e58125
+GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
 Directory: 2.2
 
 Tags: 3.0.15, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 50fbd6b9fe453e80f045d3a84f55c77240369658
+GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
 Directory: 3.0
 
 Tags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: b77e932d6935318f599026cd1ccf0a2697b3224a
+GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
 Directory: 3.11

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.19.0, 1.19, 1, latest
+Tags: 1.19.1, 1.19, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e506751c29fb0be921eed1eff856ba93c6f67d2
+GitCommit: c802ef9aef0a62a3eac531e58b2ec2b9458ec178
 Directory: 1/debian
 
-Tags: 1.19.0-alpine, 1.19-alpine, 1-alpine, alpine
+Tags: 1.19.1-alpine, 1.19-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 1e506751c29fb0be921eed1eff856ba93c6f67d2
+GitCommit: c802ef9aef0a62a3eac531e58b2ec2b9458ec178
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64
 GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
 Directory: 1.5/alpine
 
-Tags: 1.6.13, 1.6
+Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
+GitCommit: 24cc5b511f2dc452c656c0e2cef9b5cf28799e8e
 Directory: 1.6
 
-Tags: 1.6.13-alpine, 1.6-alpine
+Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64
-GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
+GitCommit: 24cc5b511f2dc452c656c0e2cef9b5cf28799e8e
 Directory: 1.6/alpine
 
-Tags: 1.7.9, 1.7
+Tags: 1.7.10, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
+GitCommit: 100a0a6586377869d797cc5cec3834688a4d1860
 Directory: 1.7
 
-Tags: 1.7.9-alpine, 1.7-alpine
+Tags: 1.7.10-alpine, 1.7-alpine
 Architectures: amd64
-GitCommit: 56a8d73e8f835d736544676a30cfe1b445f84836
+GitCommit: 100a0a6586377869d797cc5cec3834688a4d1860
 Directory: 1.7/alpine
 
 Tags: 1.8.3, 1.8, 1, latest

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.6-apache, 11.0-apache, 11-apache, 11.0.6, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
+GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
 Directory: 11.0/apache
 
 Tags: 11.0.6-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
+GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
 Directory: 11.0/fpm
 
 Tags: 12.0.4-apache, 12.0-apache, 12-apache, apache, 12.0.4, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
+GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
 Directory: 12.0/apache
 
 Tags: 12.0.4-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a4cbc594fa8c2566e147ec2f940c2a9a4c5a290
+GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
 Directory: 12.0/fpm

--- a/library/php
+++ b/library/php
@@ -6,155 +6,155 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.0-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.0-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.0-cli, 7.2-cli, 7-cli, cli, 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.0-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.0-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.0-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.0-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.0-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.0-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.0-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.0-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.0-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.0-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 6afe1891039011a7562bd40c5a955f955e52510a
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.0-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.0-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.0-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.0-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.0-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.0-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.0-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7.1.12-jessie, 7.1-jessie, 7.1.12-cli, 7.1-cli, 7.1.12, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7.1.12-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7.1.12-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7.1.12-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7.1.12-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.1/alpine3.4/cli
 
 Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.1/alpine3.4/fpm
 
 Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.0/alpine3.4/cli
 
 Tags: 7.0.26-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.26-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.0/alpine3.4/fpm
 
 Tags: 7.0.26-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.26-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6677546d599d3980781b520f84d03ecaad291dd1
+GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 5.6/alpine3.4/cli
 
 Tags: 5.6.32-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.32-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 5.6/alpine3.4/fpm
 
 Tags: 5.6.32-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.32-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 1a00d92ff469906a4b46f2646d5dfea29ea129f1
+GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
 Directory: 5.6/alpine3.4/zts

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.3, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
+GitCommit: cb871da497d6825f6a3fcbdd00adc8cc087d147c
 Directory: 3.4
 
 Tags: 3.4.3-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.5, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
+GitCommit: cb871da497d6825f6a3fcbdd00adc8cc087d147c
 Directory: 3.3
 
 Tags: 3.3.5-passenger, 3.3-passenger
@@ -24,7 +24,7 @@ Directory: 3.3/passenger
 
 Tags: 3.2.8, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e003073c29bc0f92cf4d6e70327c8bf9ab3bd9c0
+GitCommit: cb871da497d6825f6a3fcbdd00adc8cc087d147c
 Directory: 3.2
 
 Tags: 3.2.8-passenger, 3.2-passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.60.2, 0.60, 0, latest
-GitCommit: c23cebb33d618db69cbe572d4ecf7140e696e38f
+Tags: 0.60.3, 0.60, 0, latest
+GitCommit: 150f93250894c4669f6113f640eb47811d6ccd50

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php5.6/apache
 
 Tags: 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php5.6/fpm
 
 Tags: 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
@@ -21,12 +21,12 @@ Directory: php5.6/fpm-alpine
 
 Tags: 4.9.1-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.1-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.0/apache
 
 Tags: 4.9.1-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.0/fpm
 
 Tags: 4.9.1-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
@@ -36,12 +36,12 @@ Directory: php7.0/fpm-alpine
 
 Tags: 4.9.1-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.1-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.1/apache
 
 Tags: 4.9.1-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.1/fpm
 
 Tags: 4.9.1-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
@@ -51,12 +51,12 @@ Directory: php7.1/fpm-alpine
 
 Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.1-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.2/apache
 
 Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
 Directory: php7.2/fpm
 
 Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine


### PR DESCRIPTION
- `cassandra`: add `docker-entrypoint.sh` to PATH (docker-library/cassandra#130)
- `ghost`: 1.19.1
- `haproxy`: 1.6.14, 1.7.10
- `nextcloud`: redis-3.1.6, APCu-5.1.9
- `php`: better libs-preserving code (docker-library/php#556)
- `redmine`: add `sqlserver` database adapter (docker-library/redmine#100)
- `rocket.chat`: 0.60.3
- `wordpress`: remove `-dev` dependencies (docker-library/wordpress#267)