### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,70 +1,70 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/a1c6e11e057f23aa1cfcbeba99a45a2355cdc358/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/f08240caaa705f584cb6479880136d273c442658/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 6b38-jdk, 6b38, 6-jdk, 6
+Tags: 6b38-jdk-wheezy, 6b38-wheezy, 6-jdk-wheezy, 6-wheezy, 6b38-jdk, 6b38, 6-jdk, 6
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 6-jdk
 
-Tags: 6b38-jdk-slim, 6b38-slim, 6-jdk-slim, 6-slim
+Tags: 6b38-jdk-slim-wheezy, 6b38-slim-wheezy, 6-jdk-slim-wheezy, 6-slim-wheezy, 6b38-jdk-slim, 6b38-slim, 6-jdk-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 6-jdk/slim
 
-Tags: 6b38-jre, 6-jre
+Tags: 6b38-jre-wheezy, 6-jre-wheezy, 6b38-jre, 6-jre
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
 Directory: 6-jre
 
-Tags: 6b38-jre-slim, 6-jre-slim
+Tags: 6b38-jre-slim-wheezy, 6-jre-slim-wheezy, 6b38-jre-slim, 6-jre-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
 Directory: 6-jre/slim
 
-Tags: 7u151-jdk, 7u151, 7-jdk, 7
+Tags: 7u151-jdk-jessie, 7u151-jessie, 7-jdk-jessie, 7-jessie, 7u151-jdk, 7u151, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jdk
 
-Tags: 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
+Tags: 7u151-jdk-slim-jessie, 7u151-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jdk/slim
 
-Tags: 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jdk/alpine
 
-Tags: 7u151-jre, 7-jre
+Tags: 7u151-jre-jessie, 7-jre-jessie, 7u151-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jre
 
-Tags: 7u151-jre-slim, 7-jre-slim
+Tags: 7u151-jre-slim-jessie, 7-jre-slim-jessie, 7u151-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
 Directory: 7-jre/slim
 
-Tags: 7u151-jre-alpine, 7-jre-alpine
+Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jre/alpine
 
-Tags: 8u151-jdk, 8u151, 8-jdk, 8, jdk, latest
+Tags: 8u151-jdk-stretch, 8u151-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u151-jdk, 8u151, 8-jdk, 8, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jdk
 
-Tags: 8u151-jdk-slim, 8u151-slim, 8-jdk-slim, 8-slim, jdk-slim, slim
+Tags: 8u151-jdk-slim-stretch, 8u151-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, jdk-slim-stretch, slim-stretch, 8u151-jdk-slim, 8u151-slim, 8-jdk-slim, 8-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jdk/slim
 
-Tags: 8u151-jdk-alpine, 8u151-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+Tags: 8u151-jdk-alpine3.7, 8u151-alpine3.7, 8-jdk-alpine3.7, 8-alpine3.7, jdk-alpine3.7, alpine3.7, 8u151-jdk-alpine, 8u151-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
 Directory: 8-jdk/alpine
@@ -90,27 +90,27 @@ GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
 Directory: 8-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u151-jre, 8-jre, jre
+Tags: 8u151-jre-stretch, 8-jre-stretch, jre-stretch, 8u151-jre, 8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jre
 
-Tags: 8u151-jre-slim, 8-jre-slim, jre-slim
+Tags: 8u151-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u151-jre-slim, 8-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 8-jre/slim
 
-Tags: 8u151-jre-alpine, 8-jre-alpine, jre-alpine
+Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
 Directory: 8-jre/alpine
 
-Tags: 9.0.1-11-jdk, 9.0.1-11, 9.0.1-jdk, 9.0.1, 9.0-jdk, 9.0, 9-jdk, 9
+Tags: 9.0.1-11-jdk-sid, 9.0.1-11-sid, 9.0.1-jdk-sid, 9.0.1-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.1-11-jdk, 9.0.1-11, 9.0.1-jdk, 9.0.1, 9.0-jdk, 9.0, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jdk
 
-Tags: 9.0.1-11-jdk-slim, 9.0.1-11-slim, 9.0.1-jdk-slim, 9.0.1-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
+Tags: 9.0.1-11-jdk-slim-sid, 9.0.1-11-slim-sid, 9.0.1-jdk-slim-sid, 9.0.1-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.1-11-jdk-slim, 9.0.1-11-slim, 9.0.1-jdk-slim, 9.0.1-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jdk/slim
@@ -136,12 +136,12 @@ GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
 Directory: 9-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre
+Tags: 9.0.1-11-jre-sid, 9.0.1-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jre
 
-Tags: 9.0.1-11-jre-slim, 9.0.1-jre-slim, 9.0-jre-slim, 9-jre-slim
+Tags: 9.0.1-11-jre-slim-sid, 9.0.1-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.1-11-jre-slim, 9.0.1-jre-slim, 9.0-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jre/slim

--- a/library/percona
+++ b/library/percona
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.20, 5.7, 5, latest
-GitCommit: 3b791041e48c8a764a7a6266fd58172277dca6a6
+GitCommit: 4ef7358aa77fb90c21003a61c09c6c4c8399284e
 Directory: 5.7
 
 Tags: 5.6.38, 5.6


### PR DESCRIPTION
- `openjdk`: add explicit suite / OS version tags (docker-library/openjdk#157)
- `percona`: `5.7.20-19-1.jessie`