### PR TITLE
znc: Support arm, upgrade alpine to 3.7

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,6 +1,7 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
-GitCommit: 642a0520caaf080f665c77c6abd8bc72d8223db6
+GitCommit: 7f4f14214b67e540892a281d69f855aefcef35ce
+Architectures: amd64, arm32v6
 
 Tags: 1.6.5, 1.6, latest
 Directory: full


### PR DESCRIPTION
I tested this on RPi3+gentoo, with arm32v7. However, docker seemed to pull alpine arm32v6. What architecture should I use, or both?