### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
+GitCommit: 1f3be2bd5373e6d902df99a3619add9183e4f675
 Directory: 5
 # Docker EOL: 2018-10-10
 

--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.19.2, 1.19, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 719b29029d61c4ccbd52d90403818a2f8f9af6ac
+GitCommit: 832c9278919592baa30ada2fabd8fcc9a6e2ae31
 Directory: 1/debian
 
 Tags: 1.19.2-alpine, 1.19-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 719b29029d61c4ccbd52d90403818a2f8f9af6ac
+GitCommit: 832c9278919592baa30ada2fabd8fcc9a6e2ae31
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.0.5, 1.0, 1, latest
+Tags: 1.0.6, 1.0, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: baf8c9887dcbe070d522ebd50e8cfd272e0618fd
+GitCommit: d235fab08c171d7abf22ffe8869439725165c901
 Directory: debian
 
-Tags: 1.0.5-alpine, 1.0-alpine, 1-alpine, alpine
+Tags: 1.0.6-alpine, 1.0-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: baf8c9887dcbe070d522ebd50e8cfd272e0618fd
+GitCommit: d235fab08c171d7abf22ffe8869439725165c901
 Directory: alpine

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.6-apache, 11.0-apache, 11-apache, 11.0.6, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
+GitCommit: ec85464109240774f754a8675c68aa36090a9f4b
 Directory: 11.0/apache
 
 Tags: 11.0.6-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
+GitCommit: ec85464109240774f754a8675c68aa36090a9f4b
 Directory: 11.0/fpm
 
 Tags: 12.0.4-apache, 12.0-apache, 12-apache, apache, 12.0.4, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
+GitCommit: ec85464109240774f754a8675c68aa36090a9f4b
 Directory: 12.0/apache
 
 Tags: 12.0.4-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 02fa7776a15843cba599703dd7f801822ffe69f1
+GitCommit: ec85464109240774f754a8675c68aa36090a9f4b
 Directory: 12.0/fpm

--- a/library/php
+++ b/library/php
@@ -4,157 +4,157 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.0-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.0-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.0-cli, 7.2-cli, 7-cli, cli, 7.2.0, 7.2, 7, latest
+Tags: 7.2.1-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.1-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.1-cli, 7.2-cli, 7-cli, cli, 7.2.1, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.0-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.0-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.1-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.1-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.0-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.0-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.1-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.1-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.0-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.0-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.1-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.1-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.0-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.0-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.1-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.1-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.0-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.1-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.0-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.1-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.0-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.0-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.0-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.1-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.1-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.1-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.0-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.0-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.1-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.1-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.0-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.0-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.1-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.1-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.12-cli-jessie, 7.1-cli-jessie, 7.1.12-jessie, 7.1-jessie, 7.1.12-cli, 7.1-cli, 7.1.12, 7.1
+Tags: 7.1.13-cli-jessie, 7.1-cli-jessie, 7.1.13-jessie, 7.1-jessie, 7.1.13-cli, 7.1-cli, 7.1.13, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.12-apache-jessie, 7.1-apache-jessie, 7.1.12-apache, 7.1-apache
+Tags: 7.1.13-apache-jessie, 7.1-apache-jessie, 7.1.13-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.12-fpm-jessie, 7.1-fpm-jessie, 7.1.12-fpm, 7.1-fpm
+Tags: 7.1.13-fpm-jessie, 7.1-fpm-jessie, 7.1.13-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.12-zts-jessie, 7.1-zts-jessie, 7.1.12-zts, 7.1-zts
+Tags: 7.1.13-zts-jessie, 7.1-zts-jessie, 7.1.13-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.12-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.12-alpine3.4, 7.1-alpine3.4, 7.1.12-cli-alpine, 7.1-cli-alpine, 7.1.12-alpine, 7.1-alpine
+Tags: 7.1.13-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.13-alpine3.4, 7.1-alpine3.4, 7.1.13-cli-alpine, 7.1-cli-alpine, 7.1.13-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.12-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.12-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.13-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.13-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.12-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.12-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.13-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.13-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 6be205eee15aed27706a958379cec836fe305017
 Directory: 7.1/alpine3.4/zts
 
-Tags: 7.0.26-cli-jessie, 7.0-cli-jessie, 7.0.26-jessie, 7.0-jessie, 7.0.26-cli, 7.0-cli, 7.0.26, 7.0
+Tags: 7.0.27-cli-jessie, 7.0-cli-jessie, 7.0.27-jessie, 7.0-jessie, 7.0.27-cli, 7.0-cli, 7.0.27, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.26-apache-jessie, 7.0-apache-jessie, 7.0.26-apache, 7.0-apache
+Tags: 7.0.27-apache-jessie, 7.0-apache-jessie, 7.0.27-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.26-fpm-jessie, 7.0-fpm-jessie, 7.0.26-fpm, 7.0-fpm
+Tags: 7.0.27-fpm-jessie, 7.0-fpm-jessie, 7.0.27-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.26-zts-jessie, 7.0-zts-jessie, 7.0.26-zts, 7.0-zts
+Tags: 7.0.27-zts-jessie, 7.0-zts-jessie, 7.0.27-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.26-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.26-alpine3.4, 7.0-alpine3.4, 7.0.26-cli-alpine, 7.0-cli-alpine, 7.0.26-alpine, 7.0-alpine
+Tags: 7.0.27-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.27-alpine3.4, 7.0-alpine3.4, 7.0.27-cli-alpine, 7.0-cli-alpine, 7.0.27-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/alpine3.4/cli
 
-Tags: 7.0.26-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.26-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.27-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.27-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/alpine3.4/fpm
 
-Tags: 7.0.26-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.26-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.27-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.27-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
 Directory: 7.0/alpine3.4/zts
 
-Tags: 5.6.32-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.32-jessie, 5.6-jessie, 5-jessie, 5.6.32-cli, 5.6-cli, 5-cli, 5.6.32, 5.6, 5
+Tags: 5.6.33-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.33-jessie, 5.6-jessie, 5-jessie, 5.6.33-cli, 5.6-cli, 5-cli, 5.6.33, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.32-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.32-apache, 5.6-apache, 5-apache
+Tags: 5.6.33-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.33-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.32-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.32-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.33-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.33-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.32-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.32-zts, 5.6-zts, 5-zts
+Tags: 5.6.33-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.33-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32313ea407379d70259e14414ec8aa0311c0a4c4
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.32-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.32-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.32-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.32-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.33-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.33-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.33-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.33-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/alpine3.4/cli
 
-Tags: 5.6.32-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.32-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.33-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.33-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/alpine3.4/fpm
 
-Tags: 5.6.32-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.32-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.33-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.33-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 0e056693f2483fe7a0d808f1f493a1e4744186b8
+GitCommit: a37af189869968236a8b832beac950b78b26b471
 Directory: 5.6/alpine3.4/zts

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/0283b756f739400cb3b25d0ad97fcbbad05a109e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/7fa1f0efbe36eb723f34dd0a5cfcd99948ed5638/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -23,6 +23,26 @@ Tags: 3.7.2-management-alpine, 3.7-management-alpine, 3-management-alpine, manag
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
+
+Tags: 3.6.15-rc.1, 3.6-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
+Directory: 3.6-rc/debian
+
+Tags: 3.6.15-rc.1-management, 3.6-rc-management
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
+Directory: 3.6-rc/debian/management
+
+Tags: 3.6.15-rc.1-alpine, 3.6-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
+Directory: 3.6-rc/alpine
+
+Tags: 3.6.15-rc.1-management-alpine, 3.6-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
+Directory: 3.6-rc/alpine/management
 
 Tags: 3.6.14, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
- `gcc`: fix `update.sh` bug that caused repeated compression oscillation (https://github.com/docker-library/gcc/commit/ee35fa4d124d9996ec8c975976d719392cf06ba1)
- `ghost`: ghost-cli 1.4.2
- `irssi`: 1.0.6
- `nextcloud`: remove build deps (nextcloud/docker#215)
- `php`: 5.6.33, 7.0.27, 7.1.13, 7.2.1
- `rabbitmq`: 3.6.15-rc.1