### PR TITLE
Bump Alpine for 3.1 timezone and edge arch fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -3,98 +3,97 @@
 Maintainers: Glider Labs <team@gliderlabs.com> (@gliderlabs)
 GitRepo: https://github.com/gliderlabs/docker-alpine.git
 GitFetch: refs/heads/release
-GitCommit: 109f757ad851c6c934c26090166a5f095517a200
+GitCommit: b8aa42c90c3b6c4a78ea8c84f20eb922ff189173
 
 Tags: 3.6
 Architectures: arm64v8, arm32v6, ppc64le, s390x, i386, amd64
 arm64v8-GitFetch: refs/heads/rootfs/library-3.6/aarch64
-arm64v8-GitCommit: 67cd303088de88050647247fc3b7eee4fa6c45f0
+arm64v8-GitCommit: 0991d9ae2dc06c8791cf56725e76d0f580e31fb9
 arm64v8-Directory: versions/library-3.6/aarch64
 arm32v6-GitFetch: refs/heads/rootfs/library-3.6/armhf
-arm32v6-GitCommit: f3b51a1e951a50a6be49210f6eab18a18228bd1e
+arm32v6-GitCommit: 1690b582953126e8b2e8571921143936da15a93c
 arm32v6-Directory: versions/library-3.6/armhf
 ppc64le-GitFetch: refs/heads/rootfs/library-3.6/ppc64le
-ppc64le-GitCommit: a76a752b8fe4cf4e6e3bc91be49f520f2fe2ff09
+ppc64le-GitCommit: 45a5e2f69d9c5c7ffd65cfa8409b7d6d1197bfcb
 ppc64le-Directory: versions/library-3.6/ppc64le
 s390x-GitFetch: refs/heads/rootfs/library-3.6/s390x
-s390x-GitCommit: ca8445d093781bd60914d042e019cc344bb405d6
+s390x-GitCommit: f2d7e84b6260f98d5b8b3f96b221427e183bcb7d
 s390x-Directory: versions/library-3.6/s390x
 i386-GitFetch: refs/heads/rootfs/library-3.6/x86
-i386-GitCommit: 009559ca242e82c24248fbfe2347ccf208d7fed0
+i386-GitCommit: e1d5b2fe96f96430ee67ff3ba2144b4b5ece214f
 i386-Directory: versions/library-3.6/x86
 amd64-GitFetch: refs/heads/rootfs/library-3.6/x86_64
-amd64-GitCommit: 43d9d69ad998e89d6737abf47b40a2be11d0ad54
+amd64-GitCommit: 2127169e2d9dcbb7ae8c7eca599affd2d61b49a7
 amd64-Directory: versions/library-3.6/x86_64
 
 Tags: 3.7, latest
 Architectures: arm64v8, arm32v6, ppc64le, s390x, i386, amd64
 arm64v8-GitFetch: refs/heads/rootfs/library-3.7/aarch64
-arm64v8-GitCommit: 994cafc104b35a59f653fdd0e0d7e40b3d379cbb
+arm64v8-GitCommit: 966695a05adcfc72d0323fc658736213b91aecc9
 arm64v8-Directory: versions/library-3.7/aarch64
 arm32v6-GitFetch: refs/heads/rootfs/library-3.7/armhf
-arm32v6-GitCommit: ba989fd9cb6a1fe661509ae4caffe929eebf6afb
+arm32v6-GitCommit: a12961cc31718486b276f352b875169885f53e4c
 arm32v6-Directory: versions/library-3.7/armhf
 ppc64le-GitFetch: refs/heads/rootfs/library-3.7/ppc64le
-ppc64le-GitCommit: 810123d58d40f294d1c81f510ea62ad0d4a7d4af
+ppc64le-GitCommit: c5a305750a287faafd9f08c8d6e2db60f1150df4
 ppc64le-Directory: versions/library-3.7/ppc64le
 s390x-GitFetch: refs/heads/rootfs/library-3.7/s390x
-s390x-GitCommit: 557ca2b10c9881b5ea32b9203b253fdf92f0b699
+s390x-GitCommit: 370648e63046542f9b0bccb6b5def1ab39207963
 s390x-Directory: versions/library-3.7/s390x
 i386-GitFetch: refs/heads/rootfs/library-3.7/x86
-i386-GitCommit: da96ae93d314a6c1cf7935d7dddc02817c6c6451
+i386-GitCommit: 85b9549c0e2ede18bfa3b179d8148461ade74658
 i386-Directory: versions/library-3.7/x86
 amd64-GitFetch: refs/heads/rootfs/library-3.7/x86_64
-amd64-GitCommit: 87816df28b1385c99cb57a9d245d3a28a899213a
+amd64-GitCommit: 61c3181ad3127c5bedd098271ac05f49119c9915
 amd64-Directory: versions/library-3.7/x86_64
 
 Tags: edge
 Architectures: arm64v8, arm32v6, ppc64le, s390x, i386, amd64
 arm64v8-GitFetch: refs/heads/rootfs/library-edge/aarch64
-arm64v8-GitCommit: ce346cab485f52f056e72ddbc0b82127cd3672e4
+arm64v8-GitCommit: 7c8f868ed8d6137ceac5ca9537e7ff985210f9e9
 arm64v8-Directory: versions/library-edge/aarch64
 arm32v6-GitFetch: refs/heads/rootfs/library-edge/armhf
-arm32v6-GitCommit: ec02c3de3d5e8b234cb59b96d03be254a1fe0b08
+arm32v6-GitCommit: ea9cf5a12beae739c87900e513119af46f68a21b
 arm32v6-Directory: versions/library-edge/armhf
 ppc64le-GitFetch: refs/heads/rootfs/library-edge/ppc64le
-ppc64le-GitCommit: 2b5190bee31f2d7df6e8667f920d95122cfe1f02
+ppc64le-GitCommit: ee22e36c72fea7c953f5fa5b0dcf23de9ed32ef4
 ppc64le-Directory: versions/library-edge/ppc64le
 s390x-GitFetch: refs/heads/rootfs/library-edge/s390x
-s390x-GitCommit: e289de92d36e9050b07386c438641a5e71e8a665
+s390x-GitCommit: 1bf4ed0e831191b74ba7479efdb7231f75e00bd2
 s390x-Directory: versions/library-edge/s390x
 i386-GitFetch: refs/heads/rootfs/library-edge/x86
-i386-GitCommit: 77dbb5353a3ed00bdb0713ec05d8e088868fa1f2
+i386-GitCommit: 8f5fca108c4ee56095856b38aeab9b6e30ad10b4
 i386-Directory: versions/library-edge/x86
 amd64-GitFetch: refs/heads/rootfs/library-edge/x86_64
-amd64-GitCommit: 1b57aae29e41272ef8f3b0b0b342df951c419d3b
+amd64-GitCommit: edd30a358e57a880645e25a83e9d9bd79bff06f5
 amd64-Directory: versions/library-edge/x86_64
 
 Tags: 3.1
 Architectures: amd64
 amd64-GitFetch: refs/heads/rootfs/library-3.1
-amd64-GitCommit: 3d39369dd6f6b26824e0595cd7906cec3c3202f8
+amd64-GitCommit: 62606823dbae10f763dae1878f44ec918ac8dce5
 amd64-Directory: versions/library-3.1
 
 Tags: 3.2
 Architectures: amd64
 amd64-GitFetch: refs/heads/rootfs/library-3.2
-amd64-GitCommit: 673bd394ded668e06f3f9e818404d5de1e261a57
+amd64-GitCommit: 41ee859116107fe6e45487afddbf773c09fe5e41
 amd64-Directory: versions/library-3.2
 
 Tags: 3.3
 Architectures: amd64
 amd64-GitFetch: refs/heads/rootfs/library-3.3
-amd64-GitCommit: 4957827c6150016df99394d835860f86a3adf216
+amd64-GitCommit: 3683598b841a0bbdd4a892ff575e60e02119d37d
 amd64-Directory: versions/library-3.3
 
 Tags: 3.4
 Architectures: amd64
 amd64-GitFetch: refs/heads/rootfs/library-3.4
-amd64-GitCommit: 640af6126d4a4eca7c8b1fcb5c88cf81e8c5685c
+amd64-GitCommit: eaf8d6dd72bacb1d739bcfee475eda78c70e3ecc
 amd64-Directory: versions/library-3.4
 
 Tags: 3.5
 Architectures: amd64
 amd64-GitFetch: refs/heads/rootfs/library-3.5
-amd64-GitCommit: 3dd1ba6807195cdf414b83e9d13e178425da35d3
+amd64-GitCommit: 791bc2db0eef96f9a90b662079114a5eb5a2ffc2
 amd64-Directory: versions/library-3.5
-


### PR DESCRIPTION
Since last release: https://github.com/gliderlabs/docker-alpine/compare/109f757ad851c6c934c26090166a5f095517a200...release.