### PR TITLE
Add official image for PM2 runtime

### DIFF
--- a/library/pm2
+++ b/library/pm2
@@ -1,0 +1,86 @@
+# This file is generated via https://github.com/keymetrics/docker-pm2/blob/3b715c519b6b5453ceef63c578805a2ea879b87a/docker-tags.sh
+# 2018-01-10 14:36:46
+
+Maintainers: Keymetrics.io <https://github.com/keymetrics/docker-pm2> (@keymetrics)
+GitRepo: https://github.com/keymetrics/docker-pm2.git
+
+Tags: latest-alpine
+GitCommit: 2ff618938de9d75396f709da58f894bfdc525dc6
+Directory: tags/latest/alpine
+
+Tags: latest-stretch
+GitCommit: ff45312e04cbebb51193c07e9798a8c8ae914e68
+Directory: tags/latest/stretch
+
+Tags: latest-jessie
+GitCommit: ff45312e04cbebb51193c07e9798a8c8ae914e68
+Directory: tags/latest/jessie
+
+Tags: latest-slim
+GitCommit: ff45312e04cbebb51193c07e9798a8c8ae914e68
+Directory: tags/latest/slim
+
+Tags: latest-wheezy
+GitCommit: ff45312e04cbebb51193c07e9798a8c8ae914e68
+Directory: tags/latest/wheezy
+
+Tags: 4-alpine
+GitCommit: 2ff618938de9d75396f709da58f894bfdc525dc6
+Directory: tags/4/alpine
+
+Tags: 4-stretch
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/4/stretch
+
+Tags: 4-jessie
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/4/jessie
+
+Tags: 4-slim
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/4/slim
+
+Tags: 4-wheezy
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/4/wheezy
+
+Tags: 6-alpine
+GitCommit: 2ff618938de9d75396f709da58f894bfdc525dc6
+Directory: tags/6/alpine
+
+Tags: 6-stretch
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/6/stretch
+
+Tags: 6-jessie
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/6/jessie
+
+Tags: 6-slim
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/6/slim
+
+Tags: 6-wheezy
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/6/wheezy
+
+Tags: 8-alpine
+GitCommit: 2ff618938de9d75396f709da58f894bfdc525dc6
+Directory: tags/8/alpine
+
+Tags: 8-stretch
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/8/stretch
+
+Tags: 8-jessie
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/8/jessie
+
+Tags: 8-slim
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/8/slim
+
+Tags: 8-wheezy
+GitCommit: 23d531ea377bff96e2cf23d3438f813078d019e5
+Directory: tags/8/wheezy
+


### PR DESCRIPTION
# Summary

This PR add the `pm2` file as requested in the README, the PR for the documentation is [here](https://github.com/docker-library/docs/pull/1118).

Github repo: https://github.com/Unitech/pm2

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
           - @keymetrics / @Unitech / @vmarchaud
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
           - not sure but i would say `service`
-	[ ] is it reasonably popular, or does it solve a particular use case well?
           - see https://github.com/Unitech/pm2
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
          - https://github.com/docker-library/docs/pull/1118
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
         - We have our tests [here](https://github.com/keymetrics/docker-pm2/tree/master/example-app) and the build are done [here](https://travis-ci.org/keymetrics/docker-pm2)