### PR TITLE
Remove haproxy 1.4

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,16 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.4.27, 1.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
-Directory: 1.4
-
-Tags: 1.4.27-alpine, 1.4-alpine
-Architectures: amd64
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
-Directory: 1.4/alpine
-
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25


### PR DESCRIPTION
ref. docker-library/haproxy@13fb828fe6d62175411a3d07a390ff0cc644a904