### PR TITLE
Update haproxy test to use curl's --resolve option

### DIFF
--- a/test/tests/haproxy-basics/haproxy.cfg
+++ b/test/tests/haproxy-basics/haproxy.cfg
@@ -8,5 +8,3 @@ frontend http-in
 	default_backend google
 backend google
 	server google0 www.google.com
-	# this doesn't work on HAProxy 1.4 :(
-	#http-request replace-header Host .* www.google.com

--- a/test/tests/haproxy-basics/haproxy.cfg
+++ b/test/tests/haproxy-basics/haproxy.cfg
@@ -1,10 +1,13 @@
 defaults
-	mode http
+	mode tcp
 	timeout connect 5000ms
 	timeout client 50000ms
 	timeout server 50000ms
 frontend http-in
 	bind *:80
-	default_backend google
-backend google
-	server google0 www.google.com
+	default_backend example
+frontend https-in
+	bind *:443
+	default_backend example
+backend example
+	server example0 example.com

--- a/test/tests/haproxy-basics/run.sh
+++ b/test/tests/haproxy-basics/run.sh
@@ -8,7 +8,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 serverImage="$("$dir/../image-name.sh" librarytest/haproxy-basics "$image")"
@@ -33,7 +33,7 @@ _request() {
 	fi
 
 	docker run --rm --link "$cid":haproxy "$clientImage" \
-		curl -fs -X"$method" --header 'Host: www.google.com' "$@" "http://haproxy/$url"
+		curl -fsSL -X"$method" --resolve www.google.com:80:$(docker inspect -f '{{.NetworkSettings.IPAddress}}' $cid) "$@" "http://www.google.com/$url"
 }
 
 . "$dir/../../retry.sh" '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'


### PR DESCRIPTION
haproxy 1.4 will probably be removed with #3894 and thus the comment in `test/tests/haproxy-basics/haproxy.cfg` will be obsolete then. But: IMO the `--resolve` option of curl is superior to manually setting the `Host` header. I am successfully using it for my spiped tests as of Aug, 17 2017: TimWolla/docker-spiped@a13528c2f5dc257ea15c4c8d4d1163a9d38b24fe.