### PR TITLE
Bump Traefik to v1.5.0-rc5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.5.0-rc4, 1.5.0-rc4, v1.5, 1.5, cancoillotte
+Tags: v1.5.0-rc5, 1.5.0-rc5, v1.5, 1.5, cancoillotte
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: c32b156f3f11eb905416caf3d0c93a47e0c42743
+GitCommit: ff5cbe3809d54e1594586975184781d1a44662a9
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.5.0-rc4-alpine, 1.5.0-rc4-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
+Tags: v1.5.0-rc5-alpine, 1.5.0-rc5-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: c32b156f3f11eb905416caf3d0c93a47e0c42743
+GitCommit: ff5cbe3809d54e1594586975184781d1a44662a9
 Directory: alpine
 
 Tags: v1.4.6, 1.4.6, v1.4, 1.4, roquefort, latest


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.0-rc5.

/cc @vdemeester @emilevauge

Cheers
