### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.01.0-ce-rc1, 18.01-rc, rc, test
+Tags: 18.01.0-ce, 18.01.0, 18.01, 18, edge, test, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8de8842b2fffc6bb43609c133b54207ffb7b4ce2
-Directory: 18.01-rc
+GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
+Directory: 18.01
 
-Tags: 18.01.0-ce-rc1-dind, 18.01-rc-dind, rc-dind, test-dind
+Tags: 18.01.0-ce-dind, 18.01.0-dind, 18.01-dind, 18-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8de8842b2fffc6bb43609c133b54207ffb7b4ce2
-Directory: 18.01-rc/dind
+GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
+Directory: 18.01/dind
 
-Tags: 18.01.0-ce-rc1-git, 18.01-rc-git, rc-git, test-git
+Tags: 18.01.0-ce-git, 18.01.0-git, 18.01-git, 18-git, edge-git, test-git, git
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8de8842b2fffc6bb43609c133b54207ffb7b4ce2
-Directory: 18.01-rc/git
+GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
+Directory: 18.01/git
 
-Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable, edge, latest
+Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 51ba3bdf3e104e8af01150daec9122c4fbeaa41e
 Directory: 17.12
 
-Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind, edge-dind, dind
+Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/dind
 
-Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git, edge-git, git
+Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/git

--- a/library/golang
+++ b/library/golang
@@ -5,35 +5,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10beta1-stretch, 1.10-rc-stretch, rc-stretch
-SharedTags: 1.10beta1, 1.10-rc, rc
+Tags: 1.10beta2-stretch, 1.10-rc-stretch, rc-stretch
+SharedTags: 1.10beta2, 1.10-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01662edd98bfea507162776c08fbfb51aa8f1e3d
+GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/stretch
 
-Tags: 1.10beta1-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10beta1-alpine, 1.10-rc-alpine, rc-alpine
+Tags: 1.10beta2-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10beta2-alpine, 1.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/alpine3.7
 
-Tags: 1.10beta1-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.10beta1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta1, 1.10-rc, rc
+Tags: 1.10beta2-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 01662edd98bfea507162776c08fbfb51aa8f1e3d
+GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10beta1-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.10beta1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta1, 1.10-rc, rc
+Tags: 1.10beta2-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 01662edd98bfea507162776c08fbfb51aa8f1e3d
+GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10beta1-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.10beta1-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
+Tags: 1.10beta2-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.10beta2-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 01662edd98bfea507162776c08fbfb51aa8f1e3d
+GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/mongo
+++ b/library/mongo
@@ -70,24 +70,24 @@ GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.1-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.1, 3.6, 3, latest
+Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.2, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
+GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
 Directory: 3.6
 
-Tags: 3.6.1-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.1, 3.6, 3, latest
+Tags: 3.6.2-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
+GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.1-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.6.1-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.1, 3.6, 3, latest
+Tags: 3.6.2-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: 657b1a53a9680b972a6344f3d958a17775dd8719
+GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/mysql
+++ b/library/mysql
@@ -8,14 +8,14 @@ Tags: 8.0.3, 8.0, 8
 GitCommit: 6c414e7f38c2079c7193beae5dc7c34ee46cd6e7
 Directory: 8.0
 
-Tags: 5.7.20, 5.7, 5, latest
-GitCommit: 6c414e7f38c2079c7193beae5dc7c34ee46cd6e7
+Tags: 5.7.21, 5.7, 5, latest
+GitCommit: 607b2a65aa76adf495730b9f7e6f28f146a9f95f
 Directory: 5.7
 
-Tags: 5.6.38, 5.6
-GitCommit: 36f2030de879bea73e808183302d27c3b670ce7a
+Tags: 5.6.39, 5.6
+GitCommit: b6156cf8c6a1e9702440489bfa9a92c2078ba4b5
 Directory: 5.6
 
-Tags: 5.5.58, 5.5
-GitCommit: 36f2030de879bea73e808183302d27c3b670ce7a
+Tags: 5.5.59, 5.5
+GitCommit: 90c4f75a642d6685f4fe4d8fc585e88339ed2cb1
 Directory: 5.5

--- a/library/piwik
+++ b/library/piwik
@@ -2,10 +2,10 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
-Tags: 3.2.1-apache, 3.2-apache, 3-apache, apache, 3.2.1, 3.2, 3, latest
-GitCommit: baf563abb7b48d9cb852c37713080f3e979097c3
+Tags: 3.3.0-apache, 3.3-apache, 3-apache, apache, 3.3.0, 3.3, 3, latest
+GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
 Directory: apache
 
-Tags: 3.2.1-fpm, 3.2-fpm, 3-fpm, fpm
-GitCommit: baf563abb7b48d9cb852c37713080f3e979097c3
+Tags: 3.3.0-fpm, 3.3-fpm, 3-fpm, fpm
+GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
 Directory: fpm

--- a/library/pypy
+++ b/library/pypy
@@ -14,12 +14,12 @@ Architectures: amd64, arm32v5, i386
 GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
 Directory: 2/slim
 
-Tags: 3-5.10.0, 3-5.10, 3-5, 3, latest
+Tags: 3-5.10.1, 3-5.10, 3-5, 3, latest
 Architectures: amd64, arm32v5, i386
-GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
+GitCommit: b8683312287c8972c23f43c756decd14e69f1f5c
 Directory: 3
 
-Tags: 3-5.10.0-slim, 3-5.10-slim, 3-5-slim, 3-slim, slim
+Tags: 3-5.10.1-slim, 3-5.10-slim, 3-5-slim, 3-slim, slim
 Architectures: amd64, arm32v5, i386
-GitCommit: 2b2b28c8d47683df043de22ddd11cb1bc6c5d151
+GitCommit: b8683312287c8972c23f43c756decd14e69f1f5c
 Directory: 3/slim


### PR DESCRIPTION
- `docker`: 18.01.0-ce (GA)
- `golang`: 1.10beta2
- `mongo`: 3.6.2
- `mysql`: 5.5.59, 5.6.39, 5.7.21
- `piwik`: 3.3.0
- `pypy`: 5.10.1