### PR TITLE
Fix typo in the ES clustername configuration

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -13,9 +13,9 @@ GitCommit: 20df98ce84f12cd3cfdcfd08ab8c9e029f7f01ab
 Directory: 8.10
 
 Tags: 9.3, FT
-GitCommit: c2e850faf39198a055cb0e461186305b7a5a4378
+GitCommit: 261cb4cb5bee049a8c756366b5257b4bc48e811d
 Directory: 9.3
 
 Tags: 9.10, 9, LTS-2017, LTS, latest
-GitCommit: c2e850faf39198a055cb0e461186305b7a5a4378
+GitCommit: 261cb4cb5bee049a8c756366b5257b4bc48e811d
 Directory: 9.10


### PR DESCRIPTION
the before 9.x releases and documentation refer to  `NUXEO_ES_CLUSTER_NAME`, so we go back to that scheme.