### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -138,18 +138,3 @@ Tags: xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: xenial
-
-Tags: zesty-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
-Directory: zesty/curl
-
-Tags: zesty-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9aa327dcc582d5384affbc5a19672e3077489e97
-Directory: zesty/scm
-
-Tags: zesty
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
-Directory: zesty

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.5, 5.6, 5, latest
-GitCommit: 71454903d8d33c7050d7725b825fb8c6a65007e4
+Tags: 5.6.6, 5.6, 5, latest
+GitCommit: e7ccd59cec2328020c005d94010d91b95ee7f291
 Directory: 5
 
-Tags: 5.6.5-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 71454903d8d33c7050d7725b825fb8c6a65007e4
+Tags: 5.6.6-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: e7ccd59cec2328020c005d94010d91b95ee7f291
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.20.0, 1.20, 1, latest
+Tags: 1.20.1, 1.20, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: df02b55358fd2b5280a2aa0c4a988cd44ecde06c
+GitCommit: bb03747105f2c6d03b57889b6b856e7684335f3e
 Directory: 1/debian
 
-Tags: 1.20.0-alpine, 1.20-alpine, 1-alpine, alpine
+Tags: 1.20.1-alpine, 1.20-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: df02b55358fd2b5280a2aa0c4a988cd44ecde06c
+GitCommit: bb03747105f2c6d03b57889b6b856e7684335f3e
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.0.6, 1.0, 1, latest
+Tags: 1.1.0, 1.1, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d235fab08c171d7abf22ffe8869439725165c901
+GitCommit: c03bebcef55d683530f420ba4f13ae87e878e645
 Directory: debian
 
-Tags: 1.0.6-alpine, 1.0-alpine, 1-alpine, alpine
+Tags: 1.1.0-alpine, 1.1-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d235fab08c171d7abf22ffe8869439725165c901
+GitCommit: c03bebcef55d683530f420ba4f13ae87e878e645
 Directory: alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.5, 5.6, 5, latest
-GitCommit: c7f35a7103f04d289ae93427eafb24a6fa28aa78
+Tags: 5.6.6, 5.6, 5, latest
+GitCommit: ff12294eaa9dfddb854c2ba989308beb993bf69c
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.5, 5.6, 5, latest
-GitCommit: eccd95622eebf46a20cb8fb6484d1a7854fb44b6
+Tags: 5.6.6, 5.6, 5, latest
+GitCommit: 40679c7efe82cd24a003c310a3635d583375ac7b
 Directory: 5
 
-Tags: 5.6.5-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: eccd95622eebf46a20cb8fb6484d1a7854fb44b6
+Tags: 5.6.6-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 40679c7efe82cd24a003c310a3635d583375ac7b
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -91,3 +91,25 @@ Architectures: windows-amd64
 GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 3.7.1-jessie, 3.7-jessie, unstable-jessie
+SharedTags: 3.7.1, 3.7, unstable
+# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
+# (i386 is empty, as is ppc64el)
+Architectures: amd64
+GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+Directory: 3.7
+
+Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
+Architectures: windows-amd64
+GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+Directory: 3.7/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.7.1-windowsservercore-1709, 3.7-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
+Architectures: windows-amd64
+GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+Directory: 3.7/windows/windowsservercore-1709
+Constraints: windowsservercore-1709

--- a/library/mongo
+++ b/library/mongo
@@ -97,7 +97,7 @@ SharedTags: 3.7.1, 3.7, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+GitCommit: b19d47c63e26ae755640ae5b74fa7b4e475c992f
 Directory: 3.7
 
 Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,6 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.7.3-rc.1, 3.7-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+Directory: 3.7-rc/debian
+
+Tags: 3.7.3-rc.1-management, 3.7-rc-management
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+Directory: 3.7-rc/debian/management
+
+Tags: 3.7.3-rc.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.3-rc.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.2, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 79b144f64991538d29f8c071270d157a5bf7a9b7

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.3-rc.1, 3.7-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+GitCommit: dab7fec58190fd07f000fa08b7f7de793895c373
 Directory: 3.7-rc/debian
 
 Tags: 3.7.3-rc.1-management, 3.7-rc-management


### PR DESCRIPTION
- `buildpack-deps`: remove EOL zesty variants
- `elasticsearch`: 5.6.6
- `ghost`: 1.20.1
- `irssi`: 1.1.0
- `kibana`: 5.6.6
- `logstash`: 5.6.6
- `mongo`: 3.7.1
- `rabbitmq`: 3.7.3-rc.1