### PR TITLE
Add additional tags for more capable configurations

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -19,7 +19,7 @@ Tags: javaee7, javaee7-java8-ibm, latest
 Directory: release/javaee7/java8/ibmjava
 
 Tags: javaee7-java8-ibmsfj
-Directory: release/javaee7/ibmsfj
+Directory: release/javaee7/java8/ibmsfj
 
 Tags: microProfile1, microProfile1-java8-ibm
 Directory: release/microProfile1/java8/ibmjava

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: a9576a73b3a554c6b27345c2dcd4ca77c394e953
+GitCommit: 99e1bbdc8b98b4afd80b01dea78ca923091d46d4
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm
@@ -8,3 +8,21 @@ Directory: release/kernel/java8/ibmjava
 
 Tags: kernel-java8-ibmsfj
 Directory: release/kernel/java8/ibmsfj
+
+Tags: webProfile7, webProfile7-java8-ibm
+Directory: release/webProfile7/java8/ibmjava
+
+Tags: webProfile7-java8-ibmsfj
+Directory: release/webProfile7/java8/ibmsfj
+
+Tags: javaee7, javaee7-java8-ibm, latest
+Directory: release/javaee7/java8/ibmjava
+
+Tags: javaee7-java8-ibmsfj
+Directory: release/javaee7/ibmsfj
+
+Tags: microProfile1, microProfile1-java8-ibm
+Directory: release/microProfile1/java8/ibmjava
+
+Tags: microProfile1-java8-ibmsfj
+Directory: release/microProfile1/java8/ibmsfj


### PR DESCRIPTION
Add some tags to support base images that have the following configured:

1. webProfile7
2. microProfile1
3. javaee7

and also add latest to be javaee7.

Docs PR: https://github.com/docker-library/docs/pull/1123