### PR TITLE
Upgrades elixir to 1.6.0

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,17 +1,29 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/f2528c0158d465f96f311faa19aff3cffb4e7f25/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-elixir/blob/8bf491be3e7a3e0959bd99c2a862d5590ef89d6d/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.5.3, 1.5, latest
+Tags: 1.6.0, 1.6, latest
+GitCommit: 8bf491be3e7a3e0959bd99c2a862d5590ef89d6d
+Directory: 1.6
+
+Tags: 1.6.0-slim, 1.6-slim, slim
+GitCommit: 8bf491be3e7a3e0959bd99c2a862d5590ef89d6d
+Directory: 1.6/slim
+
+Tags: 1.6.0-alpine, 1.6-alpine, alpine
+GitCommit: 8bf491be3e7a3e0959bd99c2a862d5590ef89d6d
+Directory: 1.6/alpine
+
+Tags: 1.5.3, 1.5
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5
 
-Tags: 1.5.3-slim, 1.5-slim, slim
+Tags: 1.5.3-slim, 1.5-slim
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/slim
 
-Tags: 1.5.3-alpine, 1.5-alpine, alpine
+Tags: 1.5.3-alpine, 1.5-alpine
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/alpine
 


### PR DESCRIPTION
Approval by maintainer @c0b can be found at https://github.com/c0b/docker-elixir/pull/52