### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.20.1, 1.20, 1, latest
+Tags: 1.20.2, 1.20, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb03747105f2c6d03b57889b6b856e7684335f3e
+GitCommit: 89601afa8ed43d66fdbba5be189cc200e3cd6a9b
 Directory: 1/debian
 
-Tags: 1.20.1-alpine, 1.20-alpine, 1-alpine, alpine
+Tags: 1.20.2-alpine, 1.20-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: bb03747105f2c6d03b57889b6b856e7684335f3e
+GitCommit: 89601afa8ed43d66fdbba5be189cc200e3cd6a9b
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,58 +1,84 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/f08240caaa705f584cb6479880136d273c442658/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/4365c863956250d758341b86035862b111269ed9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 6b38-jdk-wheezy, 6b38-wheezy, 6-jdk-wheezy, 6-wheezy, 6b38-jdk, 6b38, 6-jdk, 6
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jdk
-
-Tags: 6b38-jdk-slim-wheezy, 6b38-slim-wheezy, 6-jdk-slim-wheezy, 6-slim-wheezy, 6b38-jdk-slim, 6b38-slim, 6-jdk-slim, 6-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jdk/slim
-
-Tags: 6b38-jre-wheezy, 6-jre-wheezy, 6b38-jre, 6-jre
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
-Directory: 6-jre
-
-Tags: 6b38-jre-slim-wheezy, 6-jre-slim-wheezy, 6b38-jre-slim, 6-jre-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jre/slim
-
-Tags: 7u151-jdk-jessie, 7u151-jessie, 7-jdk-jessie, 7-jessie, 7u151-jdk, 7u151, 7-jdk, 7
+Tags: 10-ea-32-jre-experimental, 10-ea-jre-experimental, 10-jre-experimental, 10-ea-32-jre, 10-ea-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
-Directory: 7-jdk
+GitCommit: 4365c863956250d758341b86035862b111269ed9
+Directory: 10-jre
 
-Tags: 7u151-jdk-slim-jessie, 7u151-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
+Tags: 10-ea-32-jre-slim-experimental, 10-ea-jre-slim-experimental, 10-jre-slim-experimental, 10-ea-32-jre-slim, 10-ea-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
-Directory: 7-jdk/slim
+GitCommit: 4365c863956250d758341b86035862b111269ed9
+Directory: 10-jre/slim
 
-Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
+Tags: 10-ea-32-jdk-experimental, 10-ea-32-experimental, 10-ea-jdk-experimental, 10-ea-experimental, 10-jdk-experimental, 10-experimental, 10-ea-32-jdk, 10-ea-32, 10-ea-jdk, 10-ea, 10-jdk, 10
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4365c863956250d758341b86035862b111269ed9
+Directory: 10-jdk
+
+Tags: 10-ea-32-jdk-slim-experimental, 10-ea-32-slim-experimental, 10-ea-jdk-slim-experimental, 10-ea-slim-experimental, 10-jdk-slim-experimental, 10-slim-experimental, 10-ea-32-jdk-slim, 10-ea-32-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4365c863956250d758341b86035862b111269ed9
+Directory: 10-jdk/slim
+
+Tags: 9.0.1-11-jre-sid, 9.0.1-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 9-jre
+
+Tags: 9.0.1-11-jre-slim-sid, 9.0.1-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.1-11-jre-slim, 9.0.1-jre-slim, 9.0-jre-slim, 9-jre-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 9-jre/slim
+
+Tags: 9.0.1-11-jdk-sid, 9.0.1-11-sid, 9.0.1-jdk-sid, 9.0.1-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.1-11-jdk, 9.0.1-11, 9.0.1-jdk, 9.0.1, 9.0-jdk, 9.0, 9-jdk, 9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 9-jdk
+
+Tags: 9.0.1-11-jdk-slim-sid, 9.0.1-11-slim-sid, 9.0.1-jdk-slim-sid, 9.0.1-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.1-11-jdk-slim, 9.0.1-11-slim, 9.0.1-jdk-slim, 9.0.1-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 9-jdk/slim
+
+Tags: 9.0.1-jdk-windowsservercore-ltsc2016, 9.0.1-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
+SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Architectures: windows-amd64
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 9.0.1-jdk-windowsservercore-1709, 9.0.1-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
+SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Architectures: windows-amd64
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 9.0.1-jdk-nanoserver-sac2016, 9.0.1-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
+SharedTags: 9.0.1-jdk-nanoserver, 9.0.1-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
+Architectures: windows-amd64
+GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+Directory: 9-jdk/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
+
+Tags: 8u151-jre-stretch, 8-jre-stretch, jre-stretch, 8u151-jre, 8-jre, jre
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 8-jre
+
+Tags: 8u151-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u151-jre-slim, 8-jre-slim, jre-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
+Directory: 8-jre/slim
+
+Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
-Directory: 7-jdk/alpine
-
-Tags: 7u151-jre-jessie, 7-jre-jessie, 7u151-jre, 7-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
-Directory: 7-jre
-
-Tags: 7u151-jre-slim-jessie, 7-jre-slim-jessie, 7u151-jre-slim, 7-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
-Directory: 7-jre/slim
-
-Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
-Directory: 7-jre/alpine
+GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
+Directory: 8-jre/alpine
 
 Tags: 8u151-jdk-stretch, 8u151-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u151-jdk, 8u151, 8-jdk, 8, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -90,58 +116,52 @@ GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
 Directory: 8-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u151-jre-stretch, 8-jre-stretch, jre-stretch, 8u151-jre, 8-jre, jre
+Tags: 7u151-jre-jessie, 7-jre-jessie, 7u151-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 8-jre
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+Directory: 7-jre
 
-Tags: 8u151-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u151-jre-slim, 8-jre-slim, jre-slim
+Tags: 7u151-jre-slim-jessie, 7-jre-slim-jessie, 7u151-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 8-jre/slim
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+Directory: 7-jre/slim
 
-Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
+Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
-Directory: 8-jre/alpine
+GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
+Directory: 7-jre/alpine
 
-Tags: 9.0.1-11-jdk-sid, 9.0.1-11-sid, 9.0.1-jdk-sid, 9.0.1-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.1-11-jdk, 9.0.1-11, 9.0.1-jdk, 9.0.1, 9.0-jdk, 9.0, 9-jdk, 9
+Tags: 7u151-jdk-jessie, 7u151-jessie, 7-jdk-jessie, 7-jessie, 7u151-jdk, 7u151, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jdk
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+Directory: 7-jdk
 
-Tags: 9.0.1-11-jdk-slim-sid, 9.0.1-11-slim-sid, 9.0.1-jdk-slim-sid, 9.0.1-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.1-11-jdk-slim, 9.0.1-11-slim, 9.0.1-jdk-slim, 9.0.1-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
+Tags: 7u151-jdk-slim-jessie, 7u151-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jdk/slim
+GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+Directory: 7-jdk/slim
 
-Tags: 9.0.1-jdk-windowsservercore-ltsc2016, 9.0.1-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
-SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
-Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
-Directory: 9-jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
+Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
+Directory: 7-jdk/alpine
 
-Tags: 9.0.1-jdk-windowsservercore-1709, 9.0.1-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
-SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
-Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
-Directory: 9-jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
+Tags: 6b38-jre-wheezy, 6-jre-wheezy, 6b38-jre, 6-jre
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
+Directory: 6-jre
 
-Tags: 9.0.1-jdk-nanoserver-sac2016, 9.0.1-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
-SharedTags: 9.0.1-jdk-nanoserver, 9.0.1-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
-Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
-Directory: 9-jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
+Tags: 6b38-jre-slim-wheezy, 6-jre-slim-wheezy, 6b38-jre-slim, 6-jre-slim
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+Directory: 6-jre/slim
 
-Tags: 9.0.1-11-jre-sid, 9.0.1-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jre
+Tags: 6b38-jdk-wheezy, 6b38-wheezy, 6-jdk-wheezy, 6-wheezy, 6b38-jdk, 6b38, 6-jdk, 6
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+Directory: 6-jdk
 
-Tags: 9.0.1-11-jre-slim-sid, 9.0.1-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.1-11-jre-slim, 9.0.1-jre-slim, 9.0-jre-slim, 9-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
-Directory: 9-jre/slim
+Tags: 6b38-jdk-slim-wheezy, 6b38-slim-wheezy, 6-jdk-slim-wheezy, 6-slim-wheezy, 6b38-jdk-slim, 6b38-slim, 6-jdk-slim, 6-slim
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
+Directory: 6-jdk/slim

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -44,42 +44,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
 
-Tags: 3.6.15-rc.1, 3.6-rc
+Tags: 3.6.15, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
-Directory: 3.6-rc/debian
-
-Tags: 3.6.15-rc.1-management, 3.6-rc-management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
-Directory: 3.6-rc/debian/management
-
-Tags: 3.6.15-rc.1-alpine, 3.6-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
-Directory: 3.6-rc/alpine
-
-Tags: 3.6.15-rc.1-management-alpine, 3.6-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f1b33563bcaf75a9f5cdb670570e173fda52092a
-Directory: 3.6-rc/alpine/management
-
-Tags: 3.6.14, 3.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
+GitCommit: da82eb0f68ed89a876fc44e915f20fc1e6e6bd8d
 Directory: 3.6/debian
 
-Tags: 3.6.14-management, 3.6-management
+Tags: 3.6.15-management, 3.6-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/debian/management
 
-Tags: 3.6.14-alpine, 3.6-alpine
+Tags: 3.6.15-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2558d958a0ab9c38f58ad616e387063b33bb229c
+GitCommit: da82eb0f68ed89a876fc44e915f20fc1e6e6bd8d
 Directory: 3.6/alpine
 
-Tags: 3.6.14-management-alpine, 3.6-management-alpine
+Tags: 3.6.15-management-alpine, 3.6-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/alpine/management

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/35e89070548111261cf6a9e9398556d5b2c4f7f7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/5d317a0a21e6c927e415dfc8dd452619ea4b4643/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,70 +6,110 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.82-jre7, 7.0-jre7, 7-jre7, 7.0.82, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 7/jre7
+
+Tags: 7.0.82-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.82-slim, 7.0-slim, 7-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 7/jre7-slim
 
 Tags: 7.0.82-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.82-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 7/jre7-alpine
 
 Tags: 7.0.82-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 7/jre8
+
+Tags: 7.0.82-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 7/jre8-slim
 
 Tags: 7.0.82-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a78361a9ce7ef48979acbcabe2acd9342d0168a
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 7/jre8-alpine
 
 Tags: 8.0.48-jre7, 8.0-jre7, 8.0.48, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.0/jre7
+
+Tags: 8.0.48-jre7-slim, 8.0-jre7-slim, 8.0.48-slim, 8.0-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 8.0/jre7-slim
 
 Tags: 8.0.48-jre7-alpine, 8.0-jre7-alpine, 8.0.48-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e8cf7367b4e3f3d77e8bc98fcec509bb7a8d7be
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.48-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.0/jre8
+
+Tags: 8.0.48-jre8-slim, 8.0-jre8-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 8.0/jre8-slim
 
 Tags: 8.0.48-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e8cf7367b4e3f3d77e8bc98fcec509bb7a8d7be
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.24-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.24, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.5/jre8
+
+Tags: 8.5.24-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.24-slim, 8.5-slim, 8-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 8.5/jre8-slim
 
 Tags: 8.5.24-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.24-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efab5942d355f9bac6f6e2a99d82a40a564bef3c
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.5/jre8-alpine
 
 Tags: 8.5.24-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.5/jre9
+
+Tags: 8.5.24-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 8.5/jre9-slim
 
 Tags: 9.0.2-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 9.0/jre8
+
+Tags: 9.0.2-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 9.0/jre8-slim
 
 Tags: 9.0.2-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b6a8794a995e0f482a3832b7c7041eec9a804f2a
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 9.0/jre8-alpine
 
 Tags: 9.0.2-jre9, 9.0-jre9, 9-jre9, 9.0.2, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35e89070548111261cf6a9e9398556d5b2c4f7f7
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 9.0/jre9
+
+Tags: 9.0.2-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.2-slim, 9.0-slim, 9-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+Directory: 9.0/jre9-slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.1-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.1-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.2-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.2-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php5.6/apache
 
-Tags: 4.9.1-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.2-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php5.6/fpm
 
-Tags: 4.9.1-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.2-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.1-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.1-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.2-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.2-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.0/apache
 
-Tags: 4.9.1-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.2-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.0/fpm
 
-Tags: 4.9.1-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.2-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.1-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.1-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.2-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.2-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.1/apache
 
-Tags: 4.9.1-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.2-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.1/fpm
 
-Tags: 4.9.1-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.2-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.1-apache, 4.9-apache, 4-apache, apache, 4.9.1, 4.9, 4, latest, 4.9.1-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.1-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.2-apache, 4.9-apache, 4-apache, apache, 4.9.2, 4.9, 4, latest, 4.9.2-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.2-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.2/apache
 
-Tags: 4.9.1-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.1-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.2-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.2-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6a085d90853b8baffadbd3f0a41d6814a2513c11
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.2/fpm
 
-Tags: 4.9.1-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.1-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.2-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.2-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 43d32697c6862dcb48ca520e87e1e0fb585aee03
+GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost`: 1.20.2
- `openjdk`: OpenJDK 10 early access (docker-library/openjdk#160)
- `rabbitmq`: 3.6.15 GA
- `tomcat`: `slim` variants (docker-library/tomcat#104)
- `wordpress`: 4.9.2