### PR TITLE
Update docker-library images

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.2.34, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
+GitCommit: 49d553ae79f1b42ba541714c4e611aec5eefdfa8
 Directory: 2.2
 
 Tags: 2.2.34-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: c14a031c014aa2219aea2e73786f577300756f0b
+GitCommit: 49d553ae79f1b42ba541714c4e611aec5eefdfa8
 Directory: 2.2/alpine
 
 Tags: 2.4.29, 2.4, 2, latest

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.3, 10.3
-GitCommit: 506cd7c6b9d6c53d7b514a2c94db5d3daee832fd
+Tags: 10.3.4, 10.3
+GitCommit: 25d4485e6192c1cfa2f9b12882c291258b73ed64
 Directory: 10.3
 
 Tags: 10.2.12, 10.2, 10, latest

--- a/library/memcached
+++ b/library/memcached
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.5.4-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6af843ea5c1ada3cc711424c6a533292cca31a40
+GitCommit: d27b35d037dcb8bde2a926f50bd73013a5c5c63f
 Directory: alpine

--- a/library/php
+++ b/library/php
@@ -16,7 +16,7 @@ Directory: 7.2/stretch/apache
 
 Tags: 7.2.1-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.1-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.1-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.1-zts, 7.2-zts, 7-zts, zts
@@ -31,7 +31,7 @@ Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.1-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.1-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
@@ -46,7 +46,7 @@ Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.1-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.1-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.1-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.1-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
@@ -66,7 +66,7 @@ Directory: 7.1/jessie/apache
 
 Tags: 7.1.13-fpm-jessie, 7.1-fpm-jessie, 7.1.13-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.13-zts-jessie, 7.1-zts-jessie, 7.1.13-zts, 7.1-zts
@@ -81,7 +81,7 @@ Directory: 7.1/alpine3.4/cli
 
 Tags: 7.1.13-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.13-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.1/alpine3.4/fpm
 
 Tags: 7.1.13-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.13-zts-alpine, 7.1-zts-alpine
@@ -101,7 +101,7 @@ Directory: 7.0/jessie/apache
 
 Tags: 7.0.27-fpm-jessie, 7.0-fpm-jessie, 7.0.27-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.27-zts-jessie, 7.0-zts-jessie, 7.0.27-zts, 7.0-zts
@@ -116,7 +116,7 @@ Directory: 7.0/alpine3.4/cli
 
 Tags: 7.0.27-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.27-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 2eb7af007026493eb02f5e87c082ab78543a1f2d
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 7.0/alpine3.4/fpm
 
 Tags: 7.0.27-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.27-zts-alpine, 7.0-zts-alpine
@@ -136,7 +136,7 @@ Directory: 5.6/jessie/apache
 
 Tags: 5.6.33-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.33-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a37af189869968236a8b832beac950b78b26b471
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.33-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.33-zts, 5.6-zts, 5-zts
@@ -151,7 +151,7 @@ Directory: 5.6/alpine3.4/cli
 
 Tags: 5.6.33-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.33-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: a37af189869968236a8b832beac950b78b26b471
+GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
 Directory: 5.6/alpine3.4/fpm
 
 Tags: 5.6.33-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.33-zts-alpine, 5.6-zts-alpine, 5-zts-alpine


### PR DESCRIPTION
- `httpd`: update patches (https://www.apache.org/dist/httpd/patches/apply_to_2.2.34/2.2.x-mod_proxy-without-APR_HAS_THREADS.patch)
- `mariadb`: 10.3.4
- `memcached`: Alpine 3.7 (docker-library/memcached#31)
- `php`: adjust FPM `listen` to be port-only (docker-library/php#562)