### PR TITLE
Update Solr to 7.2.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,122 +4,62 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.2.0, 7.2, 7, latest
+Tags: 7.2.1, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41f27ad4aa36e0f1d8485432e1a40cded663f17b
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.2
 
-Tags: 7.2.0-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 41f27ad4aa36e0f1d8485432e1a40cded663f17b
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.2/alpine
 
-Tags: 7.2.0-slim, 7.2-slim, 7-slim, slim
+Tags: 7.2.1-slim, 7.2-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41f27ad4aa36e0f1d8485432e1a40cded663f17b
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 7.1/slim
-
-Tags: 7.0.1, 7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 7.0
-
-Tags: 7.0.1-alpine, 7.0-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 7.0/alpine
-
-Tags: 7.0.1-slim, 7.0-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 7.0/slim
 
 Tags: 6.6.2, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 6.6
 
 Tags: 6.6.2-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 6.6/alpine
 
 Tags: 6.6.2-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 6.6/slim
-
-Tags: 6.5.1, 6.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.5
-
-Tags: 6.5.1-alpine, 6.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.5/alpine
-
-Tags: 6.5.1-slim, 6.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.5/slim
-
-Tags: 6.4.2, 6.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.4
-
-Tags: 6.4.2-alpine, 6.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.4/alpine
-
-Tags: 6.4.2-slim, 6.4-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.4/slim
-
-Tags: 6.3.0, 6.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.3
-
-Tags: 6.3.0-alpine, 6.3-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.3/alpine
-
-Tags: 6.3.0-slim, 6.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
-Directory: 6.3/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46459f813c8bacc84449de5e7c4c5d1ade791a46
+GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
 Directory: 5.5/slim


### PR DESCRIPTION
Update Solr to 7.2.1
Announcement: http://lucene.apache.org/solr/news.html#15-january-2018-apache-solrtm-721-available
Changes: https://lucene.apache.org/solr/7_2_1/changes/Changes.html

Remove older minor versions

On the docker-solr side, make it possible to override SOLR_PORT. 