### PR TITLE
Add teamspeak

### DIFF
--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,10 +2,6 @@ Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn)
              Maximilian Münchow <maximilian.muenchow@teamspeak.com> (@muenchow)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-Tags: 3.1, 3.1.0, 3.1.0-beta-2, latest
+Tags: 3.1, 3.1.0, latest
 GitCommit: 0aa60b817eec11e41f8a93b225bab48f82133b1b
-Directory: 3.1.0
-
-Tags: 3.1.0-beta-1
-GitCommit: c07609623893eb96bda1616acd63898bca72ffec
 Directory: 3.1.0

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -3,7 +3,7 @@ Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
 Tags: 3.1, 3.1.0, 3.1.0-Beta-2, latest
-GitCommit: 6a4c4663f607394cb3198320989bc2c7f997037f
+GitCommit: 0aa60b817eec11e41f8a93b225bab48f82133b1b
 Directory: 3.1.0
 
 Tags: 3.1.0-Beta-1

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,6 +2,10 @@ Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn)
              Maximilian Münchow <maximilian.muenchow@teamspeak.com> (@muenchow)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-Tags: 3.1, 3.1.0, 3.1.0-Beta-1, latest
+Tags: 3.1, 3.1.0, 3.1.0-Beta-2, latest
+GitCommit: 6a4c4663f607394cb3198320989bc2c7f997037f
+Directory: 3.1.0
+
+Tags: 3.1.0-Beta-1
 GitCommit: a540f3a1babe6e0419afb07bb2f088dd98a3f74d
 Directory: 3.1.0

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -1,0 +1,7 @@
+Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn),
+             Maximilian Münchow <maximilian.muenchow@teamspeak.com> (@muenchow)
+GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
+
+Tags: 3.1, 3.1.0, 3.1.0-Beta-1, latest
+GitCommit: a540f3a1babe6e0419afb07bb2f088dd98a3f74d
+Directory: 3.1.0

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -7,5 +7,5 @@ GitCommit: 0aa60b817eec11e41f8a93b225bab48f82133b1b
 Directory: 3.1.0
 
 Tags: 3.1.0-Beta-1
-GitCommit: a540f3a1babe6e0419afb07bb2f088dd98a3f74d
+GitCommit: c07609623893eb96bda1616acd63898bca72ffec
 Directory: 3.1.0

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,10 +2,10 @@ Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn)
              Maximilian Münchow <maximilian.muenchow@teamspeak.com> (@muenchow)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-Tags: 3.1, 3.1.0, 3.1.0-Beta-2, latest
+Tags: 3.1, 3.1.0, 3.1.0-beta-2, latest
 GitCommit: 0aa60b817eec11e41f8a93b225bab48f82133b1b
 Directory: 3.1.0
 
-Tags: 3.1.0-Beta-1
+Tags: 3.1.0-beta-1
 GitCommit: c07609623893eb96bda1616acd63898bca72ffec
 Directory: 3.1.0


### PR DESCRIPTION
# Summary

We wish to add to the official image our TeamSpeak server.
Documentation can be found [here](https://github.com/docker-library/docs/pull/1126). The TeamSpeak server is closed source, so only the dockerfile can be found on github: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images


# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/TeamSpeak-Systems
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service!
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1126
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
