### PR TITLE
Bump Traefik to v1.5.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.5.0-rc5, 1.5.0-rc5, v1.5, 1.5, cancoillotte
+Tags: v1.5.0, 1.5.0, v1.5, 1.5, cancoillotte, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: ff5cbe3809d54e1594586975184781d1a44662a9
+GitCommit: 4ac72271d92558226f76ef1a4043ac9fe1be05dd
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.5.0-rc5-alpine, 1.5.0-rc5-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine
+Tags: v1.5.0-alpine, 1.5.0-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: ff5cbe3809d54e1594586975184781d1a44662a9
-Directory: alpine
-
-Tags: v1.4.6, 1.4.6, v1.4, 1.4, roquefort, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 11fb07f3be330bece4875ced219372c6bda16868
-amd64-Directory: scratch/amd64
-arm32v6-Directory: scratch/arm
-arm64v8-Directory: scratch/arm64
-
-Tags: v1.4.6-alpine, 1.4.6-alpine, v1.4-alpine, 1.4-alpine, roquefort-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 11fb07f3be330bece4875ced219372c6bda16868
+GitCommit: 4ac72271d92558226f76ef1a4043ac9fe1be05dd
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.0.

/cc @vdemeester @emilevauge

Cheers
