### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.19, 2.1
 Architectures: amd64, i386
-GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
+GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
 Directory: 2.1
 
 Tags: 2.2.11, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
+GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
 Directory: 2.2
 
 Tags: 3.0.15, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
+GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
 Directory: 3.0
 
 Tags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 88c25000ef8da0e0f7eb3a6b8202b2f7678c8dab
+GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
 Directory: 3.11

--- a/library/gcc
+++ b/library/gcc
@@ -7,20 +7,20 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f3be2bd5373e6d902df99a3619add9183e4f675
+GitCommit: 0423cc3f79023c2ab821d2377f73105217c46892
 Directory: 5
 # Docker EOL: 2018-10-10
 
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 18171698e694c648ccf2cc1aa98ea806b58701d5
+GitCommit: 0423cc3f79023c2ab821d2377f73105217c46892
 Directory: 6
 # Docker EOL: 2018-07-04
 
 # Last Modified: 2017-08-14
 Tags: 7.2.0, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9bf9204098e91914c02bc07d1fb44e33555276ed
+GitCommit: 0423cc3f79023c2ab821d2377f73105217c46892
 Directory: 7
 # Docker EOL: 2018-08-14

--- a/library/golang
+++ b/library/golang
@@ -37,86 +37,86 @@ GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
 Directory: 1.10-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.9.2-stretch, 1.9-stretch, 1-stretch, stretch
-SharedTags: 1.9.2, 1.9, 1, latest
+Tags: 1.9.3-stretch, 1.9-stretch, 1-stretch, stretch
+SharedTags: 1.9.3, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/stretch
 
-Tags: 1.9.2-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
+Tags: 1.9.3-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e2ddb8ec8c9f59a56ddfb343e1bd8e65440b6db
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/alpine3.7
 
-Tags: 1.9.2-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.3-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.3-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.2-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.2, 1.9, 1, latest
+Tags: 1.9.3-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.9.3-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.3, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.2-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.2, 1.9, 1, latest
+Tags: 1.9.3-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.9.3-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.3, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.9.2-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.9.2-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.9.3-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.9.3-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
 Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.8.5-stretch, 1.8-stretch
+Tags: 1.8.6-stretch, 1.8-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/stretch
 
-Tags: 1.8.5-jessie, 1.8-jessie
-SharedTags: 1.8.5, 1.8
+Tags: 1.8.6-jessie, 1.8-jessie
+SharedTags: 1.8.6, 1.8
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/jessie
 
-Tags: 1.8.5-alpine3.6, 1.8-alpine3.6
+Tags: 1.8.6-alpine3.6, 1.8-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/alpine3.6
 
-Tags: 1.8.5-alpine3.5, 1.8-alpine3.5, 1.8.5-alpine, 1.8-alpine
+Tags: 1.8.6-alpine3.5, 1.8-alpine3.5, 1.8.6-alpine, 1.8-alpine
 Architectures: amd64
-GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/alpine3.5
 
-Tags: 1.8.5-onbuild, 1.8-onbuild
+Tags: 1.8.6-onbuild, 1.8-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
-Tags: 1.8.5-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
-SharedTags: 1.8.5-windowsservercore, 1.8-windowsservercore, 1.8.5, 1.8
+Tags: 1.8.6-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
+SharedTags: 1.8.6-windowsservercore, 1.8-windowsservercore, 1.8.6, 1.8
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.8.5-windowsservercore-1709, 1.8-windowsservercore-1709
-SharedTags: 1.8.5-windowsservercore, 1.8-windowsservercore, 1.8.5, 1.8
+Tags: 1.8.6-windowsservercore-1709, 1.8-windowsservercore-1709
+SharedTags: 1.8.6-windowsservercore, 1.8-windowsservercore, 1.8.6, 1.8
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.8.5-nanoserver-sac2016, 1.8-nanoserver-sac2016
-SharedTags: 1.8.5-nanoserver, 1.8-nanoserver
+Tags: 1.8.6-nanoserver-sac2016, 1.8-nanoserver-sac2016
+SharedTags: 1.8.6-nanoserver, 1.8-nanoserver
 Architectures: windows-amd64
-GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
 Directory: 1.8/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016

--- a/library/haproxy
+++ b/library/haproxy
@@ -6,40 +6,40 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
+GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64
-GitCommit: c4e5aad8e303cdf6911e944b667ee2ef69caaa25
+GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
 Directory: 1.5/alpine
 
 Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24cc5b511f2dc452c656c0e2cef9b5cf28799e8e
+GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
 Directory: 1.6
 
 Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64
-GitCommit: 24cc5b511f2dc452c656c0e2cef9b5cf28799e8e
+GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
 Directory: 1.6/alpine
 
 Tags: 1.7.10, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 100a0a6586377869d797cc5cec3834688a4d1860
+GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
 Directory: 1.7
 
 Tags: 1.7.10-alpine, 1.7-alpine
 Architectures: amd64
-GitCommit: 100a0a6586377869d797cc5cec3834688a4d1860
+GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
 Directory: 1.7/alpine
 
 Tags: 1.8.3, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d04b60897f650493ecb1f031048c2c48b25b63fc
+GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
 Directory: 1.8
 
 Tags: 1.8.3-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d04b60897f650493ecb1f031048c2c48b25b63fc
+GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
 Directory: 1.8/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -20,6 +20,6 @@ Tags: 10.0.33, 10.0
 GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
 Directory: 10.0
 
-Tags: 5.5.58, 5.5, 5
-GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
+Tags: 5.5.59, 5.5, 5
+GitCommit: 13319ccb3c41c7c84404e628e9b051d340e9d055
 Directory: 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -15,14 +15,14 @@ Directory: 3.0
 Tags: 3.0.15-windowsservercore-ltsc2016, 3.0-windowsservercore-ltsc2016
 SharedTags: 3.0.15-windowsservercore, 3.0-windowsservercore, 3.0.15, 3.0
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.0.15-windowsservercore-1709, 3.0-windowsservercore-1709
 SharedTags: 3.0.15-windowsservercore, 3.0-windowsservercore, 3.0.15, 3.0
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -37,14 +37,14 @@ Directory: 3.2
 Tags: 3.2.18-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
 SharedTags: 3.2.18-windowsservercore, 3.2-windowsservercore, 3.2.18, 3.2
 Architectures: windows-amd64
-GitCommit: 1af403f9d70fed1da9502b6f486a5f68f384eef7
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.2.18-windowsservercore-1709, 3.2-windowsservercore-1709
 SharedTags: 3.2.18-windowsservercore, 3.2-windowsservercore, 3.2.18, 3.2
 Architectures: windows-amd64
-GitCommit: 1af403f9d70fed1da9502b6f486a5f68f384eef7
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -59,14 +59,14 @@ Directory: 3.4
 Tags: 3.4.10-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
 SharedTags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3.4.10, 3.4
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.4.10-windowsservercore-1709, 3.4-windowsservercore-1709
 SharedTags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3.4.10, 3.4
 Architectures: windows-amd64
-GitCommit: daeeeccd0edd110e6341ba3ee2d699caf885fbce
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -81,14 +81,14 @@ Directory: 3.6
 Tags: 3.6.2-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.2-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -103,13 +103,13 @@ Directory: 3.7
 Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
 SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
 Architectures: windows-amd64
-GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.1-windowsservercore-1709, 3.7-windowsservercore-1709, unstable-windowsservercore-1709
 SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
 Architectures: windows-amd64
-GitCommit: 692ec82754bde8d6d4e663462669b3be2a6f8b2b
+GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 3.2/32bit
 
 Tags: 3.2.11-alpine, 3.2-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 99a06c057297421f9ea46934c342a2fc00644c4f
+GitCommit: 14e48621e40c6b6c84e474e28b06430a3261916a
 Directory: 3.2/alpine
 
 Tags: 4.0.6, 4.0, 4, latest
@@ -31,5 +31,5 @@ Directory: 4.0/32bit
 
 Tags: 4.0.6-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c63bd5fc7b52cc3d8f3441a660a593028a0ed15
+GitCommit: 14e48621e40c6b6c84e474e28b06430a3261916a
 Directory: 4.0/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -64,52 +64,52 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.24-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.24, 8.5, 8, latest
+Tags: 8.5.27-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.27, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
 Directory: 8.5/jre8
 
-Tags: 8.5.24-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.24-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.27-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.27-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.24-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.24-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.27-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.27-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: bd0e24fdb2c21cccb32d9ee821e0c96cf8b2f393
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.24-jre9, 8.5-jre9, 8-jre9, jre9
+Tags: 8.5.27-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
 Directory: 8.5/jre9
 
-Tags: 8.5.24-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
+Tags: 8.5.27-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
 Directory: 8.5/jre9-slim
 
-Tags: 9.0.2-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.4-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
 Directory: 9.0/jre8
 
-Tags: 9.0.2-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.4-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.2-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.4-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: fe11a5d3316d12d4b68c05f2006fb35a8c8a80c1
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.2-jre9, 9.0-jre9, 9-jre9, 9.0.2, 9.0, 9
+Tags: 9.0.4-jre9, 9.0-jre9, 9-jre9, 9.0.4, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
 Directory: 9.0/jre9
 
-Tags: 9.0.2-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.2-slim, 9.0-slim, 9-slim
+Tags: 9.0.4-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.4-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d317a0a21e6c927e415dfc8dd452619ea4b4643
+GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
 Directory: 9.0/jre9-slim


### PR DESCRIPTION
- `cassandra`: https
- `gcc`: https
- `golang`: 1.9.3, 1.8.6
- `haproxy`: https
- `mariadb`: 5.5.59, 10.3.4
- `mongo`: https
- `redis`: Alpine 3.7 (docker-library/redis#123)
- `tomcat`: 8.5.27, 9.0.4