### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/f3b69761c32e9b861140d8da5cd93ceacfdb4499/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/f2583bd2013d77140210bbde5942d6ddd3ec3b84/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: f3b69761c32e9b861140d8da5cd93ceacfdb4499
+GitCommit: f2583bd2013d77140210bbde5942d6ddd3ec3b84
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4650afd74a979f1c4cde5e817e9a13b33576ff76
+amd64-GitCommit: 1d83005cfbf84342f08f320bb71eb10be8543a0a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 669eba7f4fc52fe25b0faf7adf89f1fbed0e9957
+arm32v5-GitCommit: d37b30651b40738df2d9d835e9ed54089d0ceb62
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 723b8049d149a24c9432c6cef785875f18872849
+arm32v6-GitCommit: 0c8f454ac56c109528a5a8275ca1b60052317772
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 13c90b4662440bc252aacf2d818dccdab2e1309c
+arm32v7-GitCommit: b9141b40da344c58679fde3a9684672ba119ea66
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1722d7eccafa5c41f9727573ed1400a0302a02f9
+arm64v8-GitCommit: d1a9616e4b77e43b128ccd61db087399b27029eb
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 7212f67c6021f903067d562723000782e74cee4f
+i386-GitCommit: e40f65681fbfb3d9a34fef883936cddc17e7fe8f
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: c22e8505cb431aba0051cdb1eac26b18c160bdda
+ppc64le-GitCommit: ed4319d69de3774c357b4cc56705360f2c587ffc
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 5723a612a26a2659b816969647dc1ca6a4141d82
+s390x-GitCommit: acd7c55515923f3deb1a45f76a354dd7d0e4bccf
 
 Tags: 1.28.0-uclibc, 1.28-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.0, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.5/stretch
 
 Tags: 2.5.0-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.0-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.0-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e5d5ed23036c66c5797c39e0e156de5d006dbfc0
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.3-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/stretch
 
 Tags: 2.4.3-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.3-jessie, 2.4-jessie, 2.4.3, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/jessie
 
 Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2.4.3-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.3-onbuild, 2.4-onbuild
@@ -46,27 +46,27 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.3-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.3-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2.4.3-alpine, 2.4-alpine
 Architectures: amd64
-GitCommit: 1d0fe6a9d5c75d8a114fb03016f528d68c613d80
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.3/jessie
 
 Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.6-onbuild, 2.3-onbuild
@@ -76,17 +76,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 9ef6f79b6a6aeab1856a8c890bbb16b1dd5e0745
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.2/jessie
 
 Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.9-onbuild, 2.2-onbuild
@@ -96,5 +96,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: c441f3dcacc103f0ebea5f0d9fd2ad773516e7ad
+GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
- `busybox`: `musl` from Alpine 3.7 (docker-library/busybox#38), use buildroot permissions directly (docker-library/busybox#39), update to buildroot 2017.11.1 (docker-library/busybox#40)
- `ruby`: remove unnecessary `/root/.gem` to reduce size (docker-library/ruby#185)