### PR TITLE
Remove images based on old or not-yet-supported images

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -14,12 +14,6 @@ Directory: dockerfiles/xenial
 Tags: xenial-non-free, nd16.04-non-free
 Directory: dockerfiles/xenial-non-free
 
-Tags: zesty, nd17.04
-Directory: dockerfiles/zesty
-
-Tags: zesty-non-free, nd17.04-non-free
-Directory: dockerfiles/zesty-non-free
-
 Tags: artful, nd17.10
 Directory: dockerfiles/artful
 

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -8,21 +8,25 @@ Directory: release/kernel/java8/ibmjava
 
 Tags: kernel-java8-ibmsfj
 Directory: release/kernel/java8/ibmsfj
+Architectures: amd64
 
 Tags: webProfile7, webProfile7-java8-ibm
 Directory: release/webProfile7/java8/ibmjava
 
 Tags: webProfile7-java8-ibmsfj
 Directory: release/webProfile7/java8/ibmsfj
+Architectures: amd64
 
 Tags: javaee7, javaee7-java8-ibm, latest
 Directory: release/javaee7/java8/ibmjava
 
 Tags: javaee7-java8-ibmsfj
 Directory: release/javaee7/java8/ibmsfj
+Architectures: amd64
 
 Tags: microProfile1, microProfile1-java8-ibm
 Directory: release/microProfile1/java8/ibmjava
 
 Tags: microProfile1-java8-ibmsfj
 Directory: release/microProfile1/java8/ibmsfj
+Architectures: amd64


### PR DESCRIPTION
- `neurodebian:zesty`
  - `ubuntu:zesty` is EOL as of January 13, 2018
    - see also https://github.com/docker-library/official-images/pull/3901 and https://github.com/neurodebian/dockerfiles/pull/9
  - recommend removing since the base image will no longer receive updates
  - cc @yarikoptic

- `open-liberty:kernel-java8-ibmsfj` (and children)
  - cannot build on any non-amd64 arch since there is no base image
  - `ibmjava:8-sfj-alpine` currently only supports amd64 architecture
  - can be added back once ibmjava adds more arches for their alpine based image https://github.com/docker-library/official-images/pull/3418#issuecomment-359383227
  - cc @NottyCode
  - YMMV, but you might be interested in the scripts we use to keep our image/arch combinations aligned: [example](https://github.com/docker-library/redis/blob/cf9b54aee062b2fabe2d29ac39f1f2574807b0e5/generate-stackbrew-library.sh) from redis whose output becomes [`library/redis`](https://github.com/docker-library/official-images/blob/b805d4a4470032c51f54825867c81c6d89050049/library/redis)