### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,47 +4,62 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.01.0-ce, 18.01.0, 18.01, 18, edge, test, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
+Tags: 18.02.0-ce-rc1, 18.02-rc, rc, test
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
+Directory: 18.02-rc
+
+Tags: 18.02.0-ce-rc1-dind, 18.02-rc-dind, rc-dind, test-dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
+Directory: 18.02-rc/dind
+
+Tags: 18.02.0-ce-rc1-git, 18.02-rc-git, rc-git, test-git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
+Directory: 18.02-rc/git
+
+Tags: 18.01.0-ce, 18.01.0, 18.01, 18, edge, latest
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
 Directory: 18.01
 
-Tags: 18.01.0-ce-dind, 18.01.0-dind, 18.01-dind, 18-dind, edge-dind, test-dind, dind
-Architectures: amd64, arm64v8, ppc64le, s390x
+Tags: 18.01.0-ce-dind, 18.01.0-dind, 18.01-dind, 18-dind, edge-dind, dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
 Directory: 18.01/dind
 
-Tags: 18.01.0-ce-git, 18.01.0-git, 18.01-git, 18-git, edge-git, test-git, git
-Architectures: amd64, arm64v8, ppc64le, s390x
+Tags: 18.01.0-ce-git, 18.01.0-git, 18.01-git, 18-git, edge-git, git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
 Directory: 18.01/git
 
 Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51ba3bdf3e104e8af01150daec9122c4fbeaa41e
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
 Directory: 17.12
 
 Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/dind
 
 Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/git
 
 Tags: 17.09.1-ce, 17.09.1, 17.09
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 4e80fad160cf70fac2ad8920528b43870426a00c
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
 Directory: 17.09
 
 Tags: 17.09.1-ce-dind, 17.09.1-dind, 17.09-dind
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
 Directory: 17.09/dind
 
 Tags: 17.09.1-ce-git, 17.09.1-git, 17.09-git
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
 Directory: 17.09/git

--- a/library/golang
+++ b/library/golang
@@ -8,12 +8,12 @@ GitRepo: https://github.com/docker-library/golang.git
 Tags: 1.10beta2-stretch, 1.10-rc-stretch, rc-stretch
 SharedTags: 1.10beta2, 1.10-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
+GitCommit: fe39454becd30a04a8f398fc83bd19a8117eadab
 Directory: 1.10-rc/stretch
 
 Tags: 1.10beta2-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10beta2-alpine, 1.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
+GitCommit: fe39454becd30a04a8f398fc83bd19a8117eadab
 Directory: 1.10-rc/alpine3.7
 
 Tags: 1.10beta2-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.3-rc.1, 3.7-rc
+Tags: 3.7.3-rc.2, 3.7-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dab7fec58190fd07f000fa08b7f7de793895c373
+GitCommit: eb92a062fe8ef5f33ac9a9bfd8b1fa0201dabf4b
 Directory: 3.7-rc/debian
 
-Tags: 3.7.3-rc.1-management, 3.7-rc-management
+Tags: 3.7.3-rc.2-management, 3.7-rc-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
 Directory: 3.7-rc/debian/management
 
-Tags: 3.7.3-rc.1-alpine, 3.7-rc-alpine
+Tags: 3.7.3-rc.2-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
+GitCommit: dd7f0e66ae7b6eb8d7002a3e7fd6713e6a9cc2f3
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.3-rc.1-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.3-rc.2-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
 Directory: 3.7-rc/alpine/management


### PR DESCRIPTION
- `docker`: 18.02.0-ce-rc1, `arm32v6`
- `golang`: deprecate `go-wrapper` in 1.10+ (docker-library/golang#205)
- `rabbitmq`: 3.7.3-rc.2