### PR TITLE
[ros] remove images that use zesty as base image

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -132,29 +132,6 @@ GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
-# Distro: ubuntu:zesty
-
-Tags: lunar-ros-core-zesty
-Architectures: amd64
-GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
-Directory: ros/lunar/ubuntu/zesty/ros-core
-
-Tags: lunar-ros-base-zesty
-Architectures: amd64
-GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
-Directory: ros/lunar/ubuntu/zesty/ros-base
-
-Tags: lunar-robot-zesty
-Architectures: amd64
-GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
-Directory: ros/lunar/ubuntu/zesty/robot
-
-Tags: lunar-perception-zesty
-Architectures: amd64
-GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
-Directory: ros/lunar/ubuntu/zesty/perception
-
-########################################
 # Distro: debian:stretch
 
 Tags: lunar-ros-core-stretch
@@ -176,3 +153,4 @@ Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
 GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/perception
+


### PR DESCRIPTION
Related to https://github.com/osrf/docker_images/issues/111