### PR TITLE
[ros] Remove tags from EOL ros distribution: jade

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -29,33 +29,6 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 
 ################################################################################
-# Release: jade
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: jade-ros-core, jade-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
-Directory: ros/jade/ubuntu/trusty/ros-core
-
-Tags: jade-ros-base, jade-ros-base-trusty, jade
-Architectures: amd64, arm32v7
-GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
-Directory: ros/jade/ubuntu/trusty/ros-base
-
-Tags: jade-robot, jade-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
-Directory: ros/jade/ubuntu/trusty/robot
-
-Tags: jade-perception, jade-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
-Directory: ros/jade/ubuntu/trusty/perception
-
-
-################################################################################
 # Release: kinetic
 
 ########################################


### PR DESCRIPTION
ROS Jade is EOL. We decided that the ros images should not be rebuilt once the distro goes EOL.

Relevant discussion https://github.com/osrf/docker_images/issues/79#issuecomment-334848074.

The goals here is to stop building the images of ROS distributions once they go EOL so that the image reflects the final operating state of the distribution but that the images of that final state are still available for users.
Can you confirm if this PR will achieve this? and if not, could you please advice on what is the right way to do it ?

Thanks!