### PR TITLE
Update library images: golang and httpd; remove mongo:windows

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,35 +5,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10beta2-stretch, 1.10-rc-stretch, rc-stretch
-SharedTags: 1.10beta2, 1.10-rc, rc
+Tags: 1.10rc1-stretch, 1.10-rc-stretch, rc-stretch
+SharedTags: 1.10rc1, 1.10-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe39454becd30a04a8f398fc83bd19a8117eadab
+GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
 Directory: 1.10-rc/stretch
 
-Tags: 1.10beta2-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10beta2-alpine, 1.10-rc-alpine, rc-alpine
+Tags: 1.10rc1-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10rc1-alpine, 1.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe39454becd30a04a8f398fc83bd19a8117eadab
+GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
 Directory: 1.10-rc/alpine3.7
 
-Tags: 1.10beta2-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
+Tags: 1.10rc1-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.10rc1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc1, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
+GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
 Directory: 1.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10beta2-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
+Tags: 1.10rc1-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.10rc1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc1, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
+GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
 Directory: 1.10-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10beta2-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.10beta2-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
+Tags: 1.10rc1-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.10rc1-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: d4c78f49b7e192e064909a40d7c3e198887fc68f
+GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
 Directory: 1.10-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/httpd
+++ b/library/httpd
@@ -4,22 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.2.34, 2.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 49d553ae79f1b42ba541714c4e611aec5eefdfa8
-Directory: 2.2
-
-Tags: 2.2.34-alpine, 2.2-alpine
-Architectures: amd64
-GitCommit: 49d553ae79f1b42ba541714c4e611aec5eefdfa8
-Directory: 2.2/alpine
-
 Tags: 2.4.29, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d50d7f89f4d8bc6a6a3f86d892e254f4d6bfd8b
+GitCommit: 17166574dea6a8c574443fc3a06bdb5a8bc97743
 Directory: 2.4
 
 Tags: 2.4.29-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7976cabe162268bd5ad2d233d61e340447bfc371
+GitCommit: 17166574dea6a8c574443fc3a06bdb5a8bc97743
 Directory: 2.4/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/39c5967c35edc6132f0fd36a3a047391a5d382cc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/b9ae5fa0781a4f80e0ccb6d585edc569fd207f15/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -12,20 +12,6 @@ Architectures: amd64
 GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
 Directory: 3.0
 
-Tags: 3.0.15-windowsservercore-ltsc2016, 3.0-windowsservercore-ltsc2016
-SharedTags: 3.0.15-windowsservercore, 3.0-windowsservercore, 3.0.15, 3.0
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.0/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.0.15-windowsservercore-1709, 3.0-windowsservercore-1709
-SharedTags: 3.0.15-windowsservercore, 3.0-windowsservercore, 3.0.15, 3.0
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.0/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 3.2.18-jessie, 3.2-jessie
 SharedTags: 3.2.18, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
@@ -33,20 +19,6 @@ SharedTags: 3.2.18, 3.2
 Architectures: amd64
 GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
 Directory: 3.2
-
-Tags: 3.2.18-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
-SharedTags: 3.2.18-windowsservercore, 3.2-windowsservercore, 3.2.18, 3.2
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.2/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.2.18-windowsservercore-1709, 3.2-windowsservercore-1709
-SharedTags: 3.2.18-windowsservercore, 3.2-windowsservercore, 3.2.18, 3.2
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.2/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
 
 Tags: 3.4.10-jessie, 3.4-jessie
 SharedTags: 3.4.10, 3.4
@@ -56,20 +28,6 @@ Architectures: amd64
 GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
 Directory: 3.4
 
-Tags: 3.4.10-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
-SharedTags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3.4.10, 3.4
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.4/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.4.10-windowsservercore-1709, 3.4-windowsservercore-1709
-SharedTags: 3.4.10-windowsservercore, 3.4-windowsservercore, 3.4.10, 3.4
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.4/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
 SharedTags: 3.6.2, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
@@ -78,20 +36,6 @@ Architectures: amd64
 GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
 Directory: 3.6
 
-Tags: 3.6.2-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.6/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.6.2-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.6.2-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.2, 3.6, 3, latest
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.6/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 3.7.1-jessie, 3.7-jessie, unstable-jessie
 SharedTags: 3.7.1, 3.7, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
@@ -99,17 +43,3 @@ SharedTags: 3.7.1, 3.7, unstable
 Architectures: amd64
 GitCommit: b19d47c63e26ae755640ae5b74fa7b4e475c992f
 Directory: 3.7
-
-Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.7/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.7.1-windowsservercore-1709, 3.7-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, unstable-windowsservercore, 3.7.1, 3.7, unstable
-Architectures: windows-amd64
-GitCommit: 87c1f8dcad39836c90fd1d53eedf502e978e2437
-Directory: 3.7/windows/windowsservercore-1709
-Constraints: windowsservercore-1709


### PR DESCRIPTION
 - `golang` `1.10rc1` bump
 - `httpd` drop 2.2 eol https://github.com/docker-library/httpd/pull/88, add MPMs https://github.com/docker-library/httpd/pull/87
 - `mongo` remove windows variants https://github.com/docker-library/mongo/pull/241