### PR TITLE
use alpine3.7 based erlang images

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -5,7 +5,7 @@ GitRepo: https://github.com/c0b/docker-erlang-otp.git
 
 Tags: 20.2.2, 20.2, 20, latest
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 91f55f9a69925e7fc16b467c155897bbe8646f12
+GitCommit: f6606389b995d24dce8933e4ca4d6d46fce8612b
 Directory: 20
 
 Tags: 20.2.2-slim, 20.2-slim, 20-slim, slim
@@ -14,8 +14,8 @@ GitCommit: 91f55f9a69925e7fc16b467c155897bbe8646f12
 Directory: 20/slim
 
 Tags: 20.2.2-alpine, 20.2-alpine, 20-alpine, alpine
-Architectures: amd64
-GitCommit: 91f55f9a69925e7fc16b467c155897bbe8646f12
+Architectures: amd64, arm64v8, i386, s390x, ppc64le
+GitCommit: 7bed62e30a4e6557c146b2865413c9ce924366be
 Directory: 20/alpine
 
 Tags: 19.3.6.5, 19.3.6, 19.3, 19


### PR DESCRIPTION
for c0b/docker-erlang-otp#102; verified working on arm64v8; from https://github.com/c0b/docker-erlang-otp/pull/70#issue-255420685 the erlang:20 alpine images should also work on i386, s390x, ppc64le; except arm32v7 not verified