### PR TITLE
Update to Adminer 4.5.0

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -1,14 +1,14 @@
-# this file is generated via https://github.com/TimWolla/docker-adminer/blob/adad6c44329f98b4f71e8cabf84d09a90b8af220/generate-stackbrew-library.sh
+# this file is generated via https://github.com/TimWolla/docker-adminer/blob/e99f98a8334ff8dad913bf2cbe8ac476594e4089/generate-stackbrew-library.sh
 
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
-Tags: 4.4.0-standalone, 4.4-standalone, 4-standalone, standalone, 4.4.0, 4.4, 4, latest
+Tags: 4.5.0-standalone, 4.5-standalone, 4-standalone, standalone, 4.5.0, 4.5, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a49e226a52f856d35b28a907b53a649eb4eda7c5
-Directory: 4.4
+GitCommit: e99f98a8334ff8dad913bf2cbe8ac476594e4089
+Directory: 4.5
 
-Tags: 4.4.0-fastcgi, 4.4-fastcgi, 4-fastcgi, fastcgi
+Tags: 4.5.0-fastcgi, 4.5-fastcgi, 4-fastcgi, fastcgi
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a49e226a52f856d35b28a907b53a649eb4eda7c5
-Directory: 4.4/fastcgi
+GitCommit: e99f98a8334ff8dad913bf2cbe8ac476594e4089
+Directory: 4.5/fastcgi


### PR DESCRIPTION
On an unrelated note: I noticed that Docker is listed in the [“References” section on adminer.org](https://www.adminer.org/en/#references). That counts as an endorsement, right? 😏 