### PR TITLE
Bump Traefik to v1.5.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.5.0, 1.5.0, v1.5, 1.5, cancoillotte, latest
+Tags: v1.5.1, 1.5.1, v1.5, 1.5, cancoillotte, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 4ac72271d92558226f76ef1a4043ac9fe1be05dd
+GitCommit: 22e195e57ae284786e2cd76bc5e9407de9d06571
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.5.0-alpine, 1.5.0-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine, alpine
+Tags: v1.5.1-alpine, 1.5.1-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 4ac72271d92558226f76ef1a4043ac9fe1be05dd
+GitCommit: 22e195e57ae284786e2cd76bc5e9407de9d06571
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.1.

/cc @vdemeester @emilevauge

Cheers
