### PR TITLE
[nats-streaming] Release v0.8.0-beta

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,26 +1,26 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 
-Tags: 0.7.2-linux, linux
-SharedTags: 0.7.2, latest
+Tags: 0.8.0-beta-linux, linux
+SharedTags: 0.8.0-beta, latest
 Architectures: amd64, arm32v7, arm64v8
-amd64-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+amd64-GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 amd64-Directory: amd64
-arm32v7-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+arm32v7-GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+arm64v8-GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 arm64v8-Directory: arm64v8
 
-Tags: 0.7.2-nanoserver, nanoserver
-SharedTags: 0.7.2, latest
+Tags: 0.8.0-beta-nanoserver, nanoserver
+SharedTags: 0.8.0-beta, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+windows-amd64-GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.7.2-windowsservercore, windowsservercore
+Tags: 0.8.0-beta-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: ddeb1e1c9f5b248089ed69b7315bfe1a16ce5d15
+windows-amd64-GitCommit: 48f1a5bd7bc869f50d1379035fa65505196abc28
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
This release introduces clustering feature as a beta.
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.8.0-beta)