### PR TITLE
Build as a multi-arch image

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -4,49 +4,61 @@ Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
 Tags: 1.6.1, 1.6, latest
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 089cab9aeb7e5ae1fec8cdc9cd308711e1855c4d
 Directory: 1.6
 
 Tags: 1.6.1-slim, 1.6-slim, slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 089cab9aeb7e5ae1fec8cdc9cd308711e1855c4d
 Directory: 1.6/slim
 
 Tags: 1.6.1-alpine, 1.6-alpine, alpine
+Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: 089cab9aeb7e5ae1fec8cdc9cd308711e1855c4d
 Directory: 1.6/alpine
 
 Tags: 1.5.3, 1.5
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5
 
 Tags: 1.5.3-slim, 1.5-slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/slim
 
 Tags: 1.5.3-alpine, 1.5-alpine
+Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/alpine
 
 Tags: 1.4.5, 1.4
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 8f1888ae05506b9ad12e1b97f084a15e7588f442
 Directory: 1.4
 
 Tags: 1.4.5-slim, 1.4-slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 8f1888ae05506b9ad12e1b97f084a15e7588f442
 Directory: 1.4/slim
 
 Tags: 1.3.4, 1.3
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: d8d656d7c0dc9dd2956a22276c93cb97568ea6d4
 Directory: 1.3
 
 Tags: 1.3.4-slim, 1.3-slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: d8d656d7c0dc9dd2956a22276c93cb97568ea6d4
 Directory: 1.3/slim
 
 Tags: 1.2.6, 1.2
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
 Directory: 1.2
 
 Tags: 1.2.6-slim, 1.2-slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
 Directory: 1.2/slim


### PR DESCRIPTION
this add multi-arch support as similar to #3415 to Erlang; I did manually test amd64 and arm64v8, and as Elixir designed in pure Elixir/Erlang code only, no C code, should be able to run anywhere that Erlang VM runs, so I added other architectures from each architecture supported by base Erlang image

| Elixir version | FROM Erlang version | Arch |
|---|--|--|
| 1.6 1.5 | Erlang 20 | amd64, arm32v7, arm64v8, i386, s390x, ppc64le (the alpine didn't verify on arm32v7) |
| 1.4 1.3 | Erlang 19 | amd64, arm32v7, arm64v8, i386, s390x |
| 1.2 | Erlang 18 | amd64, arm32v7, arm64v8, i386, s390x |

resolves c0b/docker-elixir#47