### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.12, 4.4, 4, latest
+Tags: 4.4.18, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 63052402ddc3427912d780eaf9caf71bd03f8b2d
+GitCommit: 6c4cae1513b6df70011b64620ebc5fd4eb173727
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/mariadb
+++ b/library/mariadb
@@ -16,8 +16,8 @@ Tags: 10.1.30, 10.1
 GitCommit: 04e2b9adcccd3cc634d8ef92f10b2f92e2c76076
 Directory: 10.1
 
-Tags: 10.0.33, 10.0
-GitCommit: 1037a0b7ab09343e011826078fbdffb0bf465fc3
+Tags: 10.0.34, 10.0
+GitCommit: ef09e6e573d40aa512dee1309437fc6a9553b7c2
 Directory: 10.0
 
 Tags: 5.5.59, 5.5, 5

--- a/library/mongo
+++ b/library/mongo
@@ -20,12 +20,12 @@ Architectures: amd64
 GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
 Directory: 3.2
 
-Tags: 3.4.10-jessie, 3.4-jessie
-SharedTags: 3.4.10, 3.4
+Tags: 3.4.11-jessie, 3.4-jessie
+SharedTags: 3.4.11, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
+GitCommit: 8a439d6df6a95f424c41dab451f640cd08ba68c7
 Directory: 3.4
 
 Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie

--- a/library/openjdk
+++ b/library/openjdk
@@ -44,24 +44,24 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a893fe3cd82757e7bccc0948c88bfee09bd916c3
 Directory: 9-jdk/slim
 
-Tags: 9.0.1-jdk-windowsservercore-ltsc2016, 9.0.1-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
-SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
+SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
 Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
 Directory: 9-jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 9.0.1-jdk-windowsservercore-1709, 9.0.1-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
-SharedTags: 9.0.1-jdk-windowsservercore, 9.0.1-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Tags: 9.0.4-jdk-windowsservercore-1709, 9.0.4-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
+SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
 Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
 Directory: 9-jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 9.0.1-jdk-nanoserver-sac2016, 9.0.1-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
-SharedTags: 9.0.1-jdk-nanoserver, 9.0.1-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
+Tags: 9.0.4-jdk-nanoserver-sac2016, 9.0.4-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
+SharedTags: 9.0.4-jdk-nanoserver, 9.0.4-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
 Architectures: windows-amd64
-GitCommit: 873fb56728befef8ecaf8436c3a27fd239cba301
+GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
 Directory: 9-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/percona
+++ b/library/percona
@@ -12,6 +12,6 @@ Tags: 5.6.38, 5.6
 GitCommit: d05195d80f65146ba72189947097fefd1bcf694c
 Directory: 5.6
 
-Tags: 5.5.58, 5.5
-GitCommit: 7b5f657baecb23a2638658e05ce9f466b181812c
+Tags: 5.5.59, 5.5
+GitCommit: 6b511c1afee7545d8e3ebe307d3186cf7c92bb2d
 Directory: 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.3-rc.2, 3.7-rc
+Tags: 3.7.3, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb92a062fe8ef5f33ac9a9bfd8b1fa0201dabf4b
-Directory: 3.7-rc/debian
-
-Tags: 3.7.3-rc.2-management, 3.7-rc-management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
-Directory: 3.7-rc/debian/management
-
-Tags: 3.7.3-rc.2-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd7f0e66ae7b6eb8d7002a3e7fd6713e6a9cc2f3
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.3-rc.2-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 501a83a7b54f4b151e6ad9eae37602b964b1f5d0
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.2, 3.7, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 79b144f64991538d29f8c071270d157a5bf7a9b7
+GitCommit: b5543df2789c16d8ea1c2119484378d4c23baa6c
 Directory: 3.7/debian
 
-Tags: 3.7.2-management, 3.7-management, 3-management, management
+Tags: 3.7.3-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/debian/management
 
-Tags: 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.3-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 31a69457c8adbe0d7fe7e33afeaa95e4faf2b73e
+GitCommit: b5543df2789c16d8ea1c2119484378d4c23baa6c
 Directory: 3.7/alpine
 
-Tags: 3.7.2-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.3-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 86a208cc744d9743a219973ba2ab675f6718bec4
 Directory: 3.4
 
 Tags: 3.4.4-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
+GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
 Directory: 3.4/passenger
 
 Tags: 3.3.6, 3.3
@@ -19,7 +19,7 @@ GitCommit: 1a66905d6ed69f74e74e6b48fedb39f8e3bff949
 Directory: 3.3
 
 Tags: 3.3.6-passenger, 3.3-passenger
-GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
+GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: 1c1b50f263969b2214ba772bca3a72d3a403b517
+GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
 Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -59,6 +59,16 @@ Architectures: amd64
 GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
 Directory: 2.4/alpine3.4
 
+Tags: 2.3.6-stretch, 2.3-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4d2e178d3847b5458602d908c48782b6b18cd62e
+Directory: 2.3/stretch
+
+Tags: 2.3.6-slim-stretch, 2.3-slim-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4d2e178d3847b5458602d908c48782b6b18cd62e
+Directory: 2.3/stretch/slim
+
 Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191

--- a/library/wordpress
+++ b/library/wordpress
@@ -66,22 +66,22 @@ Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.4.1-php5.6, cli-1.4-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.5.0-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
+GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
 Directory: php5.6/cli
 
-Tags: cli-1.4.1-php7.0, cli-1.4-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.5.0-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
+GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
 Directory: php7.0/cli
 
-Tags: cli-1.4.1-php7.1, cli-1.4-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.5.0-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
+GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
 Directory: php7.1/cli
 
-Tags: cli-1.4.1, cli-1.4, cli-1, cli, cli-1.4.1-php7.2, cli-1.4-php7.2, cli-1-php7.2, cli-php7.2
+Tags: cli-1.5.0, cli-1.5, cli-1, cli, cli-1.5.0-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1e6d4be06a13412e57d670283b6b1c03cb4698be
+GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
 Directory: php7.2/cli


### PR DESCRIPTION
- `bash` Update to 4.4, patch level 18
- `mariadb` Update to `10.0.34`
- `mongo` Update to `3.4.11`
- `openjdk` Update to `9.0.4` on windows
- `percona` Update to `5.5.59`
- `rabbitmq` Update to `3.7.3`
- `redmine` Update to passenger `5.2.0`
- `ruby` stretch variants of `2.3`
- `wordpress` Update to cli `1.5.0`