### PR TITLE
Update for Node.js v9.5.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,34 +3,34 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.4.0, 9.4, 9, latest
+Tags: 9.5.0, 9.5, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9
 
-Tags: 9.4.0-alpine, 9.4-alpine, 9-alpine, alpine
+Tags: 9.5.0-alpine, 9.5-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9/alpine
 
-Tags: 9.4.0-onbuild, 9.4-onbuild, 9-onbuild, onbuild
+Tags: 9.5.0-onbuild, 9.5-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9/onbuild
 
-Tags: 9.4.0-slim, 9.4-slim, 9-slim, slim
+Tags: 9.5.0-slim, 9.5-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9/slim
 
-Tags: 9.4.0-stretch, 9.4-stretch, 9-stretch, stretch
+Tags: 9.5.0-stretch, 9.5-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9/stretch
 
-Tags: 9.4.0-wheezy, 9.4-wheezy, 9-wheezy, wheezy
+Tags: 9.5.0-wheezy, 9.5-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: df8782dfddf8c70663f0a7d19942120b1d6977a5
+GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
 Directory: 9/wheezy
 
 Tags: 8.9.4, 8.9, 8, carbon


### PR DESCRIPTION
See:

- https://github.com/nodejs/docker-node/pull/619
- https://nodejs.org/en/blog/release/v9.5.0/