### PR TITLE
Updating oraclelinux:7.4 to resolve CVE-2018-1049

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -1,7 +1,7 @@
 Maintainers: Oracle Linux Product Team <ol-ovm-info_ww@oracle.com> (@Oracle)
 GitRepo: https://github.com/oracle/ol-container-images.git
 GitFetch: refs/heads/master
-GitCommit: d76e09dfc8f4d54ea6e3cede8559721655798a75
+GitCommit: 74409877de8c1ca942904ff77dd5d002a3dac360
 Constraints: !aufs
 
 Tags: 7-slim


### PR DESCRIPTION
https://linux.oracle.com/cve/CVE-2018-1049.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>