### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.02.0-ce-rc1, 18.02-rc, rc, test
+Tags: 18.02.0-ce-rc2, 18.02-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
+GitCommit: 70e698f1e2f12ed3de3a32e3f25b3c781f918aa0
 Directory: 18.02-rc
 
-Tags: 18.02.0-ce-rc1-dind, 18.02-rc-dind, rc-dind, test-dind
+Tags: 18.02.0-ce-rc2-dind, 18.02-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
 Directory: 18.02-rc/dind
 
-Tags: 18.02.0-ce-rc1-git, 18.02-rc-git, rc-git, test-git
+Tags: 18.02.0-ce-rc2-git, 18.02-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
 Directory: 18.02-rc/git


### PR DESCRIPTION
- `docker` bump to `18.02.0-ce-rc2`