### PR TITLE
Update docker image Silverpeas to the main major stable version 6.0

### DIFF
--- a/library/silverpeas
+++ b/library/silverpeas
@@ -1,6 +1,6 @@
 Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
 
-Tags: 6.0-beta1, latest
-GitCommit: 03bd2800e83bf262d07b53f067758115fa6f05fc
+Tags: 6.0, latest
+GitCommit: 80bd9752fac5793594ddc80943ecdcf88e25f3b1
 


### PR DESCRIPTION
Silverpeas 6.0 is out. A docker image for this new major version is now available