### PR TITLE
Add Jobber

### DIFF
--- a/library/jobber
+++ b/library/jobber
@@ -1,8 +1,8 @@
 Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
 GitRepo: https://github.com/dshearer/jobber-docker.git
 
-Tags: 1.3.2-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
-GitCommit: a46d8d7aa4f359a5a27a9ca7a7dbf7d1d3d71d38
+Tags: 1.3.3-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
+GitCommit: 9afae73c3a114f2595468212b60309d9b0cf7fe3
 GitFetch: refs/heads/maint-1.3
 Directory: alpine3.7
 

--- a/library/jobber
+++ b/library/jobber
@@ -1,7 +1,8 @@
 Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
 GitRepo: https://github.com/dshearer/jobber-docker.git
 
-Tags: 1.3.1-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
-GitCommit: 9f8d7477936b6693271f284c026a7b5e53d73684
-Directory: 1.3/alpine3.7
+Tags: 1.3.2-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
+GitCommit: a46d8d7aa4f359a5a27a9ca7a7dbf7d1d3d71d38
+GitFetch: refs/heads/maint-1.3
+Directory: alpine3.7
 

--- a/library/jobber
+++ b/library/jobber
@@ -1,0 +1,7 @@
+Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
+GitRepo: https://github.com/dshearer/jobber-docker.git
+
+Tags: 1.3.1-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
+GitCommit: 9f8d7477936b6693271f284c026a7b5e53d73684
+Directory: 1.3/alpine3.7
+

--- a/library/jobber
+++ b/library/jobber
@@ -2,7 +2,7 @@ Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
 GitRepo: https://github.com/dshearer/jobber-docker.git
 
 Tags: 1.4.0-alpine3.10, 1.4-alpine3.10, 1-alpine3.10, latest
-GitCommit: d261712ed0986a40dac9c7992d6f9367edf516f0
+GitCommit: 64d2a0778ae73986cb90f1c374d9dfb42c9b8483
 GitFetch: refs/heads/maint-1.4
 Directory: alpine3.10
 

--- a/library/jobber
+++ b/library/jobber
@@ -1,8 +1,8 @@
 Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
 GitRepo: https://github.com/dshearer/jobber-docker.git
 
-Tags: 1.3.3-alpine3.7, 1.3-alpine3.7, 1-alpine3.7, latest
-GitCommit: 9afae73c3a114f2595468212b60309d9b0cf7fe3
-GitFetch: refs/heads/maint-1.3
-Directory: alpine3.7
+Tags: 1.4.0-alpine3.10, 1.4-alpine3.10, 1-alpine3.10, latest
+GitCommit: d261712ed0986a40dac9c7992d6f9367edf516f0
+GitFetch: refs/heads/maint-1.4
+Directory: alpine3.10
 


### PR DESCRIPTION
# Summary

This PR adds the library file for Jobber images.

Docker repo: https://github.com/dshearer/jobber-docker
Jobber repo: https://github.com/dshearer/jobber

Jobber is an alternative to cron.  Users have found it useful to run it in a Docker container, so I thought I should make official Docker images for it.

# Checklist

- [x] associated with or contacted upstream?
  - I maintain upstream
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
  - It's a service
- [x] is it reasonably popular, or does it solve a particular use case well?
  - I'd like to think it solves some use-cases
- [x] does a documentation PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
  - https://github.com/docker-library/docs/pull/1142
- [x] dockerization review for best practices and cache gotchas/improvements?
- [x] 2+ dockerization review?
- [x] existing official images have been considered as a base?
  - Using golang:1.9-alpine
- [x] if FROM scratch, tarballs only exist in a single commit within the associated history?
- [x] passes current tests? any simple new tests that might be appropriate to add? 
  - https://travis-ci.org/dshearer/official-images