### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.6, 5.6, 5, latest
-GitCommit: e7ccd59cec2328020c005d94010d91b95ee7f291
+Tags: 5.6.7, 5.6, 5, latest
+GitCommit: f6c7bea6ff0e4008e531ac6b97aa3f593872e73a
 Directory: 5
 
-Tags: 5.6.6-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: e7ccd59cec2328020c005d94010d91b95ee7f291
+Tags: 5.6.7-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: f6c7bea6ff0e4008e531ac6b97aa3f593872e73a
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.6, 5.6, 5, latest
-GitCommit: ff12294eaa9dfddb854c2ba989308beb993bf69c
+Tags: 5.6.7, 5.6, 5, latest
+GitCommit: 0b0f9abbd2f17b4625d1210f5224bd1e32c09b4a
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.6, 5.6, 5, latest
-GitCommit: 40679c7efe82cd24a003c310a3635d583375ac7b
+Tags: 5.6.7, 5.6, 5, latest
+GitCommit: 97fb4e0e3738cfabcb64456c1bf5de1eef357576
 Directory: 5
 
-Tags: 5.6.6-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 40679c7efe82cd24a003c310a3635d583375ac7b
+Tags: 5.6.7-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 97fb4e0e3738cfabcb64456c1bf5de1eef357576
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,20 +5,20 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.7-apache, 11.0-apache, 11-apache, 11.0.7, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 402d9424c5dc83e74746c02b261211c4baf3b8fe
+GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 11.0/apache
 
 Tags: 11.0.7-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 402d9424c5dc83e74746c02b261211c4baf3b8fe
+GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 11.0/fpm
 
 Tags: 12.0.5-apache, 12.0-apache, 12-apache, apache, 12.0.5, 12.0, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 26d58913be47abf611530c89c133475e546298ff
+GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 12.0/apache
 
 Tags: 12.0.5-fpm, 12.0-fpm, 12-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 26d58913be47abf611530c89c133475e546298ff
+GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 12.0/fpm

--- a/library/pypy
+++ b/library/pypy
@@ -16,10 +16,10 @@ Directory: 2/slim
 
 Tags: 3-5.10.1, 3-5.10, 3-5, 3, latest
 Architectures: amd64, arm32v5, i386
-GitCommit: b8683312287c8972c23f43c756decd14e69f1f5c
+GitCommit: 90d6f08b46c99c7cccae534f4ba003c132cc1afe
 Directory: 3
 
 Tags: 3-5.10.1-slim, 3-5.10-slim, 3-5-slim, 3-slim, slim
 Architectures: amd64, arm32v5, i386
-GitCommit: b8683312287c8972c23f43c756decd14e69f1f5c
+GitCommit: 90d6f08b46c99c7cccae534f4ba003c132cc1afe
 Directory: 3/slim

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 14e48621e40c6b6c84e474e28b06430a3261916a
 Directory: 3.2/alpine
 
-Tags: 4.0.7, 4.0, 4, latest
+Tags: 4.0.8, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb2878cdad9c2fa9648ff97a1ca55a2a35b3081b
+GitCommit: d53b982b387634092c6f11069401679034054ecb
 Directory: 4.0
 
-Tags: 4.0.7-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.8-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: cb2878cdad9c2fa9648ff97a1ca55a2a35b3081b
+GitCommit: d53b982b387634092c6f11069401679034054ecb
 Directory: 4.0/32bit
 
-Tags: 4.0.7-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.8-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb2878cdad9c2fa9648ff97a1ca55a2a35b3081b
+GitCommit: d53b982b387634092c6f11069401679034054ecb
 Directory: 4.0/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.60.4, 0.60, 0, latest
-GitCommit: 056f6c33b7fad8a9a6167734b5e748b61c0cf063
+Tags: 0.61.0, 0.61, 0, latest
+GitCommit: 80d0c06e8003d99d5fa9e10e176691a2cdb79987


### PR DESCRIPTION
- `elasticsearch`: 5.6.7
- `kibana`: 5.6.7
- `logstash`: 5.6.7
- `nextcloud`: simplify cron usage (nextcloud/docker#220)
- `pypy`: 5.10.1
- `redis`: 4.0.8
- `rocket.chat`: 0.61.0