### PR TITLE
haxe: update to haxe 3.4.5

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,45 +1,45 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 3.4.4-stretch, 3.4-stretch, 3.4.4, 3.4, latest
+Tags: 3.4.5-stretch, 3.4-stretch, 3.4.5, 3.4, latest
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.4/stretch
 
-Tags: 3.4.4-jessie, 3.4-jessie
+Tags: 3.4.5-jessie, 3.4-jessie
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.4/jessie
 
-Tags: 3.4.4-onbuild, 3.4-onbuild
+Tags: 3.4.5-onbuild, 3.4-onbuild
 Architectures: amd64
-GitCommit: 4d1efc06f99732c3530a9550adaef330e4896eda
+GitCommit: d175be53dd807e4a03e8cb7081f0c7ca1652a43c
 Directory: 3.4/onbuild
 
-Tags: 3.4.4-windowsservercore, 3.4-windowsservercore
+Tags: 3.4.5-windowsservercore, 3.4-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: d175be53dd807e4a03e8cb7081f0c7ca1652a43c
 Directory: 3.4/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.4-alpine3.7, 3.4-alpine3.7, 3.4.4-alpine, 3.4-alpine
+Tags: 3.4.5-alpine3.7, 3.4-alpine3.7, 3.4.5-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: e310a4bc9f172df541fbabac0ad9a2dcf8e08ccc
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.4/alpine3.7
 
-Tags: 3.4.4-alpine3.6, 3.4-alpine3.6
+Tags: 3.4.5-alpine3.6, 3.4-alpine3.6
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.3/stretch
 
 Tags: 3.3.0-rc.1-jessie, 3.3.0-jessie, 3.3-jessie
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.3/jessie
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
@@ -55,22 +55,22 @@ Constraints: windowsservercore
 
 Tags: 3.3.0-rc.1-alpine3.7, 3.3.0-rc.1-alpine, 3.3.0-alpine3.7, 3.3-alpine3.7, 3.3.0-alpine, 3.3-alpine
 Architectures: amd64
-GitCommit: e310a4bc9f172df541fbabac0ad9a2dcf8e08ccc
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.3/alpine3.7
 
 Tags: 3.3.0-rc.1-alpine3.6, 3.3.0-alpine3.6, 3.3-alpine3.6
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.3/alpine3.6
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.2/stretch
 
 Tags: 3.2.1-jessie, 3.2-jessie
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.2/jessie
 
 Tags: 3.2.1-onbuild, 3.2-onbuild
@@ -86,22 +86,22 @@ Constraints: windowsservercore
 
 Tags: 3.2.1-alpine3.7, 3.2-alpine3.7, 3.2.1-alpine, 3.2-alpine
 Architectures: amd64
-GitCommit: e310a4bc9f172df541fbabac0ad9a2dcf8e08ccc
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.2/alpine3.7
 
 Tags: 3.2.1-alpine3.6, 3.2-alpine3.6
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.1/stretch
 
 Tags: 3.1.3-jessie, 3.1-jessie
 Architectures: amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
 Directory: 3.1/jessie
 
 Tags: 3.1.3-onbuild, 3.1-onbuild


### PR DESCRIPTION
Update to haxe 3.4.5, as well as some other improvements:
 * standardize install location by cp manually instead of using make install
 * set HAXE_STD_PATH that points to the Haxe standard library