### PR TITLE
teamspeak: update teamspeak to 3.1.0-beta-3

### DIFF
--- a/library/teamspeak
+++ b/library/teamspeak
@@ -3,5 +3,5 @@ Maintainers: Niels Werensteijn <niels.werensteijn@teamspeak.com> (@nwerensteijn)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
 Tags: 3.1, 3.1.0, latest
-GitCommit: 0aa60b817eec11e41f8a93b225bab48f82133b1b
+GitCommit: 2e0b1dc1fb2258cfd931affd01ef2b8caa095797
 Directory: 3.1.0


### PR DESCRIPTION
update teamspeak to 3.1.0-beta-3
* increased accounting timeout to handle edge cases where replies would take to long.