### PR TITLE
Add Express-Gateway to the official images

### DIFF
--- a/library/express-gateway
+++ b/library/express-gateway
@@ -2,6 +2,6 @@ Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gatewa
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
 Tags: 1.x, 1.13.x, 1.13.0
-Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 52ffe46a4fe4a21700a9c66225d19425cb7a104e
+Architectures: arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 0c92fd48415e952be0aa037a1c7355df2da64e0e
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,7 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.10.x, 1.10.2
+Tags: 1.x, 1.11.x, 1.11.0
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 266104b97f83e825293bcee6bffa644139628e71
+GitCommit: dde8e25dc3a698482b3fdf086c2a67a4fd471207
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,5 +1,8 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/express-gateway.git
 
+Tags: 1.x, 1.8.x, 1.8.2
+GitCommit: df515d429bd06c596839d512290cc3fd3a3ba82b
+
 Tags: 1.x, 1.7.x, 1.7.3
 GitCommit: b715a408bd5c39636c0925b1739ffbc71072cc70

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -2,5 +2,6 @@ Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gatewa
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
 Tags: 1.x, 1.10.x, 1.10.2
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 266104b97f83e825293bcee6bffa644139628e71
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,11 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/express-gateway.git
 
-Tags: 1.x, 1.8.x, 1.8.2
+Tags: 1.x, 1.9.x, 1.9.1
+GitCommit: 182691960d62d9398f7483e9122174124faa02bc
+
+
+Tags: 1.8.x, 1.8.2
 GitCommit: df515d429bd06c596839d512290cc3fd3a3ba82b
 
 Tags: 1.7.x, 1.7.3

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,7 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.11.x, 1.11.0
+Tags: 1.x, 1.12.x, 1.12.0
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: dde8e25dc3a698482b3fdf086c2a67a4fd471207
+GitCommit: 7d329fb7c09a5c946bf3661e27abbffddd3b09ea
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -2,4 +2,4 @@ Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gatewa
 GitRepo: https://github.com/ExpressGateway/express-gateway.git
 
 Tags: 1.x, 1.7.x, 1.7.3
-GitCommit: b1859d557491c0f6ddd07d8b8bb1c48bed5c57de
+GitCommit: b715a408bd5c39636c0925b1739ffbc71072cc70

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,12 +1,6 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
-GitRepo: https://github.com/ExpressGateway/express-gateway.git
+GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.9.x, 1.9.1
-GitCommit: 182691960d62d9398f7483e9122174124faa02bc
-
-
-Tags: 1.8.x, 1.8.2
-GitCommit: df515d429bd06c596839d512290cc3fd3a3ba82b
-
-Tags: 1.7.x, 1.7.3
-GitCommit: b715a408bd5c39636c0925b1739ffbc71072cc70
+Tags: 1.x, 1.10.x, 1.10.2
+GitCommit: 266104b97f83e825293bcee6bffa644139628e71
+Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,7 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.12.x, 1.12.0
+Tags: 1.x, 1.13.x, 1.13.0
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 7d329fb7c09a5c946bf3661e27abbffddd3b09ea
+GitCommit: 52ffe46a4fe4a21700a9c66225d19425cb7a104e
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,0 +1,5 @@
+Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
+GitRepo: https://github.com/ExpressGateway/express-gateway.git
+
+Tags: 1.x, 1.7.x, 1.7.3
+GitCommit: b1859d557491c0f6ddd07d8b8bb1c48bed5c57de

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -4,5 +4,5 @@ GitRepo: https://github.com/ExpressGateway/express-gateway.git
 Tags: 1.x, 1.8.x, 1.8.2
 GitCommit: df515d429bd06c596839d512290cc3fd3a3ba82b
 
-Tags: 1.x, 1.7.x, 1.7.3
+Tags: 1.7.x, 1.7.3
 GitCommit: b715a408bd5c39636c0925b1739ffbc71072cc70

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -3,5 +3,5 @@ GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
 Tags: 1.x, 1.14.x, 1.14.0
 Architectures: arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 8028516e39d34ad2d8b64ca29aeb5286504297f4
+GitCommit: ff6e4d728bf4a83cfe4be69ff10148010ad04903
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,7 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.14.x, 1.14.0
+Tags: 1.x, 1.14.x, 1.14.0, latest
 Architectures: arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: ff6e4d728bf4a83cfe4be69ff10148010ad04903
 Directory: alpine

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,7 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.13.x, 1.13.0
+Tags: 1.x, 1.14.x, 1.14.0
 Architectures: arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 0c92fd48415e952be0aa037a1c7355df2da64e0e
+GitCommit: 8028516e39d34ad2d8b64ca29aeb5286504297f4
 Directory: alpine


### PR DESCRIPTION
Hello guys,

I'd love Express-Gateway, the project we're building, be part of the Docker Official Image program.

I'm quite sure we'll have a lot to work on, but this is a start.

Thanks a lot!

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1144
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)