### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -12,12 +12,12 @@ Architectures: amd64
 GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
 Directory: 3.0
 
-Tags: 3.2.18-jessie, 3.2-jessie
-SharedTags: 3.2.18, 3.2
+Tags: 3.2.19-jessie, 3.2-jessie
+SharedTags: 3.2.19, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
+GitCommit: 22dd36a9194de8797f3c558857c0120a794daf25
 Directory: 3.2
 
 Tags: 3.4.11-jessie, 3.4-jessie

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -13,12 +13,22 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 11.0/fpm
 
-Tags: 12.0.5-apache, 12.0-apache, 12-apache, apache, 12.0.5, 12.0, 12, latest
+Tags: 12.0.5-apache, 12.0-apache, 12-apache, 12.0.5, 12.0, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 12.0/apache
 
-Tags: 12.0.5-fpm, 12.0-fpm, 12-fpm, fpm
+Tags: 12.0.5-fpm, 12.0-fpm, 12-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
 Directory: 12.0/fpm
+
+Tags: 13.0.0-apache, 13.0-apache, 13-apache, apache, 13.0.0, 13.0, 13, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bc9d5f807e70e7eae63e692d128360a5fb3097e4
+Directory: 13.0/apache
+
+Tags: 13.0.0-fpm, 13.0-fpm, 13-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bc9d5f807e70e7eae63e692d128360a5fb3097e4
+Directory: 13.0/fpm

--- a/library/php
+++ b/library/php
@@ -4,89 +4,89 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.1-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.1-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.1-cli, 7.2-cli, 7-cli, cli, 7.2.1, 7.2, 7, latest
+Tags: 7.2.2-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.2-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.2-cli, 7.2-cli, 7-cli, cli, 7.2.2, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.1-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.1-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.2-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.2-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.1-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.1-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.2-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.2-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.1-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.1-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.2-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.2-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.1-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.1-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.2-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.2-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.1-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.2-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.1-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.2-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.1-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.1-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.1-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.2-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.2-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.2-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.2-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.1-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.1-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.2-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.2-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.1-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.1-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.2-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.2-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f4baf0edbc4e05e241938c68bcc7c9635707583d
+GitCommit: fd8e15250a0c7667b161c34a25f7916b01f72367
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.13-cli-jessie, 7.1-cli-jessie, 7.1.13-jessie, 7.1-jessie, 7.1.13-cli, 7.1-cli, 7.1.13, 7.1
+Tags: 7.1.14-cli-jessie, 7.1-cli-jessie, 7.1.14-jessie, 7.1-jessie, 7.1.14-cli, 7.1-cli, 7.1.14, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.13-apache-jessie, 7.1-apache-jessie, 7.1.13-apache, 7.1-apache
+Tags: 7.1.14-apache-jessie, 7.1-apache-jessie, 7.1.14-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.13-fpm-jessie, 7.1-fpm-jessie, 7.1.13-fpm, 7.1-fpm
+Tags: 7.1.14-fpm-jessie, 7.1-fpm-jessie, 7.1.14-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.13-zts-jessie, 7.1-zts-jessie, 7.1.13-zts, 7.1-zts
+Tags: 7.1.14-zts-jessie, 7.1-zts-jessie, 7.1.14-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.13-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.13-alpine3.4, 7.1-alpine3.4, 7.1.13-cli-alpine, 7.1-cli-alpine, 7.1.13-alpine, 7.1-alpine
+Tags: 7.1.14-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.14-alpine3.4, 7.1-alpine3.4, 7.1.14-cli-alpine, 7.1-cli-alpine, 7.1.14-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.13-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.13-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.14-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.14-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 57b41cfc2d1e07acab2e60d59a0cb19d83056fc1
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.13-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.13-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.14-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.14-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 6be205eee15aed27706a958379cec836fe305017
+GitCommit: 499a0e89e73db985874082ea936529b96413ceb0
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.27-cli-jessie, 7.0-cli-jessie, 7.0.27-jessie, 7.0-jessie, 7.0.27-cli, 7.0-cli, 7.0.27, 7.0

--- a/library/python
+++ b/library/python
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0a4-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0a4, 3.7-rc, rc
+Tags: 3.7.0b1-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0b1, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f73f58fb5ad731616109e0b8ed6367a0d474c52
+GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0a4-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0a4-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0b1-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b1-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f73f58fb5ad731616109e0b8ed6367a0d474c52
+GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0a4-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0a4-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0b1-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b1-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f73f58fb5ad731616109e0b8ed6367a0d474c52
+GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
 Directory: 3.7-rc/alpine3.7
 
-Tags: 3.7.0a4-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.7.0a4-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0a4, 3.7-rc, rc
+Tags: 3.7.0b1-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.7.0b1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b1, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 2f73f58fb5ad731616109e0b8ed6367a0d474c52
+GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0a4-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 3.7.0a4-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0a4, 3.7-rc, rc
+Tags: 3.7.0b1-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 3.7.0b1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b1, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 2f73f58fb5ad731616109e0b8ed6367a0d474c52
+GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -89,65 +89,65 @@ GitCommit: a1aa406bfd8c7b129e6e0ee0ba972b863624ac0d
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.5.4-jessie, 3.5-jessie
-SharedTags: 3.5.4, 3.5
+Tags: 3.5.5-jessie, 3.5-jessie
+SharedTags: 3.5.5, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebbaa8a56cdf4021c78e87b3872be3861ac072a
+GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/jessie
 
-Tags: 3.5.4-slim-jessie, 3.5-slim-jessie, 3.5.4-slim, 3.5-slim
+Tags: 3.5.5-slim-jessie, 3.5-slim-jessie, 3.5.5-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4ce69de053337ec22d7f322cd997398eeba2350
+GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/jessie/slim
 
-Tags: 3.5.4-onbuild, 3.5-onbuild
+Tags: 3.5.5-onbuild, 3.5-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.5/jessie/onbuild
 
-Tags: 3.5.4-alpine3.4, 3.5-alpine3.4, 3.5.4-alpine, 3.5-alpine
+Tags: 3.5.5-alpine3.4, 3.5-alpine3.4, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64
-GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
+GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/alpine3.4
 
-Tags: 3.5.4-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016
-SharedTags: 3.5.4-windowsservercore, 3.5-windowsservercore, 3.5.4, 3.5
+Tags: 3.5.5-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016
+SharedTags: 3.5.5-windowsservercore, 3.5-windowsservercore, 3.5.5, 3.5
 Architectures: windows-amd64
-GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.5.4-windowsservercore-1709, 3.5-windowsservercore-1709
-SharedTags: 3.5.4-windowsservercore, 3.5-windowsservercore, 3.5.4, 3.5
+Tags: 3.5.5-windowsservercore-1709, 3.5-windowsservercore-1709
+SharedTags: 3.5.5-windowsservercore, 3.5-windowsservercore, 3.5.5, 3.5
 Architectures: windows-amd64
-GitCommit: ce648832b041293fa3542af884ac5a44a67354d3
+GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.4.7-jessie, 3.4-jessie
-SharedTags: 3.4.7, 3.4
+Tags: 3.4.8-jessie, 3.4-jessie
+SharedTags: 3.4.8, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
+GitCommit: 55186d2c2c8b78bd8293293af42a5db3f815f332
 Directory: 3.4/jessie
 
-Tags: 3.4.7-slim-jessie, 3.4-slim-jessie, 3.4.7-slim, 3.4-slim
+Tags: 3.4.8-slim-jessie, 3.4-slim-jessie, 3.4.8-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4ce69de053337ec22d7f322cd997398eeba2350
+GitCommit: 55186d2c2c8b78bd8293293af42a5db3f815f332
 Directory: 3.4/jessie/slim
 
-Tags: 3.4.7-onbuild, 3.4-onbuild
+Tags: 3.4.8-onbuild, 3.4-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.4/jessie/onbuild
 
-Tags: 3.4.7-wheezy, 3.4-wheezy
+Tags: 3.4.8-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 27516b7347b3236a3accd4b2e1242a53fb54d04c
+GitCommit: 55186d2c2c8b78bd8293293af42a5db3f815f332
 Directory: 3.4/wheezy
 
-Tags: 3.4.7-alpine3.4, 3.4-alpine3.4, 3.4.7-alpine, 3.4-alpine
+Tags: 3.4.8-alpine3.4, 3.4-alpine3.4, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 8717dc2523c8093990cb958bb8c47ade6f851c05
+GitCommit: 55186d2c2c8b78bd8293293af42a5db3f815f332
 Directory: 3.4/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch

--- a/library/ruby
+++ b/library/ruby
@@ -6,37 +6,37 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.5.0-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.0, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 99e8080d3cda7d7ee49d582ca2dc16b1999370bf
 Directory: 2.5/stretch
 
 Tags: 2.5.0-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.0-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 99e8080d3cda7d7ee49d582ca2dc16b1999370bf
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.0-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 99e8080d3cda7d7ee49d582ca2dc16b1999370bf
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.3-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/stretch
 
 Tags: 2.4.3-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.3-jessie, 2.4-jessie, 2.4.3, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/jessie
 
 Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2.4.3-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.3-onbuild, 2.4-onbuild
@@ -46,37 +46,37 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.3-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.3-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2.4.3-alpine, 2.4-alpine
 Architectures: amd64
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: 4b43155d8a8ec30fe1cb9ea6f0fcf8a432096a53
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.6-stretch, 2.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d2e178d3847b5458602d908c48782b6b18cd62e
+GitCommit: d5cab201f7f689688b121cd4831aeb8e23becf96
 Directory: 2.3/stretch
 
 Tags: 2.3.6-slim-stretch, 2.3-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d2e178d3847b5458602d908c48782b6b18cd62e
+GitCommit: d5cab201f7f689688b121cd4831aeb8e23becf96
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: d5cab201f7f689688b121cd4831aeb8e23becf96
 Directory: 2.3/jessie
 
 Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: d5cab201f7f689688b121cd4831aeb8e23becf96
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.6-onbuild, 2.3-onbuild
@@ -86,17 +86,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: d5cab201f7f689688b121cd4831aeb8e23becf96
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: b42e7bb58583ec9854aecf651980917dd06aa5da
 Directory: 2.2/jessie
 
 Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: b42e7bb58583ec9854aecf651980917dd06aa5da
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.9-onbuild, 2.2-onbuild
@@ -106,5 +106,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: c9a4472a019d18aba1fdab6a63b96474b40ca191
+GitCommit: b42e7bb58583ec9854aecf651980917dd06aa5da
 Directory: 2.2/alpine3.4

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.2-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.2-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.3-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.3-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php5.6/apache
 
-Tags: 4.9.2-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.3-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php5.6/fpm
 
-Tags: 4.9.2-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.3-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.2-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.2-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.3-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.3-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.0/apache
 
-Tags: 4.9.2-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.3-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.0/fpm
 
-Tags: 4.9.2-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.3-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.2-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.2-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.3-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.3-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.1/apache
 
-Tags: 4.9.2-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.3-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.1/fpm
 
-Tags: 4.9.2-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.3-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.2-apache, 4.9-apache, 4-apache, apache, 4.9.2, 4.9, 4, latest, 4.9.2-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.2-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.3-apache, 4.9-apache, 4-apache, apache, 4.9.3, 4.9, 4, latest, 4.9.3-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.3-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.2/apache
 
-Tags: 4.9.2-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.2-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.3-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.3-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.2/fpm
 
-Tags: 4.9.2-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.2-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.3-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.3-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 549e1bd44995ba414000530749e05d8078dc9467
+GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `mongo`: 3.2.19
- `nextcloud`: 13 (nextcloud/docker#244)
- `python`: 3.7.0b1, 3.4.8, 3.5.5
- `ruby`: rubygems 2.7.5
- `wordpress`: 4.9.3