### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.12, 10.2, 10, latest
 GitCommit: a1f61de0bb84ed1b4a482361c6aa8b8f4398f5cc
 Directory: 10.2
 
-Tags: 10.1.30, 10.1
-GitCommit: 04e2b9adcccd3cc634d8ef92f10b2f92e2c76076
+Tags: 10.1.31, 10.1
+GitCommit: 8ec32d0733772952c5bcd39691b2b830f3031fea
 Directory: 10.1
 
 Tags: 10.0.34, 10.0

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/4365c863956250d758341b86035862b111269ed9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/072171f6298a3c360f26de25291a45f082d36bca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -145,23 +145,3 @@ Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jdk/alpine
-
-Tags: 6b38-jre-wheezy, 6-jre-wheezy, 6b38-jre, 6-jre
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 80490366d49e6781e9dcb5dad8ebf0fb6ec04000
-Directory: 6-jre
-
-Tags: 6b38-jre-slim-wheezy, 6-jre-slim-wheezy, 6b38-jre-slim, 6-jre-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jre/slim
-
-Tags: 6b38-jdk-wheezy, 6b38-wheezy, 6-jdk-wheezy, 6-wheezy, 6b38-jdk, 6b38, 6-jdk, 6
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jdk
-
-Tags: 6b38-jdk-slim-wheezy, 6b38-slim-wheezy, 6-jdk-slim-wheezy, 6-slim-wheezy, 6b38-jdk-slim, 6b38-slim, 6-jdk-slim, 6-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4f29ba829765552239bd18f272fcdaf09eca259
-Directory: 6-jdk/slim


### PR DESCRIPTION
- `mariadb`: 10.1.31
- `openjdk`: remove 6 (docker-library/openjdk#167)