### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.20.3, 1.20, 1, latest
+Tags: 1.21.1, 1.21, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 572460ad0ca4939ddd97132afc458ffc8fde44cb
+GitCommit: 962323a525d020a49a9165ba62f85098b8e5e09f
 Directory: 1/debian
 
-Tags: 1.20.3-alpine, 1.20-alpine, 1-alpine, alpine
+Tags: 1.21.1-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 572460ad0ca4939ddd97132afc458ffc8fde44cb
+GitCommit: 962323a525d020a49a9165ba62f85098b8e5e09f
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -5,118 +5,118 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10rc1-stretch, 1.10-rc-stretch, rc-stretch
-SharedTags: 1.10rc1, 1.10-rc, rc
+Tags: 1.10rc2-stretch, 1.10-rc-stretch, rc-stretch
+SharedTags: 1.10rc2, 1.10-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
+GitCommit: 75759d6b5bea61ea8347069221f2b03a48ee3f88
 Directory: 1.10-rc/stretch
 
-Tags: 1.10rc1-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10rc1-alpine, 1.10-rc-alpine, rc-alpine
+Tags: 1.10rc2-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10rc2-alpine, 1.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
+GitCommit: 75759d6b5bea61ea8347069221f2b03a48ee3f88
 Directory: 1.10-rc/alpine3.7
 
-Tags: 1.10rc1-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.10rc1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc1, 1.10-rc, rc
+Tags: 1.10rc2-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.10rc2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc2, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
+GitCommit: 75759d6b5bea61ea8347069221f2b03a48ee3f88
 Directory: 1.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10rc1-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.10rc1-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc1, 1.10-rc, rc
+Tags: 1.10rc2-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.10rc2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10rc2, 1.10-rc, rc
 Architectures: windows-amd64
-GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
+GitCommit: 75759d6b5bea61ea8347069221f2b03a48ee3f88
 Directory: 1.10-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10rc1-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.10rc1-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
+Tags: 1.10rc2-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.10rc2-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: ddb3ecbe839dfc9d6a3e321fec5ba41284201cec
+GitCommit: 75759d6b5bea61ea8347069221f2b03a48ee3f88
 Directory: 1.10-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.9.3-stretch, 1.9-stretch, 1-stretch, stretch
-SharedTags: 1.9.3, 1.9, 1, latest
+Tags: 1.9.4-stretch, 1.9-stretch, 1-stretch, stretch
+SharedTags: 1.9.4, 1.9, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/stretch
 
-Tags: 1.9.3-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
+Tags: 1.9.4-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/alpine3.7
 
-Tags: 1.9.3-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.3-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.4-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.4-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.3-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.9.3-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.3, 1.9, 1, latest
+Tags: 1.9.4-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.9.4-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.4, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.3-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.9.3-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.3, 1.9, 1, latest
+Tags: 1.9.4-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.9.4-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.4, 1.9, 1, latest
 Architectures: windows-amd64
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.9.3-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.9.3-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.9.4-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.9.4-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 2f2f3b620d61f533484f24a568c2ca46e4fda91c
+GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
 Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.8.6-stretch, 1.8-stretch
+Tags: 1.8.7-stretch, 1.8-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/stretch
 
-Tags: 1.8.6-jessie, 1.8-jessie
-SharedTags: 1.8.6, 1.8
+Tags: 1.8.7-jessie, 1.8-jessie
+SharedTags: 1.8.7, 1.8
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/jessie
 
-Tags: 1.8.6-alpine3.6, 1.8-alpine3.6
+Tags: 1.8.7-alpine3.6, 1.8-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/alpine3.6
 
-Tags: 1.8.6-alpine3.5, 1.8-alpine3.5, 1.8.6-alpine, 1.8-alpine
+Tags: 1.8.7-alpine3.5, 1.8-alpine3.5, 1.8.7-alpine, 1.8-alpine
 Architectures: amd64
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/alpine3.5
 
-Tags: 1.8.6-onbuild, 1.8-onbuild
+Tags: 1.8.7-onbuild, 1.8-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
 Directory: 1.8/onbuild
 
-Tags: 1.8.6-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
-SharedTags: 1.8.6-windowsservercore, 1.8-windowsservercore, 1.8.6, 1.8
+Tags: 1.8.7-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
+SharedTags: 1.8.7-windowsservercore, 1.8-windowsservercore, 1.8.7, 1.8
 Architectures: windows-amd64
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.8.6-windowsservercore-1709, 1.8-windowsservercore-1709
-SharedTags: 1.8.6-windowsservercore, 1.8-windowsservercore, 1.8.6, 1.8
+Tags: 1.8.7-windowsservercore-1709, 1.8-windowsservercore-1709
+SharedTags: 1.8.7-windowsservercore, 1.8-windowsservercore, 1.8.7, 1.8
 Architectures: windows-amd64
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.8.6-nanoserver-sac2016, 1.8-nanoserver-sac2016
-SharedTags: 1.8.6-nanoserver, 1.8-nanoserver
+Tags: 1.8.7-nanoserver-sac2016, 1.8-nanoserver-sac2016
+SharedTags: 1.8.7-nanoserver, 1.8-nanoserver
 Architectures: windows-amd64
-GitCommit: ad742b941dc3e8aa0a5763c8f0c1d7102d7ac76e
+GitCommit: e63ba9c5efb040b35b71e16722b71b2931f29eb8
 Directory: 1.8/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,30 +5,30 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.7-apache, 11.0-apache, 11-apache, 11.0.7, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 11.0/apache
 
 Tags: 11.0.7-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 11.0/fpm
 
 Tags: 12.0.5-apache, 12.0-apache, 12-apache, 12.0.5, 12.0, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 12.0/apache
 
 Tags: 12.0.5-fpm, 12.0-fpm, 12-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 423e017e3b6c76a5e361746a86a3a7789693044d
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 12.0/fpm
 
 Tags: 13.0.0-apache, 13.0-apache, 13-apache, apache, 13.0.0, 13.0, 13, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bc9d5f807e70e7eae63e692d128360a5fb3097e4
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 13.0/apache
 
 Tags: 13.0.0-fpm, 13.0-fpm, 13-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bc9d5f807e70e7eae63e692d128360a5fb3097e4
+GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
 Directory: 13.0/fpm


### PR DESCRIPTION
- `ghost`: 1.21.1
- `golang`: 1.9.4, 1.8.7, 1.10rc2 (CVE-2018-6574, http://golang.org/issue/23672)
- `nextcloud`: `freetype` (nextcloud/docker#250)