### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -20,12 +20,12 @@ Architectures: amd64
 GitCommit: 22dd36a9194de8797f3c558857c0120a794daf25
 Directory: 3.2
 
-Tags: 3.4.11-jessie, 3.4-jessie
-SharedTags: 3.4.11, 3.4
+Tags: 3.4.12-jessie, 3.4-jessie
+SharedTags: 3.4.12, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 8a439d6df6a95f424c41dab451f640cd08ba68c7
+GitCommit: b9dbfbabade7d7ad651592649eecf8b777de6ec9
 Directory: 3.4
 
 Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie


### PR DESCRIPTION
- `mongo`: 3.4.12