### PR TITLE
- Added support to the latest release of geonetwork: 3.4.1

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/adb9a87d6a919b1cf528bf416ac8f135809dae00/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/d2b5fc95c31efcc7f4cffa1fbf69f17ab315fb11/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
@@ -19,10 +19,10 @@ Tags: 3.2.2-postgres, 3.2-postgres
 GitCommit: 7ba5f533d9ee31cf1a22d4d6a1a84fbb74f86466
 Directory: 3.2.2/postgres
 
-Tags: 3.4.0, 3.4, latest
-GitCommit: 067c56d23e1ea7a422e9883410b3db318b5f42b7
-Directory: 3.4.0
+Tags: 3.4.1, 3.4, latest
+GitCommit: 01e3e23e9b277940dcac471099408695c6d12ae3
+Directory: 3.4.1
 
-Tags: 3.4.0-postgres, 3.4-postgres, postgres
-GitCommit: 067c56d23e1ea7a422e9883410b3db318b5f42b7
-Directory: 3.4.0/postgres
+Tags: 3.4.1-postgres, 3.4-postgres, latest-postgres
+GitCommit: 01e3e23e9b277940dcac471099408695c6d12ae3
+Directory: 3.4.1/postgres


### PR DESCRIPTION
- Set geonetwork 3.4.1 as the latest version (and removed 3.4.0)