### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.18, 4.4, 4, latest
+Tags: 4.4.19, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c4cae1513b6df70011b64620ebc5fd4eb173727
+GitCommit: 3bb879e5ac93f9b49f4d2d33521d8aa1524f2c12
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/docker
+++ b/library/docker
@@ -4,35 +4,20 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.02.0-ce-rc2, 18.02-rc, rc, test
+Tags: 18.02.0-ce, 18.02.0, 18.02, 18, edge, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 70e698f1e2f12ed3de3a32e3f25b3c781f918aa0
-Directory: 18.02-rc
+GitCommit: 157869f94ea90e2acb4d0f77045d99079ead821c
+Directory: 18.02
 
-Tags: 18.02.0-ce-rc2-dind, 18.02-rc-dind, rc-dind, test-dind
+Tags: 18.02.0-ce-dind, 18.02.0-dind, 18.02-dind, 18-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
-Directory: 18.02-rc/dind
+GitCommit: 157869f94ea90e2acb4d0f77045d99079ead821c
+Directory: 18.02/dind
 
-Tags: 18.02.0-ce-rc2-git, 18.02-rc-git, rc-git, test-git
+Tags: 18.02.0-ce-git, 18.02.0-git, 18.02-git, 18-git, edge-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 690c2cedc6c5e8a47507240b7d8a39a19f03bae6
-Directory: 18.02-rc/git
-
-Tags: 18.01.0-ce, 18.01.0, 18.01, 18, edge, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
-Directory: 18.01
-
-Tags: 18.01.0-ce-dind, 18.01.0-dind, 18.01-dind, 18-dind, edge-dind, dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
-Directory: 18.01/dind
-
-Tags: 18.01.0-ce-git, 18.01.0-git, 18.01-git, 18-git, edge-git, git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: d909b9fe1337c5bc6c1f851c0a7bc2d23008cc1d
-Directory: 18.01/git
+GitCommit: 157869f94ea90e2acb4d0f77045d99079ead821c
+Directory: 18.02/git
 
 Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
@@ -48,18 +33,3 @@ Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/git
-
-Tags: 17.09.1-ce, 17.09.1, 17.09
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
-Directory: 17.09
-
-Tags: 17.09.1-ce-dind, 17.09.1-dind, 17.09-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 00de5231b507c989ce900df2ef3f1abf4ce7e19c
-Directory: 17.09/dind
-
-Tags: 17.09.1-ce-git, 17.09.1-git, 17.09-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: a6b52c73daa8283cd861f41f55e53426008708ac
-Directory: 17.09/git

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
 Directory: 1.7/alpine
 
-Tags: 1.8.3, 1.8, 1, latest
+Tags: 1.8.4, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7c772b810df3afe6884d0fb8b83720f992c3951b
+GitCommit: c0c933487b09b205ad9a2a33a70987d86fa12c23
 Directory: 1.8
 
-Tags: 1.8.3-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.4-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
+GitCommit: c0c933487b09b205ad9a2a33a70987d86fa12c23
 Directory: 1.8/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10.1, 10, latest
+Tags: 10.2, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1805adb0693d9602bfb19b6bf2583b311c43b749
+GitCommit: 674466e0d47517f4e05ec2025ae996e71b26cae9
 Directory: 10
 
-Tags: 10.1-alpine, 10-alpine, alpine
+Tags: 10.2-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1805adb0693d9602bfb19b6bf2583b311c43b749
+GitCommit: e294fd35ca6243af9e35baa58724cfb432599248
 Directory: 10/alpine
 
-Tags: 9.6.6, 9.6, 9
+Tags: 9.6.7, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82e8101ff612b492507f4efc2120963b29f4188d
+GitCommit: 7da010d82077944ce39211cc610ce58c11366360
 Directory: 9.6
 
-Tags: 9.6.6-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.7-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 3d152d1a0d08cf52a1392b58243ff3c423588ccc
+GitCommit: 165ffaab649aea0797ad61739cb5c9ac69466929
 Directory: 9.6/alpine
 
 Tags: 9.5.10, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b84ddd1619ee3a7f6e318bb9ac33f39818b3b548
+GitCommit: 2100e76efe6b41e001ac13d248e7af206cc022ae
 Directory: 9.5
 
 Tags: 9.5.10-alpine, 9.5-alpine
@@ -34,22 +34,22 @@ Architectures: amd64
 GitCommit: 5a690fbbe0f256b916a01afee293e8b2dfd3ad8d
 Directory: 9.5/alpine
 
-Tags: 9.4.15, 9.4
+Tags: 9.4.16, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3001d13fcac68cf9f8b0217eafdad8e83c41907c
+GitCommit: 93dc51c2ec5b16d3d728b7f85804ae43113006d6
 Directory: 9.4
 
-Tags: 9.4.15-alpine, 9.4-alpine
+Tags: 9.4.16-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: cd2cafec4e998847fd2b10f08cc3444a2116e6d5
+GitCommit: dc36bbe68fb7f8c2a8b421944cb80aa73681e093
 Directory: 9.4/alpine
 
-Tags: 9.3.20, 9.3
+Tags: 9.3.21, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4af033ebfe50d33214c32be78c52f2693769fb14
+GitCommit: d8ce07a1e97e7caa1436a341ae7a2b06efb852dc
 Directory: 9.3
 
-Tags: 9.3.20-alpine, 9.3-alpine
+Tags: 9.3.21-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: 881448bf624ca3f461f7ddd234c198ba23aea1fe
+GitCommit: 35d59a4ae2e0b0ab25d305b7e59bef15cd732432
 Directory: 9.3/alpine

--- a/library/python
+++ b/library/python
@@ -110,20 +110,6 @@ Architectures: amd64
 GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
 Directory: 3.5/alpine3.4
 
-Tags: 3.5.5-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016
-SharedTags: 3.5.5-windowsservercore, 3.5-windowsservercore, 3.5.5, 3.5
-Architectures: windows-amd64
-GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
-Directory: 3.5/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.5.5-windowsservercore-1709, 3.5-windowsservercore-1709
-SharedTags: 3.5.5-windowsservercore, 3.5-windowsservercore, 3.5.5, 3.5
-Architectures: windows-amd64
-GitCommit: cd844bc3a3f49b1a9624df3c4a71a0b5e0106752
-Directory: 3.5/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 3.4.8-jessie, 3.4-jessie
 SharedTags: 3.4.8, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.3-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.3-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.4-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.4-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php5.6/apache
 
-Tags: 4.9.3-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.4-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php5.6/fpm
 
-Tags: 4.9.3-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.4-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.3-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.3-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.4-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.4-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.0/apache
 
-Tags: 4.9.3-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.4-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.0/fpm
 
-Tags: 4.9.3-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.4-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.3-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.3-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.4-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.4-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.1/apache
 
-Tags: 4.9.3-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.4-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.1/fpm
 
-Tags: 4.9.3-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.4-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.3-apache, 4.9-apache, 4-apache, apache, 4.9.3, 4.9, 4, latest, 4.9.3-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.3-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.4-apache, 4.9-apache, 4-apache, apache, 4.9.4, 4.9, 4, latest, 4.9.4-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.4-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.2/apache
 
-Tags: 4.9.3-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.3-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.4-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.4-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.2/fpm
 
-Tags: 4.9.3-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.3-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.4-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.4-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 0b1920428fb32b1825ae7f86e6254a225de61f62
+GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `bash`: 4.4.19
- `docker`: 18.02.0-ce (EOL 18.01 and 17.09)
- `haproxy`: 1.8.4
- `postgres`: 9.3.21, `9.5.10-2~35.gitb212664.pgdg80+1`, 9.4.16, 9.6.7, 10.2
- `python`: remove Windows 3.5 variants (docker-library/python#259)
- `wordpress`: 4.9.4