### PR TITLE
Update tests to use Stretch instead of Jessie

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -9,7 +9,7 @@ usage() {
 	cat <<EOUSAGE
 
 usage: $self [-t test ...] image:tag [...]
-   ie: $self debian:wheezy
+   ie: $self debian:stretch
        $self -t utc python:3
        $self -t utc python:3 -t python-hy
 

--- a/test/tests/elasticsearch-basics/run.sh
+++ b/test/tests/elasticsearch-basics/run.sh
@@ -9,7 +9,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # our image may not have "curl" (Alpine variants, for example)
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 # (explicitly setting a low memory limit since the image defaults to 2GB)

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -6,7 +6,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 serverImage="$1"
 
 # Use a client image with curl for testing
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$serverImage")"

--- a/test/tests/jetty-hello-web/run.sh
+++ b/test/tests/jetty-hello-web/run.sh
@@ -9,7 +9,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # Use a client image with curl for testing
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 serverImage="$("$dir/../image-name.sh" librarytest/jetty-hello-web "$image")"

--- a/test/tests/logstash-basics/run.sh
+++ b/test/tests/logstash-basics/run.sh
@@ -9,7 +9,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # our image may not have "curl" (Alpine variants, for example)
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # input via HTTP (default port 0.0.0.0:8080)
 # output via stdout, newline-delimited nothing-but-the-message

--- a/test/tests/php-fpm-hello-web/run.sh
+++ b/test/tests/php-fpm-hello-web/run.sh
@@ -8,7 +8,7 @@ image="$1"
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/php-fpm-hello-web:fcgi-client'
 docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN set -x && apt-get update && apt-get install -y libfcgi0ldbl && rm -rf /var/lib/apt/lists/*
 

--- a/test/tests/rapidoid-hello-world/run.sh
+++ b/test/tests/rapidoid-hello-world/run.sh
@@ -9,7 +9,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # Use a client image with curl for testing
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 serverImage="$("$dir/../image-name.sh" librarytest/rapidoid-hello-web "$image")"

--- a/test/tests/rapidoid-load-balancer/run.sh
+++ b/test/tests/rapidoid-load-balancer/run.sh
@@ -9,7 +9,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # Use a client image with curl for testing
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 app1id="$(docker run -d "$image" rapidoid.port=80 id=app1 app.services=ping,status)"
 app2id="$(docker run -d "$image" rapidoid.port=80 id=app2 app.services=ping,status)"

--- a/test/tests/redmine-basics/run.sh
+++ b/test/tests/redmine-basics/run.sh
@@ -6,7 +6,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 serverImage="$1"
 
 # Use a client image with curl for testing
-clientImage='buildpack-deps:jessie-curl'
+clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$serverImage")"


### PR DESCRIPTION
Intentionally skipping `haproxy-basics` due to https://github.com/docker-library/official-images/pull/3895.