### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.19, 2.1
 Architectures: amd64, i386
-GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
+GitCommit: 6f766afc6cf748ed70174dfcd11869e0a2b30eb0
 Directory: 2.1
 
 Tags: 2.2.11, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
+GitCommit: 6f766afc6cf748ed70174dfcd11869e0a2b30eb0
 Directory: 2.2
 
 Tags: 3.0.15, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
+GitCommit: 6f766afc6cf748ed70174dfcd11869e0a2b30eb0
 Directory: 3.0
 
 Tags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 59602a2819a62752388e1f8b407ec7af29d8245f
+GitCommit: 6f766afc6cf748ed70174dfcd11869e0a2b30eb0
 Directory: 3.11

--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.5.0-alpha1-apache, 8.5-rc-apache, rc-apache, 8.5.0-alpha1, 8.5-rc, rc
+Tags: 8.5.0-beta1-apache, 8.5-rc-apache, rc-apache, 8.5.0-beta1, 8.5-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 95d253b0bc92a47aed519732ebb2c116e50a1dfb
+GitCommit: 7216f79ff2fe556d8f30e9bc4734544433cfc788
 Directory: 8.5-rc/apache
 
-Tags: 8.5.0-alpha1-fpm, 8.5-rc-fpm, rc-fpm
+Tags: 8.5.0-beta1-fpm, 8.5-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 95d253b0bc92a47aed519732ebb2c116e50a1dfb
+GitCommit: 7216f79ff2fe556d8f30e9bc4734544433cfc788
 Directory: 8.5-rc/fpm
 
-Tags: 8.5.0-alpha1-fpm-alpine, 8.5-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.5.0-beta1-fpm-alpine, 8.5-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 95d253b0bc92a47aed519732ebb2c116e50a1dfb
+GitCommit: 7216f79ff2fe556d8f30e9bc4734544433cfc788
 Directory: 8.5-rc/fpm-alpine
 
 Tags: 8.4.4-apache, 8.4-apache, 8-apache, apache, 8.4.4, 8.4, 8, latest

--- a/library/mongo
+++ b/library/mongo
@@ -20,12 +20,12 @@ Architectures: amd64
 GitCommit: 22dd36a9194de8797f3c558857c0120a794daf25
 Directory: 3.2
 
-Tags: 3.4.12-jessie, 3.4-jessie
-SharedTags: 3.4.12, 3.4
+Tags: 3.4.13-jessie, 3.4-jessie
+SharedTags: 3.4.13, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: b9dbfbabade7d7ad651592649eecf8b777de6ec9
+GitCommit: cd03aec6375197ae86191886a876a12e8f2eaac7
 Directory: 3.4
 
 Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie

--- a/library/postgres
+++ b/library/postgres
@@ -24,14 +24,14 @@ Architectures: amd64
 GitCommit: 165ffaab649aea0797ad61739cb5c9ac69466929
 Directory: 9.6/alpine
 
-Tags: 9.5.10, 9.5
+Tags: 9.5.11, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2100e76efe6b41e001ac13d248e7af206cc022ae
+GitCommit: f4aa86c49b4691ea2e23934a419538df187a7f57
 Directory: 9.5
 
-Tags: 9.5.10-alpine, 9.5-alpine
+Tags: 9.5.11-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: 5a690fbbe0f256b916a01afee293e8b2dfd3ad8d
+GitCommit: 8734ceed8c5e196d3d59227a59d80df8fed70126
 Directory: 9.5/alpine
 
 Tags: 9.4.16, 9.4

--- a/library/tomcat
+++ b/library/tomcat
@@ -64,52 +64,52 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: d543d4f0d7d7dffee5ad625e08bcc517e72489bb
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.27-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.27, 8.5, 8, latest
+Tags: 8.5.28-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.28, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
+GitCommit: da8aa30aaa6593e61ab7152bcdfb25a177116ffa
 Directory: 8.5/jre8
 
-Tags: 8.5.27-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.27-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.28-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.28-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
+GitCommit: da8aa30aaa6593e61ab7152bcdfb25a177116ffa
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.27-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.27-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.28-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.28-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bd0e24fdb2c21cccb32d9ee821e0c96cf8b2f393
+GitCommit: 5985bc3fcd2479df62bdada2570651291c2e96b2
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.27-jre9, 8.5-jre9, 8-jre9, jre9
+Tags: 8.5.28-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
+GitCommit: da8aa30aaa6593e61ab7152bcdfb25a177116ffa
 Directory: 8.5/jre9
 
-Tags: 8.5.27-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
+Tags: 8.5.28-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c5a1adc5cf5e5bd13daa921909e9ab5ac60d030
+GitCommit: da8aa30aaa6593e61ab7152bcdfb25a177116ffa
 Directory: 8.5/jre9-slim
 
-Tags: 9.0.4-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.5-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
+GitCommit: 1d917f75107e599b43fd5bb56d9d73c6c8f4c036
 Directory: 9.0/jre8
 
-Tags: 9.0.4-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.5-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
+GitCommit: 1d917f75107e599b43fd5bb56d9d73c6c8f4c036
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.4-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.5-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe11a5d3316d12d4b68c05f2006fb35a8c8a80c1
+GitCommit: 55a3f09bc475c11c23f6a972b17766b2f68c29a0
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.4-jre9, 9.0-jre9, 9-jre9, 9.0.4, 9.0, 9
+Tags: 9.0.5-jre9, 9.0-jre9, 9-jre9, 9.0.5, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
+GitCommit: 1d917f75107e599b43fd5bb56d9d73c6c8f4c036
 Directory: 9.0/jre9
 
-Tags: 9.0.4-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.4-slim, 9.0-slim, 9-slim
+Tags: 9.0.5-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.5-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24572bb5195a1ca604cf56109321bf88da8c2805
+GitCommit: 1d917f75107e599b43fd5bb56d9d73c6c8f4c036
 Directory: 9.0/jre9-slim


### PR DESCRIPTION
- `cassandra`: Debian slim (docker-library/cassandra#133)
- `drupal`: 8.5.0-beta1
- `mongo`: 3.4.13
- `postgres`: 9.5.11
- `tomcat`: 9.0.5, 8.5.28