### PR TITLE
Add common image

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -7,6 +7,9 @@ Architectures: amd64, i386, ppc64le, s390x
 Tags: kernel
 Directory: ga/developer/kernel
 
+Tags: common
+Directory: ga/developer/common
+
 Tags: microProfile
 Directory: ga/developer/microProfile
 


### PR DESCRIPTION
Adding a new tag to websphere-liberty, called `common`, which will be used by some of the other tags to reduce the number of layers and remove the need to run the `installUtility` command in other images.