### PR TITLE
haxe: add 4.0.0 preview, remove source files from alpine

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -3,12 +3,12 @@ GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.4.5-stretch, 3.4-stretch, 3.4.5, 3.4, latest
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.4/stretch
 
 Tags: 3.4.5-jessie, 3.4-jessie
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.4/jessie
 
 Tags: 3.4.5-onbuild, 3.4-onbuild
@@ -24,22 +24,22 @@ Constraints: windowsservercore
 
 Tags: 3.4.5-alpine3.7, 3.4-alpine3.7, 3.4.5-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.4/alpine3.7
 
 Tags: 3.4.5-alpine3.6, 3.4-alpine3.6
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.3/stretch
 
 Tags: 3.3.0-rc.1-jessie, 3.3.0-jessie, 3.3-jessie
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.3/jessie
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
@@ -55,22 +55,22 @@ Constraints: windowsservercore
 
 Tags: 3.3.0-rc.1-alpine3.7, 3.3.0-rc.1-alpine, 3.3.0-alpine3.7, 3.3-alpine3.7, 3.3.0-alpine, 3.3-alpine
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.3/alpine3.7
 
 Tags: 3.3.0-rc.1-alpine3.6, 3.3.0-alpine3.6, 3.3-alpine3.6
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.3/alpine3.6
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.2/stretch
 
 Tags: 3.2.1-jessie, 3.2-jessie
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.2/jessie
 
 Tags: 3.2.1-onbuild, 3.2-onbuild
@@ -86,22 +86,22 @@ Constraints: windowsservercore
 
 Tags: 3.2.1-alpine3.7, 3.2-alpine3.7, 3.2.1-alpine, 3.2-alpine
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.2/alpine3.7
 
 Tags: 3.2.1-alpine3.6, 3.2-alpine3.6
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.1/stretch
 
 Tags: 3.1.3-jessie, 3.1-jessie
 Architectures: amd64
-GitCommit: 9d35e5889c0c85a936690d1005ca64aa9b8d4f93
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.1/jessie
 
 Tags: 3.1.3-onbuild, 3.1-onbuild
@@ -114,4 +114,35 @@ Architectures: windows-amd64
 GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
 Directory: 3.1/windowsservercore
 Constraints: windowsservercore
+
+Tags: 4.0.0-preview.2-stretch, 4.0.0-preview.2, 4.0.0-stretch, 4.0-stretch, 4.0.0, 4.0
+Architectures: amd64
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+Directory: 4.0/stretch
+
+Tags: 4.0.0-preview.2-jessie, 4.0.0-jessie, 4.0-jessie
+Architectures: amd64
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+Directory: 4.0/jessie
+
+Tags: 4.0.0-preview.2-onbuild, 4.0.0-onbuild, 4.0-onbuild
+Architectures: amd64
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+Directory: 4.0/onbuild
+
+Tags: 4.0.0-preview.2-windowsservercore, 4.0.0-windowsservercore, 4.0-windowsservercore
+Architectures: windows-amd64
+GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+Directory: 4.0/windowsservercore
+Constraints: windowsservercore
+
+Tags: 4.0.0-preview.2-alpine3.7, 4.0.0-preview.2-alpine, 4.0.0-alpine3.7, 4.0-alpine3.7, 4.0.0-alpine, 4.0-alpine
+Architectures: amd64
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Directory: 4.0/alpine3.7
+
+Tags: 4.0.0-preview.2-alpine3.6, 4.0.0-alpine3.6, 4.0-alpine3.6
+Architectures: amd64
+GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Directory: 4.0/alpine3.6
 


### PR DESCRIPTION
 * Added Haxe 4.0.0 preview 2. :latest is still pointing at 3.4.
 * Removed Haxe/Neko source files from the alpine variants.