### PR TITLE
Improve performance

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: b79d0f2b00bfa8fcc3a953054c18464f73c7ecf7
+GitCommit: 9cf64a59a00fe0a09a63fe467d6ca96a1f9c35b7
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 99e1bbdc8b98b4afd80b01dea78ca923091d46d4
+GitCommit: b79d0f2b00bfa8fcc3a953054c18464f73c7ecf7
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
We updated the Dockerfiles in open-liberty to do two things:

1) The docker image puts the log files in /logs, but this is different from outside docker, so we have put in a symlink between the normal location and the docker image location so it is easier to find the logs for those just moving to docker.
2) By putting a server bounce into the Dockerfile we create a layer with some caches populated that improves startup time. This means everyone who runs the docker file will get the best startup performance first time. Putting it in the build results in a one time cost for all users of the docker image.