### PR TITLE
Upgrade Couchbase Server EE to 5.1.0

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,14 +1,14 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/5.0.1
-enterprise: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/5.0.1
-5.0.1: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/5.0.1
-enterprise-5.0.1: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/5.0.1
+latest: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/5.1.0
+enterprise: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/5.1.0
+5.1.0: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/5.1.0
+enterprise-5.1.0: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/5.1.0
 
-4.6.4: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/4.6.4
-enterprise-4.6.4: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc enterprise/couchbase-server/4.6.4
+4.6.4: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/4.6.4
+enterprise-4.6.4: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf enterprise/couchbase-server/4.6.4
 
-community: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc community/couchbase-server/5.0.1
-community-5.0.1: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc community/couchbase-server/5.0.1
+community: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf community/couchbase-server/5.0.1
+community-5.0.1: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf community/couchbase-server/5.0.1
 
-community-4.5.1: git://github.com/couchbase/docker@1dc19b7a42c42edb9f777e33d3a385bb8ec612fc community/couchbase-server/4.5.1
+community-4.5.1: git://github.com/couchbase/docker@df241663db4fd87c00576109be71cd1f6beba4bf community/couchbase-server/4.5.1


### PR DESCRIPTION
Note as suggested, we've moved the base image for Couchbase Server 5.x to Ubuntu 16.04. We've also added a few startup and usability improvements to the image.