### PR TITLE
Apache Storm upgrades and cleanups

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,18 +1,14 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
 
-Tags: 0.9.7, 0.9
-GitCommit: 6e94e11977556f0f4a99633b1f835f13d20c1e30
-Directory: 0.9.7
+Tags: 1.0.6, 1.0
+GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
+Directory: 1.0.6
 
-Tags: 0.10.2, 0.10
-GitCommit: 6e94e11977556f0f4a99633b1f835f13d20c1e30
-Directory: 0.10.2
+Tags: 1.1.2, 1.1
+GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
+Directory: 1.1.2
 
-Tags: 1.0.5, 1.0
-GitCommit: 60316c9351be7dedd39cbcc308dc1fe5c00e44a5
-Directory: 1.0.5
-
-Tags: 1.1.1, 1.1, latest
-GitCommit: 35207c57594856c661adcea5063584eb22534ddb
-Directory: 1.1.1
+Tags: 1.2.0, 1.2, latest
+GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
+Directory: 1.2.0


### PR DESCRIPTION
* Update to `1.0.6`
* Update to `1.1.2`
* Introduce `1.2.0`
* Remove `0.9.7` and `0.10.2` since no longer distributed by the [upstream](http://www.apache.org/dist/storm/)