### PR TITLE
Add Thrift 0.11.0 tags

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -4,4 +4,6 @@
 0.9.3: git://github.com/ahawkins/docker-thrift@d322572f7dd6ea468a14a4d832fbec26f152c71e 0.9
 0.10: git://github.com/ahawkins/docker-thrift@e1f81dfe3e8fac5588e12d2b880166d1743dbecd 0.10
 0.10.0: git://github.com/ahawkins/docker-thrift@e1f81dfe3e8fac5588e12d2b880166d1743dbecd 0.10
-latest: git://github.com/ahawkins/docker-thrift@e1f81dfe3e8fac5588e12d2b880166d1743dbecd 0.10
+0.11: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
+0.11.0: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
+latest: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11


### PR DESCRIPTION
Simple bump to latest Thrift releases.