### PR TITLE
Update clojure images to latest git commit

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: b4e548bbaab978eaa8e0f4b31705c43526202d3c
+GitCommit: 9a5646fb242d98e8867bcbb558cf61a9bbf51f6e
 
 Tags: lein-2.8.1, lein, latest
 Directory: debian/lein


### PR DESCRIPTION
Only lein-based images are actually affected. Just updates the version of Clojure we pre-install from 1.8.0 to 1.9.0. They still work with any version of Clojure they did before, this is just the version that won't have to be re-downloaded every time because we embed it.