### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,12 +14,12 @@ Architectures: amd64, i386
 GitCommit: 0a8b0c981c2db51bcf15bda01de805f636744073
 Directory: 2.2
 
-Tags: 3.0.15, 3.0
+Tags: 3.0.16, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: ccc145c1950563dc28e05e2f889b084ba95d8387
+GitCommit: 202f69bdc8514e1f1eec4c0de31a964f79af3cff
 Directory: 3.0
 
-Tags: 3.11.1, 3.11, 3, latest
+Tags: 3.11.2, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: ccc145c1950563dc28e05e2f889b084ba95d8387
+GitCommit: 88f7b82386e788634f4a0f31711c92c268640df9
 Directory: 3.11

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.7, 5.6, 5, latest
-GitCommit: f6c7bea6ff0e4008e531ac6b97aa3f593872e73a
+Tags: 5.6.8, 5.6, 5, latest
+GitCommit: d91235c08a5a03073b918d996c125185427b25c4
 Directory: 5
 
-Tags: 5.6.7-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: f6c7bea6ff0e4008e531ac6b97aa3f593872e73a
+Tags: 5.6.8-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: d91235c08a5a03073b918d996c125185427b25c4
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.21.2, 1.21, 1, latest
+Tags: 1.21.3, 1.21, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b4d64e31b51d13ade2d67bdb383507c112dff57e
+GitCommit: b58ead46ec55252ea9674d50bbeba693b6727e80
 Directory: 1/debian
 
-Tags: 1.21.2-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.21.3-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: b4d64e31b51d13ade2d67bdb383507c112dff57e
+GitCommit: b58ead46ec55252ea9674d50bbeba693b6727e80
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.7, 5.6, 5, latest
-GitCommit: 0b0f9abbd2f17b4625d1210f5224bd1e32c09b4a
+Tags: 5.6.8, 5.6, 5, latest
+GitCommit: 353e125bf1d11c16f31966fc7fef8355e7d272b3
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.7, 5.6, 5, latest
-GitCommit: 97fb4e0e3738cfabcb64456c1bf5de1eef357576
+Tags: 5.6.8, 5.6, 5, latest
+GitCommit: 26506a8c65e1b1cb5584481b3b3f039b45f5c218
 Directory: 5
 
-Tags: 5.6.7-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 97fb4e0e3738cfabcb64456c1bf5de1eef357576
+Tags: 5.6.8-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 26506a8c65e1b1cb5584481b3b3f039b45f5c218
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mysql
+++ b/library/mysql
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.4-rc, 8.0.4, 8.0, 8
-GitCommit: 7c72a4561ccf839dace123b9eb5b2c144cdec675
+GitCommit: 7b6d186052e268079972b4ea8c871f89161a899e
 Directory: 8.0
 
 Tags: 5.7.21, 5.7, 5, latest

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,30 +5,30 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 11.0.7-apache, 11.0-apache, 11-apache, 11.0.7, 11.0, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 11.0/apache
 
 Tags: 11.0.7-fpm, 11.0-fpm, 11-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 11.0/fpm
 
 Tags: 12.0.5-apache, 12.0-apache, 12-apache, 12.0.5, 12.0, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 12.0/apache
 
 Tags: 12.0.5-fpm, 12.0-fpm, 12-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 12.0/fpm
 
 Tags: 13.0.0-apache, 13.0-apache, 13-apache, apache, 13.0.0, 13.0, 13, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 13.0/apache
 
 Tags: 13.0.0-fpm, 13.0-fpm, 13-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 81f1412a1fc11dd6594d619b784f27c8dec7baf1
+GitCommit: 013a71ac9b5b6153e52f8572f607bc7d2ad953bd
 Directory: 13.0/fpm

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,32 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 10.0.4-apache, 10.0-apache, 10-apache, apache, 10.0.4, 10.0, 10, latest
+Tags: 10.0.6-apache, 10.0-apache, 10-apache, apache, 10.0.6, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 146a37ed55bb70778feef7f4ce5a8b56b8a4b3ce
+GitCommit: df9ca81cd13cdbdf20602fb89fb01398f944858a
 Directory: 10.0/apache
 
-Tags: 10.0.4-fpm, 10.0-fpm, 10-fpm, fpm
+Tags: 10.0.6-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 146a37ed55bb70778feef7f4ce5a8b56b8a4b3ce
+GitCommit: df9ca81cd13cdbdf20602fb89fb01398f944858a
 Directory: 10.0/fpm
 
 Tags: 9.1.7-apache, 9.1-apache, 9-apache, 9.1.7, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b916cdc2840cb63d6b4ede93e88826863b150b06
+GitCommit: 158a440fa5fc7f6d0fc16c94cabdbe70ed700415
 Directory: 9.1/apache
 
 Tags: 9.1.7-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b916cdc2840cb63d6b4ede93e88826863b150b06
+GitCommit: 158a440fa5fc7f6d0fc16c94cabdbe70ed700415
 Directory: 9.1/fpm
-
-Tags: 9.0.11-apache, 9.0-apache, 9.0.11, 9.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c98a6030224193c1fae590a3f1c1c27f6a6ed6bc
-Directory: 9.0/apache
-
-Tags: 9.0.11-fpm, 9.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c98a6030224193c1fae590a3f1c1c27f6a6ed6bc
-Directory: 9.0/fpm

--- a/library/percona
+++ b/library/percona
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.20, 5.7, 5, latest
-GitCommit: 4ef7358aa77fb90c21003a61c09c6c4c8399284e
+Tags: 5.7.21, 5.7, 5, latest
+GitCommit: 34106a8d1325f2692826b98502b1c4760a716e9a
 Directory: 5.7
 
 Tags: 5.6.39, 5.6

--- a/library/piwik
+++ b/library/piwik
@@ -3,9 +3,9 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 3.3.0-apache, 3.3-apache, 3-apache, apache, 3.3.0, 3.3, 3, latest
-GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
+GitCommit: 32f54107672ac53d18aede1238e6f582fc370b4a
 Directory: apache
 
 Tags: 3.3.0-fpm, 3.3-fpm, 3-fpm, fpm
-GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
+GitCommit: 32f54107672ac53d18aede1238e6f582fc370b4a
 Directory: fpm

--- a/library/piwik
+++ b/library/piwik
@@ -3,9 +3,9 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 3.3.0-apache, 3.3-apache, 3-apache, apache, 3.3.0, 3.3, 3, latest
-GitCommit: 32f54107672ac53d18aede1238e6f582fc370b4a
+GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
 Directory: apache
 
 Tags: 3.3.0-fpm, 3.3-fpm, 3-fpm, fpm
-GitCommit: 32f54107672ac53d18aede1238e6f582fc370b4a
+GitCommit: 7ac7fe7a33569545bb595dbc8f925c03a8b79e55
 Directory: fpm

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,6 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.7.4-rc.1, 3.7-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 65c42bf5ceda842b857c9fc4afc88378563c6be6
+Directory: 3.7-rc/debian
+
+Tags: 3.7.4-rc.1-management, 3.7-rc-management
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/debian/management
+
+Tags: 3.7.4-rc.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 65c42bf5ceda842b857c9fc4afc88378563c6be6
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.4-rc.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.3, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b5543df2789c16d8ea1c2119484378d4c23baa6c

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.61.1, 0.61, 0, latest
-GitCommit: 2d88f3691d777decb3a8537446d38cd8ae6b62a5
+Tags: 0.61.2, 0.61, 0, latest
+GitCommit: df3e338dde3fae889074f892acadf3445bfd0460


### PR DESCRIPTION
- `cassandra`: 3.11.2, 3.0.16
- `elasticsearch`: 5.6.8
- `ghost`: 1.21.3
- `kibana`: 5.6.8
- `logstash`: 5.6.8
- `mysql`: add `-f` to fight GnuPG 2.x race
- `nextcloud`: APCu-5.1.10
- `owncloud`: 10.0.6, remove EOL 9.0
- `percona`: 5.7.21
- ~~`piwik`: 3.3.0~~
- `rabbitmq`: 3.7.4-rc.1
- `rocket.chat`: 0.61.2