### PR TITLE
Update Node v9.6.0 & gpg server list

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,34 +3,34 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.5.0, 9.5, 9, latest
+Tags: 9.6.0, 9.6, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
+GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
 Directory: 9
 
-Tags: 9.5.0-alpine, 9.5-alpine, 9-alpine, alpine
+Tags: 9.6.0-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
+GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
 Directory: 9/alpine
 
-Tags: 9.5.0-onbuild, 9.5-onbuild, 9-onbuild, onbuild
+Tags: 9.6.0-onbuild, 9.6-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: db3b27c8388136b5e529861d7c3fa12fd8328301
+GitCommit: 57eb0de9a948cf9d20d42139bc00ac556d80d878
 Directory: 9/onbuild
 
-Tags: 9.5.0-slim, 9.5-slim, 9-slim, slim
+Tags: 9.6.0-slim, 9.6-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
+GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
 Directory: 9/slim
 
-Tags: 9.5.0-stretch, 9.5-stretch, 9-stretch, stretch
+Tags: 9.6.0-stretch, 9.6-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
+GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
 Directory: 9/stretch
 
-Tags: 9.5.0-wheezy, 9.5-wheezy, 9-wheezy, wheezy
+Tags: 9.6.0-wheezy, 9.6-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
+GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
 Directory: 9/wheezy
 
 Tags: 8.9.4, 8.9, 8, carbon

--- a/library/node
+++ b/library/node
@@ -5,12 +5,12 @@ GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 9.5.0, 9.5, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 9
 
 Tags: 9.5.0-alpine, 9.5-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 9/alpine
 
 Tags: 9.5.0-onbuild, 9.5-onbuild, 9-onbuild, onbuild
@@ -20,27 +20,27 @@ Directory: 9/onbuild
 
 Tags: 9.5.0-slim, 9.5-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 9/slim
 
 Tags: 9.5.0-stretch, 9.5-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 9/stretch
 
 Tags: 9.5.0-wheezy, 9.5-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 9/wheezy
 
 Tags: 8.9.4, 8.9, 8, carbon
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 25f26146ac5b9f74add731b0b078e34411ae5831
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 8
 
 Tags: 8.9.4-alpine, 8.9-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 8/alpine
 
 Tags: 8.9.4-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
@@ -50,27 +50,27 @@ Directory: 8/onbuild
 
 Tags: 8.9.4-slim, 8.9-slim, 8-slim, carbon-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 25f26146ac5b9f74add731b0b078e34411ae5831
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 8/slim
 
 Tags: 8.9.4-stretch, 8.9-stretch, 8-stretch, carbon-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 8/stretch
 
 Tags: 8.9.4-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
 Architectures: amd64
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 8/wheezy
 
 Tags: 6.13.0, 6.13, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: b57e96aea75f8e7960e17b3fb0efded41b295909
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 6
 
 Tags: 6.13.0-alpine, 6.13-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: b57e96aea75f8e7960e17b3fb0efded41b295909
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 6/alpine
 
 Tags: 6.13.0-onbuild, 6.13-onbuild, 6-onbuild, boron-onbuild
@@ -80,27 +80,27 @@ Directory: 6/onbuild
 
 Tags: 6.13.0-slim, 6.13-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: b57e96aea75f8e7960e17b3fb0efded41b295909
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 6/slim
 
 Tags: 6.13.0-stretch, 6.13-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: b57e96aea75f8e7960e17b3fb0efded41b295909
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 6/stretch
 
 Tags: 6.13.0-wheezy, 6.13-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: b57e96aea75f8e7960e17b3fb0efded41b295909
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 6/wheezy
 
 Tags: 4.8.7, 4.8, 4, argon
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 4
 
 Tags: 4.8.7-alpine, 4.8-alpine, 4-alpine, argon-alpine
 Architectures: amd64
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 4/alpine
 
 Tags: 4.8.7-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
@@ -110,21 +110,21 @@ Directory: 4/onbuild
 
 Tags: 4.8.7-slim, 4.8-slim, 4-slim, argon-slim
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 4/slim
 
 Tags: 4.8.7-stretch, 4.8-stretch, 4-stretch, argon-stretch
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 4/stretch
 
 Tags: 4.8.7-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
 Architectures: amd64
-GitCommit: 4e5eda8fedf7fa355de6037f01d5699d414c1da3
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: 4/wheezy
 
 Tags: chakracore-8.9.4, chakracore-8.9, chakracore-8, chakracore
 Architectures: amd64
-GitCommit: 3f8fab48f2465cf2cc8f8ee0825a04626986e5b8
+GitCommit: 8498ff5302c19506c9edc3ce152f2bd4aa6b26b3
 Directory: chakracore/8
 


### PR DESCRIPTION
This pull request includes 2 commits to reflect the change but without messing up the history and saving time on having 2 PRs for them.

The first commit is for the update for the gpg server lists, dropped keyserver.gpg.com(https://github.com/nodejs/docker-node/pull/632) as @tianon suggested in https://github.com/docker-library/official-images/pull/4006#issuecomment-365420103, also reordered the server list in the mean time.

The second one is to update node.js v9.x from v9.5 to v9.6(https://github.com/nodejs/docker-node/pull/633)

Ref:
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V9.md#2018-02-22-version-960-current-mylesborins