### PR TITLE
haxe: 3.4.6 -> 3.4.7, use TLS1.2 for downloading in win images

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,35 +1,35 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 3.4.6-stretch, 3.4-stretch, 3.4.6, 3.4, latest
+Tags: 3.4.7-stretch, 3.4-stretch, 3.4.7, 3.4, latest
 Architectures: amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/stretch
 
-Tags: 3.4.6-jessie, 3.4-jessie
+Tags: 3.4.7-jessie, 3.4-jessie
 Architectures: amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/jessie
 
-Tags: 3.4.6-onbuild, 3.4-onbuild
+Tags: 3.4.7-onbuild, 3.4-onbuild
 Architectures: amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/onbuild
 
-Tags: 3.4.6-windowsservercore, 3.4-windowsservercore
+Tags: 3.4.7-windowsservercore, 3.4-windowsservercore
 Architectures: windows-amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.4/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.6-alpine3.7, 3.4-alpine3.7, 3.4.6-alpine, 3.4-alpine
+Tags: 3.4.7-alpine3.7, 3.4-alpine3.7, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/alpine3.7
 
-Tags: 3.4.6-alpine3.6, 3.4-alpine3.6
+Tags: 3.4.7-alpine3.6, 3.4-alpine3.6
 Architectures: amd64
-GitCommit: 56798419dd0d31f361cb5a92b8235fa454d9320d
+GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
@@ -49,7 +49,7 @@ Directory: 3.3/onbuild
 
 Tags: 3.3.0-rc.1-windowsservercore, 3.3.0-windowsservercore, 3.3-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.3/windowsservercore
 Constraints: windowsservercore
 
@@ -80,7 +80,7 @@ Directory: 3.2/onbuild
 
 Tags: 3.2.1-windowsservercore, 3.2-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.2/windowsservercore
 Constraints: windowsservercore
 
@@ -111,7 +111,7 @@ Directory: 3.1/onbuild
 
 Tags: 3.1.3-windowsservercore, 3.1-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6776e2d4be810f99c26c8e2842e03f59100e26f2
+GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.1/windowsservercore
 Constraints: windowsservercore
 
@@ -132,7 +132,7 @@ Directory: 4.0/onbuild
 
 Tags: 4.0.0-preview.2-windowsservercore, 4.0.0-windowsservercore, 4.0-windowsservercore
 Architectures: windows-amd64
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 4.0/windowsservercore
 Constraints: windowsservercore
 


### PR DESCRIPTION
* Upgraded 3.4.6 to 3.4.7, which was a bugfix release.
* Use TLS1.2 for downloading in the windows images, because now github does not accept the powershell default TLS1.0.