### PR TITLE
Update node.js v9.6.0 to v9.6.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,34 +3,34 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.6.0, 9.6, 9, latest
+Tags: 9.6.1, 9.6, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9
 
-Tags: 9.6.0-alpine, 9.6-alpine, 9-alpine, alpine
+Tags: 9.6.1-alpine, 9.6-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9/alpine
 
-Tags: 9.6.0-onbuild, 9.6-onbuild, 9-onbuild, onbuild
+Tags: 9.6.1-onbuild, 9.6-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 57eb0de9a948cf9d20d42139bc00ac556d80d878
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9/onbuild
 
-Tags: 9.6.0-slim, 9.6-slim, 9-slim, slim
+Tags: 9.6.1-slim, 9.6-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9/slim
 
-Tags: 9.6.0-stretch, 9.6-stretch, 9-stretch, stretch
+Tags: 9.6.1-stretch, 9.6-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9/stretch
 
-Tags: 9.6.0-wheezy, 9.6-wheezy, 9-wheezy, wheezy
+Tags: 9.6.1-wheezy, 9.6-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: 97ce772b3a2c62ab66f8ef3f069440a81413d7cf
+GitCommit: cd2bb38947e51a60df45b71f8637852caffb1c1d
 Directory: 9/wheezy
 
 Tags: 8.9.4, 8.9, 8, carbon


### PR DESCRIPTION
 - https://github.com/nodejs/docker-node/pull/634
 - https://github.com/nodejs/node/releases/tag/v9.6.1
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V9.md#9.6.1