### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.4, 10.3
-GitCommit: 25d4485e6192c1cfa2f9b12882c291258b73ed64
+Tags: 10.3.5, 10.3
+GitCommit: 0ab4688d0e6d3a81d7cd19e04db44fb499c49d6a
 Directory: 10.3
 
 Tags: 10.2.13, 10.2, 10, latest

--- a/library/mongo
+++ b/library/mongo
@@ -28,12 +28,12 @@ Architectures: amd64
 GitCommit: cd03aec6375197ae86191886a876a12e8f2eaac7
 Directory: 3.4
 
-Tags: 3.6.2-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.2, 3.6, 3, latest
+Tags: 3.6.3-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.3, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: a504b49bb5cf896fbf3640b4b8cb0d09a25b53ae
+GitCommit: 2e3e1bdbb31389c8bc8d43f5a3cc439134b7956b
 Directory: 3.6
 
 Tags: 3.7.2-jessie, 3.7-jessie, unstable-jessie

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.4-rc, 8.0.4, 8.0, 8
-GitCommit: 5d24fc588f78d1703b1bebfd21a5dec385c3b60e
+GitCommit: ad625c64a06e16683e997e5a0147508d115f4989
 Directory: 8.0
 
 Tags: 5.7.21, 5.7, 5, latest
-GitCommit: 607b2a65aa76adf495730b9f7e6f28f146a9f95f
+GitCommit: ad625c64a06e16683e997e5a0147508d115f4989
 Directory: 5.7
 
 Tags: 5.6.39, 5.6
-GitCommit: b6156cf8c6a1e9702440489bfa9a92c2078ba4b5
+GitCommit: f279c9cc0d20407a2c4d9465adae6b077dcf1b51
 Directory: 5.6
 
 Tags: 5.5.59, 5.5
-GitCommit: 90c4f75a642d6685f4fe4d8fc585e88339ed2cb1
+GitCommit: f279c9cc0d20407a2c4d9465adae6b077dcf1b51
 Directory: 5.5

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.4-rc.1, 3.7-rc
+Tags: 3.7.4-rc.3, 3.7-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65c42bf5ceda842b857c9fc4afc88378563c6be6
+GitCommit: 5c01b8ad083e4eb79dcc2da1fdfa1733d4b36950
 Directory: 3.7-rc/debian
 
-Tags: 3.7.4-rc.1-management, 3.7-rc-management
+Tags: 3.7.4-rc.3-management, 3.7-rc-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/debian/management
 
-Tags: 3.7.4-rc.1-alpine, 3.7-rc-alpine
+Tags: 3.7.4-rc.3-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 65c42bf5ceda842b857c9fc4afc88378563c6be6
+GitCommit: 3777da3ba1bbface12c22a8200f38629a6c41642
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.4-rc.1-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.4-rc.3-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management


### PR DESCRIPTION
- `mariadb`: 10.3.5
- `mongo`: 3.6.3
- `mysql`: less user deletion (docker-library/mysql#383), jessie to stretch (https://github.com/docker-library/mysql/pull/382)
- `rabbitmq`: 3.7.4-rc.3