### PR TITLE
Upgrade Kong to 0.12.2 & 0.13.0rc1

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -1,13 +1,22 @@
-Maintainers: Mashape Docker Maintainers <support@konghq.com> (@thekonginc)
+Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 0.12-alpine, 0.12.1-alpine
-GitCommit: d4cec3dc46c780a916a40963309554ca81da2b46
+Tags: 0.13.0rc1-alpine, 0.13.0rc1
+GitCommit: a7eafcb769a5a2447c831ce3aba1a06723fc303c
 Directory: alpine
 
-Tags: 0.12-centos, 0.12.1-centos, 0.12, 0.12.1, latest
-GitCommit: d4cec3dc46c780a916a40963309554ca81da2b46
+Tags: 0.13.0rc1-centos
+GitCommit: a7eafcb769a5a2447c831ce3aba1a06723fc303c
+Constraints: !aufs
+Directory: centos
+
+Tags: 0.12-alpine, 0.12.2-alpine
+GitCommit: 5c8b83332ed90e821f555584de40364bd18e9980
+Directory: alpine
+
+Tags: 0.12-centos, 0.12.2-centos, 0.12, 0.12.2, latest
+GitCommit: 5c8b83332ed90e821f555584de40364bd18e9980
 Constraints: !aufs
 Directory: centos
 


### PR DESCRIPTION
Hi there,

* bump 0.12 family to 0.12.2
* add 0.13.0rc1
* the 0.13.0rc1 tag points to the alpine base instead of centos, this is
  a change of defaults compared to prior versions
* s/Mashape/Kong (rebranding)