### PR TITLE
[nats] Release v1.0.6

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -1,28 +1,30 @@
-Maintainers: Derek Collison <derek@apcera.com> (@derekcollison),
-             Ivan Kozlovic <ivan.kozlovic@apcera.com> (@kozlovic),
-             Waldemar Salinas <wally@apcera.com> (@wallyqs)
+Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
+             Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
+             Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 
-Tags: 1.0.4-linux, linux
-SharedTags: 1.0.4, latest
-Architectures: amd64, arm32v7, arm64v8
-amd64-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+Tags: 1.0.6-linux, linux
+SharedTags: 1.0.6, latest
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+amd64-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 amd64-Directory: amd64
-arm32v7-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+arm32v6-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
+arm32v6-Directory: arm32v6
+arm32v7-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+arm64v8-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 arm64v8-Directory: arm64v8
 
-Tags: 1.0.4-nanoserver, nanoserver
-SharedTags: 1.0.4, latest
+Tags: 1.0.6-nanoserver, nanoserver
+SharedTags: 1.0.6, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+windows-amd64-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.0.4-windowsservercore, windowsservercore
+Tags: 1.0.6-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4e0129ffe9d12beec981238c6cb54f5faa0fbe57
+windows-amd64-GitCommit: ca1b570199ae0bb6434e600b6ee4c768e5f81f31
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v1.0.6)