### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -34,32 +34,17 @@ Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 157869f94ea90e2acb4d0f77045d99079ead821c
 Directory: 18.02/git
 
-Tags: 17.12.1-ce-rc2, 17.12-rc
+Tags: 17.12.1-ce, 17.12.1, 17.12, 17, stable
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9a1feddfc856278e289035da7a29fd218bc12d78
-Directory: 17.12-rc
-
-Tags: 17.12.1-ce-rc2-dind, 17.12-rc-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 56ff41e041f3bffbabaa9237421baa5ebe86ec74
-Directory: 17.12-rc/dind
-
-Tags: 17.12.1-ce-rc2-git, 17.12-rc-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 56ff41e041f3bffbabaa9237421baa5ebe86ec74
-Directory: 17.12-rc/git
-
-Tags: 17.12.0-ce, 17.12.0, 17.12, 17, stable
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: b9fd686dac473fb71ffb426a9ef8e0467208dd2f
+GitCommit: eec0f6e5549ab940b53332f836be817c877d1154
 Directory: 17.12
 
-Tags: 17.12.0-ce-dind, 17.12.0-dind, 17.12-dind, 17-dind, stable-dind
+Tags: 17.12.1-ce-dind, 17.12.1-dind, 17.12-dind, 17-dind, stable-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/dind
 
-Tags: 17.12.0-ce-git, 17.12.0-git, 17.12-git, 17-git, stable-git
+Tags: 17.12.1-ce-git, 17.12.1-git, 17.12-git, 17-git, stable-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
 Directory: 17.12/git

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.5, 1.5, 1, latest
+Tags: 1.5.6, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f74da18217c8d18e58976c3d7da1728efe433dc9
+GitCommit: a7c39f381206b994072a48b590f5b3fc7a2e7ca6
 Directory: debian
 
-Tags: 1.5.5-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.6-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f74da18217c8d18e58976c3d7da1728efe433dc9
+GitCommit: a7c39f381206b994072a48b590f5b3fc7a2e7ca6
 Directory: alpine

--- a/library/postgres
+++ b/library/postgres
@@ -4,52 +4,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10.2, 10, latest
+Tags: 10.3, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 674466e0d47517f4e05ec2025ae996e71b26cae9
+GitCommit: 0aaaf2094034647a552f0b1ec63b1b0ec0f6c2cc
 Directory: 10
 
-Tags: 10.2-alpine, 10-alpine, alpine
+Tags: 10.3-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 86972e37db26753818b25e82ff3816ede9877e7b
+GitCommit: f7f1e59c55bcce36cfbe7ab4604f439eb8721611
 Directory: 10/alpine
 
-Tags: 9.6.7, 9.6, 9
+Tags: 9.6.8, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7da010d82077944ce39211cc610ce58c11366360
+GitCommit: 7f18547f3779e8593e2bb35f21eba5baadc47290
 Directory: 9.6
 
-Tags: 9.6.7-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.8-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64
-GitCommit: 165ffaab649aea0797ad61739cb5c9ac69466929
+GitCommit: 65ed6d7deebc81377154f1c841b1b156c63dfb19
 Directory: 9.6/alpine
 
-Tags: 9.5.11, 9.5
+Tags: 9.5.12, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4aa86c49b4691ea2e23934a419538df187a7f57
+GitCommit: 07ae979980f889e83ee8f4afc1fee09fdb663ab3
 Directory: 9.5
 
-Tags: 9.5.11-alpine, 9.5-alpine
+Tags: 9.5.12-alpine, 9.5-alpine
 Architectures: amd64
-GitCommit: 8734ceed8c5e196d3d59227a59d80df8fed70126
+GitCommit: 7063c608f7845a56d343e71540f92b5cdd2a543b
 Directory: 9.5/alpine
 
-Tags: 9.4.16, 9.4
+Tags: 9.4.17, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93dc51c2ec5b16d3d728b7f85804ae43113006d6
+GitCommit: 61e369ce3738e38386fa01ce4809c2304e76257c
 Directory: 9.4
 
-Tags: 9.4.16-alpine, 9.4-alpine
+Tags: 9.4.17-alpine, 9.4-alpine
 Architectures: amd64
-GitCommit: dc36bbe68fb7f8c2a8b421944cb80aa73681e093
+GitCommit: 34b633b01ddcb6473e543a2e3a1ff0e2978670cb
 Directory: 9.4/alpine
 
-Tags: 9.3.21, 9.3
+Tags: 9.3.22, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d8ce07a1e97e7caa1436a341ae7a2b06efb852dc
+GitCommit: e3c9133ac3bde0aca094b616654309f3377124f2
 Directory: 9.3
 
-Tags: 9.3.21-alpine, 9.3-alpine
+Tags: 9.3.22-alpine, 9.3-alpine
 Architectures: amd64
-GitCommit: 35d59a4ae2e0b0ab25d305b7e59bef15cd732432
+GitCommit: 40158e3e1eab19a8faceef3f31c50869c964223c
 Directory: 9.3/alpine

--- a/library/python
+++ b/library/python
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0b1-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0b1, 3.7-rc, rc
+Tags: 3.7.0b2-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0b2, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
+GitCommit: 22ec2c1a8faa857b917cfc0a2fef5a52d0b8da29
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0b1-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b1-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0b2-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b2-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
+GitCommit: 22ec2c1a8faa857b917cfc0a2fef5a52d0b8da29
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0b1-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b1-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0b2-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b2-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
+GitCommit: 22ec2c1a8faa857b917cfc0a2fef5a52d0b8da29
 Directory: 3.7-rc/alpine3.7
 
-Tags: 3.7.0b1-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.7.0b1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b1, 3.7-rc, rc
+Tags: 3.7.0b2-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.7.0b2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b2, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
+GitCommit: 22ec2c1a8faa857b917cfc0a2fef5a52d0b8da29
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0b1-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 3.7.0b1-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b1, 3.7-rc, rc
+Tags: 3.7.0b2-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 3.7.0b2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b2, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 1dcbfcceba5dc2d3ebf0a414926f2645aec0150e
+GitCommit: 22ec2c1a8faa857b917cfc0a2fef5a52d0b8da29
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.4-rc.3, 3.7-rc
+Tags: 3.7.4-rc.4, 3.7-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c01b8ad083e4eb79dcc2da1fdfa1733d4b36950
+GitCommit: 828d5ed824b9c49a9696755a3872c3d45ac81bd8
 Directory: 3.7-rc/debian
 
-Tags: 3.7.4-rc.3-management, 3.7-rc-management
+Tags: 3.7.4-rc.4-management, 3.7-rc-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/debian/management
 
-Tags: 3.7.4-rc.3-alpine, 3.7-rc-alpine
+Tags: 3.7.4-rc.4-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3777da3ba1bbface12c22a8200f38629a6c41642
+GitCommit: ef175ca799b6cee50f04e464271a610cbd3d2e69
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.4-rc.3-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.4-rc.4-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 86a208cc744d9743a219973ba2ab675f6718bec4
 Directory: 3.4
 
 Tags: 3.4.4-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
+GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
 Directory: 3.4/passenger
 
 Tags: 3.3.6, 3.3
@@ -19,7 +19,7 @@ GitCommit: 1a66905d6ed69f74e74e6b48fedb39f8e3bff949
 Directory: 3.3
 
 Tags: 3.3.6-passenger, 3.3-passenger
-GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
+GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: 4ebd2edbbba5bb0a9ef1ecc101d6376bba9295a1
+GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
 Directory: 3.2/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.61.2, 0.61, 0, latest
-GitCommit: df3e338dde3fae889074f892acadf3445bfd0460
+Tags: 0.62.0, 0.62, 0, latest
+GitCommit: c4437b7ff1bd003c1e1ada03ddf54ef6e4d4f915


### PR DESCRIPTION
- `docker`: 17.12.1-ce
- `memcached`: 1.5.6
- `postgres`: 9.3.22, 9.4.17, 9.5.12, 9.6.8, 10.3
- `python`: 3.7.0b2
- `rabbitmq`: 3.7.4-rc.4
- `redmine`: passenger 5.2.1
- `rocket.chat`: 0.62.0