### PR TITLE
Erlang OTP 19.3.6.6 & 18.3.4.8

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/e7d145c915458e5bbb857a57c9aad7125f95a853/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/01daedc9c1178227d084c25f1b1890f158ec6f79/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
@@ -14,28 +14,28 @@ GitCommit: 83a747afba739592bb4d3f8a01b5d535c1f2c8dd
 Directory: 20/slim
 
 Tags: 20.2.4-alpine, 20.2-alpine, 20-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: 83a747afba739592bb4d3f8a01b5d535c1f2c8dd
 Directory: 20/alpine
 
-Tags: 19.3.6.5, 19.3.6, 19.3, 19
+Tags: 19.3.6.6, 19.3.6, 19.3, 19
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: f6606389b995d24dce8933e4ca4d6d46fce8612b
+GitCommit: bede8199e3263e936687542a0492774b3512296a
 Directory: 19
 
-Tags: 19.3.6.5-slim, 19.3.6-slim, 19.3-slim, 19-slim
+Tags: 19.3.6.6-slim, 19.3.6-slim, 19.3-slim, 19-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: 6e2088d493e6f50b82c0e416c72a2dd914e84fd2
+GitCommit: bede8199e3263e936687542a0492774b3512296a
 Directory: 19/slim
 
-Tags: 18.3.4.7, 18.3.4, 18.3, 18
+Tags: 18.3.4.8, 18.3.4, 18.3, 18
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: f6606389b995d24dce8933e4ca4d6d46fce8612b
+GitCommit: 354f85db09d403e3d970d0731b811c774086ef26
 Directory: 18
 
-Tags: 18.3.4.7-slim, 18.3.4-slim, 18.3-slim, 18-slim
+Tags: 18.3.4.8-slim, 18.3.4-slim, 18.3-slim, 18-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: 572df91d94de857de661df30f33508e472c300a9
+GitCommit: 354f85db09d403e3d970d0731b811c774086ef26
 Directory: 18/slim
 
 Tags: 17.5.6.9, 17.5.6, 17.5, 17


### PR DESCRIPTION
also fixes the removed architectures in 9645279 for erlang:20-alpine

this supercedes and closes #4085