### PR TITLE
Update Solr to 6.6.3

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 7.2.1, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.2
 
 Tags: 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.2/alpine
 
 Tags: 7.2.1-slim, 7.2-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 7.1/slim
 
-Tags: 6.6.2, 6.6, 6
+Tags: 6.6.3, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 6.6
 
-Tags: 6.6.2-alpine, 6.6-alpine, 6-alpine
+Tags: 6.6.3-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 6.6/alpine
 
-Tags: 6.6.2-slim, 6.6-slim, 6-slim
+Tags: 6.6.3-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: afe43e97be7aa764656f3e0aa068bed90f6bdd27
+GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
 Directory: 5.5/slim


### PR DESCRIPTION
Announcement: https://lists.apache.org/thread.html/26ec81783c5ce57ad72df5babc6c675085320de2f174922afd3bc05c@%3Cannounce.apache.org%3E
Changes: https://lucene.apache.org/solr/6_6_3/changes/Changes.html

On the docker-solr side, there was a minor bugfix in an error message: https://github.com/docker-solr/docker-solr/issues/167