### PR TITLE
Maven 3.5.3

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -1,132 +1,62 @@
 Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
 GitRepo: https://github.com/carlossg/docker-maven.git
 
-Tags: 3.5.2-jdk-7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-7-alpine
-
-Tags: 3.5.2-jdk-7-slim
+Tags: 3.5.3-jdk-10-slim, 3.5-jdk-10-slim, 3-jdk-10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-7-slim
-
-Tags: 3.5.2-jdk-7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-7
-
-Tags: 3.5.2-jdk-8-alpine, 3.5.2-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 798decbb2f987a14f345c017f8fa3725c2467758
-Directory: jdk-8-alpine
-
-Tags: 3.5.2-jdk-8-slim, 3.5.2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-8-slim
-
-Tags: 3.5.2-jdk-8, 3.5.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-8
-
-Tags: 3.5.2-jdk-9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-9-slim
-
-Tags: 3.5.2-jdk-9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: jdk-9
-
-Tags: 3.5.2-ibmjava-8-alpine, 3.5.2-ibmjava-alpine
-Architectures: amd64
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: ibmjava-8-alpine
-
-Tags: 3.5.2-ibmjava-8, 3.5.2-ibmjava
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: ibmjava-8
-
-Tags: 3.5.2-ibmjava-9-alpine
-Architectures: amd64
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: ibmjava-9-alpine
-
-Tags: 3.5.2-ibmjava-9
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 93d297ed2fc952af8c3638eae78c3d5e7526033f
-Directory: ibmjava-9
-
-Tags: 3.5-jdk-7-alpine, 3-jdk-7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-7-alpine
-
-Tags: 3.5-jdk-7-slim, 3-jdk-7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-7-slim
-
-Tags: 3.5-jdk-7, 3-jdk-7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-7
-
-Tags: 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-8-alpine
-
-Tags: 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-8-slim
-
-Tags: 3.5-jdk-8, 3.5, 3-jdk-8, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-8
-
-Tags: 3.5-jdk-9-slim, 3-jdk-9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-9-slim
-
-Tags: 3.5-jdk-9, 3-jdk-9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: jdk-9
-
-Tags: 3.5-jdk-10-slim, 3-jdk-10-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2df8a77137133ec3b0071e3cdc4e7793118555a5
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
 Directory: jdk-10-slim
 
-Tags: 3.5-jdk-10, 3-jdk-10
+Tags: 3.5.3-jdk-10, 3.5-jdk-10, 3-jdk-10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2df8a77137133ec3b0071e3cdc4e7793118555a5
+GitCommit: 949973eab2ea27a1e2ef09b45627b2c984a80bc7
 Directory: jdk-10
 
-Tags: 3.5-ibmjava-8-alpine, 3.5-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
+Tags: 3.5.3-jdk-7-alpine, 3.5-jdk-7-alpine, 3-jdk-7-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
+Directory: jdk-7-alpine
+
+Tags: 3.5.3-jdk-7-slim, 3.5-jdk-7-slim, 3-jdk-7-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
+Directory: jdk-7-slim
+
+Tags: 3.5.3-jdk-7, 3.5-jdk-7, 3-jdk-7
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 949973eab2ea27a1e2ef09b45627b2c984a80bc7
+Directory: jdk-7
+
+Tags: 3.5.3-jdk-8-alpine, 3.5.3-alpine, 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
+Directory: jdk-8-alpine
+
+Tags: 3.5.3-jdk-8-slim, 3.5.3-slim, 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
+Directory: jdk-8-slim
+
+Tags: 3.5.3-jdk-8, 3.5.3, 3.5-jdk-8, 3.5, 3-jdk-8, 3, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 949973eab2ea27a1e2ef09b45627b2c984a80bc7
+Directory: jdk-8
+
+Tags: 3.5.3-jdk-9-slim, 3.5-jdk-9-slim, 3-jdk-9-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
+Directory: jdk-9-slim
+
+Tags: 3.5.3-jdk-9, 3.5-jdk-9, 3-jdk-9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 949973eab2ea27a1e2ef09b45627b2c984a80bc7
+Directory: jdk-9
+
+Tags: 3.5.3-ibmjava-8-alpine, 3.5.3-ibmjava-alpine, 3.5-ibmjava-8-alpine, 3.5-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
 Architectures: amd64
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
+GitCommit: da92f8b0c8530061c539dcfc5c0257ce8565568b
 Directory: ibmjava-8-alpine
 
-Tags: 3.5-ibmjava-8, 3.5-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
+Tags: 3.5.3-ibmjava-8, 3.5.3-ibmjava, 3.5-ibmjava-8, 3.5-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
+GitCommit: 949973eab2ea27a1e2ef09b45627b2c984a80bc7
 Directory: ibmjava-8
-
-Tags: 3.5-ibmjava-9-alpine, 3-ibmjava-9-alpine
-Architectures: amd64
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: ibmjava-9-alpine
-
-Tags: 3.5-ibmjava-9, 3-ibmjava-9
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: d2e41bb4b98f827e7929eb01578538854a61726b
-Directory: ibmjava-9


### PR DESCRIPTION
ibmjava 9 builds are removed as they base image is deprecated 70b6d6e