### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.21.4, 1.21, 1, latest
+Tags: 1.21.5, 1.21, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96deac792a94a88e42d78e48c2363a8bdaa1ba0b
+GitCommit: 61cbf8b50d181e787d6ef2e3401746bdf4f322d7
 Directory: 1/debian
 
-Tags: 1.21.4-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.21.5-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 96deac792a94a88e42d78e48c2363a8bdaa1ba0b
+GitCommit: 61cbf8b50d181e787d6ef2e3401746bdf4f322d7
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 3.2/32bit
 
 Tags: 3.2.11-alpine, 3.2-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 14e48621e40c6b6c84e474e28b06430a3261916a
+GitCommit: 3f69a5c2109cd8099126548bda5d6983dec02dcf
 Directory: 3.2/alpine
 
 Tags: 4.0.8, 4.0, 4, latest
@@ -31,5 +31,5 @@ Directory: 4.0/32bit
 
 Tags: 4.0.8-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d53b982b387634092c6f11069401679034054ecb
+GitCommit: 3f69a5c2109cd8099126548bda5d6983dec02dcf
 Directory: 4.0/alpine


### PR DESCRIPTION
- `ghost`: 1.21.5
- `redis`: add missing `.so` for `arm32v6` (docker-library/redis#131)