### PR TITLE
Bump Traefik to v1.5.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.5.3, 1.5.3, v1.5, 1.5, cancoillotte, latest
+Tags: v1.5.4, 1.5.4, v1.5, 1.5, cancoillotte, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 18d4d2275ef3a6d488a3842ea3ffa4521af03eca
+GitCommit: a0b61256a1c3df401f43cf01b940f3a69fb77883
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.5.3-alpine, 1.5.3-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine, alpine
+Tags: v1.5.4-alpine, 1.5.4-alpine, v1.5-alpine, 1.5-alpine, cancoillotte-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 18d4d2275ef3a6d488a3842ea3ffa4521af03eca
+GitCommit: a0b61256a1c3df401f43cf01b940f3a69fb77883
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.5.4.

/cc @vdemeester @emilevauge @ldez

Cheers
