### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.03.0-ce-rc3, 18.03-rc, rc, test
+Tags: 18.03.0-ce-rc4, 18.03-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: c7f43d116aa4a36ed630191442774e39a9c94cb6
+GitCommit: bfaadfe76376783f53968a0e309b61ef904031fa
 Directory: 18.03-rc
 
-Tags: 18.03.0-ce-rc3-dind, 18.03-rc-dind, rc-dind, test-dind
+Tags: 18.03.0-ce-rc4-dind, 18.03-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5d58870994d0ba33a5228af06876fe2026752924
 Directory: 18.03-rc/dind
 
-Tags: 18.03.0-ce-rc3-git, 18.03-rc-git, rc-git, test-git
+Tags: 18.03.0-ce-rc4-git, 18.03-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5d58870994d0ba33a5228af06876fe2026752924
 Directory: 18.03-rc/git

--- a/library/mongo
+++ b/library/mongo
@@ -36,10 +36,10 @@ Architectures: amd64
 GitCommit: 2e3e1bdbb31389c8bc8d43f5a3cc439134b7956b
 Directory: 3.6
 
-Tags: 3.7.2-jessie, 3.7-jessie, unstable-jessie
-SharedTags: 3.7.2, 3.7, unstable
+Tags: 3.7.3-jessie, 3.7-jessie, unstable-jessie
+SharedTags: 3.7.3, 3.7, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 5ad7b10217359104c1870d2d79bcb6498bf76b70
+GitCommit: 621a206bca04c06ad3e0d8459c9d23223ea11a01
 Directory: 3.7

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 10-ea-32-jre-experimental, 10-ea-jre-experimental, 10-jre-experimental, 10-ea-32-jre, 10-ea-jre, 10-jre
+Tags: 10-ea-46-jre-experimental, 10-ea-jre-experimental, 10-jre-experimental, 10-ea-46-jre, 10-ea-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4365c863956250d758341b86035862b111269ed9
+GitCommit: df9da1156dbc0e2ae0f87aeef9c79df8720d0811
 Directory: 10-jre
 
-Tags: 10-ea-32-jre-slim-experimental, 10-ea-jre-slim-experimental, 10-jre-slim-experimental, 10-ea-32-jre-slim, 10-ea-jre-slim, 10-jre-slim
+Tags: 10-ea-46-jre-slim-experimental, 10-ea-jre-slim-experimental, 10-jre-slim-experimental, 10-ea-46-jre-slim, 10-ea-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4365c863956250d758341b86035862b111269ed9
+GitCommit: df9da1156dbc0e2ae0f87aeef9c79df8720d0811
 Directory: 10-jre/slim
 
-Tags: 10-ea-32-jdk-experimental, 10-ea-32-experimental, 10-ea-jdk-experimental, 10-ea-experimental, 10-jdk-experimental, 10-experimental, 10-ea-32-jdk, 10-ea-32, 10-ea-jdk, 10-ea, 10-jdk, 10
+Tags: 10-ea-46-jdk-experimental, 10-ea-46-experimental, 10-ea-jdk-experimental, 10-ea-experimental, 10-jdk-experimental, 10-experimental, 10-ea-46-jdk, 10-ea-46, 10-ea-jdk, 10-ea, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4365c863956250d758341b86035862b111269ed9
+GitCommit: df9da1156dbc0e2ae0f87aeef9c79df8720d0811
 Directory: 10-jdk
 
-Tags: 10-ea-32-jdk-slim-experimental, 10-ea-32-slim-experimental, 10-ea-jdk-slim-experimental, 10-ea-slim-experimental, 10-jdk-slim-experimental, 10-slim-experimental, 10-ea-32-jdk-slim, 10-ea-32-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
+Tags: 10-ea-46-jdk-slim-experimental, 10-ea-46-slim-experimental, 10-ea-jdk-slim-experimental, 10-ea-slim-experimental, 10-jdk-slim-experimental, 10-slim-experimental, 10-ea-46-jdk-slim, 10-ea-46-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4365c863956250d758341b86035862b111269ed9
+GitCommit: df9da1156dbc0e2ae0f87aeef9c79df8720d0811
 Directory: 10-jdk/slim
 
 Tags: 9.0.1-11-jre-sid, 9.0.1-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.1-11-jre, 9.0.1-jre, 9.0-jre, 9-jre

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -2,4 +2,4 @@ Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
 Tags: 0.62.2, 0.62, 0, latest
-GitCommit: e18e31b28724f7ffa3de82a8dac2757d5b73d2bd
+GitCommit: 9a408ff66d899f71d595cc8bbffbd03081ef8c2e


### PR DESCRIPTION
- `docker`: 18.03.0-ce-rc4
- `mongo`: 3.7.3
- `openjdk`: 10-ea-46
- `rocket.chat`: Node 8.9... (RocketChat/Docker.Official.Image#42)