### PR TITLE
Update spiped

### DIFF
--- a/library/spiped
+++ b/library/spiped
@@ -5,7 +5,7 @@ GitRepo: https://github.com/TimWolla/docker-spiped.git
 
 Tags: 1.6.0, 1.6, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d45a684a91cd50c98a79fbcabc479efe0b49dde
+GitCommit: 51b634a7ebe73d1066da87770baf7baf76686473
 Directory: 1.6
 
 Tags: 1.6.0-alpine, 1.6-alpine, 1-alpine, alpine


### PR DESCRIPTION
This updates the Debian based spiped image to stretch-slim
(TimWolla/docker-spiped@51b634a7ebe73d1066da87770baf7baf76686473).