### PR TITLE
upgrade r-base to R 3.4.4 released yesterday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.4.3: git://github.com/rocker-org/rocker@3019a8c8c29d9337c23e30ef42fa0c6677a0e264 r-base
-latest: git://github.com/rocker-org/rocker@3019a8c8c29d9337c23e30ef42fa0c6677a0e264 r-base
+3.4.4: git://github.com/rocker-org/rocker@151274f9052f874034489769b94eba834309dc5d r-base
+latest: git://github.com/rocker-org/rocker@151274f9052f874034489769b94eba834309dc5d r-base


### PR DESCRIPTION
Standard rolling of R to 3.4.4 released yesterday  (and the .deb package I maintainer is already there since yesterday; our build in rocker/r-base:latest has it).

I updated one more variable for the CRAN repos in the Dockerfile. It looks different ... but the DNS effect is the same:   The R Project now points to the same CDN initially set up, and still managed by, RStudio.