### PR TITLE
[nats-streaming] Release v0.9.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 
-Tags: 0.8.0-beta-linux, linux
-SharedTags: 0.8.0-beta, latest
+Tags: 0.9.0-linux, linux
+SharedTags: 0.9.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+amd64-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 amd64-Directory: amd64
-arm32v6-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+arm32v6-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+arm32v7-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+arm64v8-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 arm64v8-Directory: arm64v8
 
-Tags: 0.8.0-beta-nanoserver, nanoserver
-SharedTags: 0.8.0-beta, latest
+Tags: 0.9.0-nanoserver, nanoserver
+SharedTags: 0.9.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+windows-amd64-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.8.0-beta-windowsservercore, windowsservercore
+Tags: 0.9.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 241ef65433ca7fa0042d6015b3d1ffd191a185ec
+windows-amd64-GitCommit: bb0111a856389f8ecabc3e1459159fc6c35e6132
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.9.0)