### PR TITLE
Add simple Travis test for incorrect "latest" tags

### DIFF
--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -39,7 +39,7 @@ export BASHBREW_LIBRARY="$(dirname "$PWD")/library"
 
 if badTags="$(bashbrew list "${repos[@]}" | grep -E ':.+latest.*|:.*latest.+')" && [ -n "$badTags" ]; then
 	echo >&2
-	echo >&2 "Incorrectly 'latest' tags detected:"
+	echo >&2 "Incorrectly formatted 'latest' tags detected:"
 	echo >&2 ' ' $badTags
 	echo >&2
 	echo >&2 'Read https://github.com/docker-library/official-images#tags-and-aliases for more details.'

--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -37,8 +37,7 @@ fi
 
 export BASHBREW_LIBRARY="$(dirname "$PWD")/library"
 
-badTags="$(bashbrew list "${repos[@]}" | grep -E ':.+latest.*|:.*latest.+')"
-if [ -n "$badTags" ]; then
+if badTags="$(bashbrew list "${repos[@]}" | grep -E ':.+latest.*|:.*latest.+')" && [ -n "$badTags" ]; then
 	echo >&2
 	echo >&2 "Incorrectly 'latest' tags detected:"
 	echo >&2 ' ' $badTags

--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -37,6 +37,17 @@ fi
 
 export BASHBREW_LIBRARY="$(dirname "$PWD")/library"
 
+badTags="$(bashbrew list "${repos[@]}" | grep -E ':.+latest.*|:.*latest.+')"
+if [ -n "$badTags" ]; then
+	echo >&2
+	echo >&2 "Incorrectly 'latest' tags detected:"
+	echo >&2 ' ' $badTags
+	echo >&2
+	echo >&2 'Read https://github.com/docker-library/official-images#tags-and-aliases for more details.'
+	echo >&2
+	exit 1
+fi
+
 cmds=(
 	'list'
 	'list --uniq'


### PR DESCRIPTION
```console
$ TRAVIS_BRANCH=master TRAVIS_PULL_REQUEST=false ./bashbrew/travis.sh
Testing master -- BUILD ALL THE THINGS!

Incorrectly 'latest' tags detected:
  geonetwork:latest-postgres

Read https://github.com/docker-library/official-images#tags-and-aliases for more details.

```

See https://github.com/docker-library/official-images/pull/3992/files#r175528831 for a recent example of where this test would've been helpful. :smile: