### PR TITLE
[nats] Release v1.1.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,29 +2,29 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 
-Tags: 1.0.6-linux, linux
-SharedTags: 1.0.6, latest
+Tags: 1.1.0-linux, linux
+SharedTags: 1.1.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+amd64-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 amd64-Directory: amd64
-arm32v6-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+arm32v6-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+arm32v7-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+arm64v8-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 arm64v8-Directory: arm64v8
 
-Tags: 1.0.6-nanoserver, nanoserver
-SharedTags: 1.0.6, latest
+Tags: 1.1.0-nanoserver, nanoserver
+SharedTags: 1.1.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+windows-amd64-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.0.6-windowsservercore, windowsservercore
+Tags: 1.1.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4df27a3e2be0ea6c6929407f83dd5b52b39eeb7a
+windows-amd64-GitCommit: 738f7e2cd879f0a2642eb07a12b8303b2b99e68b
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v1.1.0)