### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.21.6, 1.21, 1, latest
+Tags: 1.21.7, 1.21, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e803c66ca4d0e420807dfeb4134a1978eba8f705
+GitCommit: c79228d3de9b5838f6e4499a8d62eb1dc256b275
 Directory: 1/debian
 
-Tags: 1.21.6-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.21.7-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: e803c66ca4d0e420807dfeb4134a1978eba8f705
+GitCommit: c79228d3de9b5838f6e4499a8d62eb1dc256b275
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/openjdk
+++ b/library/openjdk
@@ -26,22 +26,22 @@ Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f9d8d32f19425da337cf5793bdffda6909f5fec
+GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
 Directory: 9-jre
 
 Tags: 9.0.4-12-jre-slim-sid, 9.0.4-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.4-12-jre-slim, 9.0.4-jre-slim, 9.0-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f9d8d32f19425da337cf5793bdffda6909f5fec
+GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
 Directory: 9-jre/slim
 
 Tags: 9.0.4-12-jdk-sid, 9.0.4-12-sid, 9.0.4-jdk-sid, 9.0.4-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.4-12-jdk, 9.0.4-12, 9.0.4-jdk, 9.0.4, 9.0-jdk, 9.0, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f9d8d32f19425da337cf5793bdffda6909f5fec
+GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
 Directory: 9-jdk
 
 Tags: 9.0.4-12-jdk-slim-sid, 9.0.4-12-slim-sid, 9.0.4-jdk-slim-sid, 9.0.4-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.4-12-jdk-slim, 9.0.4-12-slim, 9.0.4-jdk-slim, 9.0.4-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f9d8d32f19425da337cf5793bdffda6909f5fec
+GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
 Directory: 9-jdk/slim
 
 Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016

--- a/library/piwik
+++ b/library/piwik
@@ -3,9 +3,9 @@ Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/piwik/docker-piwik.git
 
 Tags: 3.3.0-apache, 3.3-apache, 3-apache, apache, 3.3.0, 3.3, 3, latest
-GitCommit: 7e2efa6e592517e0cfcb4393721b2b0ce8045531
+GitCommit: f2d71a5128a243c2791d1626b10d6637a5a40ced
 Directory: apache
 
 Tags: 3.3.0-fpm, 3.3-fpm, 3-fpm, fpm
-GitCommit: 7e2efa6e592517e0cfcb4393721b2b0ce8045531
+GitCommit: f2d71a5128a243c2791d1626b10d6637a5a40ced
 Directory: fpm

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f69a5c2109cd8099126548bda5d6983dec02dcf
 Directory: 3.2/alpine
 
-Tags: 4.0.8, 4.0, 4, latest
+Tags: 4.0.9, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d53b982b387634092c6f11069401679034054ecb
+GitCommit: 1e20bfbe22f999959f8997a823fa1ed5784fd8cc
 Directory: 4.0
 
-Tags: 4.0.8-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.9-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: d53b982b387634092c6f11069401679034054ecb
+GitCommit: 1e20bfbe22f999959f8997a823fa1ed5784fd8cc
 Directory: 4.0/32bit
 
-Tags: 4.0.8-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.9-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f69a5c2109cd8099126548bda5d6983dec02dcf
+GitCommit: 1e20bfbe22f999959f8997a823fa1ed5784fd8cc
 Directory: 4.0/alpine


### PR DESCRIPTION
- `ghost`: 1.21.7
- `openjdk`: 9.0.4+12-3 (debian)
- `piwik`: remove `geoip` warning (matomo-org/docker#90)
- `redis`: 4.0.9