### PR TITLE
Add a flag to force push images in case a newer but wrong image was pushed in its place

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -18,6 +18,7 @@ func cmdPush(c *cli.Context) error {
 	uniq := c.Bool("uniq")
 	namespace := c.String("namespace")
 	dryRun := c.Bool("dry-run")
+	withForce := c.Bool("force")
 
 	if namespace == "" {
 		return fmt.Errorf(`"--namespace" is a required flag for "push"`)
@@ -44,7 +45,7 @@ func cmdPush(c *cli.Context) error {
 
 				created := dockerCreated(tag)
 				lastUpdated := fetchDockerHubTagMeta(tag).lastUpdatedTime()
-				if created.After(lastUpdated) {
+				if created.After(lastUpdated) || withForce {
 					fmt.Printf("Pushing %s\n", tag)
 					if !dryRun {
 						err = dockerPush(tag)

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -263,6 +263,10 @@ func main() {
 				commonFlags["uniq"],
 				commonFlags["namespace"],
 				commonFlags["dry-run"],
+				cli.BoolFlag{
+					Name:  "force",
+					Usage: `always push even if hub image is newer (very SLOW); not useful on dry-run`,
+				},
 			},
 			Before: subcommandBeforeFactory("push"),
 			Action: cmdPush,


### PR DESCRIPTION
This is part of one possible solution to help us with cleaning up https://github.com/docker-library/openjdk/issues/180.