### PR TITLE
[security] Update Ruby for CVE-2017-17742, CVE-2018-6914, CVE-2018-8777, CVE-2018-8778, CVE-2018-8779, CVE-2018-8780

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.5.0-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.0, 2.5, 2, latest
+Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6bccf4bd0c6aa158b4a842c29f78c335ec9dc41b
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/stretch
 
-Tags: 2.5.0-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.0-slim, 2.5-slim, 2-slim, slim
+Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6bccf4bd0c6aa158b4a842c29f78c335ec9dc41b
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.0-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
+Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6bccf4bd0c6aa158b4a842c29f78c335ec9dc41b
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/alpine3.7
 
-Tags: 2.4.3-stretch, 2.4-stretch
+Tags: 2.4.4-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/stretch
 
-Tags: 2.4.3-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.4-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.3-jessie, 2.4-jessie, 2.4.3, 2.4
+Tags: 2.4.4-jessie, 2.4-jessie, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/jessie
 
-Tags: 2.4.3-slim-jessie, 2.4-slim-jessie, 2.4.3-slim, 2.4-slim
+Tags: 2.4.4-slim-jessie, 2.4-slim-jessie, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.3-onbuild, 2.4-onbuild
+Tags: 2.4.4-onbuild, 2.4-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
-Tags: 2.4.3-alpine3.7, 2.4-alpine3.7
+Tags: 2.4.4-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.7
 
-Tags: 2.4.3-alpine3.6, 2.4-alpine3.6
+Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.6
 
-Tags: 2.4.3-alpine3.4, 2.4-alpine3.4, 2.4.3-alpine, 2.4-alpine
+Tags: 2.4.4-alpine3.4, 2.4-alpine3.4, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64
-GitCommit: 83c60cc26a1efb0ea581b3343a97df7508481fcf
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.4
 
-Tags: 2.3.6-stretch, 2.3-stretch
+Tags: 2.3.7-stretch, 2.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 019b9214a571d4dcb5a7e9e43ef192ca75ff27b8
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/stretch
 
-Tags: 2.3.6-slim-stretch, 2.3-slim-stretch
+Tags: 2.3.7-slim-stretch, 2.3-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 019b9214a571d4dcb5a7e9e43ef192ca75ff27b8
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/stretch/slim
 
-Tags: 2.3.6-jessie, 2.3-jessie, 2.3.6, 2.3
+Tags: 2.3.7-jessie, 2.3-jessie, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 019b9214a571d4dcb5a7e9e43ef192ca75ff27b8
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/jessie
 
-Tags: 2.3.6-slim-jessie, 2.3-slim-jessie, 2.3.6-slim, 2.3-slim
+Tags: 2.3.7-slim-jessie, 2.3-slim-jessie, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 019b9214a571d4dcb5a7e9e43ef192ca75ff27b8
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/jessie/slim
 
-Tags: 2.3.6-onbuild, 2.3-onbuild
+Tags: 2.3.7-onbuild, 2.3-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.3/jessie/onbuild
 
-Tags: 2.3.6-alpine3.4, 2.3-alpine3.4, 2.3.6-alpine, 2.3-alpine
+Tags: 2.3.7-alpine3.4, 2.3-alpine3.4, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 019b9214a571d4dcb5a7e9e43ef192ca75ff27b8
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/alpine3.4
 
-Tags: 2.2.9-jessie, 2.2-jessie, 2.2.9, 2.2
+Tags: 2.2.10-jessie, 2.2-jessie, 2.2.10, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 127b99a6f22e43c3b9e0b9544dd77d85aa299906
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/jessie
 
-Tags: 2.2.9-slim-jessie, 2.2-slim-jessie, 2.2.9-slim, 2.2-slim
+Tags: 2.2.10-slim-jessie, 2.2-slim-jessie, 2.2.10-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 127b99a6f22e43c3b9e0b9544dd77d85aa299906
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/jessie/slim
 
-Tags: 2.2.9-onbuild, 2.2-onbuild
+Tags: 2.2.10-onbuild, 2.2-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.2/jessie/onbuild
 
-Tags: 2.2.9-alpine3.4, 2.2-alpine3.4, 2.2.9-alpine, 2.2-alpine
+Tags: 2.2.10-alpine3.4, 2.2-alpine3.4, 2.2.10-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: 127b99a6f22e43c3b9e0b9544dd77d85aa299906
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/alpine3.4


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/