### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/drupal.git
 
 Tags: 8.5.1-apache, 8.5-apache, 8-apache, apache, 8.5.1, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a64d945e4181cbbe5bc643edfce1984a6812a1df
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.5/apache
 
 Tags: 8.5.1-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a64d945e4181cbbe5bc643edfce1984a6812a1df
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.5/fpm
 
 Tags: 8.5.1-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a64d945e4181cbbe5bc643edfce1984a6812a1df
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.5/fpm-alpine
 
 Tags: 8.4.6-apache, 8.4-apache, 8.4.6, 8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.4/apache
 
 Tags: 8.4.6-fpm, 8.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.4/fpm
 
 Tags: 8.4.6-fpm-alpine, 8.4-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.4/fpm-alpine
 
 Tags: 8.3.9-apache, 8.3-apache, 8.3.9, 8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.3/apache
 
 Tags: 8.3.9-fpm, 8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
 Directory: 8.3/fpm
 
 Tags: 8.3.9-fpm-alpine, 8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 94bc05ff936a4aeb6cadf792ac8894ae10d9b735
+Architectures: amd64
+GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.3/fpm-alpine
 
 Tags: 7.58-apache, 7-apache, 7.58, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 597c24e51daca68815cc687d8cc147d089db103a
+GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
 Directory: 7/apache
 
 Tags: 7.58-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 597c24e51daca68815cc687d8cc147d089db103a
+GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
 Directory: 7/fpm
 
 Tags: 7.58-fpm-alpine, 7-fpm-alpine
 Architectures: amd64
-GitCommit: 597c24e51daca68815cc687d8cc147d089db103a
+GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
 Directory: 7/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.21.7, 1.21, 1, latest
+Tags: 1.22.0, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c79228d3de9b5838f6e4499a8d62eb1dc256b275
+GitCommit: f1e7025f3766d1dfd6c91c9b86f35813585109cc
 Directory: 1/debian
 
-Tags: 1.21.7-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.22.0-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: c79228d3de9b5838f6e4499a8d62eb1dc256b275
+GitCommit: f1e7025f3766d1dfd6c91c9b86f35813585109cc
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -5,71 +5,71 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10.0-stretch, 1.10-stretch, 1-stretch, stretch
-SharedTags: 1.10.0, 1.10, 1, latest
+Tags: 1.10.1-stretch, 1.10-stretch, 1-stretch, stretch
+SharedTags: 1.10.1, 1.10, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bf6daddb324a4d8e82b0613cf348a6eff363f95
+GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
 Directory: 1.10/stretch
 
-Tags: 1.10.0-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.0-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.10.1-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.1-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bf6daddb324a4d8e82b0613cf348a6eff363f95
+GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
 Directory: 1.10/alpine3.7
 
-Tags: 1.10.0-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.10.0-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.0, 1.10, 1, latest
+Tags: 1.10.1-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 9bf6daddb324a4d8e82b0613cf348a6eff363f95
+GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10.0-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.10.0-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.0, 1.10, 1, latest
+Tags: 1.10.1-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 9bf6daddb324a4d8e82b0613cf348a6eff363f95
+GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10.0-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.10.0-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.10.1-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.10.1-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 9bf6daddb324a4d8e82b0613cf348a6eff363f95
+GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
 Directory: 1.10/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.9.4-stretch, 1.9-stretch
-SharedTags: 1.9.4, 1.9
+Tags: 1.9.5-stretch, 1.9-stretch
+SharedTags: 1.9.5, 1.9
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/stretch
 
-Tags: 1.9.4-alpine3.7, 1.9-alpine3.7
+Tags: 1.9.5-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/alpine3.7
 
-Tags: 1.9.4-alpine3.6, 1.9-alpine3.6, 1.9.4-alpine, 1.9-alpine
+Tags: 1.9.5-alpine3.6, 1.9-alpine3.6, 1.9.5-alpine, 1.9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.4-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
-SharedTags: 1.9.4-windowsservercore, 1.9-windowsservercore, 1.9.4, 1.9
+Tags: 1.9.5-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
+SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
 Architectures: windows-amd64
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.4-windowsservercore-1709, 1.9-windowsservercore-1709
-SharedTags: 1.9.4-windowsservercore, 1.9-windowsservercore, 1.9.4, 1.9
+Tags: 1.9.5-windowsservercore-1709, 1.9-windowsservercore-1709
+SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
 Architectures: windows-amd64
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.9.4-nanoserver-sac2016, 1.9-nanoserver-sac2016
-SharedTags: 1.9.4-nanoserver, 1.9-nanoserver
+Tags: 1.9.5-nanoserver-sac2016, 1.9-nanoserver-sac2016
+SharedTags: 1.9.5-nanoserver, 1.9-nanoserver
 Architectures: windows-amd64
-GitCommit: 366fe83ed839938cd04b2d546a06e2aee25a39a2
+GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
 Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,12 +8,12 @@ Tags: 10.3.5, 10.3
 GitCommit: 0ab4688d0e6d3a81d7cd19e04db44fb499c49d6a
 Directory: 10.3
 
-Tags: 10.2.13, 10.2, 10, latest
-GitCommit: a99e44ae93547f37c653299aff36a393d14bc9eb
+Tags: 10.2.14, 10.2, 10, latest
+GitCommit: a7c0715098bad9097e7ffa892ef0f67dbc74c5ea
 Directory: 10.2
 
-Tags: 10.1.31, 10.1
-GitCommit: 8ec32d0733772952c5bcd39691b2b830f3031fea
+Tags: 10.1.32, 10.1
+GitCommit: fb4c759d82536dc67b04a947bf44517236603e8b
 Directory: 10.1
 
 Tags: 10.0.34, 10.0

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.6, 1.5, 1, latest
+Tags: 1.5.7, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7c39f381206b994072a48b590f5b3fc7a2e7ca6
+GitCommit: d738ff7a7867423c9232adc7d9b418ce0f7597f0
 Directory: debian
 
-Tags: 1.5.6-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.7-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7c39f381206b994072a48b590f5b3fc7a2e7ca6
+GitCommit: d738ff7a7867423c9232adc7d9b418ce0f7597f0
 Directory: alpine

--- a/library/python
+++ b/library/python
@@ -34,58 +34,58 @@ GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.4-stretch, 3.6-stretch, 3-stretch, stretch
+Tags: 3.6.5-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/stretch
 
-Tags: 3.6.4-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
+Tags: 3.6.5-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/stretch/slim
 
-Tags: 3.6.4-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.4, 3.6, 3, latest
+Tags: 3.6.5-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.5, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/jessie
 
-Tags: 3.6.4-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.4-slim, 3.6-slim, 3-slim, slim
+Tags: 3.6.5-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.5-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.4-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Tags: 3.6.5-onbuild, 3.6-onbuild, 3-onbuild, onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
-Tags: 3.6.4-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
+Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/alpine3.7
 
-Tags: 3.6.4-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
+Tags: 3.6.5-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/alpine3.6
 
-Tags: 3.6.4-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.4-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.5-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.5-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/alpine3.4
 
-Tags: 3.6.4-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.6.4-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.4, 3.6, 3, latest
+Tags: 3.6.5-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.6.5-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.5, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.4-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.6.4-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.4, 3.6, 3, latest
+Tags: 3.6.5-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: 3.6.5-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.5, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: c9a08272dbcbcd8f917ac98f494e6f0e3e7d929e
+GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 86a208cc744d9743a219973ba2ab675f6718bec4
 Directory: 3.4
 
 Tags: 3.4.4-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
+GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
 Directory: 3.4/passenger
 
 Tags: 3.3.6, 3.3
@@ -19,7 +19,7 @@ GitCommit: 1a66905d6ed69f74e74e6b48fedb39f8e3bff949
 Directory: 3.3
 
 Tags: 3.3.6-passenger, 3.3-passenger
-GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
+GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: 6314ae1dcb66b822b61972809d53da969a2a6db7
+GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
 Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -4,6 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
+Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+Directory: 2.6-rc/stretch
+
+Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+Directory: 2.6-rc/stretch/slim
+
+Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+Directory: 2.6-rc/alpine3.7
+
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3


### PR DESCRIPTION
- `drupal` fix php version for 8.3/8.4: https://github.com/docker-library/drupal/pull/113
- `ghost` bump to `1.22.0`
- `golang` bump to `1.10.1` and `1.9.5`
- `mariadb` bump to `10.2.14` and `10.1.32`
- `memcached` bump to `1.5.7`
- `python` bump to `3.6.5`
- `redmine` update passenger `5.2.2`
- `ruby` add `2.6.0-preview1`