### PR TITLE
Update node.js v4, v6, v8 and v9

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,124 +3,124 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.10.0, 9.10, 9, latest
+Tags: 9.10.1, 9.10, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9
 
-Tags: 9.10.0-alpine, 9.10-alpine, 9-alpine, alpine
+Tags: 9.10.1-alpine, 9.10-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9/alpine
 
-Tags: 9.10.0-onbuild, 9.10-onbuild, 9-onbuild, onbuild
+Tags: 9.10.1-onbuild, 9.10-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9/onbuild
 
-Tags: 9.10.0-slim, 9.10-slim, 9-slim, slim
+Tags: 9.10.1-slim, 9.10-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9/slim
 
-Tags: 9.10.0-stretch, 9.10-stretch, 9-stretch, stretch
+Tags: 9.10.1-stretch, 9.10-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9/stretch
 
-Tags: 9.10.0-wheezy, 9.10-wheezy, 9-wheezy, wheezy
+Tags: 9.10.1-wheezy, 9.10-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: ab66de01f88284c5226ebb963ac70f038f97fab9
+GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
 Directory: 9/wheezy
 
-Tags: 8.11.0, 8.11, 8, carbon
+Tags: 8.11.1, 8.11, 8, carbon
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8
 
-Tags: 8.11.0-alpine, 8.11-alpine, 8-alpine, carbon-alpine
+Tags: 8.11.1-alpine, 8.11-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/alpine
 
-Tags: 8.11.0-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.11.1-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/onbuild
 
-Tags: 8.11.0-slim, 8.11-slim, 8-slim, carbon-slim
+Tags: 8.11.1-slim, 8.11-slim, 8-slim, carbon-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/slim
 
-Tags: 8.11.0-stretch, 8.11-stretch, 8-stretch, carbon-stretch
+Tags: 8.11.1-stretch, 8.11-stretch, 8-stretch, carbon-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/stretch
 
-Tags: 8.11.0-wheezy, 8.11-wheezy, 8-wheezy, carbon-wheezy
+Tags: 8.11.1-wheezy, 8.11-wheezy, 8-wheezy, carbon-wheezy
 Architectures: amd64
-GitCommit: 2b11af24b4bf75cc051ce2fc21e796e7e9425fd0
+GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/wheezy
 
-Tags: 6.14.0, 6.14, 6, boron
+Tags: 6.14.1, 6.14, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6
 
-Tags: 6.14.0-alpine, 6.14-alpine, 6-alpine, boron-alpine
+Tags: 6.14.1-alpine, 6.14-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6/alpine
 
-Tags: 6.14.0-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.14.1-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6/onbuild
 
-Tags: 6.14.0-slim, 6.14-slim, 6-slim, boron-slim
+Tags: 6.14.1-slim, 6.14-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6/slim
 
-Tags: 6.14.0-stretch, 6.14-stretch, 6-stretch, boron-stretch
+Tags: 6.14.1-stretch, 6.14-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6/stretch
 
-Tags: 6.14.0-wheezy, 6.14-wheezy, 6-wheezy, boron-wheezy
+Tags: 6.14.1-wheezy, 6.14-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: ebb4816d0d1424fcabe30f41c4d7c38b8db1f426
+GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
 Directory: 6/wheezy
 
-Tags: 4.9.0, 4.9, 4, argon
+Tags: 4.9.1, 4.9, 4, argon
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4
 
-Tags: 4.9.0-alpine, 4.9-alpine, 4-alpine, argon-alpine
+Tags: 4.9.1-alpine, 4.9-alpine, 4-alpine, argon-alpine
 Architectures: amd64
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/alpine
 
-Tags: 4.9.0-onbuild, 4.9-onbuild, 4-onbuild, argon-onbuild
+Tags: 4.9.1-onbuild, 4.9-onbuild, 4-onbuild, argon-onbuild
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/onbuild
 
-Tags: 4.9.0-slim, 4.9-slim, 4-slim, argon-slim
+Tags: 4.9.1-slim, 4.9-slim, 4-slim, argon-slim
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/slim
 
-Tags: 4.9.0-stretch, 4.9-stretch, 4-stretch, argon-stretch
+Tags: 4.9.1-stretch, 4.9-stretch, 4-stretch, argon-stretch
 Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/stretch
 
-Tags: 4.9.0-wheezy, 4.9-wheezy, 4-wheezy, argon-wheezy
+Tags: 4.9.1-wheezy, 4.9-wheezy, 4-wheezy, argon-wheezy
 Architectures: amd64
-GitCommit: 9d428986bacceaadd98bc774a443c873a5baebdb
+GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/wheezy
 
 Tags: chakracore-8.10.0, chakracore-8.10, chakracore-8, chakracore


### PR DESCRIPTION
 - v4.9.0 to v4.9.1
 - v6.14.0 to v6.14.1
 - v8.11.0 to v8.11.1
 - v9.10.0 to v9.10.1

Ref:
 - https://github.com/nodejs/docker-node/pull/676
 - https://github.com/nodejs/node/releases/tag/v4.9.1
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md
 - https://github.com/nodejs/node/releases/tag/v6.14.1
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md
 - https://github.com/nodejs/node/releases/tag/v8.11.1
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md
 - https://github.com/nodejs/node/releases/tag/v9.10.1
 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V9.md