### PR TITLE
Liberty 18001

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 99e1bbdc8b98b4afd80b01dea78ca923091d46d4
+GitCommit: 9cf64a59a00fe0a09a63fe467d6ca96a1f9c35b7
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 9cf64a59a00fe0a09a63fe467d6ca96a1f9c35b7
+GitCommit: 1ceace84721e043f475d92c7698cade0fb36973d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
* Update to Liberty 18.0.0.1.
* Stop using a server.xml checked into git, instead use the server.xml from the downloaded zip from maven central.