### PR TITLE
Update 2.4-alpine to reference 2.4-alpine3.7

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -59,7 +59,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.4/jessie/onbuild
 
-Tags: 2.4.4-alpine3.7, 2.4-alpine3.7
+Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.7
@@ -69,7 +69,7 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.6
 
-Tags: 2.4.4-alpine3.4, 2.4-alpine3.4, 2.4.4-alpine, 2.4-alpine
+Tags: 2.4.4-alpine3.4, 2.4-alpine3.4, 2.4.4-alpine
 Architectures: amd64
 GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.4


### PR DESCRIPTION
ruby:2.4-alpine still references ruby:2.4-alpine3.4. This is no longer the latest alpine version for ruby2.4. This PR updates the tag to reference alpine3.7 instead.