### PR TITLE
Update docker-library images.

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.03.0-ce, 18.03.0, 18.03, 18, stable, edge, test, latest
+Tags: 18.04.0-ce-rc1, 18.04-rc, rc, test
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
+Directory: 18.04-rc
+
+Tags: 18.04.0-ce-rc1-dind, 18.04-rc-dind, rc-dind, test-dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
+Directory: 18.04-rc/dind
+
+Tags: 18.04.0-ce-rc1-git, 18.04-rc-git, rc-git, test-git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
+Directory: 18.04-rc/git
+
+Tags: 18.03.0-ce, 18.03.0, 18.03, 18, stable, edge, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
 Directory: 18.03
 
-Tags: 18.03.0-ce-dind, 18.03.0-dind, 18.03-dind, 18-dind, stable-dind, edge-dind, test-dind, dind
+Tags: 18.03.0-ce-dind, 18.03.0-dind, 18.03-dind, 18-dind, stable-dind, edge-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
 Directory: 18.03/dind
 
-Tags: 18.03.0-ce-git, 18.03.0-git, 18.03-git, 18-git, stable-git, edge-git, test-git, git
+Tags: 18.03.0-ce-git, 18.03.0-git, 18.03-git, 18-git, stable-git, edge-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
 Directory: 18.03/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.0, 1.22, 1, latest
+Tags: 1.22.1, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1e7025f3766d1dfd6c91c9b86f35813585109cc
+GitCommit: 47f1ab8767c6547455dbddc0508c1856ddefde77
 Directory: 1/debian
 
-Tags: 1.22.0-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.1-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: f1e7025f3766d1dfd6c91c9b86f35813585109cc
+GitCommit: 47f1ab8767c6547455dbddc0508c1856ddefde77
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -19,14 +19,14 @@ Directory: 1.10/alpine3.7
 Tags: 1.10.1-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
+GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.10.1-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
 SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
+GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -56,14 +56,14 @@ Directory: 1.9/alpine3.6
 Tags: 1.9.5-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
 SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
 Architectures: windows-amd64
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.9.5-windowsservercore-1709, 1.9-windowsservercore-1709
 SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
 Architectures: windows-amd64
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -6,42 +6,42 @@ GitRepo: https://github.com/docker-library/openjdk.git
 
 Tags: 10-ea-46-jre-experimental, 10-ea-jre-experimental, 10-jre-experimental, 10-ea-46-jre, 10-ea-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c56f2478bf84471c5d16ca216a62aca492f96a8
+GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
 Directory: 10-jre
 
 Tags: 10-ea-46-jre-slim-experimental, 10-ea-jre-slim-experimental, 10-jre-slim-experimental, 10-ea-46-jre-slim, 10-ea-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c56f2478bf84471c5d16ca216a62aca492f96a8
+GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
 Directory: 10-jre/slim
 
 Tags: 10-ea-46-jdk-experimental, 10-ea-46-experimental, 10-ea-jdk-experimental, 10-ea-experimental, 10-jdk-experimental, 10-experimental, 10-ea-46-jdk, 10-ea-46, 10-ea-jdk, 10-ea, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c56f2478bf84471c5d16ca216a62aca492f96a8
+GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
 Directory: 10-jdk
 
 Tags: 10-ea-46-jdk-slim-experimental, 10-ea-46-slim-experimental, 10-ea-jdk-slim-experimental, 10-ea-slim-experimental, 10-jdk-slim-experimental, 10-slim-experimental, 10-ea-46-jdk-slim, 10-ea-46-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c56f2478bf84471c5d16ca216a62aca492f96a8
+GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
 Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
+GitCommit: 01ca700a105984964865430aee1251932956925e
 Directory: 9-jre
 
 Tags: 9.0.4-12-jre-slim-sid, 9.0.4-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.4-12-jre-slim, 9.0.4-jre-slim, 9.0-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
+GitCommit: 01ca700a105984964865430aee1251932956925e
 Directory: 9-jre/slim
 
 Tags: 9.0.4-12-jdk-sid, 9.0.4-12-sid, 9.0.4-jdk-sid, 9.0.4-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.4-12-jdk, 9.0.4-12, 9.0.4-jdk, 9.0.4, 9.0-jdk, 9.0, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
+GitCommit: 01ca700a105984964865430aee1251932956925e
 Directory: 9-jdk
 
 Tags: 9.0.4-12-jdk-slim-sid, 9.0.4-12-slim-sid, 9.0.4-jdk-slim-sid, 9.0.4-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.4-12-jdk-slim, 9.0.4-12-slim, 9.0.4-jdk-slim, 9.0.4-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 60b7b666c359b706a040ba80c31389c968c57582
+GitCommit: 01ca700a105984964865430aee1251932956925e
 Directory: 9-jdk/slim
 
 Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016

--- a/library/php
+++ b/library/php
@@ -4,157 +4,157 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.3-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.3-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.3-cli, 7.2-cli, 7-cli, cli, 7.2.3, 7.2, 7, latest
+Tags: 7.2.4-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.4-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.4-cli, 7.2-cli, 7-cli, cli, 7.2.4, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.3-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.3-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.4-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.4-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.3-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.3-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.4-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.4-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.3-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.3-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.4-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.4-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.3-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.3-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.4-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.4-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.3-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.4-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.3-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.4-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.3-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.3-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.3-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.3-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.4-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.4-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.4-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.4-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.3-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.3-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.4-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.4-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.3-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.3-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.4-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.4-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7707290c53077c0fbdbe8c768e98c51ba06025f1
+GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.15-cli-jessie, 7.1-cli-jessie, 7.1.15-jessie, 7.1-jessie, 7.1.15-cli, 7.1-cli, 7.1.15, 7.1
+Tags: 7.1.16-cli-jessie, 7.1-cli-jessie, 7.1.16-jessie, 7.1-jessie, 7.1.16-cli, 7.1-cli, 7.1.16, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.15-apache-jessie, 7.1-apache-jessie, 7.1.15-apache, 7.1-apache
+Tags: 7.1.16-apache-jessie, 7.1-apache-jessie, 7.1.16-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.15-fpm-jessie, 7.1-fpm-jessie, 7.1.15-fpm, 7.1-fpm
+Tags: 7.1.16-fpm-jessie, 7.1-fpm-jessie, 7.1.16-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.15-zts-jessie, 7.1-zts-jessie, 7.1.15-zts, 7.1-zts
+Tags: 7.1.16-zts-jessie, 7.1-zts-jessie, 7.1.16-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.15-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.15-alpine3.4, 7.1-alpine3.4, 7.1.15-cli-alpine, 7.1-cli-alpine, 7.1.15-alpine, 7.1-alpine
+Tags: 7.1.16-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.16-alpine3.4, 7.1-alpine3.4, 7.1.16-cli-alpine, 7.1-cli-alpine, 7.1.16-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/alpine3.4/cli
 
-Tags: 7.1.15-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.15-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.16-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.16-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/alpine3.4/fpm
 
-Tags: 7.1.15-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.15-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.16-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.16-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
 Directory: 7.1/alpine3.4/zts
 
-Tags: 7.0.28-cli-jessie, 7.0-cli-jessie, 7.0.28-jessie, 7.0-jessie, 7.0.28-cli, 7.0-cli, 7.0.28, 7.0
+Tags: 7.0.29-cli-jessie, 7.0-cli-jessie, 7.0.29-jessie, 7.0-jessie, 7.0.29-cli, 7.0-cli, 7.0.29, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.28-apache-jessie, 7.0-apache-jessie, 7.0.28-apache, 7.0-apache
+Tags: 7.0.29-apache-jessie, 7.0-apache-jessie, 7.0.29-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.28-fpm-jessie, 7.0-fpm-jessie, 7.0.28-fpm, 7.0-fpm
+Tags: 7.0.29-fpm-jessie, 7.0-fpm-jessie, 7.0.29-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.28-zts-jessie, 7.0-zts-jessie, 7.0.28-zts, 7.0-zts
+Tags: 7.0.29-zts-jessie, 7.0-zts-jessie, 7.0.29-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.28-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.28-alpine3.4, 7.0-alpine3.4, 7.0.28-cli-alpine, 7.0-cli-alpine, 7.0.28-alpine, 7.0-alpine
+Tags: 7.0.29-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.29-alpine3.4, 7.0-alpine3.4, 7.0.29-cli-alpine, 7.0-cli-alpine, 7.0.29-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/alpine3.4/cli
 
-Tags: 7.0.28-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.28-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.29-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.29-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/alpine3.4/fpm
 
-Tags: 7.0.28-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.28-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.29-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.29-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
 Directory: 7.0/alpine3.4/zts
 
-Tags: 5.6.34-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.34-jessie, 5.6-jessie, 5-jessie, 5.6.34-cli, 5.6-cli, 5-cli, 5.6.34, 5.6, 5
+Tags: 5.6.35-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.35-jessie, 5.6-jessie, 5-jessie, 5.6.35-cli, 5.6-cli, 5-cli, 5.6.35, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.34-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.34-apache, 5.6-apache, 5-apache
+Tags: 5.6.35-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.35-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.34-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.34-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.35-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.35-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.34-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.34-zts, 5.6-zts, 5-zts
+Tags: 5.6.35-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.35-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.34-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.34-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.34-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.34-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.35-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.35-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.35-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.35-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/alpine3.4/cli
 
-Tags: 5.6.34-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.34-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.35-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.35-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/alpine3.4/fpm
 
-Tags: 5.6.34-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.34-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.35-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.35-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: fe07cedc05d84a6af374dabdee82f213464ad3c5
+GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
 Directory: 5.6/alpine3.4/zts

--- a/library/python
+++ b/library/python
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0b2-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0b2, 3.7-rc, rc
+Tags: 3.7.0b3-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0b3, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
+GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0b2-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b2-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0b3-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b3-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
+GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0b2-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b2-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0b3-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b3-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
+GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
 Directory: 3.7-rc/alpine3.7
 
-Tags: 3.7.0b2-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.7.0b2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b2, 3.7-rc, rc
+Tags: 3.7.0b3-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.7.0b3-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
+GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0b2-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 3.7.0b2-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b2, 3.7-rc, rc
+Tags: 3.7.0b3-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 3.7.0b3-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: b9ecbb7d3ad02696a764c81b3625a9c71fd9bea5
+GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -62,7 +62,7 @@ Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: e48c9718ef52d14df2ac46e674b0fb55523d8284
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.5-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.85-jre7, 7.0-jre7, 7-jre7, 7.0.85, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c69186d320837884e9ed56db504b92e454f6d5
+GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
 Directory: 7/jre7
 
 Tags: 7.0.85-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.85-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c69186d320837884e9ed56db504b92e454f6d5
+GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
 Directory: 7/jre7-slim
 
 Tags: 7.0.85-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.85-alpine, 7.0-alpine, 7-alpine
@@ -21,12 +21,12 @@ Directory: 7/jre7-alpine
 
 Tags: 7.0.85-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c69186d320837884e9ed56db504b92e454f6d5
+GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
 Directory: 7/jre8
 
 Tags: 7.0.85-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c69186d320837884e9ed56db504b92e454f6d5
+GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
 Directory: 7/jre8-slim
 
 Tags: 7.0.85-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -36,12 +36,12 @@ Directory: 7/jre8-alpine
 
 Tags: 8.0.50-jre7, 8.0-jre7, 8.0.50, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af4b04d13a880a81a73dc2936afdf44147144418
+GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
 Directory: 8.0/jre7
 
 Tags: 8.0.50-jre7-slim, 8.0-jre7-slim, 8.0.50-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af4b04d13a880a81a73dc2936afdf44147144418
+GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
 Directory: 8.0/jre7-slim
 
 Tags: 8.0.50-jre7-alpine, 8.0-jre7-alpine, 8.0.50-alpine, 8.0-alpine
@@ -51,12 +51,12 @@ Directory: 8.0/jre7-alpine
 
 Tags: 8.0.50-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af4b04d13a880a81a73dc2936afdf44147144418
+GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
 Directory: 8.0/jre8
 
 Tags: 8.0.50-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af4b04d13a880a81a73dc2936afdf44147144418
+GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
 Directory: 8.0/jre8-slim
 
 Tags: 8.0.50-jre8-alpine, 8.0-jre8-alpine
@@ -66,12 +66,12 @@ Directory: 8.0/jre8-alpine
 
 Tags: 8.5.29-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.29, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a3fd22cd52b4c1fd6b263b0a42cb371a83a74c5
+GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
 Directory: 8.5/jre8
 
 Tags: 8.5.29-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.29-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a3fd22cd52b4c1fd6b263b0a42cb371a83a74c5
+GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
 Directory: 8.5/jre8-slim
 
 Tags: 8.5.29-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.29-alpine, 8.5-alpine, 8-alpine, alpine
@@ -81,22 +81,22 @@ Directory: 8.5/jre8-alpine
 
 Tags: 8.5.29-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a3fd22cd52b4c1fd6b263b0a42cb371a83a74c5
+GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
 Directory: 8.5/jre9
 
 Tags: 8.5.29-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a3fd22cd52b4c1fd6b263b0a42cb371a83a74c5
+GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
 Directory: 8.5/jre9-slim
 
 Tags: 9.0.6-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc76939453c0bec4937ae8e6fe4f1ecc0d6d19
+GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
 Directory: 9.0/jre8
 
 Tags: 9.0.6-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc76939453c0bec4937ae8e6fe4f1ecc0d6d19
+GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
 Directory: 9.0/jre8-slim
 
 Tags: 9.0.6-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
@@ -106,10 +106,10 @@ Directory: 9.0/jre8-alpine
 
 Tags: 9.0.6-jre9, 9.0-jre9, 9-jre9, 9.0.6, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc76939453c0bec4937ae8e6fe4f1ecc0d6d19
+GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
 Directory: 9.0/jre9
 
 Tags: 9.0.6-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.6-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc76939453c0bec4937ae8e6fe4f1ecc0d6d19
+GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
 Directory: 9.0/jre9-slim


### PR DESCRIPTION
- `docker` update to `18.04.0-ce-rc1`
- `ghost` update to `1.22.1`
- `golang` https://github.com/docker-library/golang/pull/215
- `openjdk` minor Debian openjdk bumps
- `php` bump to `7.2.4`, `7.1.16`, `7.0.29`, and `5.6.35`
- `python` https://github.com/docker-library/python/pull/274
- `tomcat` openssl `1.1.0f-3+deb9u2` (CVE-2017-3738, CVE-2018-0733, CVE-2018-0739)