### PR TITLE
Bump Traefik to v1.6.0-rc4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.0-rc3, 1.6.0-rc3, v1.6, 1.6, tetedemoine
+Tags: v1.6.0-rc4, 1.6.0-rc4, v1.6, 1.6, tetedemoine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 3bee4eda5016f93e9b497a306df98d62341acf16
+GitCommit: caeb2cc1700b1d3c708eec82840d265816a46832
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.6.0-rc3-alpine, 1.6.0-rc3-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine
+Tags: v1.6.0-rc4-alpine, 1.6.0-rc4-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 3bee4eda5016f93e9b497a306df98d62341acf16
+GitCommit: caeb2cc1700b1d3c708eec82840d265816a46832
 Directory: alpine
 
 Tags: v1.5.4, 1.5.4, v1.5, 1.5, cancoillotte, latest


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.6.0-rc4.

/cc @vdemeester @emilevauge

Cheers
