### PR TITLE
Update to 18.0.0.1 of Liberty and use server.xml from zip

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,6 +1,6 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 9cf64a59a00fe0a09a63fe467d6ca96a1f9c35b7
+GitCommit: 1ceace84721e043f475d92c7698cade0fb36973d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
Update Open Liberty to 18.0.0.1 and also instead of having a copy of server.xml checked into the docker build just pick the version from the zip downloaded from maven central. This means it'll always be in sync with what is in maven.