### PR TITLE
Update node.js v9.x to v9.11.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,34 +3,34 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.10.1, 9.10, 9, latest
+Tags: 9.11.1, 9.11, 9, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9
 
-Tags: 9.10.1-alpine, 9.10-alpine, 9-alpine, alpine
+Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/alpine
 
-Tags: 9.10.1-onbuild, 9.10-onbuild, 9-onbuild, onbuild
+Tags: 9.11.1-onbuild, 9.11-onbuild, 9-onbuild, onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/onbuild
 
-Tags: 9.10.1-slim, 9.10-slim, 9-slim, slim
+Tags: 9.11.1-slim, 9.11-slim, 9-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/slim
 
-Tags: 9.10.1-stretch, 9.10-stretch, 9-stretch, stretch
+Tags: 9.11.1-stretch, 9.11-stretch, 9-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/stretch
 
-Tags: 9.10.1-wheezy, 9.10-wheezy, 9-wheezy, wheezy
+Tags: 9.11.1-wheezy, 9.11-wheezy, 9-wheezy, wheezy
 Architectures: amd64
-GitCommit: d5badac9d19e01d12d446a556c344aba66ed6b96
+GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/wheezy
 
 Tags: 8.11.1, 8.11, 8, carbon


### PR DESCRIPTION
- v9.10.1 to v9.11.1

Ref:
- https://github.com/nodejs/docker-node/pull/681
- https://github.com/nodejs/node/releases/tag/v9.11.0
- https://github.com/nodejs/node/releases/tag/v9.11.1
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V9.md