### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.04.0-ce-rc1, 18.04-rc, rc, test
+Tags: 18.04.0-ce-rc2, 18.04-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
+GitCommit: fcbb33386d9cff655bbde45f0ecd532ea65cda9c
 Directory: 18.04-rc
 
-Tags: 18.04.0-ce-rc1-dind, 18.04-rc-dind, rc-dind, test-dind
+Tags: 18.04.0-ce-rc2-dind, 18.04-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
+GitCommit: 5b158e3ca87bdc20069754a796c00b270e40cfdb
 Directory: 18.04-rc/dind
 
-Tags: 18.04.0-ce-rc1-git, 18.04-rc-git, rc-git, test-git
+Tags: 18.04.0-ce-rc2-git, 18.04-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 045fbbc0ac44b1db42ef8b499f2bef1db8dcfe61
 Directory: 18.04-rc/git
@@ -26,7 +26,7 @@ Directory: 18.03
 
 Tags: 18.03.0-ce-dind, 18.03.0-dind, 18.03-dind, 18-dind, stable-dind, edge-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
+GitCommit: 5b158e3ca87bdc20069754a796c00b270e40cfdb
 Directory: 18.03/dind
 
 Tags: 18.03.0-ce-git, 18.03.0-git, 18.03-git, 18-git, stable-git, edge-git, git
@@ -41,7 +41,7 @@ Directory: 17.12
 
 Tags: 17.12.1-ce-dind, 17.12.1-dind, 17.12-dind, 17-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
+GitCommit: 5b158e3ca87bdc20069754a796c00b270e40cfdb
 Directory: 17.12/dind
 
 Tags: 17.12.1-ce-git, 17.12.1-git, 17.12-git, 17-git

--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,21 +3,6 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 11.0.8-apache, 11.0-apache, 11-apache, 11.0.8, 11.0, 11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e01caa961ff579ba753e7e55a4ef987c199938fa
-Directory: 11.0/apache
-
-Tags: 11.0.8-fpm, 11.0-fpm, 11-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 18db7e679fd92e2d36d6113b1e174e6f1afda2d6
-Directory: 11.0/fpm
-
-Tags: 11.0.8-fpm-alpine, 11.0-fpm-alpine, 11-fpm-alpine
-Architectures: amd64
-GitCommit: 18db7e679fd92e2d36d6113b1e174e6f1afda2d6
-Directory: 11.0/fpm-alpine
-
 Tags: 12.0.6-apache, 12.0-apache, 12-apache, production-apache, 12.0.6, 12.0, 12, production
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e01caa961ff579ba753e7e55a4ef987c199938fa

--- a/library/openjdk
+++ b/library/openjdk
@@ -47,21 +47,21 @@ Directory: 9-jdk/slim
 Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
 SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
 Architectures: windows-amd64
-GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 9-jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 9.0.4-jdk-windowsservercore-1709, 9.0.4-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
 SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
 Architectures: windows-amd64
-GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 9-jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 9.0.4-jdk-nanoserver-sac2016, 9.0.4-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
 SharedTags: 9.0.4-jdk-nanoserver, 9.0.4-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
 Architectures: windows-amd64
-GitCommit: 41532fd149c05cb3bbc0c143bfcfa4589f1c3a61
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 9-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -98,32 +98,32 @@ Directory: 8-jdk/alpine
 Tags: 8u161-jdk-windowsservercore-ltsc2016, 8u161-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 8u161-jdk-windowsservercore, 8u161-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 0584b2804ed12dca7c5e264b5fc55fc07a3ac148
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 8-jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u161-jdk-windowsservercore-1709, 8u161-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 8u161-jdk-windowsservercore, 8u161-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 0584b2804ed12dca7c5e264b5fc55fc07a3ac148
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 8-jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 8u161-jdk-nanoserver-sac2016, 8u161-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 8u161-jdk-nanoserver, 8u161-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 0584b2804ed12dca7c5e264b5fc55fc07a3ac148
+GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
 Directory: 8-jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 7u151-jre-jessie, 7-jre-jessie, 7u151-jre, 7-jre
+Tags: 7u171-jre-jessie, 7-jre-jessie, 7u171-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
 Directory: 7-jre
 
-Tags: 7u151-jre-slim-jessie, 7-jre-slim-jessie, 7u151-jre-slim, 7-jre-slim
+Tags: 7u171-jre-slim-jessie, 7-jre-slim-jessie, 7u171-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
 Directory: 7-jre/slim
 
 Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
@@ -131,14 +131,14 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
 Directory: 7-jre/alpine
 
-Tags: 7u151-jdk-jessie, 7u151-jessie, 7-jdk-jessie, 7-jessie, 7u151-jdk, 7u151, 7-jdk, 7
+Tags: 7u171-jdk-jessie, 7u171-jessie, 7-jdk-jessie, 7-jessie, 7u171-jdk, 7u171, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
 Directory: 7-jdk
 
-Tags: 7u151-jdk-slim-jessie, 7u151-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u151-jdk-slim, 7u151-slim, 7-jdk-slim, 7-slim
+Tags: 7u171-jdk-slim-jessie, 7u171-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u171-jdk-slim, 7u171-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceae8e7dba4eb818279cc7f6947f3dc6003ae535
+GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
 Directory: 7-jdk/slim
 
 Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 86a208cc744d9743a219973ba2ab675f6718bec4
 Directory: 3.4
 
 Tags: 3.4.4-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
+GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
 Directory: 3.4/passenger
 
 Tags: 3.3.6, 3.3
@@ -19,7 +19,7 @@ GitCommit: 1a66905d6ed69f74e74e6b48fedb39f8e3bff949
 Directory: 3.3
 
 Tags: 3.3.6-passenger, 3.3-passenger
-GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
+GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: d7dd333e37cfe68ca51e630cd5fe4a63322fae12
+GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
 Directory: 3.2/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.62.2, 0.62, 0, latest
-GitCommit: 9a408ff66d899f71d595cc8bbffbd03081ef8c2e
+Tags: 0.63.0, 0.63, 0, latest
+GitCommit: c76db6d89aff8ec3624be938d408950c00b4fdee

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.4-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.4-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.5-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.5-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php5.6/apache
 
-Tags: 4.9.4-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.5-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php5.6/fpm
 
-Tags: 4.9.4-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.5-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.4-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.4-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.5-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.5-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.0/apache
 
-Tags: 4.9.4-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.5-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.0/fpm
 
-Tags: 4.9.4-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.5-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.4-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.4-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.5-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.5-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.1/apache
 
-Tags: 4.9.4-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.5-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.1/fpm
 
-Tags: 4.9.4-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.5-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.4-apache, 4.9-apache, 4-apache, apache, 4.9.4, 4.9, 4, latest, 4.9.4-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.4-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.5-apache, 4.9-apache, 4-apache, apache, 4.9.5, 4.9, 4, latest, 4.9.5-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.5-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.2/apache
 
-Tags: 4.9.4-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.4-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.5-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.5-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.2/fpm
 
-Tags: 4.9.4-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.4-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.5-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.5-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 59f3b513af128d12da1403721e4f9be8d882ec54
+GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker`: 18.04.0-ce-rc2
- `nextcloud`: remove 11 (EOL; https://github.com/nextcloud/docker/pull/303)
- `openjdk`: debian 7u171-2.6.13-1~deb8u1, Windows TLS 1.2 (https://github.com/docker-library/openjdk/pull/182)
- `redmine`: passenger 5.2.3
- `rocket.chat`: 0.63.0
- `wordpress`: 4.9.5