### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -13,7 +13,7 @@ Directory: 1.10/stretch
 
 Tags: 1.10.1-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.1-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
+GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
 Directory: 1.10/alpine3.7
 
 Tags: 1.10.1-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -45,12 +45,12 @@ Directory: 1.9/stretch
 
 Tags: 1.9.5-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
 Directory: 1.9/alpine3.7
 
 Tags: 1.9.5-alpine3.6, 1.9-alpine3.6, 1.9.5-alpine, 1.9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
 Directory: 1.9/alpine3.6
 
 Tags: 1.9.5-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64
 GitCommit: fbf8924b471f678bbc7a4866a2beb0db37d7e9d0
 Directory: 1.7/alpine
 
-Tags: 1.8.5, 1.8, 1, latest
+Tags: 1.8.7, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4123afaeaca50fe88317b6f4313e309700318b41
+GitCommit: 13ea38d1d6b71144ba199dac16932fd8ed91e88e
 Directory: 1.8
 
-Tags: 1.8.5-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.7-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4123afaeaca50fe88317b6f4313e309700318b41
+GitCommit: 13ea38d1d6b71144ba199dac16932fd8ed91e88e
 Directory: 1.8/alpine

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -8,31 +8,31 @@ GitCommit: d206a435163e171e629490b2803b2615b3831906
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 amd64-Directory: amd64/hello-seattle
-arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v5-Directory: arm32v5/hello-seattle
-arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v7-Directory: arm32v7/hello-seattle
-arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm64v8-Directory: arm64v8/hello-seattle
-i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 i386-Directory: i386/hello-seattle
-ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 ppc64le-Directory: ppc64le/hello-seattle
-s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 s390x-Directory: s390x/hello-seattle
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1709
 Constraints: nanoserver-1709

--- a/library/hello-world
+++ b/library/hello-world
@@ -8,31 +8,31 @@ GitCommit: d206a435163e171e629490b2803b2615b3831906
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 amd64-Directory: amd64/hello-world
-arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v5-Directory: arm32v5/hello-world
-arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v7-Directory: arm32v7/hello-world
-arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm64v8-Directory: arm64v8/hello-world
-i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 i386-Directory: i386/hello-world
-ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 ppc64le-Directory: ppc64le/hello-world
-s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 s390x-Directory: s390x/hello-world
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hello-world/nanoserver-1709
 Constraints: nanoserver-1709

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -8,31 +8,31 @@ GitCommit: d206a435163e171e629490b2803b2615b3831906
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 amd64-Directory: amd64/hola-mundo
-arm32v5-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v5-Directory: arm32v5/hola-mundo
-arm32v7-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm32v7-Directory: arm32v7/hola-mundo
-arm64v8-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 arm64v8-Directory: arm64v8/hola-mundo
-i386-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 i386-Directory: i386/hola-mundo
-ppc64le-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 ppc64le-Directory: ppc64le/hola-mundo
-s390x-GitCommit: c83a065a24e94e635ddd518c2a3cffc91accf30d
+s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 s390x-Directory: s390x/hola-mundo
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: d206a435163e171e629490b2803b2615b3831906
+windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1709
 Constraints: nanoserver-1709

--- a/library/redmine
+++ b/library/redmine
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.4.4, 3.4, 3, latest
+Tags: 3.4.5, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86a208cc744d9743a219973ba2ab675f6718bec4
+GitCommit: 7885b55d69f209c5aa676ba60b727dd240e199bd
 Directory: 3.4
 
-Tags: 3.4.4-passenger, 3.4-passenger, 3-passenger, passenger
+Tags: 3.4.5-passenger, 3.4-passenger, 3-passenger, passenger
 GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
 Directory: 3.4/passenger
 
-Tags: 3.3.6, 3.3
+Tags: 3.3.7, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a66905d6ed69f74e74e6b48fedb39f8e3bff949
+GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
 Directory: 3.3
 
-Tags: 3.3.6-passenger, 3.3-passenger
+Tags: 3.3.7-passenger, 3.3-passenger
 GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
 Directory: 3.3/passenger
 

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.63.0, 0.63, 0, latest
-GitCommit: c76db6d89aff8ec3624be938d408950c00b4fdee
+Tags: 0.63.1, 0.63, 0, latest
+GitCommit: 2b2881054b3fcd6eb061e9acc70ba4dcd9ed00f3

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/5d317a0a21e6c927e415dfc8dd452619ea4b4643/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/fae008566295d1eec89de04385215fdd54eceda5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,110 +6,130 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.85-jre7, 7.0-jre7, 7-jre7, 7.0.85, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre7
 
 Tags: 7.0.85-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.85-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre7-slim
 
 Tags: 7.0.85-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.85-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 85486f9d3edfa08a827037e556924b1aeb7069d9
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre7-alpine
 
 Tags: 7.0.85-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre8
 
 Tags: 7.0.85-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a8eb8d07236e132d98cbada87d32bd0cfd2dd42
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre8-slim
 
 Tags: 7.0.85-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 85486f9d3edfa08a827037e556924b1aeb7069d9
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 7/jre8-alpine
 
 Tags: 8.0.50-jre7, 8.0-jre7, 8.0.50, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre7
 
 Tags: 8.0.50-jre7-slim, 8.0-jre7-slim, 8.0.50-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre7-slim
 
 Tags: 8.0.50-jre7-alpine, 8.0-jre7-alpine, 8.0.50-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 99e449dbecd64705dd81c07b8767ec67e706be41
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.50-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre8
 
 Tags: 8.0.50-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58ae57a15b0b06bc97d91ba144c5fb99d6ca2067
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre8-slim
 
 Tags: 8.0.50-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 99e449dbecd64705dd81c07b8767ec67e706be41
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.29-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.29, 8.5, 8, latest
+Tags: 8.5.30-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.30, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.5/jre8
 
-Tags: 8.5.29-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.29-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.30-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.30-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.29-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.29-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.30-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.30-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cd46dd92802bc82fb544906ae8b0108996c5de65
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.29-jre9, 8.5-jre9, 8-jre9, jre9
+Tags: 8.5.30-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.5/jre9
 
-Tags: 8.5.29-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
+Tags: 8.5.30-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 271dd9b73316d3cc6f5742207bf8a776c9c8583b
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 8.5/jre9-slim
 
-Tags: 9.0.6-jre8, 9.0-jre8, 9-jre8
+Tags: 8.5.30-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+Directory: 8.5/jre10
+
+Tags: 8.5.30-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+Directory: 8.5/jre10-slim
+
+Tags: 9.0.7-jre8, 9.0-jre8, 9-jre8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 9.0/jre8
 
-Tags: 9.0.6-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.7-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.6-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.7-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f4f5d57a2574e4d4c646041822ab72e6fff461e4
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.6-jre9, 9.0-jre9, 9-jre9, 9.0.6, 9.0, 9
+Tags: 9.0.7-jre9, 9.0-jre9, 9-jre9, 9.0.7, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 9.0/jre9
 
-Tags: 9.0.6-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.6-slim, 9.0-slim, 9-slim
+Tags: 9.0.7-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.7-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d5a066020c6084b2adce6c3fb1fddbcb18467d1
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
 Directory: 9.0/jre9-slim
+
+Tags: 9.0.7-jre10, 9.0-jre10, 9-jre10
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+Directory: 9.0/jre10
+
+Tags: 9.0.7-jre10-slim, 9.0-jre10-slim, 9-jre10-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+Directory: 9.0/jre10-slim


### PR DESCRIPTION
- `golang`: remove `no-pic.patch` (docker-library/golang#213)
- `haproxy`: 1.8.7
- `hello-seattle`, `hello-world`, `hola-mundo`: swap Docker Cloud links for Docker Hub (docker-library/hello-world#46)
- `redmine`: 3.4.5, 3.3.7
- `rocket.chat`: 0.63.1
- `tomcat`: replace SHA1 with SHA512 (docker-library/tomcat#116)