### PR TITLE
Update Solr to 7.3.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,17 +6,17 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 7.3.0, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
 Directory: 7.3
 
 Tags: 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
 Directory: 7.3/alpine
 
 Tags: 7.3.0-slim, 7.3-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2

--- a/library/solr
+++ b/library/solr
@@ -1,65 +1,80 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/d46b75125441499dde3df7d64e86efa19e4885b2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/cdd1a07972438a0123371f09cd05edaff5932d30/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.2.1, 7.2, 7, latest
+Tags: 7.3.0, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+Directory: 7.3
+
+Tags: 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+Directory: 7.3/alpine
+
+Tags: 7.3.0-slim, 7.3-slim, 7-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+Directory: 7.3/slim
+
+Tags: 7.2.1, 7.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.2
 
-Tags: 7.2.1-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.1-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.2/alpine
 
-Tags: 7.2.1-slim, 7.2-slim, 7-slim, slim
+Tags: 7.2.1-slim, 7.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 7.1/slim
 
 Tags: 6.6.3, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 6.6
 
 Tags: 6.6.3-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 6.6/alpine
 
 Tags: 6.6.3-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df068583b90e82844d2bf6cfe481d23c2840636
+GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
 Directory: 5.5/slim


### PR DESCRIPTION
Update Solr to 7.3

Announcement: http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201804.mbox/browser
Changes:  https://lucene.apache.org/solr/7_3_0/changes/Changes.html

Release highlights:

    OpenNLP request processors
    Automatic time-based collection creation
    Multivalued primitive fields can be used in sorting
    SortableTextField allows sorting and faceting on free text
    New stream evaluators
    Improvements around leader-initiated recovery
    New autoscaling features
    A Prometheus metrics exporter
    Filtering with exclusions on parent and child queries
    Filtering with exclusions via a new query parser
    Neural network modelling via learning to rank
    Solr runs with Java 10


On the  docker-solr side, I'm switching to Java 9 for Solr 7.3 and above. As Java 9 is not available on Alpine, that remains on Java 8.
Note that there is an incompatibility with Kerberos on Java 9 ([SOLR-10210](https://issues.apache.org/jira/browse/SOLR-10210) and [HADOOP-11123](https://issues.apache.org/jira/browse/HADOOP-11123)). If that affects you, use the Alpine version for now, or build a custom image.