### PR TITLE
Exclude removed files

### DIFF
--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -26,7 +26,7 @@ elif [ "$(git diff --numstat "$UPSTREAM...$HEAD" -- . | wc -l)" -ne 0 ]; then
 	echo >&2 'Changes in bashbrew/ detected!'
 	extraCommands=1
 else
-	repos=( $(git diff --numstat "$UPSTREAM...$HEAD" -- ../library | awk -F '/' '{ print $2 }') )
+	repos=( $(git diff --name-status "$UPSTREAM...$HEAD" -- ../library | awk -F ' ' '{ if ($1 != "D") print $2 }') )
 	extraCommands=1
 fi
 

--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -72,7 +72,7 @@ git -C oi fetch --quiet \
 
 images=( "$@" )
 if [ "${#images[@]}" -eq 0 ]; then
-	images=( $(git -C oi/library diff --name-only master...pull -- . | xargs -n1 basename) )
+	images=( $(git -C oi/library diff --name-status master...pull -- . | awk -F ' ' '{ if ($1 != "D") print $2 }' | xargs basename) )
 fi
 
 export BASHBREW_CACHE="${BASHBREW_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/bashbrew}"

--- a/test-pr.sh
+++ b/test-pr.sh
@@ -136,7 +136,6 @@ export BASHBREW_LIBRARY="$PWD/library"
 if [ "$#" -eq 0 ]; then
 	IFS=$'\n'
 	files=( $(git diff --name-status origin/master...HEAD -- library | awk -F ' ' '{ if ($1 != "D") print $2 }' | xargs basename) )
-	echo $files;
         unset IFS
 
 	# TODO narrow this down into groups of the exact tags for each image that changed >:)

--- a/test-pr.sh
+++ b/test-pr.sh
@@ -135,8 +135,9 @@ export BASHBREW_LIBRARY="$PWD/library"
 
 if [ "$#" -eq 0 ]; then
 	IFS=$'\n'
-	files=( $(git diff --name-only origin/master...HEAD -- library | xargs -n1 basename) )
-	unset IFS
+	files=( $(git diff --name-status origin/master...HEAD -- library | awk -F ' ' '{ if ($1 != "D") print $2 }' | xargs basename) )
+	echo $files;
+        unset IFS
 
 	# TODO narrow this down into groups of the exact tags for each image that changed >:)
 else


### PR DESCRIPTION
When **removing** official docker images (e.g. #4196, #2046, #2698), the build will fail since it detects the removed file as an image to check for.

In fact, we should **ignore** those removed files and mark the build as passed once all other changed/added images have been built successfully. Therefore, we have to filter the `git diff` results according to their status.