### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,140 +1,140 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/7bbf2f06c74e0a8ca54c97f5a0f0b729b39011df/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/89ef755062d82d098069a216e8924b6b13e815a0/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
-Tags: artful-curl
+Tags: artful-curl, 17.10-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: artful/curl
 
-Tags: artful-scm
+Tags: artful-scm, 17.10-scm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
 Directory: artful/scm
 
-Tags: artful
+Tags: artful, 17.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: artful
 
-Tags: bionic-curl
+Tags: bionic-curl, 18.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
 Directory: bionic/curl
 
-Tags: bionic-scm
+Tags: bionic-scm, 18.04-scm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
 Directory: bionic/scm
 
-Tags: bionic
+Tags: bionic, 18.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
 Directory: bionic
 
-Tags: buster-curl
+Tags: buster-curl, testing-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: buster/curl
 
-Tags: buster-scm
+Tags: buster-scm, testing-scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a1c33fda559272e9322b02a5d778bbd04154e7
 Directory: buster/scm
 
-Tags: buster
+Tags: buster, testing
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: buster
 
-Tags: jessie-curl
+Tags: jessie-curl, oldstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: jessie/curl
 
-Tags: jessie-scm
+Tags: jessie-scm, oldstable-scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
-Tags: jessie
+Tags: jessie, oldstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: jessie
 
-Tags: sid-curl
+Tags: sid-curl, unstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: sid/curl
 
-Tags: sid-scm
+Tags: sid-scm, unstable-scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 99a1c33fda559272e9322b02a5d778bbd04154e7
 Directory: sid/scm
 
-Tags: sid
+Tags: sid, unstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: sid
 
-Tags: stretch-curl, curl
+Tags: stretch-curl, stable-curl, curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: stretch/curl
 
-Tags: stretch-scm, scm
+Tags: stretch-scm, stable-scm, scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: stretch/scm
 
-Tags: stretch, latest
+Tags: stretch, stable, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: stretch
 
-Tags: trusty-curl
+Tags: trusty-curl, 14.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: trusty/curl
 
-Tags: trusty-scm
+Tags: trusty-scm, 14.04-scm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: trusty/scm
 
-Tags: trusty
+Tags: trusty, 14.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: trusty
 
-Tags: wheezy-curl
+Tags: wheezy-curl, oldoldstable-curl
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: wheezy/curl
 
-Tags: wheezy-scm
+Tags: wheezy-scm, oldoldstable-scm
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: wheezy/scm
 
-Tags: wheezy
+Tags: wheezy, oldoldstable
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: wheezy
 
-Tags: xenial-curl
+Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d662dc69f910feb241f6d0c9d2cd6cc2fb6c5e6c
 Directory: xenial/curl
 
-Tags: xenial-scm
+Tags: xenial-scm, 16.04-scm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2da658b9a1b91fa61d63ffad2ea52685cac6c702
 Directory: xenial/scm
 
-Tags: xenial
+Tags: xenial, 16.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: xenial

--- a/library/docker
+++ b/library/docker
@@ -19,6 +19,21 @@ Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 574fe5c582aa0ba432cf5f57ac921d42eafd5e36
 Directory: 18.04/git
 
+Tags: 18.03.1-ce-rc1, 18.03-rc, rc
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 9fef62af4ad3a24c43894a16e06ba160b592e06a
+Directory: 18.03-rc
+
+Tags: 18.03.1-ce-rc1-dind, 18.03-rc-dind, rc-dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 9fef62af4ad3a24c43894a16e06ba160b592e06a
+Directory: 18.03-rc/dind
+
+Tags: 18.03.1-ce-rc1-git, 18.03-rc-git, rc-git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 9fef62af4ad3a24c43894a16e06ba160b592e06a
+Directory: 18.03-rc/git
+
 Tags: 18.03.0-ce, 18.03.0, 18.03, stable
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.1, 1.22, 1, latest
+Tags: 1.22.2, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 77ace608cc35923cadb9684bb15ab0fdbfe6dca3
+GitCommit: 8e29a02e28c641e39a509588fc06c63d5cc281ea
 Directory: 1/debian
 
-Tags: 1.22.1-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.2-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 77ace608cc35923cadb9684bb15ab0fdbfe6dca3
+GitCommit: 8e29a02e28c641e39a509588fc06c63d5cc281ea
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0


### PR DESCRIPTION
- `buildpack-deps`: more aliases (docker-library/buildpack-deps#79)
- `docker`: 18.03.1-ce-rc1
- `ghost`: 1.22.2