### PR TITLE
Update websphere-liberty beta to 2018.4.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,7 +1,7 @@
 Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 792f4b0165a980688c675df5472bca8c8a0d8f31
+GitCommit: ea29e87ad8452d836ccade5fca969c1c2916c5e0
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Updating for the April Liberty Beta release.