### PR TITLE
Fix "python-pip-requests-ssl" test to no longer "import pip"

### DIFF
--- a/test/tests/python-pip-requests-ssl/container.py
+++ b/test/tests/python-pip-requests-ssl/container.py
@@ -1,8 +1,6 @@
-import pip
-
-pip.main(['install', '-q', 'requests'])
+import subprocess, sys
+subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
 
 import requests
-
 r = requests.get('https://google.com')
 assert(r.status_code == 200)


### PR DESCRIPTION
(https://blog.python.org/2018/04/pip-10-has-been-released.html)

> In addition, the previously announced reorganisation of pip's internals has now taken place. Unless you are the author of code that imports the pip module (or a user of such code), this change will not affect you. If you are affected, please report the issue to the author of the offending code (refer them to https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html for the details of the announcement).