### PR TITLE
Fix "hylang-sh" test to no longer "import pip"

### DIFF
--- a/test/tests/hylang-sh/container.hy
+++ b/test/tests/hylang-sh/container.hy
@@ -2,8 +2,8 @@
   (+ 2 2)
   (print))
 
-(import [pip])
-(pip.main ["install" "-q" "sh"])
+(import [subprocess] [sys])
+(subprocess.check_call [sys.executable "-m" "pip" "install" "-q" "sh"])
 
 (import [sh [echo]])
 (->


### PR DESCRIPTION
(https://blog.python.org/2018/04/pip-10-has-been-released.html)

> In addition, the previously announced reorganisation of pip's internals has now taken place. Unless you are the author of code that imports the pip module (or a user of such code), this change will not affect you. If you are affected, please report the issue to the author of the offending code (refer them to https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html for the details of the announcement).

Follow-up to https://github.com/docker-library/official-images/pull/4253.