### PR TITLE
Reference new WebSphere Liberty commit

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,7 +1,8 @@
 Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
-             Andy Naumann <naumann@us.ibm.com> (@naumanna)
+             Andy Naumann <naumann@us.ibm.com> (@naumanna),
+             Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: ea29e87ad8452d836ccade5fca969c1c2916c5e0
+GitCommit: 5e7810ada00c061b6fd014384a9979653a7b0129
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
A new commit was added to the WebSphere Liberty GitHub repo, improving the startup performance of the containers by doing a server start/stop priming during build.  