### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.8, 5.6, 5, latest
-GitCommit: d91235c08a5a03073b918d996c125185427b25c4
+Tags: 5.6.9, 5.6, 5, latest
+GitCommit: a83e1837684d580e66f31cb01940ac1b99eef3aa
 Directory: 5
 
-Tags: 5.6.8-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: d91235c08a5a03073b918d996c125185427b25c4
+Tags: 5.6.9-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: a83e1837684d580e66f31cb01940ac1b99eef3aa
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.2, 1.22, 1, latest
+Tags: 1.22.3, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e29a02e28c641e39a509588fc06c63d5cc281ea
+GitCommit: 2f6ac6c7770e428a4a50d23d46ec470d5e727456
 Directory: 1/debian
 
-Tags: 1.22.2-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.3-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 8e29a02e28c641e39a509588fc06c63d5cc281ea
+GitCommit: 2f6ac6c7770e428a4a50d23d46ec470d5e727456
 Directory: 1/alpine
 
 Tags: 0.11.12, 0.11, 0

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.8, 5.6, 5, latest
-GitCommit: 353e125bf1d11c16f31966fc7fef8355e7d272b3
+Tags: 5.6.9, 5.6, 5, latest
+GitCommit: 249795079412622520b290ce2a93eae360db3b68
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.8, 5.6, 5, latest
-GitCommit: 26506a8c65e1b1cb5584481b3b3f039b45f5c218
+Tags: 5.6.9, 5.6, 5, latest
+GitCommit: 6bc0d60b136c959d38965a5e9515331945e3ec4f
 Directory: 5
 
-Tags: 5.6.8-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 26506a8c65e1b1cb5584481b3b3f039b45f5c218
+Tags: 5.6.9-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 6bc0d60b136c959d38965a5e9515331945e3ec4f
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,11 +1,11 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/c3066d832b6eb6691ef96860dcba19791e4332b7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/ae7d138ed25303f4067dcc9b2f2218342c5362c5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.5, 10.3
-GitCommit: 0ab4688d0e6d3a81d7cd19e04db44fb499c49d6a
+Tags: 10.3.6, 10.3
+GitCommit: a8f8451c2fa537cf57a32eadf474019546721b42
 Directory: 10.3
 
 Tags: 10.2.14, 10.2, 10, latest

--- a/library/mongo
+++ b/library/mongo
@@ -28,18 +28,18 @@ Architectures: amd64
 GitCommit: b96fddd1e1a100c01f0ea6d28e1c7ccc750fd5c0
 Directory: 3.4
 
-Tags: 3.6.3-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.3, 3.6, 3, latest
+Tags: 3.6.4-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.4, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 2e3e1bdbb31389c8bc8d43f5a3cc439134b7956b
+GitCommit: dd8ceb3b3552d11c901a603d0b8b303e2fe4bc2e
 Directory: 3.6
 
-Tags: 3.7.3-jessie, 3.7-jessie, unstable-jessie
-SharedTags: 3.7.3, 3.7, unstable
+Tags: 3.7.5-jessie, 3.7-jessie, unstable-jessie
+SharedTags: 3.7.5, 3.7, unstable
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 621a206bca04c06ad3e0d8459c9d23223ea11a01
+GitCommit: 5d91c7654eea29e6ff03933331e3ae85a3b32734
 Directory: 3.7

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 10-ea-46-jre-experimental, 10-ea-jre-experimental, 10-jre-experimental, 10-ea-46-jre, 10-ea-jre, 10-jre
+Tags: 11-ea-9-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-9-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
+GitCommit: 02a49915095f254cbf321292ab7a021529686448
+Directory: 11-jre
+
+Tags: 11-ea-9-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-9-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 02a49915095f254cbf321292ab7a021529686448
+Directory: 11-jre/slim
+
+Tags: 11-ea-9-jdk-sid, 11-ea-9-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-9-jdk, 11-ea-9, 11-ea-jdk, 11-ea, 11-jdk, 11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 02a49915095f254cbf321292ab7a021529686448
+Directory: 11-jdk
+
+Tags: 11-ea-9-jdk-slim-sid, 11-ea-9-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-9-jdk-slim, 11-ea-9-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 02a49915095f254cbf321292ab7a021529686448
+Directory: 11-jdk/slim
+
+Tags: 10-ea-46-jre-sid, 10-ea-jre-sid, 10-jre-sid, 10-ea-46-jre, 10-ea-jre, 10-jre
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e56d5358b1a786ab84f976fa67410621a7692cd6
 Directory: 10-jre
 
-Tags: 10-ea-46-jre-slim-experimental, 10-ea-jre-slim-experimental, 10-jre-slim-experimental, 10-ea-46-jre-slim, 10-ea-jre-slim, 10-jre-slim
+Tags: 10-ea-46-jre-slim-sid, 10-ea-jre-slim-sid, 10-jre-slim-sid, 10-ea-46-jre-slim, 10-ea-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
+GitCommit: e56d5358b1a786ab84f976fa67410621a7692cd6
 Directory: 10-jre/slim
 
-Tags: 10-ea-46-jdk-experimental, 10-ea-46-experimental, 10-ea-jdk-experimental, 10-ea-experimental, 10-jdk-experimental, 10-experimental, 10-ea-46-jdk, 10-ea-46, 10-ea-jdk, 10-ea, 10-jdk, 10
+Tags: 10-ea-46-jdk-sid, 10-ea-46-sid, 10-ea-jdk-sid, 10-ea-sid, 10-jdk-sid, 10-sid, 10-ea-46-jdk, 10-ea-46, 10-ea-jdk, 10-ea, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
+GitCommit: e56d5358b1a786ab84f976fa67410621a7692cd6
 Directory: 10-jdk
 
-Tags: 10-ea-46-jdk-slim-experimental, 10-ea-46-slim-experimental, 10-ea-jdk-slim-experimental, 10-ea-slim-experimental, 10-jdk-slim-experimental, 10-slim-experimental, 10-ea-46-jdk-slim, 10-ea-46-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
+Tags: 10-ea-46-jdk-slim-sid, 10-ea-46-slim-sid, 10-ea-jdk-slim-sid, 10-ea-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10-ea-46-jdk-slim, 10-ea-46-slim, 10-ea-jdk-slim, 10-ea-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9c46dc617c9fab69f8fe427a3e3e1523bda461f
+GitCommit: e56d5358b1a786ab84f976fa67410621a7692cd6
 Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre

--- a/library/python
+++ b/library/python
@@ -7,52 +7,52 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.0b3-stretch, 3.7-rc-stretch, rc-stretch
 SharedTags: 3.7.0b3, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
+GitCommit: 5a8233e1b0729298bac9c062ffd4cf0d873e83a2
 Directory: 3.7-rc/stretch
 
 Tags: 3.7.0b3-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b3-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
+GitCommit: 5a8233e1b0729298bac9c062ffd4cf0d873e83a2
 Directory: 3.7-rc/stretch/slim
 
 Tags: 3.7.0b3-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b3-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
+GitCommit: 5a8233e1b0729298bac9c062ffd4cf0d873e83a2
 Directory: 3.7-rc/alpine3.7
 
 Tags: 3.7.0b3-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.7.0b3-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
+GitCommit: 5a8233e1b0729298bac9c062ffd4cf0d873e83a2
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.0b3-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
 SharedTags: 3.7.0b3-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b3, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: 33b16b4747706dd47ade94bebfde6b1144e4b758
+GitCommit: 5a8233e1b0729298bac9c062ffd4cf0d873e83a2
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.5-stretch, 3.6-stretch, 3-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/stretch
 
 Tags: 3.6.5-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.5-jessie, 3.6-jessie, 3-jessie, jessie
 SharedTags: 3.6.5, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/jessie
 
 Tags: 3.6.5-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.5-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.5-onbuild, 3.6-onbuild, 3-onbuild, onbuild
@@ -62,42 +62,42 @@ Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e48c9718ef52d14df2ac46e674b0fb55523d8284
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.5-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.5-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.5-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/alpine3.4
 
 Tags: 3.6.5-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.6.5-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.5, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.5-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.6.5-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.5, 3.6, 3, latest
 Architectures: windows-amd64
-GitCommit: caba688d74997c2d063907e35f5439b1b1811d9e
+GitCommit: 5024b32567b3da4bdd9ce6e317c6c84603015999
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.5-jessie, 3.5-jessie
 SharedTags: 3.5.5, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 49d4db584f3d8199fba353fd6f84b3aa4979a0ad
+GitCommit: 56ef54cb22c90a372e5af27ffe81ec24c042cb71
 Directory: 3.5/jessie
 
 Tags: 3.5.5-slim-jessie, 3.5-slim-jessie, 3.5.5-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 49d4db584f3d8199fba353fd6f84b3aa4979a0ad
+GitCommit: 56ef54cb22c90a372e5af27ffe81ec24c042cb71
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.5-onbuild, 3.5-onbuild
@@ -107,18 +107,18 @@ Directory: 3.5/jessie/onbuild
 
 Tags: 3.5.5-alpine3.4, 3.5-alpine3.4, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64
-GitCommit: 49d4db584f3d8199fba353fd6f84b3aa4979a0ad
+GitCommit: 56ef54cb22c90a372e5af27ffe81ec24c042cb71
 Directory: 3.5/alpine3.4
 
 Tags: 3.4.8-jessie, 3.4-jessie
 SharedTags: 3.4.8, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bea6f2bc3398d59c312492c403399b4078d3f6c9
+GitCommit: d4af596595307d6d940569fab727199a8f8e92b1
 Directory: 3.4/jessie
 
 Tags: 3.4.8-slim-jessie, 3.4-slim-jessie, 3.4.8-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bea6f2bc3398d59c312492c403399b4078d3f6c9
+GitCommit: d4af596595307d6d940569fab727199a8f8e92b1
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.8-onbuild, 3.4-onbuild
@@ -128,33 +128,33 @@ Directory: 3.4/jessie/onbuild
 
 Tags: 3.4.8-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: bea6f2bc3398d59c312492c403399b4078d3f6c9
+GitCommit: d4af596595307d6d940569fab727199a8f8e92b1
 Directory: 3.4/wheezy
 
 Tags: 3.4.8-alpine3.4, 3.4-alpine3.4, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64
-GitCommit: bea6f2bc3398d59c312492c403399b4078d3f6c9
+GitCommit: d4af596595307d6d940569fab727199a8f8e92b1
 Directory: 3.4/alpine3.4
 
 Tags: 2.7.14-stretch, 2.7-stretch, 2-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/stretch
 
 Tags: 2.7.14-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.14-jessie, 2.7-jessie, 2-jessie
 SharedTags: 2.7.14, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/jessie
 
 Tags: 2.7.14-slim-jessie, 2.7-slim-jessie, 2-slim-jessie, 2.7.14-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.14-onbuild, 2.7-onbuild, 2-onbuild
@@ -164,34 +164,34 @@ Directory: 2.7/jessie/onbuild
 
 Tags: 2.7.14-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/wheezy
 
 Tags: 2.7.14-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.14-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.14-alpine3.4, 2.7-alpine3.4, 2-alpine3.4, 2.7.14-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/alpine3.4
 
 Tags: 2.7.14-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.14, 2.7, 2
 Architectures: windows-amd64
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.14-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.14-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.14, 2.7, 2
 Architectures: windows-amd64
-GitCommit: fb58b39c5ac1cfd5c901fde02b0bf08f8a6b4990
+GitCommit: 04c9c2858a82f0558b4dc2e3788e65103b71af3b
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709


### PR DESCRIPTION
- `elasticsearch`: 5.6.9
- `ghost`: 1.22.3
- `kibana`: 5.6.9
- `logstash`: 5.6.9
- `mariadb`: 10.3.6
- `mongo`: 3.6.4
- `openjdk`: 11 (docker-library/openjdk#186), debian `10~46-5`
- `python`: pip 10.0.0