### PR TITLE
Update perl image for 5.24.4/5.26.2 and cpanm 1.7044

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,19 +1,20 @@
-Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini), Zak B. Elep <zakame@cpan.org> (@zakame)
+Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
+             Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: a5c2d6c896807e9c1beec4ebac01c7f30c075bf0
+GitCommit: 1c201e950ebe90f35c449f69df6ca7151cb0068d
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.26, 5.26.1
-Directory: 5.026.001-64bit
+Tags: latest, 5, 5.26, 5.26.2
+Directory: 5.026.002-64bit
 
-Tags: threaded, 5-threaded, 5.26-threaded, 5.26.1-threaded
-Directory: 5.026.001-64bit,threaded
+Tags: threaded, 5-threaded, 5.26-threaded, 5.26.2-threaded
+Directory: 5.026.002-64bit,threaded
 
-Tags: 5.24, 5.24.3
-Directory: 5.024.003-64bit
+Tags: 5.24, 5.24.4
+Directory: 5.024.004-64bit
 
-Tags: 5.24-threaded, 5.24.3-threaded
-Directory: 5.024.003-64bit,threaded
+Tags: 5.24-threaded, 5.24.4-threaded
+Directory: 5.024.004-64bit,threaded
 
 Tags: 5.22, 5.22.4
 Directory: 5.022.004-64bit


### PR DESCRIPTION
- Update to Perl 5.24.4 and 5.26.2
- Update bundled App::cpanminus to 1.7044

https://github.com/Perl/docker-perl/issues/49