### PR TITLE
Update docker-library images

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -11,5 +11,5 @@ Directory: 2.4
 
 Tags: 2.4.33-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 325f792b50fa2a0afdcfd7d1147f43ce1e8edbc3
+GitCommit: eaf4c70fb21f167f77e0c9d4b6f8b8635b1cb4b6
 Directory: 2.4/alpine

--- a/library/irssi
+++ b/library/irssi
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.1.1-alpine, 1.1-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a01102b70c724f1e3415dde1f5181c29675ecd56
+GitCommit: 3166eac4730178900099a1e4fb255f25bbea6156
 Directory: alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -26,22 +26,22 @@ Directory: 11-jdk/slim
 
 Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d4a88c802fd2c3d230a71e6e8a4af49295aca5e
+GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
 Directory: 10-jre
 
 Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d4a88c802fd2c3d230a71e6e8a4af49295aca5e
+GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
 Directory: 10-jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d4a88c802fd2c3d230a71e6e8a4af49295aca5e
+GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
 Directory: 10-jdk
 
 Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d4a88c802fd2c3d230a71e6e8a4af49295aca5e
+GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
 Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre

--- a/library/php
+++ b/library/php
@@ -6,155 +6,155 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.4-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.4-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.4-cli, 7.2-cli, 7-cli, cli, 7.2.4, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.4-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.4-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.4-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.4-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.4-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.4-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.4-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.4-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.4-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.4-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.4-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.4-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.4-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.4-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.4-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.4-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.4-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.4-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c4f059d09d7eefcb73304d198faa7674610ed810
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.16-cli-jessie, 7.1-cli-jessie, 7.1.16-jessie, 7.1-jessie, 7.1.16-cli, 7.1-cli, 7.1.16, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.16-apache-jessie, 7.1-apache-jessie, 7.1.16-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.16-fpm-jessie, 7.1-fpm-jessie, 7.1.16-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.16-zts-jessie, 7.1-zts-jessie, 7.1.16-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.16-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.16-alpine3.4, 7.1-alpine3.4, 7.1.16-cli-alpine, 7.1-cli-alpine, 7.1.16-alpine, 7.1-alpine
 Architectures: amd64
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/alpine3.4/cli
 
 Tags: 7.1.16-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.16-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/alpine3.4/fpm
 
 Tags: 7.1.16-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.16-zts-alpine, 7.1-zts-alpine
 Architectures: amd64
-GitCommit: 756e51407761a3bfecd7b920f6617add3a1bbaaf
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.1/alpine3.4/zts
 
 Tags: 7.0.29-cli-jessie, 7.0-cli-jessie, 7.0.29-jessie, 7.0-jessie, 7.0.29-cli, 7.0-cli, 7.0.29, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.29-apache-jessie, 7.0-apache-jessie, 7.0.29-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.29-fpm-jessie, 7.0-fpm-jessie, 7.0.29-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.29-zts-jessie, 7.0-zts-jessie, 7.0.29-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.29-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.29-alpine3.4, 7.0-alpine3.4, 7.0.29-cli-alpine, 7.0-cli-alpine, 7.0.29-alpine, 7.0-alpine
 Architectures: amd64
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/alpine3.4/cli
 
 Tags: 7.0.29-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.29-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/alpine3.4/fpm
 
 Tags: 7.0.29-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.29-zts-alpine, 7.0-zts-alpine
 Architectures: amd64
-GitCommit: 3ed155f67f686ac3cfeaee00346a7639f559192c
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 7.0/alpine3.4/zts
 
 Tags: 5.6.35-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.35-jessie, 5.6-jessie, 5-jessie, 5.6.35-cli, 5.6-cli, 5-cli, 5.6.35, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.35-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.35-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.35-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.35-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.35-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.35-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.35-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.35-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.35-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.35-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/alpine3.4/cli
 
 Tags: 5.6.35-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.35-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/alpine3.4/fpm
 
 Tags: 5.6.35-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.35-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64
-GitCommit: 568145207f15ea0d521b09c9e8f9c65f772cee22
+GitCommit: f504394473ea762a02a707325a9114df02987e71
 Directory: 5.6/alpine3.4/zts

--- a/library/piwik
+++ b/library/piwik
@@ -1,11 +1,13 @@
-# This file is generated via https://github.com/piwik/docker-piwik/blob/6806ec6f57bcb2581520977330060fc2df55bf40/generate-stackbrew-library.sh
+# This file is generated via https://github.com/matomo-org/docker/blob/15153dcb2ab39b0b2b131fec3738843a298fcf1d/generate-stackbrew-library.sh
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
-GitRepo: https://github.com/piwik/docker-piwik.git
+GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.3.0-apache, 3.3-apache, 3-apache, apache, 3.3.0, 3.3, 3, latest
-GitCommit: f2d71a5128a243c2791d1626b10d6637a5a40ced
+Tags: 3.4.0-apache, 3.4-apache, 3-apache, 3.4.0, 3.4, 3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
 Directory: apache
 
-Tags: 3.3.0-fpm, 3.3-fpm, 3-fpm, fpm
-GitCommit: f2d71a5128a243c2791d1626b10d6637a5a40ced
+Tags: 3.4.0-fpm, 3.4-fpm, 3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
 Directory: fpm

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.63.1, 0.63, 0, latest
-GitCommit: 2b2881054b3fcd6eb061e9acc70ba4dcd9ed00f3
+Tags: 0.63.3, 0.63, 0, latest
+GitCommit: 077a8fc4d69b22ac7812287ce6b4cb14ffdb821b

--- a/library/wordpress
+++ b/library/wordpress
@@ -66,22 +66,22 @@ Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.5.0-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64
-GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
+GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php5.6/cli
 
-Tags: cli-1.5.0-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64
-GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
+GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php7.0/cli
 
-Tags: cli-1.5.0-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64
-GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
+GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php7.1/cli
 
-Tags: cli-1.5.0, cli-1.5, cli-1, cli, cli-1.5.0-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
+Tags: cli-1.5.1, cli-1.5, cli-1, cli, cli-1.5.1-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 6fb1a99b550441edb5d1e554703f9f26afa73305
+GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php7.2/cli


### PR DESCRIPTION
- `httpd`: Alpine 3.7
- `irssi`: Alpine 3.7
- `openjdk`: debian `10.0.1+10-3`
- `php`: superficial `docker-php-ext-enable` issues (docker-library/php#626)
- `piwik`: 3.4.0, multi-arch
- `rocket.chat`: 0.63.3
- `wordpress`: cli 1.5.1