### PR TITLE
Update Debian to 20180426, especially for perl-base CVEs (and "iputils-ping" change)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,28 +7,28 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: c793937632f8bcc6712a14535c37b870c2f63374
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 603ba998fd1175e70bf3ac5d79a5d2c1ed9a52fe
+amd64-GitCommit: b024a792c752a5c6ccc422152ab0fd7197ae8860
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: c9cd437b635957d8992ea41e56b6d051e3bcecde
+arm32v5-GitCommit: 19dfff4171f10b80c5bac4fa2f7a57d87000f3f0
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: ec65021e6c67a334e0272973748c369187d982c2
+arm32v7-GitCommit: e0ddf19f4060289511d90cc21dbf5eb8729a7234
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 017f8443447e59f365bb12f43ca2a0b0ac8e16ce
+arm64v8-GitCommit: 774c95e9240f7aaf13df9e38e487d2ddc63c85bf
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 0c54ebe1b3f5d2b9a2a84fdf8667f83a33c0aff2
+i386-GitCommit: 5bcad9981a4524936db68f4d5f5d6e0bd98a241a
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 3bb315f73cbd06211118f718463723e9f2f2d953
+ppc64le-GitCommit: 8cdb589bb388b97321c15abe066411568c600321
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: af6c80a81f6f764d9b4406baf3e23f34834ad861
+s390x-GitCommit: e3f6b24e26eaf27927234ef10fba83c7f9884d78
 
 # buster -- Debian x.y Testing distribution - Not Released
-Tags: buster, buster-20180312
+Tags: buster, buster-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster
 
@@ -37,12 +37,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster/slim
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20180312
+Tags: experimental, experimental-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: experimental
 
 # jessie -- Debian 8.10 Released 09 December 2017
-Tags: jessie, jessie-20180312, 8.10, 8
+Tags: jessie, jessie-20180426, 8.10, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jessie
 
@@ -55,7 +55,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jessie/slim
 
 # oldoldstable -- Debian 7.11 Released 04 June 2016
-Tags: oldoldstable, oldoldstable-20180312
+Tags: oldoldstable, oldoldstable-20180426
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable
 
@@ -68,7 +68,7 @@ Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable/slim
 
 # oldstable -- Debian 8.10 Released 09 December 2017
-Tags: oldstable, oldstable-20180312
+Tags: oldstable, oldstable-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: oldstable
 
@@ -81,12 +81,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: oldstable/slim
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20180312
+Tags: rc-buggy, rc-buggy-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20180312
+Tags: sid, sid-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid
 
@@ -95,7 +95,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid/slim
 
 # stable -- Debian 9.4 Released 10 March 2018
-Tags: stable, stable-20180312
+Tags: stable, stable-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable
 
@@ -108,7 +108,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/slim
 
 # stretch -- Debian 9.4 Released 10 March 2018
-Tags: stretch, stretch-20180312, 9.4, 9, latest
+Tags: stretch, stretch-20180426, 9.4, 9, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch
 
@@ -121,7 +121,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/slim
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20180312
+Tags: testing, testing-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing
 
@@ -130,7 +130,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing/slim
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20180312
+Tags: unstable, unstable-20180426
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable
 
@@ -139,7 +139,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable/slim
 
 # wheezy -- Debian 7.11 Released 04 June 2016
-Tags: wheezy, wheezy-20180312, 7.11, 7
+Tags: wheezy, wheezy-20180426, 7.11, 7
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy
 


### PR DESCRIPTION
See https://github.com/debuerreotype/docker-debian-artifacts/issues/35.