### PR TITLE
Amazon Linux: add 2018.03.0.20180424

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,11 +12,19 @@ Tags: 2017.12.0.20180330-with-sources, 2017.12-with-sources, 2-with-sources
 GitFetch: refs/heads/2017.12-with-sources
 GitCommit: 9129377feea1176b636427b295e8af57656db079
 
-Tags: 2017.09.1.20180409, 2017.09, 1, latest
+Tags: 2018.03.0.20180424, 2018.03, 1, latest
+GitFetch: refs/heads/2018.03
+GitCommit: 2d98947f57ed4afe97daef60f4c05ec5e4adc69d
+
+Tags: 2018.03.0.20180424-with-sources, 2018.03-with-sources, 1-with-sources, with-sources
+GitFetch: refs/heads/2018.03-with-sources
+GitCommit: e323bc6480b6eb08de5ed48f5d049aa04dcef7d3
+
+Tags: 2017.09.1.20180409, 2017.09
 GitFetch: refs/heads/2017.09
 GitCommit: 0b2dad813345cab464c6c0a716aa5be2ae072f79
 
-Tags: 2017.09.1.20180409-with-sources, 2017.09-with-sources, 1-with-sources, with-sources
+Tags: 2017.09.1.20180409-with-sources, 2017.09-with-sources
 GitFetch: refs/heads/2017.09-with-sources
 GitCommit: 6d5273cf53b85c27690ac394bee2c2935cca73b8
 


### PR DESCRIPTION
Updates (to this image) include curl ([ALAS-2018-995](https://alas.aws.amazon.com/ALAS-2018-995.html)) and ca-certificates.

The main change in 2018.03 is kernel 4.14, which really isn't demonstrated much in this image. :)