### PR TITLE
upgrade r-base to R 3.5.0 released last Monday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.4.4: git://github.com/rocker-org/rocker@151274f9052f874034489769b94eba834309dc5d r-base
-latest: git://github.com/rocker-org/rocker@151274f9052f874034489769b94eba834309dc5d r-base
+3.5.0: git://github.com/rocker-org/rocker@629c6f89d81a336a7fa6a8a18f8365f1fd2878be r-base
+latest: git://github.com/rocker-org/rocker@629c6f89d81a336a7fa6a8a18f8365f1fd2878be r-base


### PR DESCRIPTION
This PR is a little different from the ones we had in the past.  R 3.5.0 requires a rebuild of all packages, and Debian has a full-blown transition [planned but not started](https://release.debian.org/transitions/html/r-base-3.5.html).  Packages for R 3.5.0 itself are still in Debian's experimental release.

So for this release, I created a deb repo on GH with the packages that would be in unstable, and use it. All Debian source are in my git repos on salsa.debian.org; I am the maintainer of all the packages in the local repo so in that sense it is all clean and proper.

However, if your policy is to only take packages from the distro I'd understand.  We can wait.  However, I think the r-base container is useful when current so I felt it was worth the effort to update it now while Debian catches up with the transition.

Happy to answer any and all other questions if you have any.