### PR TITLE
Update node.js v6 to v6.14.2 with Yarn v1.6.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -63,34 +63,34 @@ Architectures: amd64
 GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/wheezy
 
-Tags: 6.14.1, 6.14, 6, boron
+Tags: 6.14.2, 6.14, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6
 
-Tags: 6.14.1-alpine, 6.14-alpine, 6-alpine, boron-alpine
+Tags: 6.14.2-alpine, 6.14-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/alpine
 
-Tags: 6.14.1-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.14.2-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/onbuild
 
-Tags: 6.14.1-slim, 6.14-slim, 6-slim, boron-slim
+Tags: 6.14.2-slim, 6.14-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/slim
 
-Tags: 6.14.1-stretch, 6.14-stretch, 6-stretch, boron-stretch
+Tags: 6.14.2-stretch, 6.14-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/stretch
 
-Tags: 6.14.1-wheezy, 6.14-wheezy, 6-wheezy, boron-wheezy
+Tags: 6.14.2-wheezy, 6.14-wheezy, 6-wheezy, boron-wheezy
 Architectures: amd64
-GitCommit: 987139fc2385fc985aaa2545f7aeeef255eced79
+GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/wheezy
 
 Tags: 4.9.1, 4.9, 4, argon


### PR DESCRIPTION
 - https://github.com/nodejs/docker-node/pull/711
 - https://github.com/nodejs/node/releases/tag/v6.14.2