### PR TITLE
Adding a CentOS tag

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 5e7810ada00c061b6fd014384a9979653a7b0129
+GitCommit: 639446f344606684e5a878dda181a8a774e237cf
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -22,3 +22,6 @@ Directory: ga/developer/javaee7
 
 Tags: beta
 Directory: beta
+
+Tags: centos
+Directory: ga/developer/centos


### PR DESCRIPTION
Adding a new WebSphere Liberty image that builds upon the CentOS base image.  This OS is often used in cloud environment that require the docker container to run as non-root, so the corresponding [Dockerfile](https://github.com/WASdev/ci.docker/blob/master/ga/developer/centos/Dockerfile) accomplishes this.  

The technique of externally referenced multi-stage is used to avoid code duplication for fetching IBM Java and IBM WebSphere Liberty binaries.