### PR TITLE
Update Golang to 1.9.6 and 1.10.2

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,71 +5,71 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10.1-stretch, 1.10-stretch, 1-stretch, stretch
-SharedTags: 1.10.1, 1.10, 1, latest
+Tags: 1.10.2-stretch, 1.10-stretch, 1-stretch, stretch
+SharedTags: 1.10.2, 1.10, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
+GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
 Directory: 1.10/stretch
 
-Tags: 1.10.1-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.1-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.10.2-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.2-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
+GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
 Directory: 1.10/alpine3.7
 
-Tags: 1.10.1-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
+Tags: 1.10.2-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.10.2-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.2, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
+GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10.1-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.10.1-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.1, 1.10, 1, latest
+Tags: 1.10.2-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.10.2-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.2, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
+GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10.1-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.10.1-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.10.2-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.10.2-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 906e04de73168f643c5c2b40dca0877a14d2377c
+GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
 Directory: 1.10/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.9.5-stretch, 1.9-stretch
-SharedTags: 1.9.5, 1.9
+Tags: 1.9.6-stretch, 1.9-stretch
+SharedTags: 1.9.6, 1.9
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
 Directory: 1.9/stretch
 
-Tags: 1.9.5-alpine3.7, 1.9-alpine3.7
+Tags: 1.9.6-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
+GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
 Directory: 1.9/alpine3.7
 
-Tags: 1.9.5-alpine3.6, 1.9-alpine3.6, 1.9.5-alpine, 1.9-alpine
+Tags: 1.9.6-alpine3.6, 1.9-alpine3.6, 1.9.6-alpine, 1.9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8dca7d74ac8797db0525fd4efa4c59fc3c0c5675
+GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.5-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
-SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
+Tags: 1.9.6-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
+SharedTags: 1.9.6-windowsservercore, 1.9-windowsservercore, 1.9.6, 1.9
 Architectures: windows-amd64
-GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
+GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.5-windowsservercore-1709, 1.9-windowsservercore-1709
-SharedTags: 1.9.5-windowsservercore, 1.9-windowsservercore, 1.9.5, 1.9
+Tags: 1.9.6-windowsservercore-1709, 1.9-windowsservercore-1709
+SharedTags: 1.9.6-windowsservercore, 1.9-windowsservercore, 1.9.6, 1.9
 Architectures: windows-amd64
-GitCommit: 770b8477f1f43564c0b9a0929f9133b733fd141c
+GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.9.5-nanoserver-sac2016, 1.9-nanoserver-sac2016
-SharedTags: 1.9.5-nanoserver, 1.9-nanoserver
+Tags: 1.9.6-nanoserver-sac2016, 1.9-nanoserver-sac2016
+SharedTags: 1.9.6-nanoserver, 1.9-nanoserver
 Architectures: windows-amd64
-GitCommit: 97535d47a7c8312b25fc98418771f943c0bbdfb3
+GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
 Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016


### PR DESCRIPTION
Fixes docker-library/golang#220.