### PR TITLE
Adding centOS tag

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -3,7 +3,6 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitCommit: 6c582d04a7201e23f1af9dc0d955a0f66cb53354
-
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 5e7810ada00c061b6fd014384a9979653a7b0129
+GitCommit: 7b68d96512f1bacfeef5454ff345718b4707695e
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -22,3 +22,6 @@ Directory: ga/developer/javaee7
 
 Tags: beta
 Directory: beta
+
+Tags: centos
+Directory: ga/developer/centos


### PR DESCRIPTION
Adding a tag for CentOS-based image.  This image runs as non-root, which allows it to run in restricted environments such as OpenShift.

This image is also important for developers that want to use CentOS for dev and RHEL for production.