### PR TITLE
recover reference to the oraclelinux 7.4 amd64 image

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -24,7 +24,7 @@ Architectures: amd64
 Directory: 7.5
 
 Tags: 7.4
-Architectures: arm64v8
+Architectures: amd64, arm64v8
 Directory: 7.4
 
 Tags: 6-slim


### PR DESCRIPTION
Recover the 7.4 reference on amd64.

Signed-off-by: Jesse Butler <jesse.butler@oracle.com>