### PR TITLE
Update consul to RFC 2822-based format and add Architectures:

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,7 @@
-# maintainer: Preetha Appan <preetha@hashicorp.com> (@preetapan)
+Maintainers: Preetha Appan <preetha@hashicorp.com> (@preetapan)
 
-1.0.7: git://github.com/hashicorp/docker-consul@389ad67978f3fb9c43ae270e31c2d7b121df46c0 0.X
-latest: git://github.com/hashicorp/docker-consul@389ad67978f3fb9c43ae270e31c2d7b121df46c0 0.X
+Tags: 1.0.7, latest
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: e55eb42b1f60434ede55c021743117e190e60e8d
+Directory: 0.X


### PR DESCRIPTION
See also https://github.com/hashicorp/docker-consul/pull/82.

cc @preetapan @pearkes (this is the other half of the above PR which will make `consul:latest` and `consul:1.0.7` work OOB on all four supported architectures :+1:)