### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -11,7 +11,7 @@ Directory: 18.05-rc
 
 Tags: 18.05.0-ce-rc1-dind, 18.05-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9209ff1b2ef5f25cffff9e0e67bc681dd43fcaca
+GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
 Directory: 18.05-rc/dind
 
 Tags: 18.05.0-ce-rc1-git, 18.05-rc-git, rc-git, test-git
@@ -26,7 +26,7 @@ Directory: 18.04
 
 Tags: 18.04.0-ce-dind, 18.04.0-dind, 18.04-dind, 18-dind, edge-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 574fe5c582aa0ba432cf5f57ac921d42eafd5e36
+GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
 Directory: 18.04/dind
 
 Tags: 18.04.0-ce-git, 18.04.0-git, 18.04-git, 18-git, edge-git, git
@@ -41,7 +41,7 @@ Directory: 18.03
 
 Tags: 18.03.1-ce-dind, 18.03.1-dind, 18.03-dind, stable-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5b158e3ca87bdc20069754a796c00b270e40cfdb
+GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
 Directory: 18.03/dind
 
 Tags: 18.03.1-ce-git, 18.03.1-git, 18.03-git, stable-git
@@ -56,7 +56,7 @@ Directory: 17.12
 
 Tags: 17.12.1-ce-dind, 17.12.1-dind, 17.12-dind, 17-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5b158e3ca87bdc20069754a796c00b270e40cfdb
+GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
 Directory: 17.12/dind
 
 Tags: 17.12.1-ce-git, 17.12.1-git, 17.12-git, 17-git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.5, 1.22, 1, latest
+Tags: 1.22.6, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53e795e2393aac6e237cf2158edad465bde7636a
+GitCommit: 3d80eb98bcc2446bee783a3519002518ca04caa7
 Directory: 1/debian
 
-Tags: 1.22.5-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.6-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 53e795e2393aac6e237cf2158edad465bde7636a
+GitCommit: 3d80eb98bcc2446bee783a3519002518ca04caa7
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.6, 10.3
-GitCommit: a8f8451c2fa537cf57a32eadf474019546721b42
+GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.3
 
 Tags: 10.2.14, 10.2, 10, latest
-GitCommit: a7c0715098bad9097e7ffa892ef0f67dbc74c5ea
+GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.2
 
 Tags: 10.1.32, 10.1
-GitCommit: fb4c759d82536dc67b04a947bf44517236603e8b
+GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.1
 
 Tags: 10.0.35, 10.0
-GitCommit: c2ac79887ca8ac50d846cbf28ef1d98cf318d857
+GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.0
 
 Tags: 5.5.60, 5.5, 5
-GitCommit: 478097ba183fabfcbbdc94ce7591bce9277546f1
+GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,44 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-11-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-11-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-12-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-12-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f29e745facb32c529934eda4e4608be721cca04c
+GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
 Directory: 11-jre
 
-Tags: 11-ea-11-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-11-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-12-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-12-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f29e745facb32c529934eda4e4608be721cca04c
+GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
 Directory: 11-jre/slim
 
-Tags: 11-ea-11-jdk-sid, 11-ea-11-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-11-jdk, 11-ea-11, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-12-jdk-sid, 11-ea-12-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-12-jdk, 11-ea-12, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f29e745facb32c529934eda4e4608be721cca04c
+GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
 Directory: 11-jdk
 
-Tags: 11-ea-11-jdk-slim-sid, 11-ea-11-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-11-jdk-slim, 11-ea-11-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-12-jdk-slim-sid, 11-ea-12-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-12-jdk-slim, 11-ea-12-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f29e745facb32c529934eda4e4608be721cca04c
+GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
 Directory: 11-jdk/slim
 
 Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
+GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
 Directory: 10-jre
 
 Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
+GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
 Directory: 10-jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
+GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
 Directory: 10-jdk
 
 Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ab38b79b0a20fcd4a04c58dfa57a9c0b9b24dd4
+GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
 Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre

--- a/library/postgres
+++ b/library/postgres
@@ -6,50 +6,50 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.3, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef4545c07bd97e5585bb9e7f2680a4859b9ccf3c
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 10
 
 Tags: 10.3-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f1e59c55bcce36cfbe7ab4604f439eb8721611
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 10/alpine
 
 Tags: 9.6.8, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef4545c07bd97e5585bb9e7f2680a4859b9ccf3c
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.6
 
 Tags: 9.6.8-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c66fc738ed2eb957881a855eda7f921f785ec7a3
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.6/alpine
 
 Tags: 9.5.12, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef4545c07bd97e5585bb9e7f2680a4859b9ccf3c
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.5
 
 Tags: 9.5.12-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c66fc738ed2eb957881a855eda7f921f785ec7a3
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.5/alpine
 
 Tags: 9.4.17, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef4545c07bd97e5585bb9e7f2680a4859b9ccf3c
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.4
 
 Tags: 9.4.17-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c66fc738ed2eb957881a855eda7f921f785ec7a3
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.4/alpine
 
 Tags: 9.3.22, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef4545c07bd97e5585bb9e7f2680a4859b9ccf3c
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.3
 
 Tags: 9.3.22-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c66fc738ed2eb957881a855eda7f921f785ec7a3
+GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
 Directory: 9.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -64,72 +64,72 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 6ab703d29e98ab7a091bee846a58b8288cb81521
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.30-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.30, 8.5, 8, latest
+Tags: 8.5.31-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.31, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre8
 
-Tags: 8.5.30-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.30-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.31-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.31-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.30-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.30-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.31-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.31-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 1ce7bd2eed038fb722527f41f0f185322d53e979
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.30-jre9, 8.5-jre9, 8-jre9, jre9
+Tags: 8.5.31-jre9, 8.5-jre9, 8-jre9, jre9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre9
 
-Tags: 8.5.30-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
+Tags: 8.5.31-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre9-slim
 
-Tags: 8.5.30-jre10, 8.5-jre10, 8-jre10, jre10
+Tags: 8.5.31-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre10
 
-Tags: 8.5.30-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Tags: 8.5.31-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
 Directory: 8.5/jre10-slim
 
-Tags: 9.0.7-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.8-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre8
 
-Tags: 9.0.7-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.8-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.7-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.8-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: 8fffa7246aacceb0e7390aafe978efeea9c104e3
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.7-jre9, 9.0-jre9, 9-jre9, 9.0.7, 9.0, 9
+Tags: 9.0.8-jre9, 9.0-jre9, 9-jre9, 9.0.8, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre9
 
-Tags: 9.0.7-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.7-slim, 9.0-slim, 9-slim
+Tags: 9.0.8-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.8-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre9-slim
 
-Tags: 9.0.7-jre10, 9.0-jre10, 9-jre10
+Tags: 9.0.8-jre10, 9.0-jre10, 9-jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre10
 
-Tags: 9.0.7-jre10-slim, 9.0-jre10-slim, 9-jre10-slim
+Tags: 9.0.8-jre10-slim, 9.0-jre10-slim, 9-jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8a6bec69c82f8d55c5c2c17021a62b36d8bfb19
+GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre10-slim


### PR DESCRIPTION
- `docker`: docker-library/docker#110 (updated `dind` wrapper)
- `ghost`: 1.22.6
- `mariadb`: docker-library/mariadb#161 (remove unnecessary `FLUSH PRIVILEGES`)
- `openjdk`: `debian 11~12-1`, `debian 10.0.1+10-4`
- `postgres`: docker-library/postgres#440 (listen only on the unix socket during initdb)
- `tomcat`: 8.5.31, 9.0.8