### PR TITLE
Update node.js v10 and remove EOL v4

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/c3baf8491ef0967ac32ee7b20afc66a32e2c4c73/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/36135d58af893b99c4b95517deb499eb34afc7cc/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
@@ -93,59 +93,29 @@ Architectures: amd64
 GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/wheezy
 
-Tags: 4.9.1, 4.9, 4, argon
-Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4
-
-Tags: 4.9.1-alpine, 4.9-alpine, 4-alpine, argon-alpine
-Architectures: amd64
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4/alpine
-
-Tags: 4.9.1-onbuild, 4.9-onbuild, 4-onbuild, argon-onbuild
-Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4/onbuild
-
-Tags: 4.9.1-slim, 4.9-slim, 4-slim, argon-slim
-Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4/slim
-
-Tags: 4.9.1-stretch, 4.9-stretch, 4-stretch, argon-stretch
-Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4/stretch
-
-Tags: 4.9.1-wheezy, 4.9-wheezy, 4-wheezy, argon-wheezy
-Architectures: amd64
-GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
-Directory: 4/wheezy
-
-Tags: 10.0.0, 10.0, 10, latest
+Tags: 10.1.0, 10.1, 10, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
+GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10
 
-Tags: 10.0.0-alpine, 10.0-alpine, 10-alpine, alpine
+Tags: 10.1.0-alpine, 10.1-alpine, 10-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
+GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10/alpine
 
-Tags: 10.0.0-slim, 10.0-slim, 10-slim, slim
+Tags: 10.1.0-slim, 10.1-slim, 10-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
+GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10/slim
 
-Tags: 10.0.0-stretch, 10.0-stretch, 10-stretch, stretch
+Tags: 10.1.0-stretch, 10.1-stretch, 10-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
+GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10/stretch
 
-Tags: 10.0.0-wheezy, 10.0-wheezy, 10-wheezy, wheezy
+Tags: 10.1.0-wheezy, 10.1-wheezy, 10-wheezy, wheezy
 Architectures: amd64
-GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
+GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10/wheezy
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/722
- https://github.com/nodejs/node/releases/tag/v10.1.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md