### PR TITLE
- Added support to the latest release of GeoNetwork (v3.4.2)

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/fa8781ec155a6a3315c40e33e558c416b5b26e7b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/ecb319cf88982b8ca4ce400ad2447d46660171e3/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
@@ -19,10 +19,10 @@ Tags: 3.2.2-postgres, 3.2-postgres
 GitCommit: 7ba5f533d9ee31cf1a22d4d6a1a84fbb74f86466
 Directory: 3.2.2/postgres
 
-Tags: 3.4.1, 3.4, latest
-GitCommit: 01e3e23e9b277940dcac471099408695c6d12ae3
-Directory: 3.4.1
+Tags: 3.4.2, 3.4, latest
+GitCommit: 2bee6fcc7e0095d60ddd0034d27eb2053f177543
+Directory: 3.4.2
 
-Tags: 3.4.1-postgres, 3.4-postgres, postgres
-GitCommit: 01e3e23e9b277940dcac471099408695c6d12ae3
-Directory: 3.4.1/postgres
+Tags: 3.4.2-postgres, 3.4-postgres, postgres
+GitCommit: 9f096b5af8fb3a41c73d74d7b990544a50a33a2d
+Directory: 3.4.2/postgres


### PR DESCRIPTION
- Set 3.4.2 as the only version on the 3.4. branch
- Set 3.4.2 as the default version (latest)