### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,35 +4,20 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.05.0-ce-rc1, 18.05-rc, rc, test
+Tags: 18.05.0-ce, 18.05.0, 18.05, 18, edge, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9209ff1b2ef5f25cffff9e0e67bc681dd43fcaca
-Directory: 18.05-rc
+GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
+Directory: 18.05
 
-Tags: 18.05.0-ce-rc1-dind, 18.05-rc-dind, rc-dind, test-dind
+Tags: 18.05.0-ce-dind, 18.05.0-dind, 18.05-dind, 18-dind, edge-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
-Directory: 18.05-rc/dind
+GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
+Directory: 18.05/dind
 
-Tags: 18.05.0-ce-rc1-git, 18.05-rc-git, rc-git, test-git
+Tags: 18.05.0-ce-git, 18.05.0-git, 18.05-git, 18-git, edge-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9209ff1b2ef5f25cffff9e0e67bc681dd43fcaca
-Directory: 18.05-rc/git
-
-Tags: 18.04.0-ce, 18.04.0, 18.04, 18, edge, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 574fe5c582aa0ba432cf5f57ac921d42eafd5e36
-Directory: 18.04
-
-Tags: 18.04.0-ce-dind, 18.04.0-dind, 18.04-dind, 18-dind, edge-dind, dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
-Directory: 18.04/dind
-
-Tags: 18.04.0-ce-git, 18.04.0-git, 18.04-git, 18-git, edge-git, git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 574fe5c582aa0ba432cf5f57ac921d42eafd5e36
-Directory: 18.04/git
+GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
+Directory: 18.05/git
 
 Tags: 18.03.1-ce, 18.03.1, 18.03, stable
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
@@ -48,18 +33,3 @@ Tags: 18.03.1-ce-git, 18.03.1-git, 18.03-git, stable-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
 Directory: 18.03/git
-
-Tags: 17.12.1-ce, 17.12.1, 17.12, 17
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: eec0f6e5549ab940b53332f836be817c877d1154
-Directory: 17.12
-
-Tags: 17.12.1-ce-dind, 17.12.1-dind, 17.12-dind, 17-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
-Directory: 17.12/dind
-
-Tags: 17.12.1-ce-git, 17.12.1-git, 17.12-git, 17-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: de9fda490429cf83734ef78b58f0ae9cfed1b087
-Directory: 17.12/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.6, 1.22, 1, latest
+Tags: 1.22.7, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d80eb98bcc2446bee783a3519002518ca04caa7
+GitCommit: 34c67df3c75a9db60aeab5dc23075fdf4d78e44f
 Directory: 1/debian
 
-Tags: 1.22.6-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.7-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 3d80eb98bcc2446bee783a3519002518ca04caa7
+GitCommit: 34c67df3c75a9db60aeab5dc23075fdf4d78e44f
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/julia
+++ b/library/julia
@@ -1,9 +1,25 @@
-# this file is generated via https://github.com/docker-library/julia/blob/4eff23fd0270ed08c727f1ddb10c497559732c22/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/0406b201251d57f571e07f17ab5c3b0bd417c96d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.6.2, 0.6, 0, latest
+Tags: 0.6.2-jessie, 0.6-jessie, 0-jessie, jessie
+SharedTags: 0.6.2, 0.6, 0, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7dc8567964481b8ff4370671ca57b79f1bab7bb4
+GitCommit: 0406b201251d57f571e07f17ab5c3b0bd417c96d
+Directory: jessie
+
+Tags: 0.6.2-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.6.2, 0.6, 0, latest
+Architectures: windows-amd64
+GitCommit: 96d3dd0bf37bf7993c63ec2ff7c786d001c25193
+Directory: windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 0.6.2-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
+SharedTags: 0.6.2, 0.6, 0, latest
+Architectures: windows-amd64
+GitCommit: 96d3dd0bf37bf7993c63ec2ff7c786d001c25193
+Directory: windows/windowsservercore-1709
+Constraints: windowsservercore-1709

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.14, 10.2, 10, latest
 GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.2
 
-Tags: 10.1.32, 10.1
-GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
+Tags: 10.1.33, 10.1
+GitCommit: 662b59f5d1418a93ba0f10982338514b376a5ed0
 Directory: 10.1
 
 Tags: 10.0.35, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -4,20 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.0.15-wheezy, 3.0-wheezy
-SharedTags: 3.0.15, 3.0
-# see http://repo.mongodb.org/apt/debian/dists/wheezy/mongodb-org/3.0/main/
-# (i386 is empty, as is ppc64el)
-Architectures: amd64
-GitCommit: 58bdba62b65b1d1e1ea5cbde54c1682f120e0676
-Directory: 3.0
-
-Tags: 3.2.19-jessie, 3.2-jessie
-SharedTags: 3.2.19, 3.2
+Tags: 3.2.20-jessie, 3.2-jessie
+SharedTags: 3.2.20, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: 22dd36a9194de8797f3c558857c0120a794daf25
+GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
 Directory: 3.2
 
 Tags: 3.4.14-jessie, 3.4-jessie

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.5-rc.1, 3.7-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d38cebd5e7ea48e649ad2a90d54cad5136cb8afd
+GitCommit: 0480b1954a18b45eb0d403e59d0cb9844b4f466f
 Directory: 3.7-rc/debian
 
 Tags: 3.7.5-rc.1-management, 3.7-rc-management
@@ -24,22 +24,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management
 
-Tags: 3.7.4, 3.7, 3, latest
+Tags: 3.7.5, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a37166704d2ca7c386980387e81615985d5db47
+GitCommit: 75bbd3f7ae9c106a23b0f10809d45690045f805a
 Directory: 3.7/debian
 
-Tags: 3.7.4-management, 3.7-management, 3-management, management
+Tags: 3.7.5-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/debian/management
 
-Tags: 3.7.4-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.5-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 94de3d0908514407dfa02a61aa37642a1884de45
+GitCommit: 1d60d6f4314e5282c7fc4299c1e56450522414f1
 Directory: 3.7/alpine
 
-Tags: 3.7.4-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.5-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 7885b55d69f209c5aa676ba60b727dd240e199bd
 Directory: 3.4
 
 Tags: 3.4.5-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
+GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
 Directory: 3.4/passenger
 
 Tags: 3.3.7, 3.3
@@ -19,7 +19,7 @@ GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
 Directory: 3.3
 
 Tags: 3.3.7-passenger, 3.3-passenger
-GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
+GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: e5a95c0ca089652541f12d9008d9be6332f59899
+GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
 Directory: 3.2/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -34,34 +34,34 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: a46495d93b02266f616208b1599c26a2df0ae7f8
 Directory: 7/jre8-alpine
 
-Tags: 8.0.51-jre7, 8.0-jre7, 8.0.51, 8.0
+Tags: 8.0.52-jre7, 8.0-jre7, 8.0.52, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb611b28ea26adad400611ac46691a0c3dc89c7d
+GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
 Directory: 8.0/jre7
 
-Tags: 8.0.51-jre7-slim, 8.0-jre7-slim, 8.0.51-slim, 8.0-slim
+Tags: 8.0.52-jre7-slim, 8.0-jre7-slim, 8.0.52-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb611b28ea26adad400611ac46691a0c3dc89c7d
+GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
 Directory: 8.0/jre7-slim
 
-Tags: 8.0.51-jre7-alpine, 8.0-jre7-alpine, 8.0.51-alpine, 8.0-alpine
+Tags: 8.0.52-jre7-alpine, 8.0-jre7-alpine, 8.0.52-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ab703d29e98ab7a091bee846a58b8288cb81521
+GitCommit: d183e24a7f4239f84bf521ac96690904adb21a86
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.51-jre8, 8.0-jre8
+Tags: 8.0.52-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb611b28ea26adad400611ac46691a0c3dc89c7d
+GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
 Directory: 8.0/jre8
 
-Tags: 8.0.51-jre8-slim, 8.0-jre8-slim
+Tags: 8.0.52-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb611b28ea26adad400611ac46691a0c3dc89c7d
+GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
 Directory: 8.0/jre8-slim
 
-Tags: 8.0.51-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.52-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ab703d29e98ab7a091bee846a58b8288cb81521
+GitCommit: d183e24a7f4239f84bf521ac96690904adb21a86
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.31-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.31, 8.5, 8, latest


### PR DESCRIPTION
- `docker`: 18.05.0-ce GA
- `ghost`: 1.22.7, ghost-cli 1.7.3
- `julia`: Windows! (docker-library/julia#17)
- `mariadb`: `10.1.33+maria-1~jessie`
- `mongo`: drop 3.0 (EOL), 3.2.20
- `rabbitmq`: 3.7.5
- `redmine`: passenger 5.3.0
- `tomcat`: 8.0.52