### PR TITLE
Update websphere-liberty beta to 2018.5.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 5e7810ada00c061b6fd014384a9979653a7b0129
+GitCommit: 3cb2adf201dea86ed1b01a84ab2a44968ef5e239
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Updating to new May beta version released today.