### PR TITLE
Node: Drop Wheezy variant

### DIFF
--- a/library/node
+++ b/library/node
@@ -5,7 +5,7 @@ GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 9.11.1, 9.11, 9
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
+GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
 Directory: 9
 
 Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine
@@ -28,14 +28,9 @@ Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/stretch
 
-Tags: 9.11.1-wheezy, 9.11-wheezy, 9-wheezy
-Architectures: amd64
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
-Directory: 9/wheezy
-
 Tags: 8.11.1, 8.11, 8, carbon
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
+GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
 Directory: 8
 
 Tags: 8.11.1-alpine, 8.11-alpine, 8-alpine, carbon-alpine
@@ -58,14 +53,9 @@ Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
 Directory: 8/stretch
 
-Tags: 8.11.1-wheezy, 8.11-wheezy, 8-wheezy, carbon-wheezy
-Architectures: amd64
-GitCommit: b3ca6573b5c179148b446107386ae96ac6204ad3
-Directory: 8/wheezy
-
 Tags: 6.14.2, 6.14, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
+GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
 Directory: 6
 
 Tags: 6.14.2-alpine, 6.14-alpine, 6-alpine, boron-alpine
@@ -88,14 +78,9 @@ Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
 Directory: 6/stretch
 
-Tags: 6.14.2-wheezy, 6.14-wheezy, 6-wheezy, boron-wheezy
-Architectures: amd64
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
-Directory: 6/wheezy
-
 Tags: 10.1.0, 10.1, 10, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
+GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
 Directory: 10
 
 Tags: 10.1.0-alpine, 10.1-alpine, 10-alpine, alpine
@@ -112,11 +97,6 @@ Tags: 10.1.0-stretch, 10.1-stretch, 10-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
 Directory: 10/stretch
-
-Tags: 10.1.0-wheezy, 10.1-wheezy, 10-wheezy, wheezy
-Architectures: amd64
-GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
-Directory: 10/wheezy
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64


### PR DESCRIPTION
Full support for wheezy ended on April 26, 2016. LTS support will drop
in May 2018:

https://wiki.debian.org/DebianReleases#Production_Releases

Note: this PR replaces #4345 
