### PR TITLE
Fix Fedora 28 "Architectures" (no s390x, has ppc64le)

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -31,10 +31,10 @@ arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 
 Tags: latest, 28
-Architectures: amd64, arm32v7, arm64v8, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitFetch: refs/heads/28
 GitCommit: 0ef99659611684364cda45192c3558fc7bcbc2d5
 amd64-Directory: x86_64/
 arm32v7-Directory: armhfp/
 arm64v8-Directory: aarch64/
-s390x-Directory: s390x/
+ppc64le-Directory: ppc64le/


### PR DESCRIPTION
See https://github.com/docker-library/official-images/pull/4320#discussion_r187690442, https://github.com/fedora-cloud/docker-brew-fedora/tree/0ef99659611684364cda45192c3558fc7bcbc2d5.

cc @puiterwijk, @maxamillion