### PR TITLE
Update docker-library images

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -1,13 +1,18 @@
-# this file is generated via https://github.com/docker-library/julia/blob/0406b201251d57f571e07f17ab5c3b0bd417c96d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/3cb2698ed2475db46cc17d5d1cd309626ef87c1c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.6.2-jessie, 0.6-jessie, 0-jessie, jessie
+Tags: 0.6.2-stretch, 0.6-stretch, 0-stretch, stretch
 SharedTags: 0.6.2, 0.6, 0, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0406b201251d57f571e07f17ab5c3b0bd417c96d
+GitCommit: 3cb2698ed2475db46cc17d5d1cd309626ef87c1c
+Directory: stretch
+
+Tags: 0.6.2-jessie, 0.6-jessie, 0-jessie, jessie
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 3cb2698ed2475db46cc17d5d1cd309626ef87c1c
 Directory: jessie
 
 Tags: 0.6.2-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016

--- a/library/matomo
+++ b/library/matomo
@@ -2,12 +2,12 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.4.0-apache, 3.4-apache, 3-apache, apache, 3.4.0, 3.4, 3, latest
+Tags: 3.5.0-apache, 3.5-apache, 3-apache, apache, 3.5.0, 3.5, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
+GitCommit: edd76a3640e34e8318f7dbb08b4875838cb83e0c
 Directory: apache
 
-Tags: 3.4.0-fpm, 3.4-fpm, 3-fpm, fpm
+Tags: 3.5.0-fpm, 3.5-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
+GitCommit: edd76a3640e34e8318f7dbb08b4875838cb83e0c
 Directory: fpm

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-12-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-12-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-13-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-13-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
+GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
 Directory: 11-jre
 
-Tags: 11-ea-12-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-12-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-13-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-13-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
+GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
 Directory: 11-jre/slim
 
-Tags: 11-ea-12-jdk-sid, 11-ea-12-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-12-jdk, 11-ea-12, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-13-jdk-sid, 11-ea-13-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-13-jdk, 11-ea-13, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
+GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
 Directory: 11-jdk
 
-Tags: 11-ea-12-jdk-slim-sid, 11-ea-12-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-12-jdk-slim, 11-ea-12-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-13-jdk-slim-sid, 11-ea-13-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-13-jdk-slim, 11-ea-13-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a45699ce1082b389dfe3ed052814a28433e0668
+GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
 Directory: 11-jdk/slim
 
 Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 10-jre
 
 Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 10-jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 10-jdk
 
 Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a09d082da6e09c075495827ce74fbed4af044b96
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 10-jdk/slim
 
 Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01ca700a105984964865430aee1251932956925e
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 9-jre
 
 Tags: 9.0.4-12-jre-slim-sid, 9.0.4-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.4-12-jre-slim, 9.0.4-jre-slim, 9.0-jre-slim, 9-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01ca700a105984964865430aee1251932956925e
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 9-jre/slim
 
 Tags: 9.0.4-12-jdk-sid, 9.0.4-12-sid, 9.0.4-jdk-sid, 9.0.4-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.4-12-jdk, 9.0.4-12, 9.0.4-jdk, 9.0.4, 9.0-jdk, 9.0, 9-jdk, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01ca700a105984964865430aee1251932956925e
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 9-jdk
 
 Tags: 9.0.4-12-jdk-slim-sid, 9.0.4-12-slim-sid, 9.0.4-jdk-slim-sid, 9.0.4-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.4-12-jdk-slim, 9.0.4-12-slim, 9.0.4-jdk-slim, 9.0.4-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01ca700a105984964865430aee1251932956925e
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 9-jdk/slim
 
 Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
@@ -87,12 +87,12 @@ Constraints: nanoserver-sac2016
 
 Tags: 8u171-jre-stretch, 8-jre-stretch, jre-stretch, 8u171-jre, 8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce2e2040c7f32c8cb0180ff8c72e6a171d2956b9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 8-jre
 
 Tags: 8u171-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u171-jre-slim, 8-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce2e2040c7f32c8cb0180ff8c72e6a171d2956b9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 8-jre/slim
 
 Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
@@ -102,12 +102,12 @@ Directory: 8-jre/alpine
 
 Tags: 8u171-jdk-stretch, 8u171-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u171-jdk, 8u171, 8-jdk, 8, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce2e2040c7f32c8cb0180ff8c72e6a171d2956b9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 8-jdk
 
 Tags: 8u171-jdk-slim-stretch, 8u171-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, jdk-slim-stretch, slim-stretch, 8u171-jdk-slim, 8u171-slim, 8-jdk-slim, 8-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce2e2040c7f32c8cb0180ff8c72e6a171d2956b9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 8-jdk/slim
 
 Tags: 8u151-jdk-alpine3.7, 8u151-alpine3.7, 8-jdk-alpine3.7, 8-alpine3.7, jdk-alpine3.7, alpine3.7, 8u151-jdk-alpine, 8u151-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
@@ -138,12 +138,12 @@ Constraints: nanoserver-sac2016
 
 Tags: 7u171-jre-jessie, 7-jre-jessie, 7u171-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 7-jre
 
 Tags: 7u171-jre-slim-jessie, 7-jre-slim-jessie, 7u171-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 7-jre/slim
 
 Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
@@ -153,12 +153,12 @@ Directory: 7-jre/alpine
 
 Tags: 7u171-jdk-jessie, 7u171-jessie, 7-jdk-jessie, 7-jessie, 7u171-jdk, 7u171, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 7-jdk
 
 Tags: 7u171-jdk-slim-jessie, 7u171-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u171-jdk-slim, 7u171-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b6e3ba250722e251ce8b615d3edf8a3196c08c9
+GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
 Directory: 7-jdk/slim
 
 Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine

--- a/library/piwik
+++ b/library/piwik
@@ -2,12 +2,12 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.4.0-apache, 3.4-apache, 3-apache, apache, 3.4.0, 3.4, 3, latest
+Tags: 3.5.0-apache, 3.5-apache, 3-apache, apache, 3.5.0, 3.5, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
+GitCommit: edd76a3640e34e8318f7dbb08b4875838cb83e0c
 Directory: apache
 
-Tags: 3.4.0-fpm, 3.4-fpm, 3-fpm, fpm
+Tags: 3.5.0-fpm, 3.5-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c985c710bcd7ff07a79efd60433bc7f0d1674c28
+GitCommit: edd76a3640e34e8318f7dbb08b4875838cb83e0c
 Directory: fpm

--- a/library/postgres
+++ b/library/postgres
@@ -4,52 +4,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 10.3, 10, latest
+Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: de8ba87d50de466a1e05e111927d2bc30c2db36d
 Directory: 10
 
-Tags: 10.3-alpine, 10-alpine, alpine
+Tags: 10.4-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: fe8c9a4a309a889dc057d53bf3769c25c1522c65
 Directory: 10/alpine
 
-Tags: 9.6.8, 9.6, 9
+Tags: 9.6.9, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: c4cb816b3deccc29393b8278d1a5f144d2be26f1
 Directory: 9.6
 
-Tags: 9.6.8-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: a06a9377438d8e0805e49ce65bbcb810a711df52
 Directory: 9.6/alpine
 
-Tags: 9.5.12, 9.5
+Tags: 9.5.13, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: d545428bfe50f634b4aa9114eff0c5efe1d72f94
 Directory: 9.5
 
-Tags: 9.5.12-alpine, 9.5-alpine
+Tags: 9.5.13-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: 65f0c2afd32d2b2f4b8cf3d7a68461a7c3fa00a5
 Directory: 9.5/alpine
 
-Tags: 9.4.17, 9.4
+Tags: 9.4.18, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: e348a2fe235d28692344de64c05640c38361554d
 Directory: 9.4
 
-Tags: 9.4.17-alpine, 9.4-alpine
+Tags: 9.4.18-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: dcf1338d3a29d8244aecc12555e18267b8aaeed3
 Directory: 9.4/alpine
 
-Tags: 9.3.22, 9.3
+Tags: 9.3.23, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: 253471cd5c62c48867640bcb925ffad19a24d5d9
 Directory: 9.3
 
-Tags: 9.3.22-alpine, 9.3-alpine
+Tags: 9.3.23-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fe8c15843400444e4ba6906ec6f94b0d526a678
+GitCommit: ea2860a21672636bed769e694f6af33f83270fda
 Directory: 9.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.86-jre7, 7.0-jre7, 7-jre7, 7.0.86, 7.0, 7
+Tags: 7.0.88-jre7, 7.0-jre7, 7-jre7, 7.0.88, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d30e763f14a26d2b3acfbce53ff2e53c6f119eaf
+GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
 Directory: 7/jre7
 
-Tags: 7.0.86-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.86-slim, 7.0-slim, 7-slim
+Tags: 7.0.88-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.88-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d30e763f14a26d2b3acfbce53ff2e53c6f119eaf
+GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
 Directory: 7/jre7-slim
 
-Tags: 7.0.86-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.86-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.88-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.88-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a46495d93b02266f616208b1599c26a2df0ae7f8
+GitCommit: 6c810f194f2bd912333ecb180aabdd3612824f61
 Directory: 7/jre7-alpine
 
-Tags: 7.0.86-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.88-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d30e763f14a26d2b3acfbce53ff2e53c6f119eaf
+GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
 Directory: 7/jre8
 
-Tags: 7.0.86-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
+Tags: 7.0.88-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d30e763f14a26d2b3acfbce53ff2e53c6f119eaf
+GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
 Directory: 7/jre8-slim
 
-Tags: 7.0.86-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.88-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a46495d93b02266f616208b1599c26a2df0ae7f8
+GitCommit: 6c810f194f2bd912333ecb180aabdd3612824f61
 Directory: 7/jre8-alpine
 
 Tags: 8.0.52-jre7, 8.0-jre7, 8.0.52, 8.0


### PR DESCRIPTION
- `julia`: add `stretch` variant (docker-library/julia#18)
- `matomo`: 3.5.0
- `openjdk`: `debian 11~13-2`, `--no-install-recommends` (docker-library/openjdk#193)
- `piwik`: 3.5.0
- `postgres`: 9.3.23, 9.4.18, 9.5.13, 9.6.9, 10.4
- `tomcat`: 7.0.88