### PR TITLE
Bump Traefik to v1.6.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.0, 1.6.0, v1.6, 1.6, tetedemoine, latest
+Tags: v1.6.1, 1.6.1, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 7ce854f4c0450f71cd913a1a498016d656f7dc5b
+GitCommit: f6dc778627f1df208b28c8112d9aecd7840660be
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.6.0-alpine, 1.6.0-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
+Tags: v1.6.1-alpine, 1.6.1-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 7ce854f4c0450f71cd913a1a498016d656f7dc5b
+GitCommit: f6dc778627f1df208b28c8112d9aecd7840660be
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.6.1.

/cc @vdemeester @emilevauge

Cheers
