### PR TITLE
Add Solr 7.3.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,75 +6,75 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 7.3.1, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.3
 
 Tags: 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.3/alpine
 
 Tags: 7.3.1-slim, 7.3-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.2
 
 Tags: 7.2.1-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.2/alpine
 
 Tags: 7.2.1-slim, 7.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.1/slim
 
 Tags: 6.6.3, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 6.6
 
 Tags: 6.6.3-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 6.6/alpine
 
 Tags: 6.6.3-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
+GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 5.5/slim

--- a/library/solr
+++ b/library/solr
@@ -4,77 +4,77 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.3.0, 7.3, 7, latest
+Tags: 7.3.1, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.3
 
-Tags: 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
+Tags: 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.3/alpine
 
-Tags: 7.3.0-slim, 7.3-slim, 7-slim, slim
+Tags: 7.3.1-slim, 7.3-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78b52ecefa3441518561bdd504a2ac8b53755540
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.2
 
 Tags: 7.2.1-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.2/alpine
 
 Tags: 7.2.1-slim, 7.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 7.1/slim
 
 Tags: 6.6.3, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 6.6
 
 Tags: 6.6.3-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 6.6/alpine
 
 Tags: 6.6.3-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b980ef6a0b997dd0d32be6aca1115d0099e1391
+GitCommit: e275521f113b034584a1d4d30f133d1184df72a7
 Directory: 5.5/slim


### PR DESCRIPTION
Update Solr to 7.3.1.

Announcement: http://lucene.apache.org/solr/news.html#15-may-2018-apache-solrtm-731-available
Changes: https://lucene.apache.org/solr/7_3_1/changes/Changes.html

On the docker-solr side:
- added `gosu`
- added `/opt/mysolrhome` for users of `INIT_SOLR_HOME=yes` with docker volumes