### PR TITLE
Official Convertigo 7.5.2 version

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -1,14 +1,14 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/docker
-GitCommit: bf0c0d0e3f4421e8dea60da9cc2da148e11c89a5
+GitCommit: 9b85b87284dafb51a040903d81aea9e5f6c1a9db
 
-Tags: 7.5.1, 7.5, latest
+Tags: 7.5.2, 7.5, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 7.5/7.5.1
+Directory: 7.5/7.5.2
 
-Tags: 7.5.1-alpine, 7.5-alpine, alpine
+Tags: 7.5.2-alpine, 7.5-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386
-Directory: 7.5/7.5.1/alpine
+Directory: 7.5/7.5.2/alpine
 
 Tags: 7.4.8, 7.4
 Architectures: amd64, arm32v7, arm64v8, i386


### PR DESCRIPTION
Update to the fresh Convertigo 7.5.2 version.

Thanks! 👍