### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.7, 1.22, 1, latest
+Tags: 1.22.8, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34c67df3c75a9db60aeab5dc23075fdf4d78e44f
+GitCommit: 6c929d2edd66b8a2ad621922a594b4f6cf584047
 Directory: 1/debian
 
-Tags: 1.22.7-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.8-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 34c67df3c75a9db60aeab5dc23075fdf4d78e44f
+GitCommit: 6c929d2edd66b8a2ad621922a594b4f6cf584047
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -8,8 +8,8 @@ Tags: 10.3.6, 10.3
 GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
 Directory: 10.3
 
-Tags: 10.2.14, 10.2, 10, latest
-GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
+Tags: 10.2.15, 10.2, 10, latest
+GitCommit: c10d7ea8573bc40dd6a6ba851e86c292b7fc78eb
 Directory: 10.2
 
 Tags: 10.1.33, 10.1

--- a/library/mongo
+++ b/library/mongo
@@ -12,12 +12,12 @@ Architectures: amd64
 GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
 Directory: 3.2
 
-Tags: 3.4.14-jessie, 3.4-jessie
-SharedTags: 3.4.14, 3.4
+Tags: 3.4.15-jessie, 3.4-jessie
+SharedTags: 3.4.15, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386 is empty, as is ppc64el)
 Architectures: amd64
-GitCommit: b96fddd1e1a100c01f0ea6d28e1c7ccc750fd5c0
+GitCommit: f77d645e749bdda0740a35c00213baae8859edf2
 Directory: 3.4
 
 Tags: 3.6.4-jessie, 3.6-jessie, 3-jessie, jessie

--- a/library/percona
+++ b/library/percona
@@ -12,6 +12,6 @@ Tags: 5.6.39, 5.6
 GitCommit: a3ba3b6a69a6c7a21e9ea2d4a5b746b9829039eb
 Directory: 5.6
 
-Tags: 5.5.59, 5.5
-GitCommit: 6b511c1afee7545d8e3ebe307d3186cf7c92bb2d
+Tags: 5.5.60, 5.5
+GitCommit: 12afad5976f769f545bb9f85583e40e84109b80c
 Directory: 5.5

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 3.2/32bit
 
 Tags: 3.2.11-alpine, 3.2-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f69a5c2109cd8099126548bda5d6983dec02dcf
+GitCommit: d24f2be82673ccef6957210cc985e392ebdc65e4
 Directory: 3.2/alpine
 
 Tags: 4.0.9, 4.0, 4, latest
@@ -31,5 +31,5 @@ Directory: 4.0/32bit
 
 Tags: 4.0.9-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e20bfbe22f999959f8997a823fa1ed5784fd8cc
+GitCommit: d24f2be82673ccef6957210cc985e392ebdc65e4
 Directory: 4.0/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 7885b55d69f209c5aa676ba60b727dd240e199bd
 Directory: 3.4
 
 Tags: 3.4.5-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
+GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.4/passenger
 
 Tags: 3.3.7, 3.3
@@ -19,7 +19,7 @@ GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
 Directory: 3.3
 
 Tags: 3.3.7-passenger, 3.3-passenger
-GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
+GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.3/passenger
 
 Tags: 3.2.9, 3.2
@@ -28,5 +28,5 @@ GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
 Directory: 3.2
 
 Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: ba7d91e6a5974c41a8fc91c9042a2e53410e6764
+GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -6,52 +6,52 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-onbuild, 2.4-onbuild
@@ -61,37 +61,37 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.4-alpine3.4, 2.4-alpine3.4
 Architectures: amd64
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.7-stretch, 2.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-onbuild, 2.3-onbuild
@@ -101,17 +101,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.7-alpine3.4, 2.3-alpine3.4, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.10-jessie, 2.2-jessie, 2.2.10, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
+GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
 Directory: 2.2/jessie
 
 Tags: 2.2.10-slim-jessie, 2.2-slim-jessie, 2.2.10-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
+GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.10-onbuild, 2.2-onbuild
@@ -121,5 +121,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.10-alpine3.4, 2.2-alpine3.4, 2.2.10-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
+GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
 Directory: 2.2/alpine3.4

--- a/library/ruby
+++ b/library/ruby
@@ -6,52 +6,52 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-onbuild, 2.4-onbuild
@@ -61,37 +61,37 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.6
 
 Tags: 2.4.4-alpine3.4, 2.4-alpine3.4
 Architectures: amd64
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
 Directory: 2.4/alpine3.4
 
 Tags: 2.3.7-stretch, 2.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-onbuild, 2.3-onbuild
@@ -101,17 +101,17 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.7-alpine3.4, 2.3-alpine3.4, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
 Directory: 2.3/alpine3.4
 
 Tags: 2.2.10-jessie, 2.2-jessie, 2.2.10, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/jessie
 
 Tags: 2.2.10-slim-jessie, 2.2-slim-jessie, 2.2.10-slim, 2.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/jessie/slim
 
 Tags: 2.2.10-onbuild, 2.2-onbuild
@@ -121,5 +121,5 @@ Directory: 2.2/jessie/onbuild
 
 Tags: 2.2.10-alpine3.4, 2.2-alpine3.4, 2.2.10-alpine, 2.2-alpine
 Architectures: amd64
-GitCommit: b5ef401d348ca9b1d9f6a5cb4b25f32bf013daca
+GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
 Directory: 2.2/alpine3.4

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.5-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.5-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.6-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.6-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php5.6/apache
 
-Tags: 4.9.5-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.6-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php5.6/fpm
 
-Tags: 4.9.5-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.6-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.5-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.5-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.6-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.6-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.0/apache
 
-Tags: 4.9.5-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.6-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.0/fpm
 
-Tags: 4.9.5-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.6-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.5-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.5-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.6-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.6-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.1/apache
 
-Tags: 4.9.5-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.6-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.1/fpm
 
-Tags: 4.9.5-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.6-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.5-apache, 4.9-apache, 4-apache, apache, 4.9.5, 4.9, 4, latest, 4.9.5-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.5-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.6-apache, 4.9-apache, 4-apache, apache, 4.9.6, 4.9, 4, latest, 4.9.6-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.6-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.2/apache
 
-Tags: 4.9.5-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.5-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.6-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.6-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.2/fpm
 
-Tags: 4.9.5-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.5-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.6-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.6-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1caade96b306d0ed12f5637196e8f0b1883330f5
+GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost`: 1.22.8
- `mariadb`: 10.2.15
- `mongo`: 3.4.15
- `percona`: 5.5.60
- `redis`: add `jemalloc-dev` for `arm32v6` (docker-library/redis#137)
- `redmine`: passenger 5.3.1
- ~~`ruby`: rubygems 2.7.7~~
- `wordpress`: 4.9.6