### PR TITLE
Update Solr to 6.6.4

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -49,19 +49,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.1/slim
 
-Tags: 6.6.3, 6.6, 6
+Tags: 6.6.4, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
+GitCommit: 88259161626bc9f6803076024f35c681feffa275
 Directory: 6.6
 
-Tags: 6.6.3-alpine, 6.6-alpine, 6-alpine
+Tags: 6.6.4-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
+GitCommit: 88259161626bc9f6803076024f35c681feffa275
 Directory: 6.6/alpine
 
-Tags: 6.6.3-slim, 6.6-slim, 6-slim
+Tags: 6.6.4-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
+GitCommit: 88259161626bc9f6803076024f35c681feffa275
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201805.mbox/%3CCAHPRk5FLjFzh%3DnVfCU4hd7EpN3uGiquc%2BGoGgARHztCg8B0YjQ%40mail.gmail.com%3E
Changes: https://lucene.apache.org/solr/6_6_4/changes/Changes.html