### PR TITLE
Add Friendica

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -26,7 +26,7 @@ Architectures: amd64
 GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
 Directory: develop/fpm
 
-Tags: 208-05-dev-fpm-alpine, develop-fpm-alpine, dev-fpm-alpine
+Tags: 2018-05-dev-fpm-alpine, develop-fpm-alpine, dev-fpm-alpine
 Architectures: amd64
 GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
 Directory: develop/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -3,30 +3,30 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 3.6-apache, apache, stable-apache, production-apache, 3.6, latest, stable, production
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: stable/apache
 
 Tags: 3.6-fpm, fpm, stable-fpm, production-fpm
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: stable/fpm
 
 Tags: 3.6-fpm-alpine, fpm-alpine, stable-fpm-alpine, production-fpm-alpine
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: stable/fpm-alpine
 
 Tags: 2018-05-dev-apache, develop-apache, dev-apache, dev, develop
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: develop/apache
 
 Tags: 2018-05-dev-fpm, develop-fpm, dev-fpm
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: develop/fpm
 
 Tags: 2018-05-dev-fpm-alpine, develop-fpm-alpine, dev-fpm-alpine
 Architectures: amd64
-GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+GitCommit: 1e6852cd9a8b77a1245ac523aef2c9ed93cbbe63
 Directory: develop/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -1,0 +1,32 @@
+Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@philipp.info> (@nupplaphil)
+GitRepo: https://github.com/friendica/docker.git
+
+Tags: 3.6-apache, apache, stable-apache, production-apache, 3.6, latest, stable, production
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: stable/apache
+
+Tags: 3.6-fpm, fpm, stable-fpm, production-fpm
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: stable/fpm
+
+Tags: 3.6-fpm-alpine, fpm-alpine, stable-fpm-alpine, production-fpm-alpine
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: stable/fpm-alpine
+
+Tags: 2018-05-dev-apache, develop-apache, dev-apache, dev, develop
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: develop/apache
+
+Tags: 2018-05-dev-fpm, develop-fpm, dev-fpm
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: develop/fpm
+
+Tags: 208-05-dev-fpm-alpine, develop-fpm-alpine, dev-fpm-alpine
+Architectures: amd64
+GitCommit: 9c954f4d6bc90c61f9b3552fbbf8a5f6e70580ad
+Directory: develop/fpm-alpine


### PR DESCRIPTION
Hi,

I do want to push some Friendica base images to the official-images.
This is the first PR to make things work. In case we get merged, we prepare the images for other architectures (e.g. `i386`) and maybe other PHP version (e.g. `5.6`).

-	[x] associated with or contacted upstream? 

Upstream support: @friendica @MrPetovan @tobiasd

-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")

Base distribution for Friendica (a decentralized social network)

-	[x] is it reasonably popular, or does it solve a particular use case well?

See https://friendi.ca

-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)

See https://github.com/docker-library/docs/pull/1234

-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?

As good as we can. The images are influenced by the docker-images of https://github.com/nextcloud/docker

-	[ ] 2+ dockerization review?

I'm afraid, I don't think so. @MrPetovan @tobiasd made a review, but we are not THAT familiar with docker. I'm creating personal docker-images/containers for about 2 years.

-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)

The base is `php:7.1` (apache, fpm, fpm-alpine)

-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)

See https://travis-ci.org/friendica/docker