### PR TITLE
Bump Traefik to v1.6.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.1, 1.6.1, v1.6, 1.6, tetedemoine, latest
+Tags: v1.6.2, 1.6.2, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f6dc778627f1df208b28c8112d9aecd7840660be
+GitCommit: 0389d588f1989665e706a1ba0e8ed923adae753d
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.6.1-alpine, 1.6.1-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
+Tags: v1.6.2-alpine, 1.6.2-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f6dc778627f1df208b28c8112d9aecd7840660be
+GitCommit: 0389d588f1989665e706a1ba0e8ed923adae753d
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.6.2.

/cc @vdemeester @emilevauge @ldez

Cheers
