### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,48 +1,48 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/bd762e07558c59b80eb69367835936ce07ca8bc0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/f1c44d7cbee0bffb71cdc0b1c34ccb4927efa76b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
-             Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
+             Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: bd762e07558c59b80eb69367835936ce07ca8bc0
+GitCommit: f1c44d7cbee0bffb71cdc0b1c34ccb4927efa76b
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3dcdbaf646be956f92a1f9da84cabe2fdcd53a15
+amd64-GitCommit: fe634680e32659aaf0ee0594805f74f332619a90
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: cfaaed006e4c01ba88ff9956f98981bd1d80d896
+arm32v5-GitCommit: 6aa295788aa8d5d4479f4049c16f0b5437429a48
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: bfaff5d0e60b144ec48fd2c7b282474a6faeb210
+arm32v6-GitCommit: 91b3752f551f9a9fef5c348592dfb891791ea3ea
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 97be2e6bc9cea603f6595ce25b7167333e8becfc
+arm32v7-GitCommit: 7999d9270d327742972e5fc07dd0814794943056
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9aa5bcf197d4b58a13fea0da849bc1883019e1d6
+arm64v8-GitCommit: 9e0791531420ee5806a9867efcf8ff32441883fa
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 24c73d484d4d4fd2e173a9f391b322188047a48a
+i386-GitCommit: 548de304fffc34dacb7bf217ae86e3ad2b663c7c
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 5706e321c74f8b71d3450307ea101f879d0661d6
+ppc64le-GitCommit: 7a707d54eb34d8ade76d20b8eff8f74fccf03825
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: bc9c901b4f5b61c569d34283921afed9557bb796
+s390x-GitCommit: 1b15bf82d120140790a02ceca6980449223db29b
 
-Tags: 1.28.3-uclibc, 1.28-uclibc, 1-uclibc, uclibc
+Tags: 1.28.4-uclibc, 1.28-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: uclibc
 
-Tags: 1.28.3-glibc, 1.28-glibc, 1-glibc, glibc
+Tags: 1.28.4-glibc, 1.28-glibc, 1-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: glibc
 
-Tags: 1.28.3-musl, 1.28-musl, 1-musl, musl
+Tags: 1.28.4-musl, 1.28-musl, 1-musl, musl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: musl
 
-Tags: 1.28.3, 1.28, 1, latest
+Tags: 1.28.4, 1.28, 1, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
 arm32v5-Directory: uclibc

--- a/library/cassandra
+++ b/library/cassandra
@@ -1,11 +1,11 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/e3667b174ec7705ee383c98a5dab78789be3ff86/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/deeb9b3ede9118ce4f642860d74c8513d39461b8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
-Architectures: amd64, i386
+Architectures: amd64, arm64v8, i386
 GitCommit: 01786683a1b060f813bce5539b1743695f9cc043
 Directory: 2.1
 

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.22.8, 1.22, 1, latest
+Tags: 1.23.0, 1.23, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c929d2edd66b8a2ad621922a594b4f6cf584047
+GitCommit: 88a49fdb0539c3f810f62dbc346d04c65aefe5cf
 Directory: 1/debian
 
-Tags: 1.22.8-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.23.0-alpine, 1.23-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 6c929d2edd66b8a2ad621922a594b4f6cf584047
+GitCommit: 88a49fdb0539c3f810f62dbc346d04c65aefe5cf
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: f12d1ddc03e1061f379893cb97cb26931f82ed81
 Directory: 1.7/alpine
 
-Tags: 1.8.8, 1.8, 1, latest
+Tags: 1.8.9, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c6d92913f56e05d6985d2f0f2131675de68f915
+GitCommit: 7837715e428efe0943053aae0130c709d017fd81
 Directory: 1.8
 
-Tags: 1.8.8-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.9-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: feefabf1ea0f03879f9d529dcc5b8ec6f3112bba
+GitCommit: 7837715e428efe0943053aae0130c709d017fd81
 Directory: 1.8/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.6, 10.3
-GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
+GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.3
 
 Tags: 10.2.15, 10.2, 10, latest
-GitCommit: c10d7ea8573bc40dd6a6ba851e86c292b7fc78eb
+GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.2
 
 Tags: 10.1.33, 10.1
-GitCommit: 662b59f5d1418a93ba0f10982338514b376a5ed0
+GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.1
 
 Tags: 10.0.35, 10.0
-GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
+GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.0
 
 Tags: 5.5.60, 5.5, 5
-GitCommit: 27b1b68e3bd68f114609090ccb54318fe48d7e7e
+GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/b9ae5fa0781a4f80e0ccb6d585edc569fd207f15/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/de4376792e103d35e9b16a023c4046d17cf15f22/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/mongo.git
 Tags: 3.2.20-jessie, 3.2-jessie
 SharedTags: 3.2.20, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
-# (i386 is empty, as is ppc64el)
+# (i386, ppc64el, s390x are empty)
 Architectures: amd64
 GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
 Directory: 3.2
@@ -15,23 +15,31 @@ Directory: 3.2
 Tags: 3.4.15-jessie, 3.4-jessie
 SharedTags: 3.4.15, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
-# (i386 is empty, as is ppc64el)
+# (i386, ppc64el, s390x are empty)
 Architectures: amd64
 GitCommit: f77d645e749bdda0740a35c00213baae8859edf2
 Directory: 3.4
 
-Tags: 3.6.4-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.4, 3.6, 3, latest
+Tags: 3.6.5-jessie, 3.6-jessie, 3-jessie, jessie
+SharedTags: 3.6.5, 3.6, 3, latest
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
-# (i386 is empty, as is ppc64el)
+# (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: dd8ceb3b3552d11c901a603d0b8b303e2fe4bc2e
+GitCommit: 4e9a69f44326f034efa79ded2275ec856673bee1
 Directory: 3.6
 
-Tags: 3.7.9-jessie, 3.7-jessie, unstable-jessie
+Tags: 3.7.9-xenial, 3.7-xenial, unstable-xenial
 SharedTags: 3.7.9, 3.7, unstable
-# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.7/main/
-# (i386 is empty, as is ppc64el)
-Architectures: amd64
-GitCommit: 25295e42263584fff5f88dcbe196c0e36f2abcc5
+# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/3.7/multiverse/
+# (i386, ppc64el, s390x are empty)
+Architectures: amd64, arm64v8
+GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
 Directory: 3.7
+
+Tags: 4.0.0-rc0-xenial, 4.0-rc-xenial, rc-xenial
+SharedTags: 4.0.0-rc0, 4.0-rc, rc
+# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/testing/multiverse/
+# (i386, ppc64el, s390x are empty)
+Architectures: amd64, arm64v8
+GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
+Directory: 4.0-rc

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/df1c388d3a8732bac85d25583880e915aaa47395/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/0139cd64d90988807a460ca65c7867d9446ab08e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,137 +24,197 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.5-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.5-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.5-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.5-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.5-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.5-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.5-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.5-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.5-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.5-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.5-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.5-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.5-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.5-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6, 7.2.5-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.5-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.5-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.5-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.5-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6, 7.2.5-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.5-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.5-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6, 7.2.5-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.5-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.17-cli-jessie, 7.1-cli-jessie, 7.1.17-jessie, 7.1-jessie, 7.1.17-cli, 7.1-cli, 7.1.17, 7.1
+Tags: 7.1.17-cli-stretch, 7.1-cli-stretch, 7.1.17-stretch, 7.1-stretch, 7.1.17-cli, 7.1-cli, 7.1.17, 7.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/stretch/cli
+
+Tags: 7.1.17-apache-stretch, 7.1-apache-stretch, 7.1.17-apache, 7.1-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 7.1/stretch/apache
+
+Tags: 7.1.17-fpm-stretch, 7.1-fpm-stretch, 7.1.17-fpm, 7.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/stretch/fpm
+
+Tags: 7.1.17-zts-stretch, 7.1-zts-stretch, 7.1.17-zts, 7.1-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/stretch/zts
+
+Tags: 7.1.17-cli-jessie, 7.1-cli-jessie, 7.1.17-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.17-apache-jessie, 7.1-apache-jessie, 7.1.17-apache, 7.1-apache
+Tags: 7.1.17-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.17-fpm-jessie, 7.1-fpm-jessie, 7.1.17-fpm, 7.1-fpm
+Tags: 7.1.17-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.17-zts-jessie, 7.1-zts-jessie, 7.1.17-zts, 7.1-zts
+Tags: 7.1.17-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.17-cli-alpine3.4, 7.1-cli-alpine3.4, 7.1.17-alpine3.4, 7.1-alpine3.4, 7.1.17-cli-alpine, 7.1-cli-alpine, 7.1.17-alpine, 7.1-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.1/alpine3.4/cli
+Tags: 7.1.17-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.17-alpine3.7, 7.1-alpine3.7, 7.1.17-cli-alpine, 7.1-cli-alpine, 7.1.17-alpine, 7.1-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.17-fpm-alpine3.4, 7.1-fpm-alpine3.4, 7.1.17-fpm-alpine, 7.1-fpm-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.1/alpine3.4/fpm
+Tags: 7.1.17-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.17-fpm-alpine, 7.1-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.17-zts-alpine3.4, 7.1-zts-alpine3.4, 7.1.17-zts-alpine, 7.1-zts-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.1/alpine3.4/zts
+Tags: 7.1.17-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.17-zts-alpine, 7.1-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.1/alpine3.7/zts
 
-Tags: 7.0.30-cli-jessie, 7.0-cli-jessie, 7.0.30-jessie, 7.0-jessie, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
+Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/stretch/cli
+
+Tags: 7.0.30-apache-stretch, 7.0-apache-stretch, 7.0.30-apache, 7.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 7.0/stretch/apache
+
+Tags: 7.0.30-fpm-stretch, 7.0-fpm-stretch, 7.0.30-fpm, 7.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/stretch/fpm
+
+Tags: 7.0.30-zts-stretch, 7.0-zts-stretch, 7.0.30-zts, 7.0-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/stretch/zts
+
+Tags: 7.0.30-cli-jessie, 7.0-cli-jessie, 7.0.30-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.30-apache-jessie, 7.0-apache-jessie, 7.0.30-apache, 7.0-apache
+Tags: 7.0.30-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.30-fpm-jessie, 7.0-fpm-jessie, 7.0.30-fpm, 7.0-fpm
+Tags: 7.0.30-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.30-zts-jessie, 7.0-zts-jessie, 7.0.30-zts, 7.0-zts
+Tags: 7.0.30-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.30-cli-alpine3.4, 7.0-cli-alpine3.4, 7.0.30-alpine3.4, 7.0-alpine3.4, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.0/alpine3.4/cli
+Tags: 7.0.30-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.30-alpine3.7, 7.0-alpine3.7, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/alpine3.7/cli
 
-Tags: 7.0.30-fpm-alpine3.4, 7.0-fpm-alpine3.4, 7.0.30-fpm-alpine, 7.0-fpm-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.0/alpine3.4/fpm
+Tags: 7.0.30-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.30-fpm-alpine, 7.0-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/alpine3.7/fpm
 
-Tags: 7.0.30-zts-alpine3.4, 7.0-zts-alpine3.4, 7.0.30-zts-alpine, 7.0-zts-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 7.0/alpine3.4/zts
+Tags: 7.0.30-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.30-zts-alpine, 7.0-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 7.0/alpine3.7/zts
 
-Tags: 5.6.36-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.36-jessie, 5.6-jessie, 5-jessie, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
+Tags: 5.6.36-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.36-stretch, 5.6-stretch, 5-stretch, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 5.6/stretch/cli
+
+Tags: 5.6.36-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.36-apache, 5.6-apache, 5-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 5.6/stretch/apache
+
+Tags: 5.6.36-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.36-fpm, 5.6-fpm, 5-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 5.6/stretch/fpm
+
+Tags: 5.6.36-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.36-zts, 5.6-zts, 5-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+Directory: 5.6/stretch/zts
+
+Tags: 5.6.36-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.36-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.36-apache-jessie, 5.6-apache-jessie, 5-apache-jessie, 5.6.36-apache, 5.6-apache, 5-apache
+Tags: 5.6.36-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.36-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie, 5.6.36-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.36-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.36-zts-jessie, 5.6-zts-jessie, 5-zts-jessie, 5.6.36-zts, 5.6-zts, 5-zts
+Tags: 5.6.36-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.36-cli-alpine3.4, 5.6-cli-alpine3.4, 5-cli-alpine3.4, 5.6.36-alpine3.4, 5.6-alpine3.4, 5-alpine3.4, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 5.6/alpine3.4/cli
+Tags: 5.6.36-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.36-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 5.6/alpine3.7/cli
 
-Tags: 5.6.36-fpm-alpine3.4, 5.6-fpm-alpine3.4, 5-fpm-alpine3.4, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 5.6/alpine3.4/fpm
+Tags: 5.6.36-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 5.6/alpine3.7/fpm
 
-Tags: 5.6.36-zts-alpine3.4, 5.6-zts-alpine3.4, 5-zts-alpine3.4, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-Architectures: amd64
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
-Directory: 5.6/alpine3.4/zts
+Tags: 5.6.36-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+Directory: 5.6/alpine3.7/zts

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: de8ba87d50de466a1e05e111927d2bc30c2db36d
+GitCommit: cdbe05265f849b028e44c01b942db7055bf37101
 Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4cb816b3deccc29393b8278d1a5f144d2be26f1
+GitCommit: 46bc23cd0dbb7935e3d2baaddfefaed42ac65ce2
 Directory: 9.6
 
 Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
@@ -26,7 +26,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.13, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d545428bfe50f634b4aa9114eff0c5efe1d72f94
+GitCommit: 54bfbc5fbef9f33d678e87470e4b7ab5ce6dd12b
 Directory: 9.5
 
 Tags: 9.5.13-alpine, 9.5-alpine
@@ -36,7 +36,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.18, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e348a2fe235d28692344de64c05640c38361554d
+GitCommit: 2534f4526aab1a378096e78a0052baeee88441b5
 Directory: 9.4
 
 Tags: 9.4.18-alpine, 9.4-alpine
@@ -46,7 +46,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.23, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 253471cd5c62c48867640bcb925ffad19a24d5d9
+GitCommit: 5ce8fc72310bf7026c971d9ce971e4ad57f0802f
 Directory: 9.3
 
 Tags: 9.3.23-alpine, 9.3-alpine

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/81f4542f38f7978cb57206b300ced41ae9687c9b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/a8eaaf400780f2b92422829a01cbd6368eed32ee/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -35,22 +35,22 @@ Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.5-stretch, 3.6-stretch, 3-stretch, stretch
+SharedTags: 3.6.5, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
 Directory: 3.6/stretch
 
-Tags: 3.6.5-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch
+Tags: 3.6.5-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch, 3.6.5-slim, 3.6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.5-jessie, 3.6-jessie, 3-jessie, jessie
-SharedTags: 3.6.5, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
 Directory: 3.6/jessie
 
-Tags: 3.6.5-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie, 3.6.5-slim, 3.6-slim, 3-slim, slim
+Tags: 3.6.5-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 3.6/jessie/slim
@@ -60,7 +60,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
-Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7
+Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7, 3.6.5-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
 Directory: 3.6/alpine3.7
@@ -69,11 +69,6 @@ Tags: 3.6.5-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
 Directory: 3.6/alpine3.6
-
-Tags: 3.6.5-alpine3.4, 3.6-alpine3.4, 3-alpine3.4, alpine3.4, 3.6.5-alpine, 3.6-alpine, 3-alpine, alpine
-Architectures: amd64
-GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
-Directory: 3.6/alpine3.4
 
 Tags: 3.6.5-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.6.5-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.5, 3.6, 3, latest
@@ -90,12 +85,11 @@ Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.5-jessie, 3.5-jessie
-SharedTags: 3.5.5, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a652f35d6ce77f02ca268d67f39e7dfa24cf08c5
 Directory: 3.5/jessie
 
-Tags: 3.5.5-slim-jessie, 3.5-slim-jessie, 3.5.5-slim, 3.5-slim
+Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 3.5/jessie/slim
@@ -105,18 +99,17 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.5/jessie/onbuild
 
-Tags: 3.5.5-alpine3.4, 3.5-alpine3.4, 3.5.5-alpine, 3.5-alpine
-Architectures: amd64
-GitCommit: a652f35d6ce77f02ca268d67f39e7dfa24cf08c5
-Directory: 3.5/alpine3.4
+Tags: 3.5.5-alpine3.7, 3.5-alpine3.7, 3.5.5-alpine, 3.5-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a8eaaf400780f2b92422829a01cbd6368eed32ee
+Directory: 3.5/alpine3.7
 
 Tags: 3.4.8-jessie, 3.4-jessie
-SharedTags: 3.4.8, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 92b33f97f0e1f1faabca46aee0f5520c1b038ed5
 Directory: 3.4/jessie
 
-Tags: 3.4.8-slim-jessie, 3.4-slim-jessie, 3.4.8-slim, 3.4-slim
+Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 3.4/jessie/slim
@@ -131,28 +124,28 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 92b33f97f0e1f1faabca46aee0f5520c1b038ed5
 Directory: 3.4/wheezy
 
-Tags: 3.4.8-alpine3.4, 3.4-alpine3.4, 3.4.8-alpine, 3.4-alpine
-Architectures: amd64
-GitCommit: 92b33f97f0e1f1faabca46aee0f5520c1b038ed5
-Directory: 3.4/alpine3.4
+Tags: 3.4.8-alpine3.7, 3.4-alpine3.7, 3.4.8-alpine, 3.4-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a8eaaf400780f2b92422829a01cbd6368eed32ee
+Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
+SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
 Directory: 2.7/stretch
 
-Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
+Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
-SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
 Directory: 2.7/jessie
 
-Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie, 2.7.15-slim, 2.7-slim, 2-slim
+Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
 Directory: 2.7/jessie/slim
@@ -167,7 +160,7 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
 Directory: 2.7/wheezy
 
-Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
+Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
 Directory: 2.7/alpine3.7
@@ -176,11 +169,6 @@ Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
 Directory: 2.7/alpine3.6
-
-Tags: 2.7.15-alpine3.4, 2.7-alpine3.4, 2-alpine3.4, 2.7.15-alpine, 2.7-alpine, 2-alpine
-Architectures: amd64
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
-Directory: 2.7/alpine3.4
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.64.1, 0.64, 0, latest
-GitCommit: 19fedd2425d940dd6a513c5c4ff01dfafa83a9f9
+Tags: 0.64.2, 0.64, 0, latest
+GitCommit: 7ec1959e223e61993c652d50e77a90e884b06be9

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/06881d7ebd92ceecd9695102b516299d63651ffb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/7766c719ed4c11dd52a8e0e35195ec82097aebfe/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,52 +6,52 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0740f2479625032bee21ea5c3a29e74464057c9
+GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c9644fe5c95cd71913db348baa41240f05d882b3
+GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
 Directory: 2.5/alpine3.7
 
-Tags: 2.4.4-stretch, 2.4-stretch
+Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/stretch
 
-Tags: 2.4.4-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.4-jessie, 2.4-jessie, 2.4.4, 2.4
+Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/jessie
 
-Tags: 2.4.4-slim-jessie, 2.4-slim-jessie, 2.4.4-slim, 2.4-slim
+Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-onbuild, 2.4-onbuild
@@ -61,37 +61,32 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
+GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
 Directory: 2.4/alpine3.6
 
-Tags: 2.4.4-alpine3.4, 2.4-alpine3.4
-Architectures: amd64
-GitCommit: 1bd8b466277668bff50528b26360e6e451e4dae4
-Directory: 2.4/alpine3.4
-
-Tags: 2.3.7-stretch, 2.3-stretch
+Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/stretch
 
-Tags: 2.3.7-slim-stretch, 2.3-slim-stretch
+Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/stretch/slim
 
-Tags: 2.3.7-jessie, 2.3-jessie, 2.3.7, 2.3
+Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/jessie
 
-Tags: 2.3.7-slim-jessie, 2.3-slim-jessie, 2.3.7-slim, 2.3-slim
+Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
+GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-onbuild, 2.3-onbuild
@@ -99,27 +94,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
 Directory: 2.3/jessie/onbuild
 
-Tags: 2.3.7-alpine3.4, 2.3-alpine3.4, 2.3.7-alpine, 2.3-alpine
-Architectures: amd64
-GitCommit: 78ecfcb108930a94eded6dfe1be50246052dc632
-Directory: 2.3/alpine3.4
-
-Tags: 2.2.10-jessie, 2.2-jessie, 2.2.10, 2.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
-Directory: 2.2/jessie
-
-Tags: 2.2.10-slim-jessie, 2.2-slim-jessie, 2.2.10-slim, 2.2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
-Directory: 2.2/jessie/slim
-
-Tags: 2.2.10-onbuild, 2.2-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
-Directory: 2.2/jessie/onbuild
-
-Tags: 2.2.10-alpine3.4, 2.2-alpine3.4, 2.2.10-alpine, 2.2-alpine
-Architectures: amd64
-GitCommit: e48cb2431e5cdcd99ce8d8c236d7b73e7d4452f2
-Directory: 2.2/alpine3.4
+Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 7766c719ed4c11dd52a8e0e35195ec82097aebfe
+Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `busybox`: 1.28.4
- `cassandra`: arm64v8 on 2.1 (docker-library/cassandra#147)
- `ghost`: 1.23.0
- `haproxy`: 1.8.9
- `mariadb`: extra `mysqld` flags to `mysql_install_db` (docker-library/mariadb#168)
- `mongo`: 3.6.5, 4.0.0-rc0, move 4.0-rc and 3.7 to Xenial (docker-library/mongo#275)
- `php`: remove Alpine 3.4 (docker-library/php#650), add Stretch and Alpine 3.7 variants (docker-library/php#646)
- `postgres`: 10.4, 9.3.23, 9.4.18, 9.5.13, 9.6.9
- `python`: remove Alpine 3.4, add Alpine 3.7 (docker-library/python#290)
- `rocket.chat`: 0.64.2
- `ruby`: remove Alpine 3.4, add Alpine 3.7 (docker-library/ruby#210), remove 2.2 (EOL; https://www.ruby-lang.org/en/downloads/branches/)