### PR TITLE
new ALT Linux base image supported by BaseALT

### DIFF
--- a/library/alt
+++ b/library/alt
@@ -1,0 +1,20 @@
+Maintainers: ALT Linux Team Cloud <alt-cloud@altlinux.org> (@alt-cloud),
+             Alexey Shabalin <shaba@altlinux.org> (@shaba),
+             Gleb Fotengauer-Malinovskiy <glebfm@altlinux.org> (@glebfm)
+GitRepo: https://github.com/alt-cloud/docker-brew-alt.git
+Constraints: !aufs
+
+Tags: p8, latest
+Architectures: amd64, i386
+GitFetch: refs/heads/p8
+GitCommit: a4632123106de690cb4417a8cea14a274cec685b
+amd64-Directory: x86_64/
+i386-Directory: i586/
+
+Tags: sisyphus
+Architectures: amd64, i386, arm64v8
+GitFetch: refs/heads/sisyphus
+GitCommit: 49f0643f2960c86abc72bbf2bb4f2392f3cad2c1
+amd64-Directory: x86_64/
+arm64v8-Directory: aarch64/
+i386-Directory: i586/

--- a/library/alt
+++ b/library/alt
@@ -7,14 +7,14 @@ Constraints: !aufs
 Tags: p8, latest
 Architectures: amd64, i386
 GitFetch: refs/heads/p8
-GitCommit: a4632123106de690cb4417a8cea14a274cec685b
+GitCommit: 36544e8ff97be06ce37670634c0e662957b8b6ad
 amd64-Directory: x86_64/
 i386-Directory: i586/
 
 Tags: sisyphus
 Architectures: amd64, i386, arm64v8
 GitFetch: refs/heads/sisyphus
-GitCommit: 49f0643f2960c86abc72bbf2bb4f2392f3cad2c1
+GitCommit: 96c27a4d66c2ad88d908a87701df71eac2092e38
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 i386-Directory: i586/


### PR DESCRIPTION
# Checklist for Review

- [x] associated with or contacted upstream?
https://en.altlinux.org
Associated with ALT Linux by BaseALT
- [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
base distribution
- [x] is it reasonably popular, or does it solve a particular use case well?
This is popular Linux distributive in Russia, sinse 2001.
https://distrowatch.com/index.php?distribution=alt
- [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
https://github.com/docker-library/docs/pull/1238
- [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.
md#review-guidelines))?
- [ ] 2+ dockerization review?
- [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
- [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
one commit for one branch(Tag).
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
