### PR TITLE
Node: Update for Node.js v10.2.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,66 +1,66 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/f384c2b6f19164bc89f7a579b92c417442c99c8c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/bb92568f3a1db52519b88c5eebfa9f7af94eb1e0/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 9.11.1, 9.11, 9
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 9
 
 Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
+Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 9/alpine
 
 Tags: 9.11.1-onbuild, 9.11-onbuild, 9-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/onbuild
 
 Tags: 9.11.1-slim, 9.11-slim, 9-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 9/slim
 
 Tags: 9.11.1-stretch, 9.11-stretch, 9-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 9/stretch
 
 Tags: 8.11.2, 8.11, 8, carbon
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 8
 
 Tags: 8.11.2-alpine, 8.11-alpine, 8-alpine, carbon-alpine
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
+Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 8/alpine
 
 Tags: 8.11.2-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
 Directory: 8/onbuild
 
 Tags: 8.11.2-slim, 8.11-slim, 8-slim, carbon-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 8/slim
 
 Tags: 8.11.2-stretch, 8.11-stretch, 8-stretch, carbon-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 8/stretch
 
 Tags: 6.14.2, 6.14, 6, boron
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6
 
 Tags: 6.14.2-alpine, 6.14-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/alpine
 
 Tags: 6.14.2-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
@@ -70,40 +70,40 @@ Directory: 6/onbuild
 
 Tags: 6.14.2-slim, 6.14-slim, 6-slim, boron-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/slim
 
 Tags: 6.14.2-stretch, 6.14-stretch, 6-stretch, boron-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/stretch
 
-Tags: 10.1.0, 10.1, 10, latest
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 773be66016fd1ff4a860529a80af61277f75c7e2
+Tags: 10.2.0, 10.2, 10, latest
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
 Directory: 10
 
-Tags: 10.1.0-alpine, 10.1-alpine, 10-alpine, alpine
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
-GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
+Tags: 10.2.0-alpine, 10.2-alpine, 10-alpine, alpine
+Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
 Directory: 10/alpine
 
-Tags: 10.1.0-slim, 10.1-slim, 10-slim, slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
+Tags: 10.2.0-slim, 10.2-slim, 10-slim, slim
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
 Directory: 10/slim
 
-Tags: 10.1.0-stretch, 10.1-stretch, 10-stretch, stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 2ecc9e8579f519ae3d267b5b497b8c04d6c7040d
+Tags: 10.2.0-stretch, 10.2-stretch, 10-stretch, stretch
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: eca9e8f34ca78bdba691e1d5ead82840e2673705
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: chakracore/8
 
 Tags: chakracore-10.0.0, chakracore-10.0, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: f713f15abe3ff05635326ba9716b7755c9d5f1aa
+GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: chakracore/10


### PR DESCRIPTION
Also includes:

- Update for Yarn 1.7.0 for v10 image
- Curl usage improvements
- Switch to jessie-slim for the slim variant