### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -30,7 +30,7 @@ GitCommit: 10087c4bbffb39e59372e9744df64ca9153334d8
 Directory: 8.4/fpm
 
 Tags: 8.4.8-fpm-alpine, 8.4-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 10087c4bbffb39e59372e9744df64ca9153334d8
 Directory: 8.4/fpm-alpine
 
@@ -45,7 +45,7 @@ GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
 Directory: 8.3/fpm
 
 Tags: 8.3.9-fpm-alpine, 8.3-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
 Directory: 8.3/fpm-alpine
 
@@ -60,6 +60,6 @@ GitCommit: ff8962fc943001457c6919fa42e3d875b9fab9f7
 Directory: 7/fpm
 
 Tags: 7.59-fpm-alpine, 7-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: ff8962fc943001457c6919fa42e3d875b9fab9f7
 Directory: 7/fpm-alpine

--- a/library/redmine
+++ b/library/redmine
@@ -15,18 +15,9 @@ Directory: 3.4/passenger
 
 Tags: 3.3.7, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
+GitCommit: bd4e9e8ed079772259cd4da9613f6ee78bd16183
 Directory: 3.3
 
 Tags: 3.3.7-passenger, 3.3-passenger
 GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.3/passenger
-
-Tags: 3.2.9, 3.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
-Directory: 3.2
-
-Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
-Directory: 3.2/passenger

--- a/library/redmine
+++ b/library/redmine
@@ -15,9 +15,18 @@ Directory: 3.4/passenger
 
 Tags: 3.3.7, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd4e9e8ed079772259cd4da9613f6ee78bd16183
+GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
 Directory: 3.3
 
 Tags: 3.3.7-passenger, 3.3-passenger
 GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.3/passenger
+
+Tags: 3.2.9, 3.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
+Directory: 3.2
+
+Tags: 3.2.9-passenger, 3.2-passenger
+GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
+Directory: 3.2/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -6,52 +6,52 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f01e5bae915b3c2e84fd4bf046ebb5dc4e5db29
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e703dc6278b7f12c84cdc587f1719cc2cf2aac96
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-onbuild, 2.4-onbuild
@@ -61,32 +61,32 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 395cce4eba52917eb9a40c72d50703a1ce9e1acd
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d06ea1d9574219883f37ecf3de7cbda2422516f
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-onbuild, 2.3-onbuild
@@ -96,5 +96,5 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7766c719ed4c11dd52a8e0e35195ec82097aebfe
+GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
 Directory: 2.3/alpine3.7

--- a/library/wordpress
+++ b/library/wordpress
@@ -15,7 +15,7 @@ GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php5.6/fpm
 
 Tags: 4.9.6-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php5.6/fpm-alpine
 
@@ -30,7 +30,7 @@ GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.0/fpm
 
 Tags: 4.9.6-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.0/fpm-alpine
 
@@ -45,7 +45,7 @@ GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.1/fpm
 
 Tags: 4.9.6-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
 Directory: php7.1/fpm-alpine
 
@@ -67,17 +67,17 @@ Directory: php7.2/fpm-alpine
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php5.6/cli
 
 Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php7.0/cli
 
 Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
-Architectures: amd64
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
 Directory: php7.1/cli
 


### PR DESCRIPTION
- `drupal`: new arches (thanks to Alpine 3.4 deprecation)
- ~~`redmine`: update Redmine 3.3 to Ruby 2.3, remove Redmine 3.2 (https://github.com/docker-library/redmine/pull/115)~~
- `ruby`: remove `BUNDLE_BIN`, adjust `PATH` (https://github.com/docker-library/ruby/pull/209)
- `wordpress`: new arches (thanks to Alpine 3.4 deprecation)