### PR TITLE
Node: Update for v10.2.1 and update chakracore to v10.1.0 

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/bb92568f3a1db52519b88c5eebfa9f7af94eb1e0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/fb8ac15c9c606e15cd7f37074d62061c39d1a6cb/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
@@ -78,24 +78,24 @@ Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/stretch
 
-Tags: 10.2.0, 10.2, 10, latest
+Tags: 10.2.1, 10.2, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
+GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
 Directory: 10
 
-Tags: 10.2.0-alpine, 10.2-alpine, 10-alpine, alpine
+Tags: 10.2.1-alpine, 10.2-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
+GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
 Directory: 10/alpine
 
-Tags: 10.2.0-slim, 10.2-slim, 10-slim, slim
+Tags: 10.2.1-slim, 10.2-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
+GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
 Directory: 10/slim
 
-Tags: 10.2.0-stretch, 10.2-stretch, 10-stretch, stretch
+Tags: 10.2.1-stretch, 10.2-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 772f98bd6e293078722cbdef5dea3b6b6fa69a3f
+GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
@@ -103,7 +103,7 @@ Architectures: amd64
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: chakracore/8
 
-Tags: chakracore-10.0.0, chakracore-10.0, chakracore-10, chakracore
+Tags: chakracore-10.1.0, chakracore-10.1, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 947280600648b70e067d35415d6812fd03127def
+GitCommit: 384512d45794367e0da3c4721559ae9e9ce9412e
 Directory: chakracore/10


### PR DESCRIPTION
Chakracore update includes Yarn update to 1.7.0

See:

- https://github.com/nodejs/docker-node/pull/759
- https://github.com/nodejs/docker-node/pull/758