### PR TITLE
Update docker-library images

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.6, 10.3
-GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
+Tags: 10.3.7, 10.3
+GitCommit: 9c407e44d78e10dbef48f5cfd450f84ab8a1702d
 Directory: 10.3
 
 Tags: 10.2.15, 10.2, 10, latest

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.7, 1.5, 1, latest
+Tags: 1.5.8, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d738ff7a7867423c9232adc7d9b418ce0f7597f0
+GitCommit: 2aae422228318150ae4f351d363d2fdbb5bfaf7c
 Directory: debian
 
-Tags: 1.5.7-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.8-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d738ff7a7867423c9232adc7d9b418ce0f7597f0
+GitCommit: 2aae422228318150ae4f351d363d2fdbb5bfaf7c
 Directory: alpine

--- a/library/php
+++ b/library/php
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.5-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.5-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.5-cli, 7.2-cli, 7-cli, cli, 7.2.5, 7.2, 7, latest
+Tags: 7.2.6-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.6-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.6-cli, 7.2-cli, 7-cli, cli, 7.2.6, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.5-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.5-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.6-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.6-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.5-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.5-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.6-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.6-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.5-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.5-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.6-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.6-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.5-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.5-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.5-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.5-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.6-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.6-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.6-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.6-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.5-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.5-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.6-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.6-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.5-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.5-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.6-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.6-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.5-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.5-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
+Tags: 7.2.6-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.6-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.5-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
+Tags: 7.2.6-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.5-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
+Tags: 7.2.6-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.17-cli-stretch, 7.1-cli-stretch, 7.1.17-stretch, 7.1-stretch, 7.1.17-cli, 7.1-cli, 7.1.17, 7.1

--- a/library/postgres
+++ b/library/postgres
@@ -6,50 +6,50 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cdbe05265f849b028e44c01b942db7055bf37101
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe8c9a4a309a889dc057d53bf3769c25c1522c65
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46bc23cd0dbb7935e3d2baaddfefaed42ac65ce2
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.6
 
 Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a06a9377438d8e0805e49ce65bbcb810a711df52
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.6/alpine
 
 Tags: 9.5.13, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 54bfbc5fbef9f33d678e87470e4b7ab5ce6dd12b
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.5
 
 Tags: 9.5.13-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 65f0c2afd32d2b2f4b8cf3d7a68461a7c3fa00a5
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.5/alpine
 
 Tags: 9.4.18, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2534f4526aab1a378096e78a0052baeee88441b5
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.4
 
 Tags: 9.4.18-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dcf1338d3a29d8244aecc12555e18267b8aaeed3
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.4/alpine
 
 Tags: 9.3.23, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ce8fc72310bf7026c971d9ce971e4ad57f0802f
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.3
 
 Tags: 9.3.23-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ea2860a21672636bed769e694f6af33f83270fda
+GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
 Directory: 9.3/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.5, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7885b55d69f209c5aa676ba60b727dd240e199bd
+GitCommit: cf4acba62e86fef7de93922b08ff85554e8978bd
 Directory: 3.4
 
 Tags: 3.4.5-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,18 +15,9 @@ Directory: 3.4/passenger
 
 Tags: 3.3.7, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd9663568f6e9617776f127a749a4f794ef4cf19
+GitCommit: cf4acba62e86fef7de93922b08ff85554e8978bd
 Directory: 3.3
 
 Tags: 3.3.7-passenger, 3.3-passenger
 GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.3/passenger
-
-Tags: 3.2.9, 3.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71453c2e7a7a0736a669a67c668f4abd59857605
-Directory: 3.2
-
-Tags: 3.2.9-passenger, 3.2-passenger
-GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
-Directory: 3.2/passenger

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,82 +6,82 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.6-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.6-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php5.6/apache
 
 Tags: 4.9.6-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php5.6/fpm
 
 Tags: 4.9.6-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.6-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.6-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.0/apache
 
 Tags: 4.9.6-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.0/fpm
 
 Tags: 4.9.6-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.6-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.6-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.1/apache
 
 Tags: 4.9.6-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.1/fpm
 
 Tags: 4.9.6-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.6-apache, 4.9-apache, 4-apache, apache, 4.9.6, 4.9, 4, latest, 4.9.6-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.6-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.2/apache
 
 Tags: 4.9.6-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.6-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.2/fpm
 
 Tags: 4.9.6-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.6-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 47c785a349228b2528b81f352dbc27d2146ee69f
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php5.6/cli
 
 Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.0/cli
 
 Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.1/cli
 
 Tags: cli-1.5.1, cli-1.5, cli-1, cli, cli-1.5.1-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 912d76560ec9e350e24aedd3a30268026082557a
+GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
 Directory: php7.2/cli


### PR DESCRIPTION
- `mariadb`: 10.3.7
- `memcached`: 1.5.8
- `php`: 7.2.6
- `postgres`: implement `nss_wrapper` for Debian variants (docker-library/postgres#448)
- `redmine`: fix build (docker-library/redmine#116)
- `wordpress`: add `zip` extension for "Export Personal Data" (docker-library/wordpress#304)