### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.23.0, 1.23, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88a49fdb0539c3f810f62dbc346d04c65aefe5cf
+GitCommit: dbab0321197d6dcb0ca4cefb0187806d447146b4
 Directory: 1/debian
 
 Tags: 1.23.0-alpine, 1.23-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 88a49fdb0539c3f810f62dbc346d04c65aefe5cf
+GitCommit: dbab0321197d6dcb0ca4cefb0187806d447146b4
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,14 +1,14 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/ae7d138ed25303f4067dcc9b2f2218342c5362c5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/4eb0a4a25e178260aeb65285d75cb777f009f932/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.7, 10.3
+Tags: 10.3.7, 10.3, 10, latest
 GitCommit: 9c407e44d78e10dbef48f5cfd450f84ab8a1702d
 Directory: 10.3
 
-Tags: 10.2.15, 10.2, 10, latest
+Tags: 10.2.15, 10.2
 GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.2
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-13-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-13-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-15-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-15-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
+GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
 Directory: 11-jre
 
-Tags: 11-ea-13-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-13-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-15-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-15-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
+GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
 Directory: 11-jre/slim
 
-Tags: 11-ea-13-jdk-sid, 11-ea-13-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-13-jdk, 11-ea-13, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-15-jdk-sid, 11-ea-15-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-15-jdk, 11-ea-15, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
+GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
 Directory: 11-jdk
 
-Tags: 11-ea-13-jdk-slim-sid, 11-ea-13-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-13-jdk-slim, 11-ea-13-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-15-jdk-slim-sid, 11-ea-15-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-15-jdk-slim, 11-ea-15-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd2bd6640a70fe2a07e2fae99d09accbc9a251c9
+GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
 Directory: 11-jdk/slim
 
 Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre

--- a/library/php
+++ b/library/php
@@ -54,59 +54,59 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.17-cli-stretch, 7.1-cli-stretch, 7.1.17-stretch, 7.1-stretch, 7.1.17-cli, 7.1-cli, 7.1.17, 7.1
+Tags: 7.1.18-cli-stretch, 7.1-cli-stretch, 7.1.18-stretch, 7.1-stretch, 7.1.18-cli, 7.1-cli, 7.1.18, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.17-apache-stretch, 7.1-apache-stretch, 7.1.17-apache, 7.1-apache
+Tags: 7.1.18-apache-stretch, 7.1-apache-stretch, 7.1.18-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.17-fpm-stretch, 7.1-fpm-stretch, 7.1.17-fpm, 7.1-fpm
+Tags: 7.1.18-fpm-stretch, 7.1-fpm-stretch, 7.1.18-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.17-zts-stretch, 7.1-zts-stretch, 7.1.17-zts, 7.1-zts
+Tags: 7.1.18-zts-stretch, 7.1-zts-stretch, 7.1.18-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.17-cli-jessie, 7.1-cli-jessie, 7.1.17-jessie, 7.1-jessie
+Tags: 7.1.18-cli-jessie, 7.1-cli-jessie, 7.1.18-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.17-apache-jessie, 7.1-apache-jessie
+Tags: 7.1.18-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.17-fpm-jessie, 7.1-fpm-jessie
+Tags: 7.1.18-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.17-zts-jessie, 7.1-zts-jessie
+Tags: 7.1.18-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.17-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.17-alpine3.7, 7.1-alpine3.7, 7.1.17-cli-alpine, 7.1-cli-alpine, 7.1.17-alpine, 7.1-alpine
+Tags: 7.1.18-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.18-alpine3.7, 7.1-alpine3.7, 7.1.18-cli-alpine, 7.1-cli-alpine, 7.1.18-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.17-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.17-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.18-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.18-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.17-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.17-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.18-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.18-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 36167a6d68c014168e89202516a55047ff335d38
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0

--- a/library/postgres
+++ b/library/postgres
@@ -4,6 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
+Tags: 11-beta1, 11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 927a8525cf80896f2bd146a1b0eff7d6ef2cb7bf
+Directory: 11
+
+Tags: 11-beta1-alpine, 11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 927a8525cf80896f2bd146a1b0eff7d6ef2cb7bf
+Directory: 11/alpine
+
 Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -16,7 +16,7 @@ Directory: 3.7/debian/management
 
 Tags: 3.7.5-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d60d6f4314e5282c7fc4299c1e56450522414f1
+GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
 Directory: 3.7/alpine
 
 Tags: 3.7.5-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
@@ -36,7 +36,7 @@ Directory: 3.6-rc/debian/management
 
 Tags: 3.6.16-rc.1-alpine, 3.6-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
+GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
 Directory: 3.6-rc/alpine
 
 Tags: 3.6.16-rc.1-management-alpine, 3.6-rc-management-alpine
@@ -56,7 +56,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.15-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da82eb0f68ed89a876fc44e915f20fc1e6e6bd8d
+GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
 Directory: 3.6/alpine
 
 Tags: 3.6.15-management-alpine, 3.6-management-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,28 +1,8 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/7fa1f0efbe36eb723f34dd0a5cfcd99948ed5638/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/736a3b3e4da08555f07d9dd9c21ddf8f16a4b97f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
-
-Tags: 3.7.5-rc.1, 3.7-rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0480b1954a18b45eb0d403e59d0cb9844b4f466f
-Directory: 3.7-rc/debian
-
-Tags: 3.7.5-rc.1-management, 3.7-rc-management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/debian/management
-
-Tags: 3.7.5-rc.1-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d018942c63a8f9c1cb4a84930b74eb142640f1ce
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.5-rc.1-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
 
 Tags: 3.7.5, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -43,6 +23,26 @@ Tags: 3.7.5-management-alpine, 3.7-management-alpine, 3-management-alpine, manag
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
+
+Tags: 3.6.16-rc.1, 3.6-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
+Directory: 3.6-rc/debian
+
+Tags: 3.6.16-rc.1-management, 3.6-rc-management
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
+Directory: 3.6-rc/debian/management
+
+Tags: 3.6.16-rc.1-alpine, 3.6-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
+Directory: 3.6-rc/alpine
+
+Tags: 3.6.16-rc.1-management-alpine, 3.6-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
+Directory: 3.6-rc/alpine/management
 
 Tags: 3.6.15, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.64.2, 0.64, 0, latest
-GitCommit: 7ec1959e223e61993c652d50e77a90e884b06be9
+Tags: 0.65.0, 0.65, 0, latest
+GitCommit: c3adf8e9a18350ab3f48ba32731b232b00604707

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.65.0, 0.65, 0, latest
-GitCommit: c3adf8e9a18350ab3f48ba32731b232b00604707
+Tags: 0.64.2, 0.64, 0, latest
+GitCommit: 7ec1959e223e61993c652d50e77a90e884b06be9


### PR DESCRIPTION
- `ghost`: ghost-cli 1.8.0
- `mariadb`: move `latest` to 10.3 (10.3.7 is GA / stable)
- `openjdk`: debian `11~15-1`
- `php`: 7.1.18
- `postgres`: 11 (docker-library/postgres#449)
- `rabbitmq`: 3.6.16-rc.1
- ~~`rocket.chat`: 0.65.0~~