### PR TITLE
Add varnish

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,0 +1,34 @@
+# this file is generated via https://github.com/coopTilleuls/docker-varnish/blob/38da28e15126dd46bc9f08f95aedb1e1eaf2e8c5/generate-stackbrew-library.sh
+
+Maintainers: Teoh Han Hui <teohhanhui@gmail.com> (@teohhanhui)
+GitRepo: https://github.com/coopTilleuls/docker-varnish.git
+
+Tags: 6.2.0-stretch, 6.2-stretch, 6-stretch, stretch, 6.2.0, 6.2, 6, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 6.2/stretch
+
+Tags: 6.2.0-alpine3.8, 6.2-alpine3.8, 6-alpine3.8, alpine3.8, 6.2.0-alpine, 6.2-alpine, 6-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 6.2/alpine3.8
+
+Tags: 6.0.3-stretch, 6.0-stretch, 6-lts-stretch, lts-stretch, 6.0.3, 6.0, 6-lts, lts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 6.0/stretch
+
+Tags: 6.0.3-alpine3.8, 6.0-alpine3.8, 6-lts-alpine3.8, lts-alpine3.8, 6.0.3-alpine, 6.0-alpine, 6-lts-alpine, lts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 6.0/alpine3.8
+
+Tags: 4.1.11-stretch, 4.1-stretch, 4-stretch, 4-lts-stretch, 4.1.11, 4.1, 4, 4-lts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 4.1/stretch
+
+Tags: 4.1.11-alpine3.8, 4.1-alpine3.8, 4-alpine3.8, 4-lts-alpine3.8, 4.1.11-alpine, 4.1-alpine, 4-alpine, 4-lts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: bdb37c46dcc3c4563b698adf2cca8722432b0913
+Directory: 4.1/alpine3.8


### PR DESCRIPTION
Reviving #1294.

Varnish Cache is a widely used caching HTTP reverse proxy.

As we've seen in #1294 (which remained open for a long time) upstream has not shown any interest.

I believe all the best practices have been sufficiently adhered to, including the [Official Images Test Suite](https://github.com/docker-library/official-images/tree/master/test), `update.sh` and `generate-stackbrew-library.sh`.

Docs PR: https://github.com/docker-library/docs/pull/1241

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
