### PR TITLE
Node: Update for Node.js v10.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,12 +1,12 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/fb8ac15c9c606e15cd7f37074d62061c39d1a6cb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/7fea7b033c5a292dd74199d2ba0fbb161f75aa0d/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.11.1, 9.11, 9
+Tags: 9.11.1-jessie, 9.11-jessie, 9-jessie, 9.11.1, 9.11, 9
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 947280600648b70e067d35415d6812fd03127def
-Directory: 9
+GitCommit: 7fea7b033c5a292dd74199d2ba0fbb161f75aa0d
+Directory: 9/jessie
 
 Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
@@ -15,7 +15,7 @@ Directory: 9/alpine
 
 Tags: 9.11.1-onbuild, 9.11-onbuild, 9-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
+GitCommit: 11a62b615492325d4cbe4ebed29dc6813c6b6826
 Directory: 9/onbuild
 
 Tags: 9.11.1-slim, 9.11-slim, 9-slim
@@ -28,10 +28,10 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 9/stretch
 
-Tags: 8.11.2, 8.11, 8, carbon
+Tags: 8.11.2-jessie, 8.11-jessie, 8-jessie, carbon-jessie, 8.11.2, 8.11, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 947280600648b70e067d35415d6812fd03127def
-Directory: 8
+GitCommit: 7fea7b033c5a292dd74199d2ba0fbb161f75aa0d
+Directory: 8/jessie
 
 Tags: 8.11.2-alpine, 8.11-alpine, 8-alpine, carbon-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
@@ -40,7 +40,7 @@ Directory: 8/alpine
 
 Tags: 8.11.2-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 9d34db0c5d314b704b7dc76481dca15b85eef7c2
+GitCommit: 11a62b615492325d4cbe4ebed29dc6813c6b6826
 Directory: 8/onbuild
 
 Tags: 8.11.2-slim, 8.11-slim, 8-slim, carbon-slim
@@ -53,10 +53,10 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 8/stretch
 
-Tags: 6.14.2, 6.14, 6, boron
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: 947280600648b70e067d35415d6812fd03127def
-Directory: 6
+Tags: 6.14.2-jessie, 6.14-jessie, 6-jessie, boron-jessie, 6.14.2, 6.14, 6, boron
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 7fea7b033c5a292dd74199d2ba0fbb161f75aa0d
+Directory: 6/jessie
 
 Tags: 6.14.2-alpine, 6.14-alpine, 6-alpine, boron-alpine
 Architectures: amd64
@@ -64,38 +64,38 @@ GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/alpine
 
 Tags: 6.14.2-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
-GitCommit: bb49c321f761c333ba87b18770121651f0a3004c
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
+GitCommit: 11a62b615492325d4cbe4ebed29dc6813c6b6826
 Directory: 6/onbuild
 
 Tags: 6.14.2-slim, 6.14-slim, 6-slim, boron-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/slim
 
 Tags: 6.14.2-stretch, 6.14-stretch, 6-stretch, boron-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: 6/stretch
 
-Tags: 10.2.1, 10.2, 10, latest
+Tags: 10.3.0-jessie, 10.3-jessie, 10-jessie, jessie, 10.3.0, 10.3, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
-Directory: 10
+GitCommit: bbae51a013b0ebef90afcd6d2ea2ac49697d3823
+Directory: 10/jessie
 
-Tags: 10.2.1-alpine, 10.2-alpine, 10-alpine, alpine
+Tags: 10.3.0-alpine, 10.3-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
+GitCommit: bbae51a013b0ebef90afcd6d2ea2ac49697d3823
 Directory: 10/alpine
 
-Tags: 10.2.1-slim, 10.2-slim, 10-slim, slim
+Tags: 10.3.0-slim, 10.3-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
+GitCommit: bbae51a013b0ebef90afcd6d2ea2ac49697d3823
 Directory: 10/slim
 
-Tags: 10.2.1-stretch, 10.2-stretch, 10-stretch, stretch
+Tags: 10.3.0-stretch, 10.3-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: bd74777e9e5c89685146d4963b6bb78970dd2133
+GitCommit: bbae51a013b0ebef90afcd6d2ea2ac49697d3823
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
Also includes new jessie tags.

See:

- https://github.com/nodejs/docker-node/pull/762
- https://nodejs.org/en/blog/release/v10.3.0/