### PR TITLE
Turn on container support by default

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,30 +5,30 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/jre/alpine
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sfj-alpine, sfj-alpine
 Architectures: amd64
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/sfj/alpine
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/sdk/ubuntu
 
 Tags: 8-sdk-alpine, sdk-alpine
 Architectures: amd64
-GitCommit: 72e1d4742296c6c8d092d2fd58d39b4afeea4bbb
+GitCommit: 5e1141743177128d563646fcf9bc4413acf68fd1
 Directory: ibmjava/8/sdk/alpine


### PR DESCRIPTION
Bump IBM Java version to 1.8.0_sr5fp16 (8.0.5.16).