### PR TITLE
Bump Traefik to v1.6.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.2, 1.6.2, v1.6, 1.6, tetedemoine, latest
+Tags: v1.6.3, 1.6.3, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0389d588f1989665e706a1ba0e8ed923adae753d
+GitCommit: 88e12c74535395647071f7dd46fe5b0afd96643c
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.6.2-alpine, 1.6.2-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
+Tags: v1.6.3-alpine, 1.6.3-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0389d588f1989665e706a1ba0e8ed923adae753d
+GitCommit: 88e12c74535395647071f7dd46fe5b0afd96643c
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.6.3.

/cc @vdemeester @emilevauge @ldez

Cheers
