### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 4.4.19, 4.4, 4, latest
+Tags: 4.4.23, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3bb879e5ac93f9b49f4d2d33521d8aa1524f2c12
+GitCommit: 534f4084e3f3daa1cb6b6f5f71e0a13e8c3de008
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.23.0, 1.23, 1, latest
+Tags: 1.23.1, 1.23, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dbab0321197d6dcb0ca4cefb0187806d447146b4
+GitCommit: f76d29468c0acb50fe54bbf1db6a02e6beb91729
 Directory: 1/debian
 
-Tags: 1.23.0-alpine, 1.23-alpine, 1-alpine, alpine
+Tags: 1.23.1-alpine, 1.23-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: dbab0321197d6dcb0ca4cefb0187806d447146b4
+GitCommit: f76d29468c0acb50fe54bbf1db6a02e6beb91729
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/julia
+++ b/library/julia
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.6.2-stretch, 0.6-stretch, 0-stretch, stretch
-SharedTags: 0.6.2, 0.6, 0, latest
+Tags: 0.6.3-stretch, 0.6-stretch, 0-stretch, stretch
+SharedTags: 0.6.3, 0.6, 0, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3cb2698ed2475db46cc17d5d1cd309626ef87c1c
+GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
 Directory: stretch
 
-Tags: 0.6.2-jessie, 0.6-jessie, 0-jessie, jessie
+Tags: 0.6.3-jessie, 0.6-jessie, 0-jessie, jessie
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3cb2698ed2475db46cc17d5d1cd309626ef87c1c
+GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
 Directory: jessie
 
-Tags: 0.6.2-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.6.2, 0.6, 0, latest
+Tags: 0.6.3-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.6.3, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: 96d3dd0bf37bf7993c63ec2ff7c786d001c25193
+GitCommit: d4f2c502f4604b25de33e6d4e2db23c8d5971c12
 Directory: windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 0.6.2-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
-SharedTags: 0.6.2, 0.6, 0, latest
+Tags: 0.6.3-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
+SharedTags: 0.6.3, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: 96d3dd0bf37bf7993c63ec2ff7c786d001c25193
+GitCommit: d4f2c502f4604b25de33e6d4e2db23c8d5971c12
 Directory: windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/matomo
+++ b/library/matomo
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.5.1-apache, 3.5-apache, 3-apache, apache, 3.5.1, 3.5, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72bf7cd7dbe96b7caf38330e8e6f80d8596ab749
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: apache
 
 Tags: 3.5.1-fpm, 3.5-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72bf7cd7dbe96b7caf38330e8e6f80d8596ab749
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: fpm
 
 Tags: 3.5.1-fpm-alpine, 3.5-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88a8be3c7f386b2c21c8ef93f32aa092c5603ea1
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: fpm-alpine

--- a/library/memcached
+++ b/library/memcached
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.5.8, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2aae422228318150ae4f351d363d2fdbb5bfaf7c
+GitCommit: 6c09fae709f1cee21d63f7b3619cad097edb6609
 Directory: debian
 
 Tags: 1.5.8-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2aae422228318150ae4f351d363d2fdbb5bfaf7c
+GitCommit: 6c09fae709f1cee21d63f7b3619cad097edb6609
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -36,10 +36,10 @@ Architectures: amd64, arm64v8
 GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
 Directory: 3.7
 
-Tags: 4.0.0-rc0-xenial, 4.0-rc-xenial, rc-xenial
-SharedTags: 4.0.0-rc0, 4.0-rc, rc
+Tags: 4.0.0-rc2-xenial, 4.0-rc-xenial, rc-xenial
+SharedTags: 4.0.0-rc2, 4.0-rc, rc
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/testing/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
+GitCommit: 0e68be0950309a39d2dbfc5d71bf5986314b9dd7
 Directory: 4.0-rc

--- a/library/openjdk
+++ b/library/openjdk
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/openjdk.git
 
 Tags: 11-ea-16-jdk-sid, 11-ea-16-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-16-jdk, 11-ea-16, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 11/jdk
 
 Tags: 11-ea-16-jdk-slim-sid, 11-ea-16-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-16-jdk-slim, 11-ea-16-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 11/jdk/slim
 
 Tags: 11-ea-16-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-16-jre, 11-ea-jre, 11-jre
@@ -26,32 +26,32 @@ Directory: 11/jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk
 
 Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk/slim
 
 Tags: 10.0.1-jdk-windowsservercore-ltsc2016, 10.0.1-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
 SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: f45f3f269d4b515201f290360b345790663e657e
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 10.0.1-jdk-windowsservercore-1709, 10.0.1-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
 SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: f45f3f269d4b515201f290360b345790663e657e
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 10.0.1-jdk-nanoserver-sac2016, 10.0.1-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
 SharedTags: 10.0.1-jdk-nanoserver, 10.0.1-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
 Architectures: windows-amd64
-GitCommit: f45f3f269d4b515201f290360b345790663e657e
+GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,167 +1,147 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/072171f6298a3c360f26de25291a45f082d36bca/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/a5cc95a14480e9b30c674aa72257f6e4cf032b8d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-15-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-15-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-16-jdk-sid, 11-ea-16-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-16-jdk, 11-ea-16, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
-Directory: 11-jre
+GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+Directory: 11/jdk
 
-Tags: 11-ea-15-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-15-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-16-jdk-slim-sid, 11-ea-16-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-16-jdk-slim, 11-ea-16-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
-Directory: 11-jre/slim
+GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+Directory: 11/jdk/slim
 
-Tags: 11-ea-15-jdk-sid, 11-ea-15-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-15-jdk, 11-ea-15, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-16-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-16-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
-Directory: 11-jdk
+GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+Directory: 11/jre
 
-Tags: 11-ea-15-jdk-slim-sid, 11-ea-15-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-15-jdk-slim, 11-ea-15-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-16-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-16-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a18717a1f0e1e48fc32e40bbe85aa89cfea3241
-Directory: 11-jdk/slim
-
-Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 10-jre
-
-Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 10-jre/slim
+GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+Directory: 11/jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 10-jdk
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 10/jdk
 
 Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 10-jdk/slim
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 10/jdk/slim
 
-Tags: 9.0.4-12-jre-sid, 9.0.4-jre-sid, 9.0-jre-sid, 9-jre-sid, 9.0.4-12-jre, 9.0.4-jre, 9.0-jre, 9-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 9-jre
-
-Tags: 9.0.4-12-jre-slim-sid, 9.0.4-jre-slim-sid, 9.0-jre-slim-sid, 9-jre-slim-sid, 9.0.4-12-jre-slim, 9.0.4-jre-slim, 9.0-jre-slim, 9-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 9-jre/slim
-
-Tags: 9.0.4-12-jdk-sid, 9.0.4-12-sid, 9.0.4-jdk-sid, 9.0.4-sid, 9.0-jdk-sid, 9.0-sid, 9-jdk-sid, 9-sid, 9.0.4-12-jdk, 9.0.4-12, 9.0.4-jdk, 9.0.4, 9.0-jdk, 9.0, 9-jdk, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 9-jdk
-
-Tags: 9.0.4-12-jdk-slim-sid, 9.0.4-12-slim-sid, 9.0.4-jdk-slim-sid, 9.0.4-slim-sid, 9.0-jdk-slim-sid, 9.0-slim-sid, 9-jdk-slim-sid, 9-slim-sid, 9.0.4-12-jdk-slim, 9.0.4-12-slim, 9.0.4-jdk-slim, 9.0.4-slim, 9.0-jdk-slim, 9.0-slim, 9-jdk-slim, 9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 9-jdk/slim
-
-Tags: 9.0.4-jdk-windowsservercore-ltsc2016, 9.0.4-windowsservercore-ltsc2016, 9.0-jdk-windowsservercore-ltsc2016, 9.0-windowsservercore-ltsc2016, 9-jdk-windowsservercore-ltsc2016, 9-windowsservercore-ltsc2016
-SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Tags: 10.0.1-jdk-windowsservercore-ltsc2016, 10.0.1-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
+SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
-Directory: 9-jdk/windows/windowsservercore-ltsc2016
+GitCommit: f45f3f269d4b515201f290360b345790663e657e
+Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 9.0.4-jdk-windowsservercore-1709, 9.0.4-windowsservercore-1709, 9.0-jdk-windowsservercore-1709, 9.0-windowsservercore-1709, 9-jdk-windowsservercore-1709, 9-windowsservercore-1709
-SharedTags: 9.0.4-jdk-windowsservercore, 9.0.4-windowsservercore, 9.0-jdk-windowsservercore, 9.0-windowsservercore, 9-jdk-windowsservercore, 9-windowsservercore
+Tags: 10.0.1-jdk-windowsservercore-1709, 10.0.1-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
+SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
-Directory: 9-jdk/windows/windowsservercore-1709
+GitCommit: f45f3f269d4b515201f290360b345790663e657e
+Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 9.0.4-jdk-nanoserver-sac2016, 9.0.4-nanoserver-sac2016, 9.0-jdk-nanoserver-sac2016, 9.0-nanoserver-sac2016, 9-jdk-nanoserver-sac2016, 9-nanoserver-sac2016
-SharedTags: 9.0.4-jdk-nanoserver, 9.0.4-nanoserver, 9.0-jdk-nanoserver, 9.0-nanoserver, 9-jdk-nanoserver, 9-nanoserver
+Tags: 10.0.1-jdk-nanoserver-sac2016, 10.0.1-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
+SharedTags: 10.0.1-jdk-nanoserver, 10.0.1-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
 Architectures: windows-amd64
-GitCommit: 3b9644b8ef34cb59878b9d75a72920b5046dec9f
-Directory: 9-jdk/windows/nanoserver-sac2016
+GitCommit: f45f3f269d4b515201f290360b345790663e657e
+Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u171-jre-stretch, 8-jre-stretch, jre-stretch, 8u171-jre, 8-jre, jre
+Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 8-jre
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 10/jre
 
-Tags: 8u171-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u171-jre-slim, 8-jre-slim, jre-slim
+Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 8-jre/slim
-
-Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
-Directory: 8-jre/alpine
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 10/jre/slim
 
 Tags: 8u171-jdk-stretch, 8u171-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u171-jdk, 8u171, 8-jdk, 8, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 8-jdk
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk
 
 Tags: 8u171-jdk-slim-stretch, 8u171-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, jdk-slim-stretch, slim-stretch, 8u171-jdk-slim, 8u171-slim, 8-jdk-slim, 8-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 8-jdk/slim
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk/slim
 
 Tags: 8u151-jdk-alpine3.7, 8u151-alpine3.7, 8-jdk-alpine3.7, 8-alpine3.7, jdk-alpine3.7, alpine3.7, 8u151-jdk-alpine, 8u151-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2598f7123fce9ea870e67f8f9df745b2b49866c0
-Directory: 8-jdk/alpine
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk/alpine
 
 Tags: 8u171-jdk-windowsservercore-ltsc2016, 8u171-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 8u171-jdk-windowsservercore, 8u171-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 4135ad55c2577bd722c575a41211c59669353d54
-Directory: 8-jdk/windows/windowsservercore-ltsc2016
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u171-jdk-windowsservercore-1709, 8u171-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 8u171-jdk-windowsservercore, 8u171-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 4135ad55c2577bd722c575a41211c59669353d54
-Directory: 8-jdk/windows/windowsservercore-1709
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 8u171-jdk-nanoserver-sac2016, 8u171-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 8u171-jdk-nanoserver, 8u171-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 4135ad55c2577bd722c575a41211c59669353d54
-Directory: 8-jdk/windows/nanoserver-sac2016
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 7u171-jre-jessie, 7-jre-jessie, 7u171-jre, 7-jre
+Tags: 8u171-jre-stretch, 8-jre-stretch, jre-stretch, 8u171-jre, 8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 7-jre
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jre
 
-Tags: 7u171-jre-slim-jessie, 7-jre-slim-jessie, 7u171-jre-slim, 7-jre-slim
+Tags: 8u171-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u171-jre-slim, 8-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 7-jre/slim
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jre/slim
 
-Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
+Tags: 8u151-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u151-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
-Directory: 7-jre/alpine
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 8/jre/alpine
 
 Tags: 7u171-jdk-jessie, 7u171-jessie, 7-jdk-jessie, 7-jessie, 7u171-jdk, 7u171, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 7-jdk
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jdk
 
 Tags: 7u171-jdk-slim-jessie, 7u171-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u171-jdk-slim, 7u171-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbbefa82b92964e6fd98b20353be7010f970c60a
-Directory: 7-jdk/slim
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jdk/slim
 
 Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 17d0f9f3411d82622c762163d85cc4a6ba69af95
-Directory: 7-jdk/alpine
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jdk/alpine
+
+Tags: 7u171-jre-jessie, 7-jre-jessie, 7u171-jre, 7-jre
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jre
+
+Tags: 7u171-jre-slim-jessie, 7-jre-slim-jessie, 7u171-jre-slim, 7-jre-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jre/slim
+
+Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+Directory: 7/jre/alpine

--- a/library/owncloud
+++ b/library/owncloud
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.8-apache, 10.0-apache, 10-apache, apache, 10.0.8, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2791cbf8de3f9feee62d2f5f4d7a773a7d980986
+GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
 Directory: 10.0/apache
 
 Tags: 10.0.8-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2791cbf8de3f9feee62d2f5f4d7a773a7d980986
+GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5124b27e3a30360672d0c31ad7c7bc952f9802b1
+GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5124b27e3a30360672d0c31ad7c7bc952f9802b1
+GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
 Directory: 9.1/fpm

--- a/library/percona
+++ b/library/percona
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.21, 5.7, 5, latest
-GitCommit: eda57cc04e59bc5d98ae3b2e5dea46f3f489c665
+Tags: 5.7.22, 5.7, 5, latest
+GitCommit: 01c136a28e68649b02fc2e00a580067e97f763c7
 Directory: 5.7
 
-Tags: 5.6.39, 5.6
-GitCommit: a3ba3b6a69a6c7a21e9ea2d4a5b746b9829039eb
+Tags: 5.6.40, 5.6
+GitCommit: 24e0d02a91dd7880e2ac7991818887fd7df1303a
 Directory: 5.6
 
 Tags: 5.5.60, 5.5

--- a/library/php
+++ b/library/php
@@ -26,32 +26,32 @@ Directory: 7.2/stretch/zts
 
 Tags: 7.2.6-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.6-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.6-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.6-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.6-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.6-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.6-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.6-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.6-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.6-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.6-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.6-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.18-cli-stretch, 7.1-cli-stretch, 7.1.18-stretch, 7.1-stretch, 7.1.18-cli, 7.1-cli, 7.1.18, 7.1
@@ -96,17 +96,17 @@ Directory: 7.1/jessie/zts
 
 Tags: 7.1.18-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.18-alpine3.7, 7.1-alpine3.7, 7.1.18-cli-alpine, 7.1-cli-alpine, 7.1.18-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.1/alpine3.7/cli
 
 Tags: 7.1.18-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.18-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.1/alpine3.7/fpm
 
 Tags: 7.1.18-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.18-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
@@ -151,17 +151,17 @@ Directory: 7.0/jessie/zts
 
 Tags: 7.0.30-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.30-alpine3.7, 7.0-alpine3.7, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.0/alpine3.7/cli
 
 Tags: 7.0.30-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.30-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.0/alpine3.7/fpm
 
 Tags: 7.0.30-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.30-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 7.0/alpine3.7/zts
 
 Tags: 5.6.36-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.36-stretch, 5.6-stretch, 5-stretch, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
@@ -206,15 +206,15 @@ Directory: 5.6/jessie/zts
 
 Tags: 5.6.36-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.36-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 5.6/alpine3.7/cli
 
 Tags: 5.6.36-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 5.6/alpine3.7/fpm
 
 Tags: 5.6.36-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
 Directory: 5.6/alpine3.7/zts

--- a/library/piwik
+++ b/library/piwik
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.5.1-apache, 3.5-apache, 3-apache, apache, 3.5.1, 3.5, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72bf7cd7dbe96b7caf38330e8e6f80d8596ab749
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: apache
 
 Tags: 3.5.1-fpm, 3.5-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72bf7cd7dbe96b7caf38330e8e6f80d8596ab749
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: fpm
 
 Tags: 3.5.1-fpm-alpine, 3.5-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88a8be3c7f386b2c21c8ef93f32aa092c5603ea1
+GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
 Directory: fpm-alpine

--- a/library/python
+++ b/library/python
@@ -4,33 +4,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0b4-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0b4, 3.7-rc, rc
+Tags: 3.7.0b5-stretch, 3.7-rc-stretch, rc-stretch
+SharedTags: 3.7.0b5, 3.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba5711fb564133bf9c8b870b431682a4db427219
+GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
 Directory: 3.7-rc/stretch
 
-Tags: 3.7.0b4-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b4-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0b5-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b5-slim, 3.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
+GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
 Directory: 3.7-rc/stretch/slim
 
-Tags: 3.7.0b4-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b4-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0b5-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b5-alpine, 3.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ba5711fb564133bf9c8b870b431682a4db427219
+GitCommit: bbbc37fff3411a34deef30dd9b34dc938fe7b134
 Directory: 3.7-rc/alpine3.7
 
-Tags: 3.7.0b4-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.7.0b4-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b4, 3.7-rc, rc
+Tags: 3.7.0b5-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.7.0b5-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b5, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: ba5711fb564133bf9c8b870b431682a4db427219
+GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
 Directory: 3.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0b4-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 3.7.0b4-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b4, 3.7-rc, rc
+Tags: 3.7.0b5-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 3.7.0b5-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b5, 3.7-rc, rc
 Architectures: windows-amd64
-GitCommit: ba5711fb564133bf9c8b870b431682a4db427219
+GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
 Directory: 3.7-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -62,12 +62,12 @@ Directory: 3.6/jessie/onbuild
 
 Tags: 3.6.5-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7, 3.6.5-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
+GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.5-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b99b66406ebe728fb4da64548066ad0be6582e08
+GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.5-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -101,7 +101,7 @@ Directory: 3.5/jessie/onbuild
 
 Tags: 3.5.5-alpine3.7, 3.5-alpine3.7, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8eaaf400780f2b92422829a01cbd6368eed32ee
+GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.8-jessie, 3.4-jessie
@@ -126,7 +126,7 @@ Directory: 3.4/wheezy
 
 Tags: 3.4.8-alpine3.7, 3.4-alpine3.7, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8eaaf400780f2b92422829a01cbd6368eed32ee
+GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
@@ -162,12 +162,12 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: 8d755d18e6990b8ad6f137d7613ba7937389b47a
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.64.2, 0.64, 0, latest
-GitCommit: 7ec1959e223e61993c652d50e77a90e884b06be9
+Tags: 0.65.1, 0.65, 0, latest
+GitCommit: 3c2c45e2bd10643abbf13b70242e4843e46fd989

--- a/library/ruby
+++ b/library/ruby
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-preview1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview1, 2.6-rc, rc
+Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
 Directory: 2.6-rc/stretch
 
-Tags: 2.6.0-preview1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview1-slim, 2.6-rc-slim, rc-slim
+Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
 Directory: 2.6-rc/stretch/slim
 
-Tags: 2.6.0-preview1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview1-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -68,20 +68,20 @@ Directory: php7.2/fpm-alpine
 
 Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
 Directory: php5.6/cli
 
 Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
 Directory: php7.0/cli
 
 Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
 Directory: php7.1/cli
 
 Tags: cli-1.5.1, cli-1.5, cli-1, cli, cli-1.5.1-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
 Directory: php7.2/cli


### PR DESCRIPTION
- `bash`: 4.4.23
- `ghost`: 1.23.1
- `julia`: 0.6.3
- `matomo`: GPG race conditions (matomo-org/docker#105)
- `memcached`: `extstore` (docker-library/memcached#38)
- `mongo`: 4.0.0~rc2
- `openjdk`: remove 9 (docker-library/openjdk#199), add 10 for Windows (docker-library/openjdk#200), 11-ea+16
- `owncloud`: update PECL exts (docker-library/owncloud#102)
- `percona`: 5.7.22, 5.6.40
- `php`: fix `wget: error getting response: Connection reset by peer`
- `piwik`: GPG race conditions (matomo-org/docker#105)
- `python`: add `nis` nonsense to 2.7 (docker-library/python#281), 3.7.0b5
- `rocket.chat`: 0.65.1
- `ruby`: 2.6.0-preview2
- `wordpress`: update GPG for wp-cli