### PR TITLE
[gazebo] new docker templates and bump gazebo from 9.0 to 9.1

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -9,12 +9,12 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver4, gzserver4-trusty
 Architectures: amd64
-GitCommit: 4459e46b70e082d0662237e1c62ea26cdcd8ee2c
+GitCommit: 1edae347ca21f301dd2396e621ed512859725924
 Directory: gazebo/4/ubuntu/trusty/gzserver4
 
 Tags: libgazebo4, libgazebo4-trusty
 Architectures: amd64
-GitCommit: 4459e46b70e082d0662237e1c62ea26cdcd8ee2c
+GitCommit: 1edae347ca21f301dd2396e621ed512859725924
 Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 
@@ -26,12 +26,12 @@ Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 Tags: gzserver5, gzserver5-trusty
 Architectures: amd64
-GitCommit: abba58d1fce0d00aa2a667917b3367142719e61c
+GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
 Directory: gazebo/5/ubuntu/trusty/gzserver5
 
 Tags: libgazebo5, libgazebo5-trusty
 Architectures: amd64
-GitCommit: abba58d1fce0d00aa2a667917b3367142719e61c
+GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
 Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 
@@ -43,12 +43,12 @@ Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 Tags: gzserver6, gzserver6-trusty
 Architectures: amd64
-GitCommit: 039483e1c90f52df528381de9d495679c412e84f
+GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
 Directory: gazebo/6/ubuntu/trusty/gzserver6
 
 Tags: libgazebo6, libgazebo6-trusty
 Architectures: amd64
-GitCommit: 039483e1c90f52df528381de9d495679c412e84f
+GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
 Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 
@@ -60,12 +60,12 @@ Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 Tags: gzserver7, gzserver7-xenial
 Architectures: amd64
-GitCommit: 707b516cdf546995718d96dcf3d41e2e4969c0ec
+GitCommit: 25f1424dda9c444d55beee151db41c6b642422da
 Directory: gazebo/7/ubuntu/xenial/gzserver7
 
 Tags: libgazebo7, libgazebo7-xenial
 Architectures: amd64
-GitCommit: 707b516cdf546995718d96dcf3d41e2e4969c0ec
+GitCommit: 25f1424dda9c444d55beee151db41c6b642422da
 Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 
@@ -77,12 +77,12 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 Tags: gzserver8, gzserver8-xenial
 Architectures: amd64
-GitCommit: 73607b28a0cc7fb9592bc2c6f74e0dfc753406f9
+GitCommit: 10b7350d07c1d8fa6c7838a5fc16c08678f91385
 Directory: gazebo/8/ubuntu/xenial/gzserver8
 
 Tags: libgazebo8, libgazebo8-xenial
 Architectures: amd64
-GitCommit: 73607b28a0cc7fb9592bc2c6f74e0dfc753406f9
+GitCommit: 10b7350d07c1d8fa6c7838a5fc16c08678f91385
 Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 
@@ -94,10 +94,10 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 Tags: gzserver9, gzserver9-xenial
 Architectures: amd64
-GitCommit: b8deb76898b59e0d43518f2cbdca6c90afc1debe
+GitCommit: c999c2fdda76a419f7374231cfbd41d30dc823e6
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9, libgazebo9-xenial, latest
 Architectures: amd64
-GitCommit: b8deb76898b59e0d43518f2cbdca6c90afc1debe
+GitCommit: c999c2fdda76a419f7374231cfbd41d30dc823e6
 Directory: gazebo/9/ubuntu/xenial/libgazebo9


### PR DESCRIPTION
Update Gazebo Dockerfiles:
- use new template using lsb-release to minimize diff between docker files

Bump gazebo9 from `9.0.0-1` to `9.1.0-1`