### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.5.3-apache, 8.5-apache, 8-apache, apache, 8.5.3, 8.5, 8, latest
+Tags: 8.5.4-apache, 8.5-apache, 8-apache, apache, 8.5.4, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 44a0d79d5c5a54081356226010cd15232288cf76
+GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
 Directory: 8.5/apache
 
-Tags: 8.5.3-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.4-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 44a0d79d5c5a54081356226010cd15232288cf76
+GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
 Directory: 8.5/fpm
 
-Tags: 8.5.3-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.4-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 44a0d79d5c5a54081356226010cd15232288cf76
+GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
 Directory: 8.5/fpm-alpine
 
 Tags: 8.4.8-apache, 8.4-apache, 8.4.8, 8.4

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.23.1, 1.23, 1, latest
+Tags: 1.24.1, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f76d29468c0acb50fe54bbf1db6a02e6beb91729
+GitCommit: 0679ef9e4b5677fd6edfeac96a8f1ddcc1a5fd13
 Directory: 1/debian
 
-Tags: 1.23.1-alpine, 1.23-alpine, 1-alpine, alpine
+Tags: 1.24.1-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: f76d29468c0acb50fe54bbf1db6a02e6beb91729
+GitCommit: 0679ef9e4b5677fd6edfeac96a8f1ddcc1a5fd13
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -5,71 +5,71 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.10.2-stretch, 1.10-stretch, 1-stretch, stretch
-SharedTags: 1.10.2, 1.10, 1, latest
+Tags: 1.10.3-stretch, 1.10-stretch, 1-stretch, stretch
+SharedTags: 1.10.3, 1.10, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
+GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/stretch
 
-Tags: 1.10.2-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.2-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.10.3-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.3-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
+GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/alpine3.7
 
-Tags: 1.10.2-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.10.2-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.2, 1.10, 1, latest
+Tags: 1.10.3-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.10.3-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.3, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
+GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10.2-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.10.2-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.2, 1.10, 1, latest
+Tags: 1.10.3-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.10.3-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.3, 1.10, 1, latest
 Architectures: windows-amd64
-GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
+GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10.2-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.10.2-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.10.3-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.10.3-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 329b6672949337c4469351b2e8b8575459a75c7f
+GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.9.6-stretch, 1.9-stretch
-SharedTags: 1.9.6, 1.9
+Tags: 1.9.7-stretch, 1.9-stretch
+SharedTags: 1.9.7, 1.9
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/stretch
 
-Tags: 1.9.6-alpine3.7, 1.9-alpine3.7
+Tags: 1.9.7-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/alpine3.7
 
-Tags: 1.9.6-alpine3.6, 1.9-alpine3.6, 1.9.6-alpine, 1.9-alpine
+Tags: 1.9.7-alpine3.6, 1.9-alpine3.6, 1.9.7-alpine, 1.9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 43f9c69e1bcb068bdb6883cd0fb2339e9b197510
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/alpine3.6
 
-Tags: 1.9.6-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
-SharedTags: 1.9.6-windowsservercore, 1.9-windowsservercore, 1.9.6, 1.9
+Tags: 1.9.7-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
+SharedTags: 1.9.7-windowsservercore, 1.9-windowsservercore, 1.9.7, 1.9
 Architectures: windows-amd64
-GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.9.6-windowsservercore-1709, 1.9-windowsservercore-1709
-SharedTags: 1.9.6-windowsservercore, 1.9-windowsservercore, 1.9.6, 1.9
+Tags: 1.9.7-windowsservercore-1709, 1.9-windowsservercore-1709
+SharedTags: 1.9.7-windowsservercore, 1.9-windowsservercore, 1.9.7, 1.9
 Architectures: windows-amd64
-GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.9.6-nanoserver-sac2016, 1.9-nanoserver-sac2016
-SharedTags: 1.9.6-nanoserver, 1.9-nanoserver
+Tags: 1.9.7-nanoserver-sac2016, 1.9-nanoserver-sac2016
+SharedTags: 1.9.7-nanoserver, 1.9-nanoserver
 Architectures: windows-amd64
-GitCommit: a9ee01751149630d296d600cbbdea0ab37e5ab04
+GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016

--- a/library/mongo
+++ b/library/mongo
@@ -36,10 +36,10 @@ Architectures: amd64, arm64v8
 GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
 Directory: 3.7
 
-Tags: 4.0.0-rc2-xenial, 4.0-rc-xenial, rc-xenial
-SharedTags: 4.0.0-rc2, 4.0-rc, rc
+Tags: 4.0.0-rc4-xenial, 4.0-rc-xenial, rc-xenial
+SharedTags: 4.0.0-rc4, 4.0-rc, rc
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/testing/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 0e68be0950309a39d2dbfc5d71bf5986314b9dd7
+GitCommit: fddc16475e53f0640f7ea46c98096baa297da1e2
 Directory: 4.0-rc

--- a/library/owncloud
+++ b/library/owncloud
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.8-apache, 10.0-apache, 10-apache, apache, 10.0.8, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
+GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
 Directory: 10.0/apache
 
 Tags: 10.0.8-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
+GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
+GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ebf83b5d47d6d861332b081aa8eaec00e2ab09a
+GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
 Directory: 9.1/fpm

--- a/library/postgres
+++ b/library/postgres
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta1, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 927a8525cf80896f2bd146a1b0eff7d6ef2cb7bf
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 11
 
 Tags: 11-beta1-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 927a8525cf80896f2bd146a1b0eff7d6ef2cb7bf
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 11/alpine
 
 Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.6
 
 Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.6/alpine
 
 Tags: 9.5.13, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.5
 
 Tags: 9.5.13-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.5/alpine
 
 Tags: 9.4.18, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.4
 
 Tags: 9.4.18-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.4/alpine
 
 Tags: 9.3.23, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.3
 
 Tags: 9.3.23-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe89a60c9bda1f1e1627f6732fdfd90f4d410bd6
+GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
 Directory: 9.3/alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -79,16 +79,6 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1ce7bd2eed038fb722527f41f0f185322d53e979
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.31-jre9, 8.5-jre9, 8-jre9, jre9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
-Directory: 8.5/jre9
-
-Tags: 8.5.31-jre9-slim, 8.5-jre9-slim, 8-jre9-slim, jre9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
-Directory: 8.5/jre9-slim
-
 Tags: 8.5.31-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
@@ -113,16 +103,6 @@ Tags: 9.0.8-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 8fffa7246aacceb0e7390aafe978efeea9c104e3
 Directory: 9.0/jre8-alpine
-
-Tags: 9.0.8-jre9, 9.0-jre9, 9-jre9, 9.0.8, 9.0, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
-Directory: 9.0/jre9
-
-Tags: 9.0.8-jre9-slim, 9.0-jre9-slim, 9-jre9-slim, 9.0.8-slim, 9.0-slim, 9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
-Directory: 9.0/jre9-slim
 
 Tags: 9.0.8-jre10, 9.0-jre10, 9-jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
- `drupal`: 8.5.4
- `ghost`: 1.24.1
- `golang`: 1.10.3, 1.9.7
- `mongo`: 4.0.0~rc4
- `owncloud`: add `unzip` (docker-library/owncloud#103)
- `postgres`: allow `initdb.d` scripts to be executed instead of sourced (docker-library/postgres#452)
- `tomcat`: remove jre9 (docker-library/tomcat#120)