### PR TITLE
[ros] EOL jessie and dockerfiles generated from new templates

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -36,46 +36,23 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/perception
-
-########################################
-# Distro: debian:jessie
-
-Tags: kinetic-ros-core-jessie
-Architectures: amd64, arm64v8
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/ros-core
-
-Tags: kinetic-ros-base-jessie
-Architectures: amd64, arm64v8
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/ros-base
-
-Tags: kinetic-robot-jessie
-Architectures: amd64, arm64v8
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/robot
-
-Tags: kinetic-perception-jessie
-Architectures: amd64, arm64v8
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/perception
 
 
 ################################################################################
@@ -86,22 +63,22 @@ Directory: ros/kinetic/debian/jessie/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -109,22 +86,22 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/perception
 
 
@@ -136,22 +113,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -159,21 +136,21 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/perception
 


### PR DESCRIPTION
Update ROS Dockerfiles:

- use new templates using lsb-release to minimize diff between docker files
- remove images based on Debian Jessie from ros docker library