### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.1, 1.24, 1, latest
+Tags: 1.24.2, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0679ef9e4b5677fd6edfeac96a8f1ddcc1a5fd13
+GitCommit: 8ad29262377075c1ae79c3dbb3731d8bbeb07d2c
 Directory: 1/debian
 
-Tags: 1.24.1-alpine, 1.24-alpine, 1-alpine, alpine
+Tags: 1.24.2-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 0679ef9e4b5677fd6edfeac96a8f1ddcc1a5fd13
+GitCommit: 8ad29262377075c1ae79c3dbb3731d8bbeb07d2c
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-16-jdk-sid, 11-ea-16-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-16-jdk, 11-ea-16, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-17-jdk-sid, 11-ea-17-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-17-jdk, 11-ea-17, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 841c5e57ac0b94b12cdbf274bed65f78137970ee
 Directory: 11/jdk
 
-Tags: 11-ea-16-jdk-slim-sid, 11-ea-16-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-16-jdk-slim, 11-ea-16-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-17-jdk-slim-sid, 11-ea-17-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-17-jdk-slim, 11-ea-17-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 841c5e57ac0b94b12cdbf274bed65f78137970ee
 Directory: 11/jdk/slim
 
-Tags: 11-ea-16-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-16-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-17-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-17-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+GitCommit: 841c5e57ac0b94b12cdbf274bed65f78137970ee
 Directory: 11/jre
 
-Tags: 11-ea-16-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-16-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-17-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-17-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 256e2f380b6ffc6c372c1ab5b7db8a28e71cef27
+GitCommit: 841c5e57ac0b94b12cdbf274bed65f78137970ee
 Directory: 11/jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
@@ -116,14 +116,14 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jre/alpine
 
-Tags: 7u171-jdk-jessie, 7u171-jessie, 7-jdk-jessie, 7-jessie, 7u171-jdk, 7u171, 7-jdk, 7
+Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk
 
-Tags: 7u171-jdk-slim-jessie, 7u171-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u171-jdk-slim, 7u171-slim, 7-jdk-slim, 7-slim
+Tags: 7u181-jdk-slim-jessie, 7u181-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u181-jdk-slim, 7u181-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk/slim
 
 Tags: 7u151-jdk-alpine3.7, 7u151-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u151-jdk-alpine, 7u151-alpine, 7-jdk-alpine, 7-alpine
@@ -131,14 +131,14 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 7/jdk/alpine
 
-Tags: 7u171-jre-jessie, 7-jre-jessie, 7u171-jre, 7-jre
+Tags: 7u181-jre-jessie, 7-jre-jessie, 7u181-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre
 
-Tags: 7u171-jre-slim-jessie, 7-jre-slim-jessie, 7u171-jre-slim, 7-jre-slim
+Tags: 7u181-jre-slim-jessie, 7-jre-slim-jessie, 7u181-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre/slim
 
 Tags: 7u151-jre-alpine3.7, 7-jre-alpine3.7, 7u151-jre-alpine, 7-jre-alpine

--- a/library/redmine
+++ b/library/redmine
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.4.5, 3.4, 3, latest
+Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf4acba62e86fef7de93922b08ff85554e8978bd
+GitCommit: 58012d31064f58611904720aa52661a9efef4678
 Directory: 3.4
 
-Tags: 3.4.5-passenger, 3.4-passenger, 3-passenger, passenger
+Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
 GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.4/passenger
 
-Tags: 3.3.7, 3.3
+Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf4acba62e86fef7de93922b08ff85554e8978bd
+GitCommit: cde2ceb34b6515ed2d5945c79206af039b696b34
 Directory: 3.3
 
-Tags: 3.3.7-passenger, 3.3-passenger
+Tags: 3.3.8-passenger, 3.3-passenger
 GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
 Directory: 3.3/passenger


### PR DESCRIPTION
- `ghost`: 1.24.2
- `openjdk`: 7u181 (debian), 11-ea+17 (debian)
- `redmine`: 3.4.6, 3.3.8