### PR TITLE
Bump Traefik to v1.6.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,14 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.3, 1.6.3, v1.6, 1.6, tetedemoine, latest
+Tags: v1.6.4, 1.6.4, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 88e12c74535395647071f7dd46fe5b0afd96643c
+GitCommit: d004e59dcb636ab24a6e2ae827fe4c8290837127
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.6.3-alpine, 1.6.3-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
+Tags: v1.6.4-alpine, 1.6.4-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 88e12c74535395647071f7dd46fe5b0afd96643c
+GitCommit: d004e59dcb636ab24a6e2ae827fe4c8290837127
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.6.4.

/cc @vdemeester @emilevauge

Cheers
