### PR TITLE
Sentry 9.0.0rc1

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,15 +1,7 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/b7d55c572e0b23c5c537432211823a8677727e1c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/ec474d97d968afdf78f4e489b58c68a2fbc46ee2/generate-stackbrew-library.sh
 
 Maintainers: Matt Robenolt <matt@sentry.io> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
-
-Tags: 8.21.0, 8.21
-GitCommit: dbfbdb991427d3e2a0d8f1d2698276846176ec40
-Directory: 8.21
-
-Tags: 8.21.0-onbuild, 8.21-onbuild
-GitCommit: dbfbdb991427d3e2a0d8f1d2698276846176ec40
-Directory: 8.21/onbuild
 
 Tags: 8.22.0, 8.22, 8, latest
 GitCommit: b7d55c572e0b23c5c537432211823a8677727e1c
@@ -18,3 +10,11 @@ Directory: 8.22
 Tags: 8.22.0-onbuild, 8.22-onbuild, 8-onbuild, onbuild
 GitCommit: b7d55c572e0b23c5c537432211823a8677727e1c
 Directory: 8.22/onbuild
+
+Tags: 9.0.0rc1, 9.0, 9
+GitCommit: ec474d97d968afdf78f4e489b58c68a2fbc46ee2
+Directory: 9.0
+
+Tags: 9.0.0rc1-onbuild, 9.0-onbuild, 9-onbuild
+GitCommit: ec474d97d968afdf78f4e489b58c68a2fbc46ee2
+Directory: 9.0/onbuild


### PR DESCRIPTION
Giving the fans what they want. A pre-release of Sentry 9 to test!

⚠️ https://github.com/getsentry/sentry/releases/tag/9.0.0rc1 ⚠️ 