### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.9, 5.6, 5, latest
-GitCommit: a83e1837684d580e66f31cb01940ac1b99eef3aa
+Tags: 5.6.10, 5.6, 5, latest
+GitCommit: be1eb53a6a62a57d0ed17e4287d3fc51a7409a9f
 Directory: 5
 
-Tags: 5.6.9-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: a83e1837684d580e66f31cb01940ac1b99eef3aa
+Tags: 5.6.10-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: be1eb53a6a62a57d0ed17e4287d3fc51a7409a9f
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.2, 1.24, 1, latest
+Tags: 1.24.4, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ad29262377075c1ae79c3dbb3731d8bbeb07d2c
+GitCommit: 9f90ae63480e514e66b37bb5e99b5d023f52e380
 Directory: 1/debian
 
-Tags: 1.24.2-alpine, 1.24-alpine, 1-alpine, alpine
+Tags: 1.24.4-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 8ad29262377075c1ae79c3dbb3731d8bbeb07d2c
+GitCommit: 9f90ae63480e514e66b37bb5e99b5d023f52e380
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.9, 5.6, 5, latest
-GitCommit: 249795079412622520b290ce2a93eae360db3b68
+Tags: 5.6.10, 5.6, 5, latest
+GitCommit: c59bd9585cbe6d62e1bd56c7975d2eb350dc11fb
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.9, 5.6, 5, latest
-GitCommit: 6bc0d60b136c959d38965a5e9515331945e3ec4f
+Tags: 5.6.10, 5.6, 5, latest
+GitCommit: 7339f3d967a5e725c8c40c8b68d0e035b6005064
 Directory: 5
 
-Tags: 5.6.9-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 6bc0d60b136c959d38965a5e9515331945e3ec4f
+Tags: 5.6.10-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 7339f3d967a5e725c8c40c8b68d0e035b6005064
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -36,10 +36,10 @@ Architectures: amd64, arm64v8
 GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
 Directory: 3.7
 
-Tags: 4.0.0-rc4-xenial, 4.0-rc-xenial, rc-xenial
-SharedTags: 4.0.0-rc4, 4.0-rc, rc
+Tags: 4.0.0-rc5-xenial, 4.0-rc-xenial, rc-xenial
+SharedTags: 4.0.0-rc5, 4.0-rc, rc
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/testing/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: fddc16475e53f0640f7ea46c98096baa297da1e2
+GitCommit: 711ff13a77afdc4e2b2fca34c80b22f700e5fdb4
 Directory: 4.0-rc

--- a/library/php
+++ b/library/php
@@ -6,215 +6,215 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.6-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.6-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.6-cli, 7.2-cli, 7-cli, cli, 7.2.6, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.6-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.6-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.6-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.6-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.6-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.6-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cf5482724142c2c249c7f873b0f7f4910e502b63
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.6-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.6-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.6-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.6-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.6-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.6-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.6-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.6-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.6-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.6-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.6-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.6-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.18-cli-stretch, 7.1-cli-stretch, 7.1.18-stretch, 7.1-stretch, 7.1.18-cli, 7.1-cli, 7.1.18, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.18-apache-stretch, 7.1-apache-stretch, 7.1.18-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.18-fpm-stretch, 7.1-fpm-stretch, 7.1.18-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.18-zts-stretch, 7.1-zts-stretch, 7.1.18-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.18-cli-jessie, 7.1-cli-jessie, 7.1.18-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.18-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.18-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.18-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36167a6d68c014168e89202516a55047ff335d38
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.18-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.18-alpine3.7, 7.1-alpine3.7, 7.1.18-cli-alpine, 7.1-cli-alpine, 7.1.18-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/alpine3.7/cli
 
 Tags: 7.1.18-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.18-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/alpine3.7/fpm
 
 Tags: 7.1.18-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.18-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/stretch/cli
 
 Tags: 7.0.30-apache-stretch, 7.0-apache-stretch, 7.0.30-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/stretch/apache
 
 Tags: 7.0.30-fpm-stretch, 7.0-fpm-stretch, 7.0.30-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/stretch/fpm
 
 Tags: 7.0.30-zts-stretch, 7.0-zts-stretch, 7.0.30-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27c65bbd606d1745765b89bf43f39b06efad1e43
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/stretch/zts
 
 Tags: 7.0.30-cli-jessie, 7.0-cli-jessie, 7.0.30-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.30-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.30-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.30-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.30-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.30-alpine3.7, 7.0-alpine3.7, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/alpine3.7/cli
 
 Tags: 7.0.30-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.30-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/alpine3.7/fpm
 
 Tags: 7.0.30-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.30-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 7.0/alpine3.7/zts
 
 Tags: 5.6.36-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.36-stretch, 5.6-stretch, 5-stretch, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/stretch/cli
 
 Tags: 5.6.36-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.36-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/stretch/apache
 
 Tags: 5.6.36-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.36-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/stretch/fpm
 
 Tags: 5.6.36-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.36-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78125d0d3c32a87a05f56c12ca45778e3d4bb7c9
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/stretch/zts
 
 Tags: 5.6.36-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.36-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.36-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.36-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.36-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b045ba7c51ceed8a495beb8ea7274df48a3c70e1
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.36-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.36-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/alpine3.7/cli
 
 Tags: 5.6.36-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/alpine3.7/fpm
 
 Tags: 5.6.36-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fa5427d3991877629b320485142e5cb776e9c5e
+GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
 Directory: 5.6/alpine3.7/zts

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,62 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.5, 3.7, 3, latest
+Tags: 3.7.6, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 75bbd3f7ae9c106a23b0f10809d45690045f805a
+GitCommit: fec4ea13595dba46c66efcb3a010e827bee5cbd4
 Directory: 3.7/debian
 
-Tags: 3.7.5-management, 3.7-management, 3-management, management
+Tags: 3.7.6-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/debian/management
 
-Tags: 3.7.5-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.6-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
+GitCommit: fa1276bb5252c429d38fded8995aa3bbcac029ff
 Directory: 3.7/alpine
 
-Tags: 3.7.5-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.6-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
 
-Tags: 3.6.16-rc.1, 3.6-rc
+Tags: 3.6.16, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
-Directory: 3.6-rc/debian
-
-Tags: 3.6.16-rc.1-management, 3.6-rc-management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
-Directory: 3.6-rc/debian/management
-
-Tags: 3.6.16-rc.1-alpine, 3.6-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
-Directory: 3.6-rc/alpine
-
-Tags: 3.6.16-rc.1-management-alpine, 3.6-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 087a9cf6059d4a71962819cb808ee8b71929790f
-Directory: 3.6-rc/alpine/management
-
-Tags: 3.6.15, 3.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da82eb0f68ed89a876fc44e915f20fc1e6e6bd8d
+GitCommit: 17eebc8b38df47b8a45a46d3afb306a359f1e0d4
 Directory: 3.6/debian
 
-Tags: 3.6.15-management, 3.6-management
+Tags: 3.6.16-management, 3.6-management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/debian/management
 
-Tags: 3.6.15-alpine, 3.6-alpine
+Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d7096266dfb047fce1eff89bd759e3ab55d779f3
+GitCommit: 46319b542643d1ad0c5380bb2a1f362d7064d2c1
 Directory: 3.6/alpine
 
-Tags: 3.6.15-management-alpine, 3.6-management-alpine
+Tags: 3.6.16-management-alpine, 3.6-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
 Directory: 3.6/alpine/management

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 58012d31064f58611904720aa52661a9efef4678
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
+GitCommit: 0e0782f918c5181cfc80131d4566bf1fc53c4a76
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
@@ -19,5 +19,5 @@ GitCommit: cde2ceb34b6515ed2d5945c79206af039b696b34
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: 6283032368948d5ac3ede71e9cec0a586a903603
+GitCommit: 0e0782f918c5181cfc80131d4566bf1fc53c4a76
 Directory: 3.3/passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/fae008566295d1eec89de04385215fdd54eceda5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/f93ce2df63e03c2467dedde31fdc6b08f84c0155/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -104,12 +104,12 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 8fffa7246aacceb0e7390aafe978efeea9c104e3
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.8-jre10, 9.0-jre10, 9-jre10
+Tags: 9.0.8-jre10, 9.0-jre10, 9-jre10, 9.0.8, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre10
 
-Tags: 9.0.8-jre10-slim, 9.0-jre10-slim, 9-jre10-slim
+Tags: 9.0.8-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.8-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
 Directory: 9.0/jre10-slim


### PR DESCRIPTION
- `elasticsearch`: 5.6.10
- `ghost`: 1.24.4
- `kibana`: 5.6.10
- `logstash`: 5.6.10
- `mongo`: 4.0.0-rc5
- `php`: enable CGI in CLI variant (docker-library/php#649)
- `rabbitmq`: 3.7.6-rc.2
- `redmine`: passenger 5.3.2
- `tomcat`: update "default JRE" for Tomcat 9.0