### PR TITLE
update R 3.5.0 image using post-transition packages

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.5.0: git://github.com/rocker-org/rocker@bdea37238c06a4501e701beaaa4ce2489bed376e r-base
-latest: git://github.com/rocker-org/rocker@bdea37238c06a4501e701beaaa4ce2489bed376e r-base
+3.5.0: git://github.com/rocker-org/rocker@960999dd029454202f59cf4beeaedaceecd27ec6 r-base
+latest: git://github.com/rocker-org/rocker@960999dd029454202f59cf4beeaedaceecd27ec6 r-base

--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,5 @@
 # maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
 # maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 
-3.5.0: git://github.com/rocker-org/rocker@629c6f89d81a336a7fa6a8a18f8365f1fd2878be r-base
-latest: git://github.com/rocker-org/rocker@629c6f89d81a336a7fa6a8a18f8365f1fd2878be r-base
+3.5.0: git://github.com/rocker-org/rocker@bdea37238c06a4501e701beaaa4ce2489bed376e r-base
+latest: git://github.com/rocker-org/rocker@bdea37238c06a4501e701beaaa4ce2489bed376e r-base


### PR DESCRIPTION
Howdy,

When R 3.5.0 came out in late April, it once again required rebuilds of packages using it. Debian uses the "transition" process for this, this tends to take a moment -- so I had create a one-off repo useable for this image, and we built our Rocker image and the corresponding r-base official image.

The transition is through, all packages are in testing so we can do it again "by the book" which is what this PR for R 3.5.0 does.  

When you diff is, you will see one or two other benign changes -- mostly just tweaks to the container.