### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.4, 1.24, 1, latest
+Tags: 1.24.5, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f90ae63480e514e66b37bb5e99b5d023f52e380
+GitCommit: c5d2125cd9d87cafcb250bef6874dd96c929fe21
 Directory: 1/debian
 
-Tags: 1.24.4-alpine, 1.24-alpine, 1-alpine, alpine
+Tags: 1.24.5-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 9f90ae63480e514e66b37bb5e99b5d023f52e380
+GitCommit: c5d2125cd9d87cafcb250bef6874dd96c929fe21
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -12,8 +12,8 @@ Tags: 10.2.15, 10.2
 GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.2
 
-Tags: 10.1.33, 10.1
-GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
+Tags: 10.1.34, 10.1
+GitCommit: 12a0273332a3a0ed007ece2ae5886f7ac9c15d1b
 Directory: 10.1
 
 Tags: 10.0.35, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -36,10 +36,10 @@ Architectures: amd64, arm64v8
 GitCommit: de4376792e103d35e9b16a023c4046d17cf15f22
 Directory: 3.7
 
-Tags: 4.0.0-rc5-xenial, 4.0-rc-xenial, rc-xenial
-SharedTags: 4.0.0-rc5, 4.0-rc, rc
+Tags: 4.0.0-rc6-xenial, 4.0-rc-xenial, rc-xenial
+SharedTags: 4.0.0-rc6, 4.0-rc, rc
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/testing/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 711ff13a77afdc4e2b2fca34c80b22f700e5fdb4
+GitCommit: 11ded25561b1657f25d903f3374593257343b825
 Directory: 4.0-rc

--- a/library/php
+++ b/library/php
@@ -6,215 +6,215 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.2.6-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.6-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.6-cli, 7.2-cli, 7-cli, cli, 7.2.6, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.6-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.6-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.6-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.6-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.6-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.6-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.6-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.6-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.6-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.6-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.6-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.6-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.6-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.6-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.6-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.6-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.6-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.6-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.18-cli-stretch, 7.1-cli-stretch, 7.1.18-stretch, 7.1-stretch, 7.1.18-cli, 7.1-cli, 7.1.18, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.18-apache-stretch, 7.1-apache-stretch, 7.1.18-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.18-fpm-stretch, 7.1-fpm-stretch, 7.1.18-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.18-zts-stretch, 7.1-zts-stretch, 7.1.18-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.18-cli-jessie, 7.1-cli-jessie, 7.1.18-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.18-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.18-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.18-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.18-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.18-alpine3.7, 7.1-alpine3.7, 7.1.18-cli-alpine, 7.1-cli-alpine, 7.1.18-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/alpine3.7/cli
 
 Tags: 7.1.18-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.18-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/alpine3.7/fpm
 
 Tags: 7.1.18-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.18-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/stretch/cli
 
 Tags: 7.0.30-apache-stretch, 7.0-apache-stretch, 7.0.30-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/stretch/apache
 
 Tags: 7.0.30-fpm-stretch, 7.0-fpm-stretch, 7.0.30-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/stretch/fpm
 
 Tags: 7.0.30-zts-stretch, 7.0-zts-stretch, 7.0.30-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/stretch/zts
 
 Tags: 7.0.30-cli-jessie, 7.0-cli-jessie, 7.0.30-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.30-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.30-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.30-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.30-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.30-alpine3.7, 7.0-alpine3.7, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/alpine3.7/cli
 
 Tags: 7.0.30-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.30-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/alpine3.7/fpm
 
 Tags: 7.0.30-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.30-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 7.0/alpine3.7/zts
 
 Tags: 5.6.36-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.36-stretch, 5.6-stretch, 5-stretch, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/stretch/cli
 
 Tags: 5.6.36-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.36-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/stretch/apache
 
 Tags: 5.6.36-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.36-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/stretch/fpm
 
 Tags: 5.6.36-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.36-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/stretch/zts
 
 Tags: 5.6.36-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.36-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.36-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.36-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.36-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.36-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.36-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/alpine3.7/cli
 
 Tags: 5.6.36-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/alpine3.7/fpm
 
 Tags: 5.6.36-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cff4da8fdbf0461c855a63d18431e18eed4cbcdc
+GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
 Directory: 5.6/alpine3.7/zts

--- a/library/redis
+++ b/library/redis
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 3.2.12, 3.2, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f137878f40e40f87a63813821d49464d2710acf
+GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 3.2
 
 Tags: 3.2.12-32bit, 3.2-32bit, 3-32bit
 Architectures: amd64
-GitCommit: 3f137878f40e40f87a63813821d49464d2710acf
+GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 3.2/32bit
 
 Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine
@@ -21,12 +21,12 @@ Directory: 3.2/alpine
 
 Tags: 4.0.10, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 87e80558fb828de53399e341af4c8a05c3e2d631
+GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 4.0
 
 Tags: 4.0.10-32bit, 4.0-32bit, 4-32bit, 32bit
 Architectures: amd64
-GitCommit: 87e80558fb828de53399e341af4c8a05c3e2d631
+GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 4.0/32bit
 
 Tags: 4.0.10-alpine, 4.0-alpine, 4-alpine, alpine

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58012d31064f58611904720aa52661a9efef4678
+GitCommit: f1b7769e2cd58c2c1941b6f3012383cf7b7c445e
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde2ceb34b6515ed2d5945c79206af039b696b34
+GitCommit: f1b7769e2cd58c2c1941b6f3012383cf7b7c445e
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.65.1, 0.65, 0, latest
-GitCommit: 3c2c45e2bd10643abbf13b70242e4843e46fd989
+Tags: 0.65.2, 0.65, 0, latest
+GitCommit: 9c795567e4aa75922085df5f7469650a5c9f9c86


### PR DESCRIPTION
- `ghost`: 1.24.5
- `mariadb`: 10.1.34
- `mongo`: 4.0.0-rc6
- `php`: add `gpgconf --kill all` (docker-library/php#666)
- `redis`: stretch (docker-library/redis#143)
- `redmine`: add back `imagemagick` (docker-library/redmine#121)
- `rocket.chat`: 0.65.2