### PR TITLE
Update Amazon Linux images (2.0.20180622.1, 2018.03.0.20180622)

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,45 +1,21 @@
 Maintainers: Amazon Linux Team <amazon-linux@amazon.com> (@aws),
-             Iliana Weller (@ilianaw),
+             iliana weller (@ilianaw),
              Praveen K Paladugu (@praveen-pk),
              Eric Warehime (@Eric-Warehime)
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
 
-Tags: 2017.12.0.20180330, 2017.12, 2
-GitFetch: refs/heads/2017.12
-GitCommit: 91cc3997375a8055ae62ffa2635acc464ec8ac51
+Tags: 2.0.20180622.1, 2, latest
+GitFetch: refs/heads/amzn2
+GitCommit: d59369b8dc1f3a41231d550274a565a349fb326b
 
-Tags: 2017.12.0.20180330-with-sources, 2017.12-with-sources, 2-with-sources
-GitFetch: refs/heads/2017.12-with-sources
-GitCommit: 9129377feea1176b636427b295e8af57656db079
+Tags: 2.0.20180622.1-with-sources, 2-with-sources, with-sources
+GitFetch: refs/heads/amzn2-with-sources
+GitCommit: 54ffc6812a9912808ead357a6cb757c4db671121
 
-Tags: 2018.03.0.20180424, 2018.03, 1, latest
+Tags: 2018.03.0.20180622, 2018.03, 1
 GitFetch: refs/heads/2018.03
-GitCommit: 2d98947f57ed4afe97daef60f4c05ec5e4adc69d
+GitCommit: 790dac3b115c84613ae36e48491db746e4b7503d
 
-Tags: 2018.03.0.20180424-with-sources, 2018.03-with-sources, 1-with-sources, with-sources
+Tags: 2018.03.0.20180622-with-sources, 2018.03-with-sources, 1-with-sources
 GitFetch: refs/heads/2018.03-with-sources
-GitCommit: e323bc6480b6eb08de5ed48f5d049aa04dcef7d3
-
-Tags: 2017.09.1.20180409, 2017.09
-GitFetch: refs/heads/2017.09
-GitCommit: 0b2dad813345cab464c6c0a716aa5be2ae072f79
-
-Tags: 2017.09.1.20180409-with-sources, 2017.09-with-sources
-GitFetch: refs/heads/2017.09-with-sources
-GitCommit: 6d5273cf53b85c27690ac394bee2c2935cca73b8
-
-Tags: 2017.03.1.20170812, 2017.03
-GitFetch: refs/heads/2017.03
-GitCommit: 577139a6f2571e3adb59cfd34d61bc07e2fba238
-
-Tags: 2017.03.1.20170812-with-sources, 2017.03-with-sources
-GitFetch: refs/heads/2017.03-with-sources
-GitCommit: 47f91aec4a189232a7feb1ec544a3a6af0347113
-
-Tags: 2016.09.1.20161221, 2016.09
-GitFetch: refs/heads/2016.09
-GitCommit: e1b56e68ebd2b274c64e0a0a18ae0a9a8122822d
-
-Tags: 2016.09.1.20161221-with-sources, 2016.09-with-sources
-GitFetch: refs/heads/2016.09-with-sources
-GitCommit: 2de60e8c98421694c293639659a88ed81ce29298
+GitCommit: 299dd79dcf37b9354decee89bc243b95c7cddbaf


### PR DESCRIPTION
Amazon Linux 2 is available and is out of the candidate stage. We dropped the YYYY.MM versioning scheme in this release. "latest" now points to AL2.

We've updated the container image for 2018.03.

I've dropped references to all other versions, as we no longer generally support those (but as I understand it, this does not keep users from pulling those images as tags never get deleted from Docker Hub).