### PR TITLE
Update WebSphere Liberty to version 18.0.0.2

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 22bbc53ecd1255868e41df09cea65f2fc145e794
+GitCommit: 9d28dfba4d20596f89b393bc9e3ae8295feec469
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 967903a078e288c3d33b61d96c393b41a2c438f3
+GitCommit: 22bbc53ecd1255868e41df09cea65f2fc145e794
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 3cb2adf201dea86ed1b01a84ab2a44968ef5e239
+GitCommit: 967903a078e288c3d33b61d96c393b41a2c438f3
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -11,14 +11,17 @@ Directory: ga/developer/kernel
 Tags: microProfile
 Directory: ga/developer/microProfile
 
-Tags: webProfile6
-Directory: ga/developer/webProfile6
-
 Tags: webProfile7
 Directory: ga/developer/webProfile7
 
-Tags: javaee7, latest
+Tags: javaee7
 Directory: ga/developer/javaee7
+
+Tags: webProfile8
+Directory: ga/developer/webProfile8
+
+Tags: javaee8, latest
+Directory: ga/developer/javaee8
 
 Tags: beta
 Directory: beta


### PR DESCRIPTION
The changes since last time:

- update WebSphere Liberty binaries to version `18.0.0.2`
- added `ONBUILD` to the server priming (server start/stop) instruction, so that it reduces the size of the Docker Hub image and defers the priming to happen during the parent build - remembering that WebSphere Liberty's Docker Hub image is always used in a `FROM` statement (not run directly)
- added new tags (`webProfile8` and `javaee8`) for our Java EE8 support
- changed `latest` to point to the `javaee8` tag
- removed `webProfile6` tag as we want to encourage users to move into EE7 and EE8
