### PR TITLE
Update Solr to 7.4.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,22 +1,37 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/cdd1a07972438a0123371f09cd05edaff5932d30/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/c2db03b35db11ebd6b9ca95d17108c3e7d721cda/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.3.1, 7.3, 7, latest
+Tags: 7.4.0, 7.4, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
+GitCommit: dc31c84b54a469091a08de7c5b6c73b397e48162
+Directory: 7.4
+
+Tags: 7.4.0-alpine, 7.4-alpine, 7-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c2db03b35db11ebd6b9ca95d17108c3e7d721cda
+Directory: 7.4/alpine
+
+Tags: 7.4.0-slim, 7.4-slim, 7-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: dc31c84b54a469091a08de7c5b6c73b397e48162
+Directory: 7.4/slim
+
+Tags: 7.3.1, 7.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: dc31c84b54a469091a08de7c5b6c73b397e48162
 Directory: 7.3
 
-Tags: 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
+Tags: 7.3.1-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.3/alpine
 
-Tags: 7.3.1-slim, 7.3-slim, 7-slim, slim
+Tags: 7.3.1-slim, 7.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
+GitCommit: dc31c84b54a469091a08de7c5b6c73b397e48162
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201806.mbox/%3CCAPsWd%2BO4M%3DjTLcGhJcAEBgeJUuq5y%3Dgr9HaFYxDO6dDYTrfYqg%40mail.gmail.com%3E
Changes: http://lucene.apache.org/solr/7_4_0/changes/Changes.html

Of note:
- The log4j configuration is now in `log4j2.xml` rather than `log4j.properties` files. See http://lucene.apache.org/solr/7_4_0/changes/Changes.html#v7.4.0.upgrade_notes
- Jetty is now 9.4.10.v20180503 
- The `unlimited: integer expression expected` error under docker has gone away

On the docker-solr side, two changes were required:
- The `generate-stackbrew-library.sh` failed because it uses the upstream openjdk manifest, which no longer contains version 9, so I've updated to 10.
- Solr no longer publishes MD5 checksums, so the `update.sh` now checks the sha512 published for new versions, and sha1 for older versions.