### PR TITLE
Bug fix/passwd rocksdb

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -8,6 +8,6 @@
 
 3.2: https://github.com/arangodb/arangodb-docker@cc4106a5a7cdb75c1ab9798cd2b75248f7745204 stretch/3.2.15
 3.2.15: https://github.com/arangodb/arangodb-docker@cc4106a5a7cdb75c1ab9798cd2b75248f7745204 stretch/3.2.15
-3.3: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11
-3.3.11: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11
-latest: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11
+3.3: https://github.com/arangodb/arangodb-docker@5e3113040163a9c02df8c2aac06b0f3b750450d7 stretch/3.3.11
+3.3.11: https://github.com/arangodb/arangodb-docker@5e3113040163a9c02df8c2aac06b0f3b750450d7 stretch/3.3.11
+latest: https://github.com/arangodb/arangodb-docker@5e3113040163a9c02df8c2aac06b0f3b750450d7 stretch/3.3.11

--- a/library/arangodb
+++ b/library/arangodb
@@ -8,6 +8,6 @@
 
 3.2: https://github.com/arangodb/arangodb-docker@cc4106a5a7cdb75c1ab9798cd2b75248f7745204 stretch/3.2.15
 3.2.15: https://github.com/arangodb/arangodb-docker@cc4106a5a7cdb75c1ab9798cd2b75248f7745204 stretch/3.2.15
-3.3: https://github.com/arangodb/arangodb-docker@56b6695e7a556b22a2c29188f8beb0fe05780fe1 stretch/3.3.11
-3.3.11: https://github.com/arangodb/arangodb-docker@56b6695e7a556b22a2c29188f8beb0fe05780fe1 stretch/3.3.11
-latest: https://github.com/arangodb/arangodb-docker@56b6695e7a556b22a2c29188f8beb0fe05780fe1 stretch/3.3.11
+3.3: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11
+3.3.11: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11
+latest: https://github.com/arangodb/arangodb-docker@e90a64b8d693d118a221f9365d49770d33eb4d76 stretch/3.3.11


### PR DESCRIPTION
This fixes a bug that prevents proper startup when a root password is given from the outside and the rocksdb storage engine is chosen at the same time.