### PR TITLE
[nats-streaming] Release v0.10.2

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 
-Tags: 0.10.0-linux, linux
-SharedTags: 0.10.0, latest
+Tags: 0.10.2-linux, linux
+SharedTags: 0.10.2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 amd64-Directory: amd64
-arm32v6-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+arm32v6-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+arm32v7-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+arm64v8-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 arm64v8-Directory: arm64v8
 
-Tags: 0.10.0-nanoserver, nanoserver
-SharedTags: 0.10.0, latest
+Tags: 0.10.2-nanoserver, nanoserver
+SharedTags: 0.10.2, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+windows-amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.10.0-windowsservercore, windowsservercore
+Tags: 0.10.2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 5639c0377daecb06d162641d81c830fa5a204c00
+windows-amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.10.2)

Note: I did not update docker-docs since there is really nothing
that need updating there. This is a patch release.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>