### PR TITLE
Update ghost, mariadb, python, tomcat

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.6, 1.24, 1, latest
+Tags: 1.24.7, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7ad05507672af18afe439c26ad5f68e037eeae5
+GitCommit: 27b3fac3ae40f6acaf9f554e9fcbb4c1acf8c71e
 Directory: 1/debian
 
-Tags: 1.24.6-alpine, 1.24-alpine, 1-alpine, alpine
+Tags: 1.24.7-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: d7ad05507672af18afe439c26ad5f68e037eeae5
+GitCommit: 27b3fac3ae40f6acaf9f554e9fcbb4c1acf8c71e
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.7, 10.3, 10, latest
-GitCommit: 9c407e44d78e10dbef48f5cfd450f84ab8a1702d
+Tags: 10.3.8, 10.3, 10, latest
+GitCommit: a7d1a184913c009c473baeb8f72385d12ae0de61
 Directory: 10.3
 
 Tags: 10.2.16, 10.2

--- a/library/python
+++ b/library/python
@@ -1,84 +1,84 @@
-# this file is generated via https://github.com/docker-library/python/blob/a8eaaf400780f2b92422829a01cbd6368eed32ee/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/2a79ecbdfdb736297c39bcae664aee0e6b01bd5c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.0b5-stretch, 3.7-rc-stretch, rc-stretch
-SharedTags: 3.7.0b5, 3.7-rc, rc
+Tags: 3.7.0-stretch, 3.7-stretch, 3-stretch, stretch
+SharedTags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
-Directory: 3.7-rc/stretch
+GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+Directory: 3.7/stretch
 
-Tags: 3.7.0b5-slim-stretch, 3.7-rc-slim-stretch, rc-slim-stretch, 3.7.0b5-slim, 3.7-rc-slim, rc-slim
+Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
-Directory: 3.7-rc/stretch/slim
+GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+Directory: 3.7/stretch/slim
 
-Tags: 3.7.0b5-alpine3.7, 3.7-rc-alpine3.7, rc-alpine3.7, 3.7.0b5-alpine, 3.7-rc-alpine, rc-alpine
+Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bbbc37fff3411a34deef30dd9b34dc938fe7b134
-Directory: 3.7-rc/alpine3.7
+GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+Directory: 3.7/alpine3.7
 
-Tags: 3.7.0b5-windowsservercore-ltsc2016, 3.7-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.7.0b5-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b5, 3.7-rc, rc
+Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
-Directory: 3.7-rc/windows/windowsservercore-ltsc2016
+GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.0b5-windowsservercore-1709, 3.7-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 3.7.0b5-windowsservercore, 3.7-rc-windowsservercore, rc-windowsservercore, 3.7.0b5, 3.7-rc, rc
+Tags: 3.7.0-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: f38c92b3fc2db507290e443b3e7b2844ebf16ab9
-Directory: 3.7-rc/windows/windowsservercore-1709
+GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.6-stretch, 3.6-stretch, 3-stretch, stretch
-SharedTags: 3.6.6, 3.6, 3, latest
+Tags: 3.6.6-stretch, 3.6-stretch
+SharedTags: 3.6.6, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/stretch
 
-Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3-slim-stretch, slim-stretch, 3.6.6-slim, 3.6-slim, 3-slim, slim
+Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3.6.6-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/stretch/slim
 
-Tags: 3.6.6-jessie, 3.6-jessie, 3-jessie, jessie
+Tags: 3.6.6-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/jessie
 
-Tags: 3.6.6-slim-jessie, 3.6-slim-jessie, 3-slim-jessie, slim-jessie
+Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.6-onbuild, 3.6-onbuild, 3-onbuild, onbuild
+Tags: 3.6.6-onbuild, 3.6-onbuild
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
-Tags: 3.6.6-alpine3.7, 3.6-alpine3.7, 3-alpine3.7, alpine3.7, 3.6.6-alpine, 3.6-alpine, 3-alpine, alpine
+Tags: 3.6.6-alpine3.7, 3.6-alpine3.7, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/alpine3.7
 
-Tags: 3.6.6-alpine3.6, 3.6-alpine3.6, 3-alpine3.6, alpine3.6
+Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/alpine3.6
 
-Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.6, 3.6, 3, latest
+Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
+SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, windowsservercore, 3.6.6, 3.6, 3, latest
+Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709
+SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
 GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/windows/windowsservercore-1709

--- a/library/tomcat
+++ b/library/tomcat
@@ -64,52 +64,52 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: d183e24a7f4239f84bf521ac96690904adb21a86
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.31-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.31, 8.5, 8, latest
+Tags: 8.5.32-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.32, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
+GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
 Directory: 8.5/jre8
 
-Tags: 8.5.31-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.31-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.32-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.32-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
+GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.31-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.31-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.32-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.32-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ce7bd2eed038fb722527f41f0f185322d53e979
+GitCommit: 6e4ee9a93be401c9c70aeda9f3c6ccf8a3ccdb8b
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.31-jre10, 8.5-jre10, 8-jre10, jre10
+Tags: 8.5.32-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
+GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
 Directory: 8.5/jre10
 
-Tags: 8.5.31-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Tags: 8.5.32-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f9b2155c4c44e3668fea5e26bae26a6f5b783e3
+GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
 Directory: 8.5/jre10-slim
 
-Tags: 9.0.8-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.10-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
+GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
 Directory: 9.0/jre8
 
-Tags: 9.0.8-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.10-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
+GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.8-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.10-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8fffa7246aacceb0e7390aafe978efeea9c104e3
+GitCommit: 52beaf7ad8bd55ae0b0f44031f370b5461209af8
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.8-jre10, 9.0-jre10, 9-jre10, 9.0.8, 9.0, 9
+Tags: 9.0.10-jre10, 9.0-jre10, 9-jre10, 9.0.10, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
+GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
 Directory: 9.0/jre10
 
-Tags: 9.0.8-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.8-slim, 9.0-slim, 9-slim
+Tags: 9.0.10-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.10-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cde74d619bfe2e522d31b02969822b0d0df0bc6c
+GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
 Directory: 9.0/jre10-slim


### PR DESCRIPTION
 - `ghost` bump to `1.24.7`
 - `mariadb` bump to `10.3.8`
 - `python` bump `3.7.0`, now GA
 - `tomecat` bump to `9.0.10` and `8.5.32`