### PR TITLE
Update node.js v9.x to v10.6.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/7fea7b033c5a292dd74199d2ba0fbb161f75aa0d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/b22fb6c84e3cac83309b083c973649b2bf6b092d/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
@@ -78,24 +78,24 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
 Directory: 6/stretch
 
-Tags: 10.5.0-jessie, 10.5-jessie, 10-jessie, jessie, 10.5.0, 10.5, 10, latest
+Tags: 10.6.0-jessie, 10.6-jessie, 10-jessie, jessie, 10.6.0, 10.6, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 65ba769f403f8c188d9be0b1ffb8a9cfc31bf703
+GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
 Directory: 10/jessie
 
-Tags: 10.5.0-alpine, 10.5-alpine, 10-alpine, alpine
+Tags: 10.6.0-alpine, 10.6-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 65ba769f403f8c188d9be0b1ffb8a9cfc31bf703
+GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
 Directory: 10/alpine
 
-Tags: 10.5.0-slim, 10.5-slim, 10-slim, slim
+Tags: 10.6.0-slim, 10.6-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 65ba769f403f8c188d9be0b1ffb8a9cfc31bf703
+GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
 Directory: 10/slim
 
-Tags: 10.5.0-stretch, 10.5-stretch, 10-stretch, stretch
+Tags: 10.6.0-stretch, 10.6-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 65ba769f403f8c188d9be0b1ffb8a9cfc31bf703
+GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/807#event-1716790836
- https://github.com/nodejs/node/releases/tag/v10.6.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.6.0