### PR TITLE
Release Neo4j 3.4.3

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 Tags: 3.4.3, 3.4, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.2/community
+Directory: 3.4.3/community
 
 Tags: 3.4.3-enterprise, 3.4-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.2/enterprise
+Directory: 3.4.3/enterprise
 
 Tags: 3.4.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git

--- a/library/neo4j
+++ b/library/neo4j
@@ -9,12 +9,22 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
              Praveena Fernandes <praveena.fernandes@neo4j.com> (@praveenag),
              Chris Gioran <chris@neo4j.com> (@digitalstain)
 
-Tags: 3.4.1, 3.4, latest
+Tags: 3.4.3, 3.4, latest
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
+Directory: 3.4.2/community
+
+Tags: 3.4.3-enterprise, 3.4-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
+Directory: 3.4.2/enterprise
+
+Tags: 3.4.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/community
 
-Tags: 3.4.1-enterprise, 3.4-enterprise, enterprise
+Tags: 3.4.1-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/enterprise


### PR DESCRIPTION
I know we skipped the 3.4.2 release. When we released 3.4.2 to Maven we accidentally packaged the wrong jar dependencies and so it's in an unknown state. You can't un-release from maven so we had to jump straight to 3.4.3 on all platforms.
I don't know what the Docker rules are on whether we can skip a release number.