### PR TITLE
Enable Neo4j for ARM64

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -10,21 +10,25 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
              Chris Gioran <chris@neo4j.com> (@digitalstain)
 
 Tags: 3.4.1, 3.4, latest
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/community
 
 Tags: 3.4.1-enterprise, 3.4-enterprise, enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/enterprise
 
 Tags: 3.4.0
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: eb6334f976453d0d8530a67b086ff96875a0742f
 Directory: 3.4.0/community
 
 Tags: 3.4.0-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: eb6334f976453d0d8530a67b086ff96875a0742f
 Directory: 3.4.0/enterprise
@@ -40,61 +44,73 @@ GitCommit: 15b853ffebb036d981002b8f6130a62a432328d4
 Directory: 3.3.6/enterprise
 
 Tags: 3.3.5
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: de5c2157b11dbf2c7256b4aceca84313a2b8350c
 Directory: 3.3.5/community
 
 Tags: 3.3.5-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: de5c2157b11dbf2c7256b4aceca84313a2b8350c
 Directory: 3.3.5/enterprise
 
 Tags: 3.3.4
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: bff364da12162093c10830b41b6b60d92f7d7c6e
 Directory: 3.3.4/community
 
 Tags: 3.3.4-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: bff364da12162093c10830b41b6b60d92f7d7c6e
 Directory: 3.3.4/enterprise
 
 Tags: 3.3.3
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: cb3ffef1bfdec6eb051d912f36aa91702c6a6f22
 Directory: 3.3.3/community
 
 Tags: 3.3.3-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: cb3ffef1bfdec6eb051d912f36aa91702c6a6f22
 Directory: 3.3.3/enterprise
 
 Tags: 3.3.2
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d2ac73d32328f299d14aad08bb82e7daefe1e575
 Directory: 3.3.2/community
 
 Tags: 3.3.2-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d2ac73d32328f299d14aad08bb82e7daefe1e575
 Directory: 3.3.2/enterprise
 
 Tags: 3.3.1
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 9a175bdb484967c609c5c369256b866a577f86b3
 Directory: 3.3.1/community
 
 Tags: 3.3.1-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 9a175bdb484967c609c5c369256b866a577f86b3
 Directory: 3.3.1/enterprise
 
 Tags: 3.3.0
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: aa31654ee8544cd544b369d2646cf372086f7b70
 Directory: 3.3.0/community
 
 Tags: 3.3.0-enterprise
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: aa31654ee8544cd544b369d2646cf372086f7b70
 Directory: 3.3.0/enterprise


### PR DESCRIPTION
Only 3.3.x and 3.4.x enabled as they were the only versions tested.

Cc: Ben Butler-Cole <ben@neo4j.com> (@benbc),
Cc: Jonas Kalderstam <jonas.kalderstam@neo4j.com> (@spacecowboy),
Cc: Praveena Fernandes <praveena.fernandes@neo4j.com> (@praveenag),
Cc: Chris Gioran <chris@neo4j.com> (@digitalstain)
Signed-off-by: Lee Jones <lee.jones@linaro.org>