### PR TITLE
Update docker, drupal, openjdk, rabbitmq, tomcat, and wordpress

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -11,7 +11,7 @@ Directory: 18.06-rc
 
 Tags: 18.06.0-ce-rc1-dind, 18.06-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 84fbcfc4cbef254dce2e7ecd7fcff788da4690df
+GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
 Directory: 18.06-rc/dind
 
 Tags: 18.06.0-ce-rc1-git, 18.06-rc-git, rc-git, test-git
@@ -26,7 +26,7 @@ Directory: 18.05
 
 Tags: 18.05.0-ce-dind, 18.05.0-dind, 18.05-dind, 18-dind, edge-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
+GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
 Directory: 18.05/dind
 
 Tags: 18.05.0-ce-git, 18.05.0-git, 18.05-git, 18-git, edge-git, git
@@ -41,7 +41,7 @@ Directory: 18.03
 
 Tags: 18.03.1-ce-dind, 18.03.1-dind, 18.03-dind, stable-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: bc5d62520258cacb230485ee96754f9f9aa117c4
+GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
 Directory: 18.03/dind
 
 Tags: 18.03.1-ce-git, 18.03.1-git, 18.03-git, stable-git

--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.5.4-apache, 8.5-apache, 8-apache, apache, 8.5.4, 8.5, 8, latest
+Tags: 8.5.5-apache, 8.5-apache, 8-apache, apache, 8.5.5, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
+GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
 Directory: 8.5/apache
 
-Tags: 8.5.4-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.5-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
+GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
 Directory: 8.5/fpm
 
-Tags: 8.5.4-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.5-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3e9c13c3b59dfe2a896898a601dc0e4d975c18a9
+GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
 Directory: 8.5/fpm-alpine
 
 Tags: 8.4.8-apache, 8.4-apache, 8.4.8, 8.4

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-19-jdk-sid, 11-ea-19-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-19-jdk, 11-ea-19, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-21-jdk-sid, 11-ea-21-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-21-jdk, 11-ea-21, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 07194db9f12e4507d5f048339c92682a0b49f89d
 Directory: 11/jdk
 
-Tags: 11-ea-19-jdk-slim-sid, 11-ea-19-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-19-jdk-slim, 11-ea-19-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-21-jdk-slim-sid, 11-ea-21-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-21-jdk-slim, 11-ea-21-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 07194db9f12e4507d5f048339c92682a0b49f89d
 Directory: 11/jdk/slim
 
-Tags: 11-ea-19-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-19-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-21-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-21-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 07194db9f12e4507d5f048339c92682a0b49f89d
 Directory: 11/jre
 
-Tags: 11-ea-19-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-19-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-21-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-21-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 07194db9f12e4507d5f048339c92682a0b49f89d
 Directory: 11/jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.6, 3.7, 3, latest
+Tags: 3.7.7, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fec4ea13595dba46c66efcb3a010e827bee5cbd4
+GitCommit: d5b3f8a8f45623b03428f54d56426f129b9064a8
 Directory: 3.7/debian
 
-Tags: 3.7.6-management, 3.7-management, 3-management, management
+Tags: 3.7.7-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/debian/management
 
-Tags: 3.7.6-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.7-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fa1276bb5252c429d38fded8995aa3bbcac029ff
+GitCommit: 80f900f149f6eba695d1947e1045b6233be83f06
 Directory: 3.7/alpine
 
-Tags: 3.7.6-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.7-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.88-jre7, 7.0-jre7, 7-jre7, 7.0.88, 7.0, 7
+Tags: 7.0.90-jre7, 7.0-jre7, 7-jre7, 7.0.90, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
+GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre7
 
-Tags: 7.0.88-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.88-slim, 7.0-slim, 7-slim
+Tags: 7.0.90-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.90-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
+GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre7-slim
 
-Tags: 7.0.88-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.88-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.90-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.90-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c810f194f2bd912333ecb180aabdd3612824f61
+GitCommit: 6d19b06d7ddb8964823867867b55cac2d2cd57a1
 Directory: 7/jre7-alpine
 
-Tags: 7.0.88-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.90-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
+GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre8
 
-Tags: 7.0.88-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
+Tags: 7.0.90-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 778588dc5bfca8086215ff2706dabcd823dc6008
+GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre8-slim
 
-Tags: 7.0.88-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.90-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c810f194f2bd912333ecb180aabdd3612824f61
+GitCommit: 6d19b06d7ddb8964823867867b55cac2d2cd57a1
 Directory: 7/jre8-alpine
 
-Tags: 8.0.52-jre7, 8.0-jre7, 8.0.52, 8.0
+Tags: 8.0.53-jre7, 8.0-jre7, 8.0.53, 8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
+GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre7
 
-Tags: 8.0.52-jre7-slim, 8.0-jre7-slim, 8.0.52-slim, 8.0-slim
+Tags: 8.0.53-jre7-slim, 8.0-jre7-slim, 8.0.53-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
+GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre7-slim
 
-Tags: 8.0.52-jre7-alpine, 8.0-jre7-alpine, 8.0.52-alpine, 8.0-alpine
+Tags: 8.0.53-jre7-alpine, 8.0-jre7-alpine, 8.0.53-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d183e24a7f4239f84bf521ac96690904adb21a86
+GitCommit: a0377566c7141395d74420b93c94f8fde72c7aa9
 Directory: 8.0/jre7-alpine
 
-Tags: 8.0.52-jre8, 8.0-jre8
+Tags: 8.0.53-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
+GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre8
 
-Tags: 8.0.52-jre8-slim, 8.0-jre8-slim
+Tags: 8.0.53-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d246358fc604ea70ee19cd4b8809d7b1843c5bd
+GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre8-slim
 
-Tags: 8.0.52-jre8-alpine, 8.0-jre8-alpine
+Tags: 8.0.53-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d183e24a7f4239f84bf521ac96690904adb21a86
+GitCommit: a0377566c7141395d74420b93c94f8fde72c7aa9
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.32-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.32, 8.5, 8, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.6-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.6-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.7-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.7-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php5.6/apache
 
-Tags: 4.9.6-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.7-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php5.6/fpm
 
-Tags: 4.9.6-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.7-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.6-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.6-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.7-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.7-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.0/apache
 
-Tags: 4.9.6-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.7-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.0/fpm
 
-Tags: 4.9.6-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.7-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.6-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.6-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.7-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.7-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.1/apache
 
-Tags: 4.9.6-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.7-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.1/fpm
 
-Tags: 4.9.6-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.7-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.6-apache, 4.9-apache, 4-apache, apache, 4.9.6, 4.9, 4, latest, 4.9.6-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.6-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.7-apache, 4.9-apache, 4-apache, apache, 4.9.7, 4.9, 4, latest, 4.9.7-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.7-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.2/apache
 
-Tags: 4.9.6-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.6-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.7-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.7-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.2/fpm
 
-Tags: 4.9.6-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.6-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.7-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.7-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c919246e5ce9a94cb0ad275072d34563ef2ecc46
+GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
 - `docker` https://github.com/docker-library/docker/pull/117
 - `drupal` bump to `8.5.5`
 - `openjdk` bump to `11-ea-21`
 - `rabbitmq` bump to `3.7.7`
 - `tomcat` bump to `7.0.90`, `8.0.53`
 - `wordpress` bump to `4.9.7`

Fixes #4547 