### PR TITLE
revert the `elixir:1.6` series to be with `erlang:20`

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,21 +1,21 @@
 # this file is generated via https://github.com/c0b/docker-elixir/blob/b4a2b8ea703865bd04490f43244198d0c95fa607/generate-stackbrew-library.sh
 
-Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
+Maintainers: . <c0b@users.noreply.github.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
 Tags: 1.6.6, 1.6, latest
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 5e9b6133376a96d56abf7ace635f66766a7c7f71
+GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6
 
 Tags: 1.6.6-slim, 1.6-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 5e9b6133376a96d56abf7ace635f66766a7c7f71
+GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/slim
 
 Tags: 1.6.6-alpine, 1.6-alpine, alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: 5e9b6133376a96d56abf7ace635f66766a7c7f71
+GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/alpine
 
 Tags: 1.5.3, 1.5


### PR DESCRIPTION
to avoid surprises to those ones who use `elixir:1.6` already in production; see c0b/docker-elixir#74
for other ones who like the latest Elixir with latest Erlang, there will be another `elixir:1.6-otp-21` series coming soon