### PR TITLE
Bump Traefik to v1.7.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,14 +1,26 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.6.4, 1.6.4, v1.6, 1.6, tetedemoine, latest
+Tags: v1.7.0-rc1, 1.7.0-rc1, v1.7, 1.7, maroilles
 Architectures: amd64, arm64v8, arm32v6
+GitCommit: 0ddabb0ef7c46ef63ef509503ce60e944a79f497
+amd64-Directory: scratch/amd64
+arm32v6-Directory: scratch/arm
+arm64v8-Directory: scratch/arm64
+
+Tags: v1.7.0-rc1-alpine, 1.7.0-rc1-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Architectures: amd64, arm64v8, arm32v6
+GitCommit: 0ddabb0ef7c46ef63ef509503ce60e944a79f497
+Directory: alpine
+
+Tags: v1.6.4, 1.6.4, v1.6, 1.6, tetedemoine, latest
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: d004e59dcb636ab24a6e2ae827fe4c8290837127
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.6.4-alpine, 1.6.4-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: d004e59dcb636ab24a6e2ae827fe4c8290837127
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.7.0-rc1.

/cc @vdemeester @emilevauge @ldez

Cheers
