### PR TITLE
Update websphere-liberty beta to 2018.7.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 9d28dfba4d20596f89b393bc9e3ae8295feec469
+GitCommit: 66b3058152daf3777b78b6556bf1572d955e85bd
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Updating websphere-liberty beta to the newly released 2018.7.0.0 version.