### PR TITLE
Add support for arm64v8 architecture.

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,7 +1,7 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
 GitCommit: 39116f34fa92cb9c9b170c60bfb32411d408a582
-Architectures: amd64, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 
 Tags: 1.7.0, 1.7, latest
 Directory: full


### PR DESCRIPTION
This PR is to update the library file to include support for ```arm64v8 architecture```.

This is in reference to https://github.com/znc/znc-docker/issues/14
ZNC is running fine on ```arm64v8``` just by building and running the default code.

-Regards