### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -49,6 +49,21 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: buster
 
+Tags: cosmic-curl, 18.10-curl
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
+Directory: cosmic/curl
+
+Tags: cosmic-scm, 18.10-scm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
+Directory: cosmic/scm
+
+Tags: cosmic, 18.10
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
+Directory: cosmic
+
 Tags: jessie-curl, oldstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: d206a435163e171e629490b2803b2615b3831906
+GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 
 Tags: linux
 SharedTags: latest
@@ -26,13 +26,20 @@ s390x-Directory: s390x/hello-seattle
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1709
 Constraints: nanoserver-1709
+
+Tags: nanoserver-1803
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-Directory: amd64/hello-seattle/nanoserver-1803
+Constraints: nanoserver-1803

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: d206a435163e171e629490b2803b2615b3831906
+GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 
 Tags: linux
 SharedTags: latest
@@ -26,13 +26,20 @@ s390x-Directory: s390x/hello-world
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hello-world/nanoserver-1709
 Constraints: nanoserver-1709
+
+Tags: nanoserver-1803
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-Directory: amd64/hello-world/nanoserver-1803
+Constraints: nanoserver-1803

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/d206a435163e171e629490b2803b2615b3831906/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: d206a435163e171e629490b2803b2615b3831906
+GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 
 Tags: linux
 SharedTags: latest
@@ -26,13 +26,20 @@ s390x-Directory: s390x/hola-mundo
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1709
 Constraints: nanoserver-1709
+
+Tags: nanoserver-1803
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-Directory: amd64/hola-mundo/nanoserver-1803
+Constraints: nanoserver-1803

--- a/library/mongo
+++ b/library/mongo
@@ -12,20 +12,20 @@ Architectures: amd64
 GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
 Directory: 3.2
 
-Tags: 3.4.15-jessie, 3.4-jessie
-SharedTags: 3.4.15, 3.4
+Tags: 3.4.16-jessie, 3.4-jessie
+SharedTags: 3.4.16, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: f77d645e749bdda0740a35c00213baae8859edf2
+GitCommit: a499e81e743b05a5237e2fd700c0284b17d3d416
 Directory: 3.4
 
-Tags: 3.6.5-jessie, 3.6-jessie, 3-jessie
-SharedTags: 3.6.5, 3.6, 3
+Tags: 3.6.6-jessie, 3.6-jessie, 3-jessie
+SharedTags: 3.6.6, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 4e9a69f44326f034efa79ded2275ec856673bee1
+GitCommit: e0735c07abced69a5d8945aace9285288d013a83
 Directory: 3.6
 
 Tags: 4.0.0-xenial, 4.0-xenial, 4-xenial, xenial

--- a/library/openjdk
+++ b/library/openjdk
@@ -75,9 +75,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jdk/slim
 
-Tags: 8u171-jdk-alpine3.7, 8u171-alpine3.7, 8-jdk-alpine3.7, 8-alpine3.7, jdk-alpine3.7, alpine3.7, 8u171-jdk-alpine, 8u171-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+Tags: 8u171-jdk-alpine3.8, 8u171-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, jdk-alpine3.8, alpine3.8, 8u171-jdk-alpine, 8u171-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd54ae37bc44d19ecb5be702d36d664fed2c68e4
+GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jdk/alpine
 
 Tags: 8u171-jdk-windowsservercore-ltsc2016, 8u171-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -111,9 +111,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jre/slim
 
-Tags: 8u171-jre-alpine3.7, 8-jre-alpine3.7, jre-alpine3.7, 8u171-jre-alpine, 8-jre-alpine, jre-alpine
+Tags: 8u171-jre-alpine3.8, 8-jre-alpine3.8, jre-alpine3.8, 8u171-jre-alpine, 8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd54ae37bc44d19ecb5be702d36d664fed2c68e4
+GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jre/alpine
 
 Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7
@@ -126,9 +126,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk/slim
 
-Tags: 7u181-jdk-alpine3.7, 7u181-alpine3.7, 7-jdk-alpine3.7, 7-alpine3.7, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u181-jdk-alpine3.8, 7u181-alpine3.8, 7-jdk-alpine3.8, 7-alpine3.8, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 7/jdk/alpine
 
 Tags: 7u181-jre-jessie, 7-jre-jessie, 7u181-jre, 7-jre
@@ -141,7 +141,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre/slim
 
-Tags: 7u181-jre-alpine3.7, 7-jre-alpine3.7, 7u181-jre-alpine, 7-jre-alpine
+Tags: 7u181-jre-alpine3.8, 7-jre-alpine3.8, 7u181-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c7846edc14a25304288c85e2e7bebe4609626512
+GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 7/jre/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -11,7 +11,7 @@ Directory: 11
 
 Tags: 11-beta2-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eacf33933eced1d5db93699c19e6f24b30596db8
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 11/alpine
 
 Tags: 10.4, 10, latest
@@ -21,7 +21,7 @@ Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9
@@ -31,7 +31,7 @@ Directory: 9.6
 
 Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 9.6/alpine
 
 Tags: 9.5.13, 9.5
@@ -41,7 +41,7 @@ Directory: 9.5
 
 Tags: 9.5.13-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 9.5/alpine
 
 Tags: 9.4.18, 9.4
@@ -51,7 +51,7 @@ Directory: 9.4
 
 Tags: 9.4.18-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 9.4/alpine
 
 Tags: 9.3.23, 9.3
@@ -61,5 +61,5 @@ Directory: 9.3
 
 Tags: 9.3.23-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
 Directory: 9.3/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -16,7 +16,7 @@ Directory: 3.7/debian/management
 
 Tags: 3.7.7-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 80f900f149f6eba695d1947e1045b6233be83f06
+GitCommit: 32c80d4ef94250c981eb212756f9e95be6150b11
 Directory: 3.7/alpine
 
 Tags: 3.7.7-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
@@ -36,7 +36,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 46319b542643d1ad0c5380bb2a1f362d7064d2c1
+GitCommit: 32c80d4ef94250c981eb212756f9e95be6150b11
 Directory: 3.6/alpine
 
 Tags: 3.6.16-management-alpine, 3.6-management-alpine

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 5.0-rc/32bit
 
 Tags: 5.0-rc3-alpine, 5.0-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 403f00a0ba7556f33850a88e27e70509aa2814dd
+GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.10, 4.0, 4, latest
@@ -31,7 +31,7 @@ Directory: 4.0/32bit
 
 Tags: 4.0.10-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87e80558fb828de53399e341af4c8a05c3e2d631
+GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
 Directory: 4.0/alpine
 
 Tags: 3.2.12, 3.2, 3
@@ -46,5 +46,5 @@ Directory: 3.2/32bit
 
 Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f137878f40e40f87a63813821d49464d2710acf
+GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
 Directory: 3.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.66.2, 0.66, 0, latest
-GitCommit: 5e1e7c0757a8bfb1ec218cd61dafab0dc3016bba
+Tags: 0.66.3, 0.66, 0, latest
+GitCommit: f2d2a10ad40f658f86a64c40a6383acae4d6c260


### PR DESCRIPTION
- `buildpack-deps`: add `cosmic` (docker-library/buildpack-deps#81)
- `hello-seattle`: Windows 1803 (docker-library/hello-world#48)
- `hello-world`: Windows 1803 (docker-library/hello-world#48)
- `hola-mundo`: Windows 1803 (docker-library/hello-world#48)
- `mongo`: 3.6.6, 3.4.16
- `openjdk`: Alpine 3.8 (docker-library/openjdk#210)
- `postgres`: Alpine 3.8 (docker-library/postgres#466)
- `rabbitmq`: Alpine 3.8 (docker-library/rabbitmq#268)
- `redis`: Alpine 3.8 (docker-library/redis#150)
- `rocket.chat`: 0.66.3