### PR TITLE
Fix gradle Architectures (also deduplicate GitCommit for easier updating)

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,82 +1,67 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
+GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 
 Tags: 4.8.1-jdk7, 4.8-jdk7, jdk7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jdk7
 
 Tags: 4.8.1-jre7, 4.8-jre7, jre7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jre7
 
 Tags: 4.8.1-jdk7-alpine, 4.8-jdk7-alpine, jdk7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jdk7-alpine
 
 Tags: 4.8.1-jdk7-slim, 4.8-jdk7-slim, jdk7-slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jdk7-slim
 
 Tags: 4.8.1-jre7-alpine, 4.8-jre7-alpine, jre7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jre7-alpine
 
 Tags: 4.8.1-jre7-slim, 4.8-jre7-slim, jre7-slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jre7-slim
 
 Tags: 4.8.1-jdk8, 4.8-jdk8, jdk8, 4.8.1-jdk, 4.8-jdk, jdk, 4.8.1, 4.8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jdk8
 
 Tags: 4.8.1-jre8, 4.8-jre8, jre8, 4.8.1-jre, 4.8-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jre8
 
 Tags: 4.8.1-jdk8-alpine, 4.8-jdk8-alpine, jdk8-alpine, 4.8.1-jdk-alpine, 4.8-jdk-alpine, jdk-alpine, 4.8.1-alpine, 4.8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jdk8-alpine
 
 Tags: 4.8.1-jdk8-slim, 4.8-jdk8-slim, jdk8-slim, 4.8.1-jdk-slim, 4.8-jdk-slim, jdk-slim, 4.8.1-slim, 4.8-slim, slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jdk8-slim
 
 Tags: 4.8.1-jre8-alpine, 4.8-jre8-alpine, jre8-alpine, 4.8.1-jre-alpine, 4.8-jre-alpine, jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jre8-alpine
 
 Tags: 4.8.1-jre8-slim, 4.8-jre8-slim, jre8-slim, 4.8.1-jre-slim, 4.8-jre-slim, jre-slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jre8-slim
 
 Tags: 4.8.1-jdk10, 4.8-jdk10, jdk10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jdk10
 
 Tags: 4.8.1-jdk10-slim, 4.8-jdk10-slim, jdk10-slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jdk10-slim
 
 Tags: 4.8.1-jre10, 4.8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
 Directory: jre10
 
 Tags: 4.8.1-jre10-slim, 4.8-jre10-slim, jre10-slim
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: efa575ae69e3f0fe82c46e64bcd50e433d12cde8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: jre10-slim


### PR DESCRIPTION
This is a followup to https://github.com/docker-library/official-images/pull/4512 and https://github.com/docker-library/official-images/pull/4451.