### PR TITLE
Add ARM64v8 architecture support

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -2,7 +2,7 @@ Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.4.7-stretch, 3.4-stretch, 3.4.7, 3.4, latest
-Architectures: amd64
+Architectures: amd64, arm64v8
 GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/stretch
 


### PR DESCRIPTION
This PR has been generated to add support for ```arm64v8 architecture```.

The ```haxe``` docker is building and running successfully without any modification when used with
```latest:3.4/stretch tag```.

The working has been verified for Softiron-OD1000 Hardware using AARCH64.

Signed-off-by: Odidev <odidev@puresoftware.com>