### PR TITLE
Add ARM64v8 support.

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -28,6 +28,7 @@ GitCommit: f93917b874809870d31a8f07b2d1012c19cf66f6
 Directory: php7.0/fpm-alpine
 
 Tags: 3.8.8-apache, 3.8-apache, 3-apache, apache, 3.8.8, 3.8, 3, latest, 3.8.8-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.8-php7.1, 3.8-php7.1, 3-php7.1, php7.1
+Architectures: amd64, arm64v8
 GitCommit: f93917b874809870d31a8f07b2d1012c19cf66f6
 Directory: php7.1/apache
 


### PR DESCRIPTION
 ```- Added Architecture tag for php7.1/apache directory.```

This PR is generated to add support for ```arm64v8``` architecture in Joomla repository which is working fine for ARM64 without any modification.

The changes are done only in tested tag.

This is aligned with https://github.com/joomla/docker-joomla/issues/64

Signed-off-by: Odidev <odidev@puresoftware.com>