### PR TITLE
Release of Neo4j 3.4.4

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 Tags: 3.4.3, 3.4, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.2/community
+Directory: 3.4.3/community
 
 Tags: 3.4.3-enterprise, 3.4-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.2/enterprise
+Directory: 3.4.3/enterprise
 
 Tags: 3.4.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git

--- a/library/neo4j
+++ b/library/neo4j
@@ -9,12 +9,22 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
              Praveena Fernandes <praveena.fernandes@neo4j.com> (@praveenag),
              Chris Gioran <chris@neo4j.com> (@digitalstain)
 
-Tags: 3.4.1, 3.4, latest
+Tags: 3.4.3, 3.4, latest
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
+Directory: 3.4.2/community
+
+Tags: 3.4.3-enterprise, 3.4-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
+Directory: 3.4.2/enterprise
+
+Tags: 3.4.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/community
 
-Tags: 3.4.1-enterprise, 3.4-enterprise, enterprise
+Tags: 3.4.1-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8ed2eb5feba2bddd6574d1326eee00593d080531
 Directory: 3.4.1/enterprise

--- a/library/neo4j
+++ b/library/neo4j
@@ -5,19 +5,17 @@
 # discussion of this point.
 
 Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
-             Jonas Kalderstam <jonas.kalderstam@neo4j.com> (@spacecowboy),
-             Praveena Fernandes <praveena.fernandes@neo4j.com> (@praveenag),
              Chris Gioran <chris@neo4j.com> (@digitalstain)
 
-Tags: 3.4.3, 3.4, latest
+Tags: 3.4.4, 3.4, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.3/community
+GitCommit: c8dc53b8ace8a2013034cd687162d1f4e6929be1
+Directory: 3.4.4/community
 
-Tags: 3.4.3-enterprise, 3.4-enterprise, enterprise
+Tags: 3.4.4-enterprise, 3.4-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 32165edea872f07683f05a43b379d78e7368e6c9
-Directory: 3.4.3/enterprise
+GitCommit: c8dc53b8ace8a2013034cd687162d1f4e6929be1
+Directory: 3.4.4/enterprise
 
 Tags: 3.4.1
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git


### PR DESCRIPTION
We purposely are not releasing 3.4.2 and 3.4.3. Hopefully that doesn't break any rules for docker official images?