### PR TITLE
haxe: enable arm32v7 and arm64v8 for the stretch variant

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -2,7 +2,7 @@ Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.4.7-stretch, 3.4-stretch, 3.4.7, 3.4, latest
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/stretch
 
@@ -33,7 +33,7 @@ GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.3/stretch
 
@@ -64,7 +64,7 @@ GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.3/alpine3.6
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.2/stretch
 
@@ -95,7 +95,7 @@ GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
 Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
 Directory: 3.1/stretch
 
@@ -116,7 +116,7 @@ Directory: 3.1/windowsservercore
 Constraints: windowsservercore
 
 Tags: 4.0.0-preview.4-stretch, 4.0.0-preview.4, 4.0.0-stretch, 4.0-stretch, 4.0.0, 4.0
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: 2fab1f21333e6472f398b9c08dd1d5117e5539c2
 Directory: 4.0/stretch
 


### PR DESCRIPTION
Tested with Raspbian Stretch (arm32-v7) and Devuan Ascii (arm64-v8) on a Raspberry Pi 3.

The other variants have some problems with OCaml and apt packages which will take me some time to investigate.