### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.06.0-ce-rc2, 18.06-rc, rc, test
+Tags: 18.06.0-ce-rc3, 18.06-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 441b13e5f1de3cf3a9afc27f99adf0e247bfba35
+GitCommit: 8e5a928fef7ac182890bd9d3be7a36736ac1497b
 Directory: 18.06-rc
 
-Tags: 18.06.0-ce-rc2-dind, 18.06-rc-dind, rc-dind, test-dind
+Tags: 18.06.0-ce-rc3-dind, 18.06-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
 Directory: 18.06-rc/dind
 
-Tags: 18.06.0-ce-rc2-git, 18.06-rc-git, rc-git, test-git
+Tags: 18.06.0-ce-rc3-git, 18.06-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 84fbcfc4cbef254dce2e7ecd7fcff788da4690df
 Directory: 18.06-rc/git

--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.33, 2.4, 2, latest
+Tags: 2.4.34, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3af22f20b54cbb7c76ef4c3b12bd9dcf6cae862b
+GitCommit: b814ed0f036c6084d67ce5d996b4648a9bda6275
 Directory: 2.4
 
-Tags: 2.4.33-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.34-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf4c70fb21f167f77e0c9d4b6f8b8635b1cb4b6
+GitCommit: 2f3a5f0a505c3ffcd3ebcb6f06824fe912c00812
 Directory: 2.4/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/4eb0a4a25e178260aeb65285d75cb777f009f932/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/9ce4ecd2783d2358d2c0fe0efa924ecae33d9e84/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.8, 10.3, 10, latest
+Tags: 10.3.8-jessie, 10.3-jessie, 10-jessie, jessie, 10.3.8, 10.3, 10, latest
 GitCommit: a7d1a184913c009c473baeb8f72385d12ae0de61
 Directory: 10.3
 
-Tags: 10.2.16, 10.2
+Tags: 10.2.16-jessie, 10.2-jessie, 10.2.16, 10.2
 GitCommit: 1e7c5c9bb2bfde0453fb52175343a360ed346104
 Directory: 10.2
 
-Tags: 10.1.34, 10.1
+Tags: 10.1.34-jessie, 10.1-jessie, 10.1.34, 10.1
 GitCommit: 12a0273332a3a0ed007ece2ae5886f7ac9c15d1b
 Directory: 10.1
 
-Tags: 10.0.35, 10.0
+Tags: 10.0.35-jessie, 10.0-jessie, 10.0.35, 10.0
 GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 10.0
 
-Tags: 5.5.60, 5.5, 5
+Tags: 5.5.60-wheezy, 5.5-wheezy, 5-wheezy, 5.5.60, 5.5, 5
 GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-21-jdk-sid, 11-ea-21-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-21-jdk, 11-ea-21, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-22-jdk-sid, 11-ea-22-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-22-jdk, 11-ea-22, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ca586ef3a0d7f60b87f2649f7965f6ce6dade70f
+GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
 Directory: 11/jdk
 
-Tags: 11-ea-21-jdk-slim-sid, 11-ea-21-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-21-jdk-slim, 11-ea-21-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-22-jdk-slim-sid, 11-ea-22-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-22-jdk-slim, 11-ea-22-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ca586ef3a0d7f60b87f2649f7965f6ce6dade70f
+GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
 Directory: 11/jdk/slim
 
-Tags: 11-ea-21-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-21-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-22-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-22-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ca586ef3a0d7f60b87f2649f7965f6ce6dade70f
+GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
 Directory: 11/jre
 
-Tags: 11-ea-21-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-21-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-22-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-22-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ca586ef3a0d7f60b87f2649f7965f6ce6dade70f
+GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
 Directory: 11/jre/slim
 
 Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta2, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 686aae6553981d5254649841bb89677dc33f1aeb
+GitCommit: 5d0b6adfd8c4b967d9fbbdc0fb96c869fcaba4f0
 Directory: 11
 
 Tags: 11-beta2-alpine, 11-alpine

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/2a79ecbdfdb736297c39bcae664aee0e6b01bd5c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/a70575c01b81fe9c8d920e13a03f55bdc0622328/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -7,17 +7,22 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.0-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.7/stretch
 
 Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.7/stretch/slim
+
+Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -37,22 +42,22 @@ Constraints: windowsservercore-1709
 Tags: 3.6.6-stretch, 3.6-stretch
 SharedTags: 3.6.6, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/stretch
 
 Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3.6.6-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.6-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/jessie
 
 Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-onbuild, 3.6-onbuild
@@ -60,14 +65,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.6/jessie/onbuild
 
+Tags: 3.6.6-alpine3.8, 3.6-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+Directory: 3.6/alpine3.8
+
 Tags: 3.6.6-alpine3.7, 3.6-alpine3.7, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
@@ -84,14 +94,25 @@ GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
+Tags: 3.5.5-stretch, 3.5-stretch
+SharedTags: 3.5.5, 3.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Directory: 3.5/stretch
+
+Tags: 3.5.5-slim-stretch, 3.5-slim-stretch, 3.5.5-slim, 3.5-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Directory: 3.5/stretch/slim
+
 Tags: 3.5.5-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a652f35d6ce77f02ca268d67f39e7dfa24cf08c5
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.5/jessie
 
 Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.5-onbuild, 3.5-onbuild
@@ -99,19 +120,35 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
 Directory: 3.5/jessie/onbuild
 
+Tags: 3.5.5-alpine3.8, 3.5-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+Directory: 3.5/alpine3.8
+
 Tags: 3.5.5-alpine3.7, 3.5-alpine3.7, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 28a22968dcd424a793dde3f7d95803fe52916da2
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.5/alpine3.7
+
+Tags: 3.4.8-stretch, 3.4-stretch
+SharedTags: 3.4.8, 3.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Directory: 3.4/stretch
+
+Tags: 3.4.8-slim-stretch, 3.4-slim-stretch, 3.4.8-slim, 3.4-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Directory: 3.4/stretch/slim
 
 Tags: 3.4.8-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92b33f97f0e1f1faabca46aee0f5520c1b038ed5
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/jessie
 
 Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.8-onbuild, 3.4-onbuild
@@ -121,33 +158,38 @@ Directory: 3.4/jessie/onbuild
 
 Tags: 3.4.8-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 92b33f97f0e1f1faabca46aee0f5520c1b038ed5
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/wheezy
+
+Tags: 3.4.8-alpine3.8, 3.4-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+Directory: 3.4/alpine3.8
 
 Tags: 3.4.8-alpine3.7, 3.4-alpine3.7, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 28a22968dcd424a793dde3f7d95803fe52916da2
+GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c94a31a98a535477200482a32c95192f85af5b
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-onbuild, 2.7-onbuild, 2-onbuild
@@ -157,17 +199,22 @@ Directory: 2.7/jessie/onbuild
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/wheezy
+
+Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d755d18e6990b8ad6f137d7613ba7937389b47a
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c71ea7995d68c3219f2d251768a384d9995d4af0
+GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 5.0-rc/32bit
 
 Tags: 5.0-rc3-alpine, 5.0-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
+GitCommit: 7f5671ebdc563464f5570a1d081a78c26b5e6ad3
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.10, 4.0, 4, latest


### PR DESCRIPTION
- `docker`: 18.06.0-ce-rc3
- `httpd`: 2.4.34
- `mariadb`: suite aliases (docker-library/mariadb#182)
- `openjdk`: 11-ea+22,
- `postgres`: `11~beta2-2.pgdg90+1`
- `python`: dependency refactoring, Alpine 3.8 (docker-library/python#311)
- `redis`: remove `wget` and `ca-certificates` from Alpine 3.8 (docker-library/redis#151)