### PR TITLE
Remove support for 1.6

### DIFF
--- a/library/eggdrop
+++ b/library/eggdrop
@@ -8,7 +8,3 @@ Directory: develop
 Tags: 1.8, 1.8.3, stable, latest
 GitCommit: 68e421d4e8f87301d921c84548407ec340f0b8ed
 Directory: 1.8
-
-Tags: 1.6, 1.6.21
-GitCommit: e50da857a808ea6593fc4bfd56997d92a0461193
-Directory: 1.6


### PR DESCRIPTION
Partly/Mostly because of EOL of alpine3.4 base image