### PR TITLE
Add Architectures tag to support multiple architectures

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,6 +3,7 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitCommit: 2dea40647eb85d6e0fc607904e0779644cf869c9
+Architectures: amd64, arm64v8
 
 Tags: stable, latest, 1.31, 1.31.0
 Directory: stable

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,7 +3,7 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitCommit: 2dea40647eb85d6e0fc607904e0779644cf869c9
-Architectures: amd64, arm64v8
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 Tags: stable, latest, 1.31, 1.31.0
 Directory: stable


### PR DESCRIPTION
Mediawiki working fine for both ```AMD64 and ARM64v8``` architectures, without any code change.

So a normal build run is required to validate both architectures.
I have added ```Architectures tag``` to extend official support for ```arm64v8``` as well.

Please have a look and let me know, if anyhting else is required to make ```mediawiki``` ```docker pull```able for ```arm64v8``` too.

Signed-off-by: Odidev <odidev@puresoftware.com>