### PR TITLE
Add a jessie flavour for erlang/otp 21

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -18,6 +18,11 @@ Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: f0fffe2ba666a5f31e1de81d80dacdbf405c8e32
 Directory: 21/alpine
 
+Tags: 21.0.3-jessie, 21.0-jessie, 21-jessie, jessie
+Architectures: amd64, arm32v7, i386
+GitCommit: cdee680cda6403ecb39d5d6858f18f338f67c7d1
+Directory: 21/jessie
+
 Tags: 20.3.8.2, 20.3.8, 20.3, 20
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 2b9b03dc41cbcc8fc94ef8767b89948388143226


### PR DESCRIPTION
there are still many users on jessie
https://github.com/erlang/docker-erlang-otp/pull/131#issuecomment-403536469