### PR TITLE
Bump Traefik to v1.7.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,26 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.7.0-rc1, 1.7.0-rc1, v1.7, 1.7, maroilles
+Tags: v1.7.0-rc2, 1.7.0-rc2, v1.7, 1.7, maroilles
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0ddabb0ef7c46ef63ef509503ce60e944a79f497
+GitCommit: 7dec7b825ca16d0524626fbbca35284adfe3ef58
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.7.0-rc1-alpine, 1.7.0-rc1-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.0-rc2-alpine, 1.7.0-rc2-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0ddabb0ef7c46ef63ef509503ce60e944a79f497
+GitCommit: 7dec7b825ca16d0524626fbbca35284adfe3ef58
 Directory: alpine
 
 Tags: v1.6.5, 1.6.5, v1.6, 1.6, tetedemoine, latest
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: 3ec5ce5d64e79eeafbe082c4690b9ca40cda013a
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.6.5-alpine, 1.6.5-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: 3ec5ce5d64e79eeafbe082c4690b9ca40cda013a
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.7.0-rc2.

/cc @vdemeester @emilevauge @ldez

Cheers
