### PR TITLE
Add arm64v8 architecture for storm

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,5 +1,6 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
+Architectures: amd64, arm64v8
 
 Tags: 1.0.6, 1.0
 GitCommit: 9986213e09356e2d5230e6af9338052ce858b224


### PR DESCRIPTION
This PR is raised to enable support of ```arm64v8``` for storm repository.

I have verified working of Storm for ```arm64v8``` with just build and run for code.
This means ```storm``` supports both amd64 and arm64v8.

By adding official support, this package will be ```docker pull```able over ```arm64v8``` too.


Signed-off-by: Odidev <odidev@puresoftware.com>