### PR TITLE
Adding springBoot tags

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 66b3058152daf3777b78b6556bf1572d955e85bd
+GitCommit: 18197ebb67c98992535b0dd7ce992f9596d51b62
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -10,6 +10,12 @@ Directory: ga/developer/kernel
 
 Tags: microProfile
 Directory: ga/developer/microProfile
+
+Tags: springBoot1
+Directory: ga/developer/springBoot1
+
+Tags: springBoot2
+Directory: ga/developer/springBoot2
 
 Tags: webProfile7
 Directory: ga/developer/webProfile7


### PR DESCRIPTION
WebSphere Liberty now has two new features for Spring Boot, so we're creating two new Docker Hub tags that have those features enabled.