### PR TITLE
Update CirrOS to 0.4.0

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -1,6 +1,14 @@
-# maintainer: Erica Windisch <eric@windisch.us> (@ewindisch)
-# Supporting latest & -1 stable releases of CirrOS.
+# this file is generated via https://github.com/tianon/docker-brew-cirros/blob/ee542009d503007fe76276b6b3f66ec55d1f9289//home/tianon/docker/hub/cirros/generate-stackbrew-library.sh
 
-latest: git://github.com/ewindisch/docker-cirros@fd9aa114c465237518535d3545d4f9c4bc1d0aa5
-0.3.4: git://github.com/ewindisch/docker-cirros@fd9aa114c465237518535d3545d4f9c4bc1d0aa5
-0.3.3: git://github.com/ewindisch/docker-cirros@5ef3f5024b0aa80553cc34be9eff6685cb31b458
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+GitRepo: https://github.com/tianon/docker-brew-cirros.git
+GitFetch: refs/heads/dist
+GitCommit: d04ffb350eb29c24bafe12f6b109aa3990309771
+Architectures: amd64, arm32v5, arm64v8, i386, ppc64le
+amd64-Directory: arches/amd64
+arm32v5-Directory: arches/arm32v5
+arm64v8-Directory: arches/arm64v8
+i386-Directory: arches/i386
+ppc64le-Directory: arches/ppc64le
+
+Tags: 0.4.0, 0.4, 0, latest


### PR DESCRIPTION
(taking over maintenance from Erica)

@ewindisch is this something you could spare a moment to provide your OK on?  Is this something you're actually OK with?  (Noticed there haven't been updates or even any correspondance for a while, so figured this was probably warranted. :heart:)

This also adds support for 4 of the non-x86_64 architectures that CirrOS upstream publishes tarballs for. :+1: