### PR TITLE
Update node.js v10 images, remove v9

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,32 +1,7 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/b22fb6c84e3cac83309b083c973649b2bf6b092d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/26550a63bccd27928771aeb704c72de8ac540aeb/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
-
-Tags: 9.11.2-jessie, 9.11-jessie, 9-jessie, 9.11.2, 9.11, 9
-Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
-Directory: 9/jessie
-
-Tags: 9.11.2-alpine, 9.11-alpine, 9-alpine
-Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
-Directory: 9/alpine
-
-Tags: 9.11.2-onbuild, 9.11-onbuild, 9-onbuild
-Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
-Directory: 9/onbuild
-
-Tags: 9.11.2-slim, 9.11-slim, 9-slim
-Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
-Directory: 9/slim
-
-Tags: 9.11.2-stretch, 9.11-stretch, 9-stretch
-Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
-Directory: 9/stretch
 
 Tags: 8.11.3-jessie, 8.11-jessie, 8-jessie, carbon-jessie, 8.11.3, 8.11, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
@@ -78,24 +53,24 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
 Directory: 6/stretch
 
-Tags: 10.6.0-jessie, 10.6-jessie, 10-jessie, jessie, 10.6.0, 10.6, 10, latest
+Tags: 10.7.0-jessie, 10.7-jessie, 10-jessie, jessie, 10.7.0, 10.7, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
+GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
 Directory: 10/jessie
 
-Tags: 10.6.0-alpine, 10.6-alpine, 10-alpine, alpine
+Tags: 10.7.0-alpine, 10.7-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
+GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
 Directory: 10/alpine
 
-Tags: 10.6.0-slim, 10.6-slim, 10-slim, slim
+Tags: 10.7.0-slim, 10.7-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
+GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
 Directory: 10/slim
 
-Tags: 10.6.0-stretch, 10.6-stretch, 10-stretch, stretch
+Tags: 10.7.0-stretch, 10.7-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 3e179a85703a6688a26486729b4466a92e818a84
+GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
- Update node.js v10.x to v10.7.0
- For Alpine based image, update Alpine from v3.7 to v3.8

Node.js v10.7.0 ref:
- https://github.com/nodejs/docker-node/pull/820
- https://github.com/nodejs/node/releases/tag/v10.7.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.7.0

Node.js v9 ref:
- https://github.com/nodejs/docker-node/pull/803
- https://github.com/docker-library/official-images/pull/4536