### PR TITLE
the elixir 1.6 images built on top of erlang 21

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -18,6 +18,16 @@ Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/alpine
 
+Tags: 1.6.6-otp-21, 1.6-otp-21, otp-21
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
+Directory: 1.6/otp-21
+
+Tags: 1.6.6-otp-21-alpine, 1.6-otp-21-alpine, otp-21-alpine
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
+Directory: 1.6/otp-21-alpine
+
 Tags: 1.5.3, 1.5
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25


### PR DESCRIPTION
the regular elixir 1.6 images series will remain on top of erlang 20;
while this new regular elixir 1.6-otp-21 image is just on top of erlang 21,

and new elixir 1.6-otp-21-alpine is on top of erlang 21-alpine, while another
difference is using hexpm/bob builds, this special precompiled image was built
with erlang 21, so should have the best features covered.