### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -65,17 +65,17 @@ GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
 Directory: cosmic
 
 Tags: jessie-curl, oldstable-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36
 Directory: jessie/curl
 
 Tags: jessie-scm, oldstable-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
 Directory: jessie/scm
 
 Tags: jessie, oldstable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
 Directory: jessie
 

--- a/library/docker
+++ b/library/docker
@@ -1,50 +1,20 @@
-# this file is generated via https://github.com/docker-library/docker/blob/cb8d918e103504ee5b9106aa254177bcb7889a03/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/d072cf169e682d1f9e65e5785a8a4dff76f75e0e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.06.0-ce-rc3, 18.06-rc, rc, test
+Tags: 18.06.0-ce, 18.06.0, 18.06, 18, edge, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 8e5a928fef7ac182890bd9d3be7a36736ac1497b
-Directory: 18.06-rc
+GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
+Directory: 18.06
 
-Tags: 18.06.0-ce-rc3-dind, 18.06-rc-dind, rc-dind, test-dind
+Tags: 18.06.0-ce-dind, 18.06.0-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
-Directory: 18.06-rc/dind
+GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
+Directory: 18.06/dind
 
-Tags: 18.06.0-ce-rc3-git, 18.06-rc-git, rc-git, test-git
+Tags: 18.06.0-ce-git, 18.06.0-git, 18.06-git, 18-git, edge-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 84fbcfc4cbef254dce2e7ecd7fcff788da4690df
-Directory: 18.06-rc/git
-
-Tags: 18.05.0-ce, 18.05.0, 18.05, 18, edge, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
-Directory: 18.05
-
-Tags: 18.05.0-ce-dind, 18.05.0-dind, 18.05-dind, 18-dind, edge-dind, dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
-Directory: 18.05/dind
-
-Tags: 18.05.0-ce-git, 18.05.0-git, 18.05-git, 18-git, edge-git, git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: cf3d3343f291146f9b79ccafa725a9bb28257ea0
-Directory: 18.05/git
-
-Tags: 18.03.1-ce, 18.03.1, 18.03, stable
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9209ff1b2ef5f25cffff9e0e67bc681dd43fcaca
-Directory: 18.03
-
-Tags: 18.03.1-ce-dind, 18.03.1-dind, 18.03-dind, stable-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9ecb1c3a6bd766b69eb1858ef721f62fbd930a2b
-Directory: 18.03/dind
-
-Tags: 18.03.1-ce-git, 18.03.1-git, 18.03-git, stable-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 1ad458b04229d155bbec6bbd4b5142497aa8126a
-Directory: 18.03/git
+GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
+Directory: 18.06/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.8, 1.24, 1, latest
+Tags: 1.24.9, 1.24, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f99bf268e644e076d71f21668a894305517dc2ee
+GitCommit: b192edd8cc892ac034a6350dc37afbce1a328ea1
 Directory: 1/debian
 
-Tags: 1.24.8-alpine, 1.24-alpine, 1-alpine, alpine
+Tags: 1.24.9-alpine, 1.24-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: f99bf268e644e076d71f21668a894305517dc2ee
+GitCommit: b192edd8cc892ac034a6350dc37afbce1a328ea1
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/golang
+++ b/library/golang
@@ -5,47 +5,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.11beta1-stretch, 1.11-rc-stretch, rc-stretch
-SharedTags: 1.11beta1, 1.11-rc, rc
+Tags: 1.11beta2-stretch, 1.11-rc-stretch, rc-stretch
+SharedTags: 1.11beta2, 1.11-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/stretch
 
-Tags: 1.11beta1-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11beta1-alpine, 1.11-rc-alpine, rc-alpine
+Tags: 1.11beta2-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11beta2-alpine, 1.11-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7a4a48a142ef2ada9c5794ba054fd008656c779
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/alpine3.8
 
-Tags: 1.11beta1-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
+Tags: 1.11beta2-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/alpine3.7
 
-Tags: 1.11beta1-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.11beta1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta1, 1.11-rc, rc
+Tags: 1.11beta2-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.11beta1-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.11beta1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta1, 1.11-rc, rc
+Tags: 1.11beta2-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.11beta1-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.11beta1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta1, 1.11-rc, rc
+Tags: 1.11beta2-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: e6528749f50809c858c6b9bad86be8541de6368e
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.11beta1-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.11beta1-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
+Tags: 1.11beta2-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.11beta2-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
+GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
 Directory: 1.11-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/httpd
+++ b/library/httpd
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.34, 2.4, 2, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b814ed0f036c6084d67ce5d996b4648a9bda6275
 Directory: 2.4
 

--- a/library/julia
+++ b/library/julia
@@ -11,7 +11,7 @@ GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
 Directory: stretch
 
 Tags: 0.6.3-jessie, 0.6-jessie, 0-jessie, jessie
-Architectures: amd64, arm32v7, arm64v8, i386
+Architectures: amd64, arm32v7, i386
 GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
 Directory: jessie
 

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/274966255b326b17a4a351867ece4eaa0eefef28/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/380200038360980631e362f964857d48489f99a2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -12,6 +12,20 @@ Architectures: amd64
 GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
 Directory: 3.2
 
+Tags: 3.2.20-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
+SharedTags: 3.2.20-windowsservercore, 3.2-windowsservercore, 3.2.20, 3.2
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.2/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.2.20-windowsservercore-1709, 3.2-windowsservercore-1709
+SharedTags: 3.2.20-windowsservercore, 3.2-windowsservercore, 3.2.20, 3.2
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.2/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
 Tags: 3.4.16-jessie, 3.4-jessie
 SharedTags: 3.4.16, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
@@ -19,6 +33,20 @@ SharedTags: 3.4.16, 3.4
 Architectures: amd64
 GitCommit: a499e81e743b05a5237e2fd700c0284b17d3d416
 Directory: 3.4
+
+Tags: 3.4.16-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: 3.4.16-windowsservercore, 3.4-windowsservercore, 3.4.16, 3.4
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.4/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.4.16-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: 3.4.16-windowsservercore, 3.4-windowsservercore, 3.4.16, 3.4
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.4/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
 
 Tags: 3.6.6-jessie, 3.6-jessie, 3-jessie
 SharedTags: 3.6.6, 3.6, 3
@@ -28,6 +56,20 @@ Architectures: amd64
 GitCommit: e0735c07abced69a5d8945aace9285288d013a83
 Directory: 3.6
 
+Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.6, 3.6, 3
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.6/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.6, 3.6, 3
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 3.6/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
 Tags: 4.0.0-xenial, 4.0-xenial, 4-xenial, xenial
 SharedTags: 4.0.0, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
@@ -35,3 +77,53 @@ SharedTags: 4.0.0, 4.0, 4, latest
 Architectures: amd64, arm64v8
 GitCommit: 274966255b326b17a4a351867ece4eaa0eefef28
 Directory: 4.0
+
+Tags: 4.0.0-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.0/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 4.0.0-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
+SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.0/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 4.0.0-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.0/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 4.1.1-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.1, 4.1, unstable
+# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
+# (i386, ppc64el, s390x are empty)
+Architectures: amd64, arm64v8
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.1
+
+Tags: 4.1.1-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.1-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.1, 4.1, unstable
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.1/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 4.1.1-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.1-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.1, 4.1, unstable
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.1/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 4.1.1-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.1-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.1, 4.1, unstable
+Architectures: windows-amd64
+GitCommit: 380200038360980631e362f964857d48489f99a2
+Directory: 4.1/windows/windowsservercore-1803
+Constraints: windowsservercore-1803

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-22-jdk-sid, 11-ea-22-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-22-jdk, 11-ea-22, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-23-jdk-sid, 11-ea-23-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-23-jdk, 11-ea-23, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
+GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
 Directory: 11/jdk
 
-Tags: 11-ea-22-jdk-slim-sid, 11-ea-22-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-22-jdk-slim, 11-ea-22-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-23-jdk-slim-sid, 11-ea-23-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-23-jdk-slim, 11-ea-23-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
+GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
 Directory: 11/jdk/slim
 
-Tags: 11-ea-22-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-22-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-23-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-23-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
+GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
 Directory: 11/jre
 
-Tags: 11-ea-22-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-22-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-23-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-23-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 15765bea4a1e184007e20ac3c94b93253f16f668
+GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
 Directory: 11/jre/slim
 
-Tags: 10.0.1-10-jdk-sid, 10.0.1-10-sid, 10.0.1-jdk-sid, 10.0.1-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.1-10-jdk, 10.0.1-10, 10.0.1-jdk, 10.0.1, 10.0-jdk, 10.0, 10-jdk, 10
+Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jdk
 
-Tags: 10.0.1-10-jdk-slim-sid, 10.0.1-10-slim-sid, 10.0.1-jdk-slim-sid, 10.0.1-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.1-10-jdk-slim, 10.0.1-10-slim, 10.0.1-jdk-slim, 10.0.1-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
+Tags: 10.0.2-13-jdk-slim-sid, 10.0.2-13-slim-sid, 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.2-13-jdk-slim, 10.0.2-13-slim, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31741b6c2bbe2625e783288664245136ffe9533c
+GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jdk/slim
 
 Tags: 10.0.1-jdk-windowsservercore-ltsc2016, 10.0.1-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
@@ -55,14 +55,14 @@ GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 10.0.1-10-jre-sid, 10.0.1-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.1-10-jre, 10.0.1-jre, 10.0-jre, 10-jre
+Tags: 10.0.2-13-jre-sid, 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.2-13-jre, 10.0.2-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jre
 
-Tags: 10.0.1-10-jre-slim-sid, 10.0.1-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.1-10-jre-slim, 10.0.1-jre-slim, 10.0-jre-slim, 10-jre-slim
+Tags: 10.0.2-13-jre-slim-sid, 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.2-13-jre-slim, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jre/slim
 
 Tags: 8u171-jdk-stretch, 8u171-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u171-jdk, 8u171, 8-jdk, 8, jdk, latest
@@ -122,7 +122,7 @@ GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk
 
 Tags: 7u181-jdk-slim-jessie, 7u181-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u181-jdk-slim, 7u181-slim, 7-jdk-slim, 7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk/slim
 
@@ -137,7 +137,7 @@ GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre
 
 Tags: 7u181-jre-slim-jessie, 7-jre-slim-jessie, 7u181-jre-slim, 7-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre/slim
 

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 10.0.8-apache, 10.0-apache, 10-apache, apache, 10.0.8, 10.0, 10, latest
+Tags: 10.0.9-apache, 10.0-apache, 10-apache, apache, 10.0.9, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
+GitCommit: e639fa023d91bdc7b60c56a19ad27343f7e4491c
 Directory: 10.0/apache
 
-Tags: 10.0.8-fpm, 10.0-fpm, 10-fpm, fpm
+Tags: 10.0.9-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
+GitCommit: e639fa023d91bdc7b60c56a19ad27343f7e4491c
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9

--- a/library/php
+++ b/library/php
@@ -4,217 +4,217 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.7-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.7-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.7-cli, 7.2-cli, 7-cli, cli, 7.2.7, 7.2, 7, latest
+Tags: 7.2.8-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.8-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.8-cli, 7.2-cli, 7-cli, cli, 7.2.8, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.7-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.7-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.8-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.8-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.7-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.7-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.8-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.8-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.7-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.7-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.8-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.8-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.7-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.7-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.7-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.7-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.8-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.8-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.8-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.8-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.7-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.7-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.8-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.8-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.7-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.7-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.8-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.8-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.7-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.7-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
+Tags: 7.2.8-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.8-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.7-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
+Tags: 7.2.8-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.7-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
+Tags: 7.2.8-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4af0a8734a48ab84ee96de513aabc45418b63dc5
+GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.19-cli-stretch, 7.1-cli-stretch, 7.1.19-stretch, 7.1-stretch, 7.1.19-cli, 7.1-cli, 7.1.19, 7.1
+Tags: 7.1.20-cli-stretch, 7.1-cli-stretch, 7.1.20-stretch, 7.1-stretch, 7.1.20-cli, 7.1-cli, 7.1.20, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.19-apache-stretch, 7.1-apache-stretch, 7.1.19-apache, 7.1-apache
+Tags: 7.1.20-apache-stretch, 7.1-apache-stretch, 7.1.20-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.19-fpm-stretch, 7.1-fpm-stretch, 7.1.19-fpm, 7.1-fpm
+Tags: 7.1.20-fpm-stretch, 7.1-fpm-stretch, 7.1.20-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.19-zts-stretch, 7.1-zts-stretch, 7.1.19-zts, 7.1-zts
+Tags: 7.1.20-zts-stretch, 7.1-zts-stretch, 7.1.20-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.19-cli-jessie, 7.1-cli-jessie, 7.1.19-jessie, 7.1-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+Tags: 7.1.20-cli-jessie, 7.1-cli-jessie, 7.1.20-jessie, 7.1-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.19-apache-jessie, 7.1-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+Tags: 7.1.20-apache-jessie, 7.1-apache-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.19-fpm-jessie, 7.1-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+Tags: 7.1.20-fpm-jessie, 7.1-fpm-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.19-zts-jessie, 7.1-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+Tags: 7.1.20-zts-jessie, 7.1-zts-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.19-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.19-alpine3.7, 7.1-alpine3.7, 7.1.19-cli-alpine, 7.1-cli-alpine, 7.1.19-alpine, 7.1-alpine
+Tags: 7.1.20-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.20-alpine3.7, 7.1-alpine3.7, 7.1.20-cli-alpine, 7.1-cli-alpine, 7.1.20-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.19-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.19-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.20-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.20-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.19-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.19-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.20-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.20-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b599d7375c12ff69e4d11ea10c3dea56dd670eb9
+GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
 Directory: 7.1/alpine3.7/zts
 
-Tags: 7.0.30-cli-stretch, 7.0-cli-stretch, 7.0.30-stretch, 7.0-stretch, 7.0.30-cli, 7.0-cli, 7.0.30, 7.0
+Tags: 7.0.31-cli-stretch, 7.0-cli-stretch, 7.0.31-stretch, 7.0-stretch, 7.0.31-cli, 7.0-cli, 7.0.31, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/stretch/cli
 
-Tags: 7.0.30-apache-stretch, 7.0-apache-stretch, 7.0.30-apache, 7.0-apache
+Tags: 7.0.31-apache-stretch, 7.0-apache-stretch, 7.0.31-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/stretch/apache
 
-Tags: 7.0.30-fpm-stretch, 7.0-fpm-stretch, 7.0.30-fpm, 7.0-fpm
+Tags: 7.0.31-fpm-stretch, 7.0-fpm-stretch, 7.0.31-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/stretch/fpm
 
-Tags: 7.0.30-zts-stretch, 7.0-zts-stretch, 7.0.30-zts, 7.0-zts
+Tags: 7.0.31-zts-stretch, 7.0-zts-stretch, 7.0.31-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/stretch/zts
 
-Tags: 7.0.30-cli-jessie, 7.0-cli-jessie, 7.0.30-jessie, 7.0-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 7.0.31-cli-jessie, 7.0-cli-jessie, 7.0.31-jessie, 7.0-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.30-apache-jessie, 7.0-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 7.0.31-apache-jessie, 7.0-apache-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.30-fpm-jessie, 7.0-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 7.0.31-fpm-jessie, 7.0-fpm-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.30-zts-jessie, 7.0-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 7.0.31-zts-jessie, 7.0-zts-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.30-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.30-alpine3.7, 7.0-alpine3.7, 7.0.30-cli-alpine, 7.0-cli-alpine, 7.0.30-alpine, 7.0-alpine
+Tags: 7.0.31-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.31-alpine3.7, 7.0-alpine3.7, 7.0.31-cli-alpine, 7.0-cli-alpine, 7.0.31-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/alpine3.7/cli
 
-Tags: 7.0.30-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.30-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.31-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.31-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/alpine3.7/fpm
 
-Tags: 7.0.30-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.30-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.31-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.31-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
 Directory: 7.0/alpine3.7/zts
 
-Tags: 5.6.36-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.36-stretch, 5.6-stretch, 5-stretch, 5.6.36-cli, 5.6-cli, 5-cli, 5.6.36, 5.6, 5
+Tags: 5.6.37-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.37-stretch, 5.6-stretch, 5-stretch, 5.6.37-cli, 5.6-cli, 5-cli, 5.6.37, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/stretch/cli
 
-Tags: 5.6.36-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.36-apache, 5.6-apache, 5-apache
+Tags: 5.6.37-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.37-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/stretch/apache
 
-Tags: 5.6.36-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.36-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.37-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.37-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/stretch/fpm
 
-Tags: 5.6.36-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.36-zts, 5.6-zts, 5-zts
+Tags: 5.6.37-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.37-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/stretch/zts
 
-Tags: 5.6.36-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.36-jessie, 5.6-jessie, 5-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 5.6.37-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.37-jessie, 5.6-jessie, 5-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.36-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 5.6.37-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.36-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 5.6.37-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.36-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+Tags: 5.6.37-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.36-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.36-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.36-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.36-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.37-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.37-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.37-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.37-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/cli
 
-Tags: 5.6.36-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.36-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.37-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.37-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/fpm
 
-Tags: 5.6.36-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.36-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.37-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.37-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b250a22ce67cd1232c11e0c17a0f1708ced6f4af
+GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/zts

--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2
 Architectures: amd64, arm32v5, i386
-GitCommit: 2f33d14520f370cd52fa13aac2c87c63ca586d8c
+GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim
 Architectures: amd64, arm32v5, i386
-GitCommit: 2f33d14520f370cd52fa13aac2c87c63ca586d8c
+GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest
 Architectures: amd64, arm32v5, i386
-GitCommit: 2f33d14520f370cd52fa13aac2c87c63ca586d8c
+GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
 Directory: 3
 
 Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, i386
-GitCommit: 2f33d14520f370cd52fa13aac2c87c63ca586d8c
+GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -56,7 +56,7 @@ GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/jessie
 
 Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.6/jessie/slim
 
@@ -111,7 +111,7 @@ GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.5/jessie
 
 Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.5/jessie/slim
 
@@ -147,7 +147,7 @@ GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/jessie
 
 Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
 Directory: 3.4/jessie/slim
 
@@ -188,7 +188,7 @@ GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
 Directory: 2.7/jessie/slim
 

--- a/library/ruby
+++ b/library/ruby
@@ -6,52 +6,52 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
+GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
+GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb78337005eb49371c4faf5f79d2675382d487a
+GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-onbuild, 2.4-onbuild
@@ -61,32 +61,32 @@ Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-onbuild, 2.3-onbuild
@@ -96,5 +96,5 @@ Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 699a04311386ecc98ca242fc9bdee17fb4008863
+GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `buildpack-deps`: update Jessie arches
- `docker`: 18.06.0-ce (GA), deprecate Edge releases (docker-library/docker#122)
- `ghost`: 1.24.9
- `golang`: 1.11beta2
- `httpd`: 2.4.34
- `julia`: updated i386 tarballs
- `mongo`: 4.1.1, Windows Server Core (docker-library/mongo#287, docker-library/mongo#288)
- `openjdk`: 11-ea+23, 10.0.2+13
- `owncloud`: 10.0.9
- `php`: 7.1.20, 5.6.37, 7.0.31, 7.2.8
- `pypy`: comment fix
- `python`: update Jessie arches
- `ruby`: bundler 1.16.3