### PR TITLE
Update node chakracore to 10.6.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -78,8 +78,8 @@ Architectures: amd64
 GitCommit: 947280600648b70e067d35415d6812fd03127def
 Directory: chakracore/8
 
-Tags: chakracore-10.1.0, chakracore-10.1, chakracore-10, chakracore
+Tags: chakracore-10.6.0, chakracore-10.6, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 384512d45794367e0da3c4721559ae9e9ce9412e
+GitCommit: ea61a26000dbc3b90708f4f024614dc41c94346e
 Directory: chakracore/10
 


### PR DESCRIPTION
https://github.com/nodejs/node-chakracore/releases/tag/node-chakracore-v10.6.0

https://github.com/nodejs/docker-node/pull/824