### PR TITLE
Update Couchbase Server Enterprise to 5.5.0 (and remove 5.5.0-beta)

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,16 +1,14 @@
 # maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
 
-latest: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/5.1.1
-enterprise: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/5.1.1
-5.1.1: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/5.1.1
-enterprise-5.1.1: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/5.1.1
+latest: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/5.5.0
+enterprise: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/5.5.0
+5.5.0: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/5.5.0
+enterprise-5.5.0: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/5.5.0
 
-5.5.0-beta: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/5.5.0-beta
+4.6.5: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/4.6.5
+enterprise-4.6.5: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e enterprise/couchbase-server/4.6.5
 
-4.6.5: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/4.6.5
-enterprise-4.6.5: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da enterprise/couchbase-server/4.6.5
+community: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e community/couchbase-server/5.1.1
+community-5.1.1: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e community/couchbase-server/5.1.1
 
-community: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da community/couchbase-server/5.1.1
-community-5.1.1: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da community/couchbase-server/5.1.1
-
-community-4.5.1: https://github.com/couchbase/docker@d6d3d0c104d699d9310b15af5acd3b3b134e28da community/couchbase-server/4.5.1
+community-4.5.1: https://github.com/couchbase/docker@fc55b9efd80129ab73373f94f9066186932e563e community/couchbase-server/4.5.1


### PR DESCRIPTION
If this could go live sometime today I'd really appreciate it!