### PR TITLE
haxe: add alpine3.8, enable arm64v8 for alpine variants

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -22,14 +22,19 @@ GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.4/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.4.7-alpine3.7, 3.4-alpine3.7, 3.4.7-alpine, 3.4-alpine
-Architectures: amd64
-GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
+Tags: 3.4.7-alpine3.8, 3.4-alpine3.8, 3.4.7-alpine, 3.4-alpine
+Architectures: amd64, arm64v8
+GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+Directory: 3.4/alpine3.8
+
+Tags: 3.4.7-alpine3.7, 3.4-alpine3.7
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.4/alpine3.7
 
 Tags: 3.4.7-alpine3.6, 3.4-alpine3.6
-Architectures: amd64
-GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
@@ -53,14 +58,19 @@ GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.3/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.3.0-rc.1-alpine3.7, 3.3.0-rc.1-alpine, 3.3.0-alpine3.7, 3.3-alpine3.7, 3.3.0-alpine, 3.3-alpine
-Architectures: amd64
-GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Tags: 3.3.0-rc.1-alpine3.8, 3.3.0-rc.1-alpine, 3.3.0-alpine3.8, 3.3-alpine3.8, 3.3.0-alpine, 3.3-alpine
+Architectures: amd64, arm64v8
+GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+Directory: 3.3/alpine3.8
+
+Tags: 3.3.0-rc.1-alpine3.7, 3.3.0-alpine3.7, 3.3-alpine3.7
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.3/alpine3.7
 
 Tags: 3.3.0-rc.1-alpine3.6, 3.3.0-alpine3.6, 3.3-alpine3.6
-Architectures: amd64
-GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.3/alpine3.6
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
@@ -84,14 +94,19 @@ GitCommit: b4440856db08d09ee96b6ab5a763cd5556f504e2
 Directory: 3.2/windowsservercore
 Constraints: windowsservercore
 
-Tags: 3.2.1-alpine3.7, 3.2-alpine3.7, 3.2.1-alpine, 3.2-alpine
-Architectures: amd64
-GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Tags: 3.2.1-alpine3.8, 3.2-alpine3.8, 3.2.1-alpine, 3.2-alpine
+Architectures: amd64, arm64v8
+GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+Directory: 3.2/alpine3.8
+
+Tags: 3.2.1-alpine3.7, 3.2-alpine3.7
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.2/alpine3.7
 
 Tags: 3.2.1-alpine3.6, 3.2-alpine3.6
-Architectures: amd64
-GitCommit: e2190dbe03fc74eff8abbf70ec029ab585462f23
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
@@ -136,13 +151,18 @@ GitCommit: 2fab1f21333e6472f398b9c08dd1d5117e5539c2
 Directory: 4.0/windowsservercore
 Constraints: windowsservercore
 
-Tags: 4.0.0-preview.4-alpine3.7, 4.0.0-preview.4-alpine, 4.0.0-alpine3.7, 4.0-alpine3.7, 4.0.0-alpine, 4.0-alpine
-Architectures: amd64
-GitCommit: 2fab1f21333e6472f398b9c08dd1d5117e5539c2
+Tags: 4.0.0-preview.4-alpine3.8, 4.0.0-preview.4-alpine, 4.0.0-alpine3.8, 4.0-alpine3.8, 4.0.0-alpine, 4.0-alpine
+Architectures: amd64, arm64v8
+GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+Directory: 4.0/alpine3.8
+
+Tags: 4.0.0-preview.4-alpine3.7, 4.0.0-alpine3.7, 4.0-alpine3.7
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 4.0/alpine3.7
 
 Tags: 4.0.0-preview.4-alpine3.6, 4.0.0-alpine3.6, 4.0-alpine3.6
-Architectures: amd64
-GitCommit: 2fab1f21333e6472f398b9c08dd1d5117e5539c2
+Architectures: amd64, arm64v8
+GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
 Directory: 4.0/alpine3.6
 


### PR DESCRIPTION
* add `alpine3.8` variant and update `alpine` to use it
* enable `arm64v8` for alpine variants (tested with a Raspberry Pi 3)