### PR TITLE
Update cassandra, drupal, ghost, haproxy, julia, mariadb, pypy, and python

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: 01786683a1b060f813bce5539b1743695f9cc043
+GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
 Directory: 2.1
 
 Tags: 2.2.12, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 01786683a1b060f813bce5539b1743695f9cc043
+GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
 Directory: 2.2
 
 Tags: 3.0.16, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 01786683a1b060f813bce5539b1743695f9cc043
+GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
 Directory: 3.0
 
 Tags: 3.11.2, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 01786683a1b060f813bce5539b1743695f9cc043
+GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
 Directory: 3.11

--- a/library/drupal
+++ b/library/drupal
@@ -4,6 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
+Tags: 8.6.0-alpha1-apache, 8.6-rc-apache, rc-apache, 8.6.0-alpha1, 8.6-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+Directory: 8.6-rc/apache
+
+Tags: 8.6.0-alpha1-fpm, 8.6-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+Directory: 8.6-rc/fpm
+
+Tags: 8.6.0-alpha1-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+Directory: 8.6-rc/fpm-alpine
+
 Tags: 8.5.5-apache, 8.5-apache, 8-apache, apache, 8.5.5, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
@@ -18,36 +33,6 @@ Tags: 8.5.5-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
 Directory: 8.5/fpm-alpine
-
-Tags: 8.4.8-apache, 8.4-apache, 8.4.8, 8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 10087c4bbffb39e59372e9744df64ca9153334d8
-Directory: 8.4/apache
-
-Tags: 8.4.8-fpm, 8.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 10087c4bbffb39e59372e9744df64ca9153334d8
-Directory: 8.4/fpm
-
-Tags: 8.4.8-fpm-alpine, 8.4-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 10087c4bbffb39e59372e9744df64ca9153334d8
-Directory: 8.4/fpm-alpine
-
-Tags: 8.3.9-apache, 8.3-apache, 8.3.9, 8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
-Directory: 8.3/apache
-
-Tags: 8.3.9-fpm, 8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 613b25738ce74aa3a675ca1f70ce9e6e3b26036c
-Directory: 8.3/fpm
-
-Tags: 8.3.9-fpm-alpine, 8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 91a83c62f177bdaa4bba79f5f32c4f9972081211
-Directory: 8.3/fpm-alpine
 
 Tags: 7.59-apache, 7-apache, 7.59, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/gcc
+++ b/library/gcc
@@ -6,14 +6,14 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7
 GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
 Directory: 5
 # Docker EOL: 2018-10-10
 
 # Last Modified: 2017-07-04
 Tags: 6.4.0, 6.4, 6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7
 GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
 Directory: 6
 # Docker EOL: 2018-07-04

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.24.9, 1.24, 1, latest
+Tags: 1.25.0, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b192edd8cc892ac034a6350dc37afbce1a328ea1
+GitCommit: 29f8e3f2c1f763474eb8d5bdbb7d6bc382c67004
 Directory: 1/debian
 
-Tags: 1.24.9-alpine, 1.24-alpine, 1-alpine, alpine
-Architectures: amd64
-GitCommit: b192edd8cc892ac034a6350dc37afbce1a328ea1
+Tags: 1.25.0-alpine, 1.25-alpine, 1-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 29f8e3f2c1f763474eb8d5bdbb7d6bc382c67004
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/haproxy
+++ b/library/haproxy
@@ -6,40 +6,40 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c6d92913f56e05d6985d2f0f2131675de68f915
+GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
-Architectures: amd64
-GitCommit: feefabf1ea0f03879f9d529dcc5b8ec6f3112bba
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
 Directory: 1.5/alpine
 
 Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f826736817e51e0745bd4356e3a33e702ee1145
+GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
 Directory: 1.6
 
 Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: feefabf1ea0f03879f9d529dcc5b8ec6f3112bba
+GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
 Directory: 1.6/alpine
 
 Tags: 1.7.11, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12d1ddc03e1061f379893cb97cb26931f82ed81
+GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f12d1ddc03e1061f379893cb97cb26931f82ed81
+GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
 Directory: 1.7/alpine
 
 Tags: 1.8.12, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 963fd7a6652025c5fcd1fc2fb856395732e45256
+GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
 Directory: 1.8
 
 Tags: 1.8.12-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 963fd7a6652025c5fcd1fc2fb856395732e45256
+GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
 Directory: 1.8/alpine

--- a/library/julia
+++ b/library/julia
@@ -1,30 +1,30 @@
-# this file is generated via https://github.com/docker-library/julia/blob/3cb2698ed2475db46cc17d5d1cd309626ef87c1c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/d3bfa97a8dba3fd1085c017798d8d02f376f29e1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.6.3-stretch, 0.6-stretch, 0-stretch, stretch
-SharedTags: 0.6.3, 0.6, 0, latest
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
+Tags: 0.6.4-stretch, 0.6-stretch, 0-stretch, stretch
+SharedTags: 0.6.4, 0.6, 0, latest
+Architectures: amd64, i386
+GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
 Directory: stretch
 
-Tags: 0.6.3-jessie, 0.6-jessie, 0-jessie, jessie
-Architectures: amd64, arm32v7, i386
-GitCommit: 3854279e1ffb49d9e34080d476ffdb7c00035455
+Tags: 0.6.4-jessie, 0.6-jessie, 0-jessie, jessie
+Architectures: amd64, i386
+GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
 Directory: jessie
 
-Tags: 0.6.3-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.6.3, 0.6, 0, latest
+Tags: 0.6.4-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.6.4, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: d4f2c502f4604b25de33e6d4e2db23c8d5971c12
+GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
 Directory: windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 0.6.3-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
-SharedTags: 0.6.3, 0.6, 0, latest
+Tags: 0.6.4-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
+SharedTags: 0.6.4, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: d4f2c502f4604b25de33e6d4e2db23c8d5971c12
+GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
 Directory: windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,25 +1,30 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/9ce4ecd2783d2358d2c0fe0efa924ecae33d9e84/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/852044c20cd24a94bb15d8fcdb7b0784a40110d9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.3.8-jessie, 10.3-jessie, 10-jessie, jessie, 10.3.8, 10.3, 10, latest
-GitCommit: a7d1a184913c009c473baeb8f72385d12ae0de61
+Tags: 10.3.8-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.8, 10.3, 10, latest
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.3
 
-Tags: 10.2.16-jessie, 10.2-jessie, 10.2.16, 10.2
-GitCommit: 1e7c5c9bb2bfde0453fb52175343a360ed346104
+Tags: 10.2.16-bionic, 10.2-bionic, 10.2.16, 10.2
+Architectures: amd64, arm64v8, i386, ppc64le
+GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.2
 
-Tags: 10.1.34-jessie, 10.1-jessie, 10.1.34, 10.1
-GitCommit: 12a0273332a3a0ed007ece2ae5886f7ac9c15d1b
+Tags: 10.1.34-bionic, 10.1-bionic, 10.1.34, 10.1
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.1
 
-Tags: 10.0.35-jessie, 10.0-jessie, 10.0.35, 10.0
-GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
+Tags: 10.0.35-xenial, 10.0-xenial, 10.0.35, 10.0
+Architectures: amd64, arm64v8, i386, ppc64le
+GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
 Directory: 10.0
 
-Tags: 5.5.60-wheezy, 5.5-wheezy, 5-wheezy, 5.5.60, 5.5, 5
-GitCommit: 20b1413b646df9a45df2d4dcc5c5c89ecb42c0b1
+Tags: 5.5.60-trusty, 5.5-trusty, 5-trusty, 5.5.60, 5.5, 5
+Architectures: amd64, i386, ppc64le
+GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -117,7 +117,7 @@ GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jre/alpine
 
 Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jdk
 
@@ -132,7 +132,7 @@ GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 7/jdk/alpine
 
 Tags: 7u181-jre-jessie, 7-jre-jessie, 7u181-jre, 7-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 2057305e0474ebf6461daea607ff02874d690914
 Directory: 7/jre
 

--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2
 Architectures: amd64, arm32v5, i386
-GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
+GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim
 Architectures: amd64, arm32v5, i386
-GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
+GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest
 Architectures: amd64, arm32v5, i386
-GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
+GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 3
 
 Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim
 Architectures: amd64, arm32v5, i386
-GitCommit: 4a71a30c057b858ae569f8465dffa8ce559ff225
+GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/a70575c01b81fe9c8d920e13a03f55bdc0622328/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/49cb32fb9c5e401178ba352d5b9e95396a74412b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -7,226 +7,206 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.0-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/stretch
 
 Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/stretch/slim
 
-Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8
+Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/alpine3.8
 
-Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.0-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: e4cfc4299e8b5ea35257d5daf3f93aaf94df0230
+GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.6-stretch, 3.6-stretch
 SharedTags: 3.6.6, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/stretch
 
 Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3.6.6-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.6-jessie, 3.6-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/jessie
 
 Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.6-onbuild, 3.6-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
-Directory: 3.6/jessie/onbuild
-
-Tags: 3.6.6-alpine3.8, 3.6-alpine3.8
+Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/alpine3.8
 
-Tags: 3.6.6-alpine3.7, 3.6-alpine3.7, 3.6.6-alpine, 3.6-alpine
+Tags: 3.6.6-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
-GitCommit: 341c752e5435f4cf4c008fbae67ae4b5b6209a02
+GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.5-stretch, 3.5-stretch
 SharedTags: 3.5.5, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/stretch
 
 Tags: 3.5.5-slim-stretch, 3.5-slim-stretch, 3.5.5-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.5-jessie, 3.5-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/jessie
 
 Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/jessie/slim
 
-Tags: 3.5.5-onbuild, 3.5-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
-Directory: 3.5/jessie/onbuild
-
-Tags: 3.5.5-alpine3.8, 3.5-alpine3.8
+Tags: 3.5.5-alpine3.8, 3.5-alpine3.8, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/alpine3.8
 
-Tags: 3.5.5-alpine3.7, 3.5-alpine3.7, 3.5.5-alpine, 3.5-alpine
+Tags: 3.5.5-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.8-stretch, 3.4-stretch
 SharedTags: 3.4.8, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/stretch
 
 Tags: 3.4.8-slim-stretch, 3.4-slim-stretch, 3.4.8-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.8-jessie, 3.4-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/jessie
 
 Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/jessie/slim
-
-Tags: 3.4.8-onbuild, 3.4-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
-Directory: 3.4/jessie/onbuild
 
 Tags: 3.4.8-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/wheezy
 
-Tags: 3.4.8-alpine3.8, 3.4-alpine3.8
+Tags: 3.4.8-alpine3.8, 3.4-alpine3.8, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c24c7b5b7c77c99793c4cff488a81e8cb3cc7e61
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/alpine3.8
 
-Tags: 3.4.8-alpine3.7, 3.4-alpine3.7, 3.4.8-alpine, 3.4-alpine
+Tags: 3.4.8-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a794688c7246e7eff898f5288716a3e7dc08484
+GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/jessie/slim
-
-Tags: 2.7.15-onbuild, 2.7-onbuild, 2-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f12c2df135aef8c3f645d90aae582b2c65dbc3b5
-Directory: 2.7/jessie/onbuild
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/wheezy
 
-Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
+Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/alpine3.8
 
-Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7, 2.7.15-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a70575c01b81fe9c8d920e13a03f55bdc0622328
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 4d640edc8df64b9cf050904f60ac03765e05d3f6
+GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/7766c719ed4c11dd52a8e0e35195ec82097aebfe/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/b9e495c8e400363e6cc2d4db6d944235b7989584/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -45,7 +45,7 @@ GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/jessie
 
@@ -53,11 +53,6 @@ Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
 Directory: 2.4/jessie/slim
-
-Tags: 2.4.4-onbuild, 2.4-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
-Directory: 2.4/jessie/onbuild
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
@@ -80,7 +75,7 @@ GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/jessie
 
@@ -88,11 +83,6 @@ Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
 Directory: 2.3/jessie/slim
-
-Tags: 2.3.7-onbuild, 2.3-onbuild
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6918175fd506b46bf2d8f899f4faa40e72296fb
-Directory: 2.3/jessie/onbuild
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x

--- a/library/tomcat
+++ b/library/tomcat
@@ -10,7 +10,7 @@ GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre7
 
 Tags: 7.0.90-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.90-slim, 7.0-slim, 7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre7-slim
 
@@ -40,7 +40,7 @@ GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre7
 
 Tags: 8.0.53-jre7-slim, 8.0-jre7-slim, 8.0.53-slim, 8.0-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre7-slim
 


### PR DESCRIPTION
Update arches following Jessie transition to LTS for gcc, openjdk, python, ruby, tomcat

- `cassandra` https://github.com/docker-library/cassandra/pull/151
- `drupal` https://github.com/docker-library/drupal/pull/126
- `gcc` architectures reduction on Jessie
- `ghost` node bump 6 -> 8, https://github.com/docker-library/ghost/pull/137
- `haproxy` bump to stretch, https://github.com/docker-library/haproxy/pull/71
- `julia` update to 0.6.4, https://github.com/docker-library/julia/commit/d3bfa97a8dba3fd1085c017798d8d02f376f29e1
- `mariadb` transition to ubuntu based images (https://github.com/docker-library/mariadb/pull/184)
- `openjdk` architectures reduction on Jessie
- `pypy` bump to pip `18.0`
- `python` architectures reduction on Jessie, default Alpine to 3.8, drop onbuild images
  - https://github.com/docker-library/python/pull/311, https://github.com/docker-library/python/pull/313, https://github.com/docker-library/python/pull/314, https://github.com/docker-library/python/pull/315
- `ruby` architectures reduction on Jessie, drop onbuild images
- `tomcat` architectures reduction on Jessie
