### PR TITLE
Updating Oracle Linux 6 and 7 images for amd64/arm64v8 

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: da106040028d1d7289d02909bf0524b7ce32dc3a
+amd64-GitCommit: be56ba6b16038485762f6058f48f6eaa018477b3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 84395cf9a5c1d549526bd69439bb982177412129
+arm64v8-GitCommit: dd5d83c3856f3facb5aa3a42b0163dcb43762721
 Constraints: !aufs
 
 Tags: 7.5, 7, latest


### PR DESCRIPTION
Fixes CVE-2018-12020: https://linux.oracle.com/cve/CVE-2018-12020.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>