### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
 Directory: 7
 # Docker EOL: 2019-01-25
 
-# Last Modified: 2018-05-02
-Tags: 8.1.0, 8.1, 8, latest
+# Last Modified: 2018-07-26
+Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
+GitCommit: ca5b263c1028b3a4fbdb8c2d800544ab43d524a0
 Directory: 8
-# Docker EOL: 2019-05-02
+# Docker EOL: 2019-07-26

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.25.0, 1.25, 1, latest
+Tags: 1.25.2, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29f8e3f2c1f763474eb8d5bdbb7d6bc382c67004
+GitCommit: cbb3933d8aacbc87c92ed7ae8bd550c2721dfdd6
 Directory: 1/debian
 
-Tags: 1.25.0-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.2-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 29f8e3f2c1f763474eb8d5bdbb7d6bc382c67004
+GitCommit: cbb3933d8aacbc87c92ed7ae8bd550c2721dfdd6
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/380200038360980631e362f964857d48489f99a2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/88e0e5bf726503c9805a1f4990096d6eb0aff6c5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.11, 8.0, 8, latest
-GitCommit: fc3e856313423dc2d6a8d74cfd6b678582090fc7
+GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
 Directory: 8.0
 
 Tags: 5.7.22, 5.7, 5
-GitCommit: fc3e856313423dc2d6a8d74cfd6b678582090fc7
+GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
 Directory: 5.7
 
 Tags: 5.6.40, 5.6
-GitCommit: fc3e856313423dc2d6a8d74cfd6b678582090fc7
+GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
 Directory: 5.6
 
 Tags: 5.5.60, 5.5
-GitCommit: fc3e856313423dc2d6a8d74cfd6b678582090fc7
+GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
 Directory: 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta2, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d0b6adfd8c4b967d9fbbdc0fb96c869fcaba4f0
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 11
 
 Tags: 11-beta2-alpine, 11-alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.4, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 9.6
 
 Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.13, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 9.5
 
 Tags: 9.5.13-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.18, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 9.4
 
 Tags: 9.4.18-alpine, 9.4-alpine
@@ -56,7 +56,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.23, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eff90effc6b5578be90bef93d96b3fceb1082a7c
+GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
 Directory: 9.3
 
 Tags: 9.3.23-alpine, 9.3-alpine

--- a/library/python
+++ b/library/python
@@ -17,12 +17,12 @@ Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -62,17 +62,17 @@ Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.6-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
@@ -112,12 +112,12 @@ Directory: 3.5/jessie/slim
 
 Tags: 3.5.5-alpine3.8, 3.5-alpine3.8, 3.5.5-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.5/alpine3.8
 
 Tags: 3.5.5-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.8-stretch, 3.4-stretch
@@ -148,12 +148,12 @@ Directory: 3.4/wheezy
 
 Tags: 3.4.8-alpine3.8, 3.4-alpine3.8, 3.4.8-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.8-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
@@ -184,17 +184,17 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/redis
+++ b/library/redis
@@ -1,50 +1,50 @@
-# this file is generated via https://github.com/docker-library/redis/blob/fe9b8845b47364a919bcf22c29295da502a15a59/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/8adb3f1eb87687ab1ce96ed1b5db3764c8f9024c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0-rc3, 5.0-rc
+Tags: 5.0-rc3, 5.0-rc, 5.0-rc3-stretch, 5.0-rc-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 403f00a0ba7556f33850a88e27e70509aa2814dd
 Directory: 5.0-rc
 
-Tags: 5.0-rc3-32bit, 5.0-rc-32bit
+Tags: 5.0-rc3-32bit, 5.0-rc-32bit, 5.0-rc3-32bit-stretch, 5.0-rc-32bit-stretch
 Architectures: amd64
 GitCommit: 403f00a0ba7556f33850a88e27e70509aa2814dd
 Directory: 5.0-rc/32bit
 
-Tags: 5.0-rc3-alpine, 5.0-rc-alpine
+Tags: 5.0-rc3-alpine, 5.0-rc-alpine, 5.0-rc3-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 7f5671ebdc563464f5570a1d081a78c26b5e6ad3
 Directory: 5.0-rc/alpine
 
-Tags: 4.0.10, 4.0, 4, latest
+Tags: 4.0.10, 4.0, 4, latest, 4.0.10-stretch, 4.0-stretch, 4-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 4.0
 
-Tags: 4.0.10-32bit, 4.0-32bit, 4-32bit, 32bit
+Tags: 4.0.10-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.10-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
 Architectures: amd64
 GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 4.0/32bit
 
-Tags: 4.0.10-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.10-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.10-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
 Directory: 4.0/alpine
 
-Tags: 3.2.12, 3.2, 3
+Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 3.2
 
-Tags: 3.2.12-32bit, 3.2-32bit, 3-32bit
+Tags: 3.2.12-32bit, 3.2-32bit, 3-32bit, 3.2.12-32bit-stretch, 3.2-32bit-stretch, 3-32bit-stretch
 Architectures: amd64
 GitCommit: 53f86805506b103b503fd392e029929290fe5346
 Directory: 3.2/32bit
 
-Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine
+Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine, 3.2.12-alpine3.8, 3.2-alpine3.8, 3-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
 Directory: 3.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.66.3, 0.66, 0, latest
-GitCommit: f2d2a10ad40f658f86a64c40a6383acae4d6c260
+Tags: 0.67.0, 0.67, 0, latest
+GitCommit: 54336806b95ef008fe593b2f6c439c2e3465ff3d

--- a/library/tomcat
+++ b/library/tomcat
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.90-jre7, 7.0-jre7, 7-jre7, 7.0.90, 7.0, 7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
 Directory: 7/jre7
 
@@ -35,7 +35,7 @@ GitCommit: 6d19b06d7ddb8964823867867b55cac2d2cd57a1
 Directory: 7/jre8-alpine
 
 Tags: 8.0.53-jre7, 8.0-jre7, 8.0.53, 8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
 Directory: 8.0/jre7
 


### PR DESCRIPTION
- `gcc`: 8.2.0
- `ghost`: 1.25.2
- `mongo`: minor comment update
- `mysql`: `gpgconf --kill all` (docker-library/mysql#459)
- `postgres`: `gpgconf --kill all` (docker-library/postgres#471)
- `python`: remove `ca-certificates` from Alpine 3.7+ (docker-library/python#307)
- `redis`: suite aliases (docker-library/redis#154)
- `rocket.chat`: 0.67.0
- `tomcat`: jessie arch removals