### PR TITLE
Updating Elixir to 1.7.1

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,29 +1,44 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/b4a2b8ea703865bd04490f43244198d0c95fa607/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-elixir/blob/634d315a5c6051a5858c25fbfdb37d0e655b971e/generate-stackbrew-library.sh
 
 Maintainers: . <c0b@users.noreply.github.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.6.6, 1.6, latest
+Tags: 1.7.1, 1.7, latest
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+Directory: 1.7
+
+Tags: 1.7.1-slim, 1.7-slim, slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+Directory: 1.7/slim
+
+Tags: 1.7.1-alpine, 1.7-alpine, alpine
+Architectures: amd64, arm64v8, i386, s390x, ppc64le
+GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+Directory: 1.7/alpine
+
+Tags: 1.6.6, 1.6
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6
 
-Tags: 1.6.6-slim, 1.6-slim, slim
+Tags: 1.6.6-slim, 1.6-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/slim
 
-Tags: 1.6.6-alpine, 1.6-alpine, alpine
+Tags: 1.6.6-alpine, 1.6-alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/alpine
 
-Tags: 1.6.6-otp-21, 1.6-otp-21, otp-21
+Tags: 1.6.6-otp-21, 1.6-otp-21
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
 Directory: 1.6/otp-21
 
-Tags: 1.6.6-otp-21-alpine, 1.6-otp-21-alpine, otp-21-alpine
+Tags: 1.6.6-otp-21-alpine, 1.6-otp-21-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
 Directory: 1.6/otp-21-alpine
@@ -52,13 +67,3 @@ Tags: 1.4.5-slim, 1.4-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
 GitCommit: 8f1888ae05506b9ad12e1b97f084a15e7588f442
 Directory: 1.4/slim
-
-Tags: 1.3.4, 1.3
-Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: d8d656d7c0dc9dd2956a22276c93cb97568ea6d4
-Directory: 1.3
-
-Tags: 1.3.4-slim, 1.3-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: d8d656d7c0dc9dd2956a22276c93cb97568ea6d4
-Directory: 1.3/slim


### PR DESCRIPTION
with upstream:
1. https://github.com/c0b/docker-elixir/pull/80#issuecomment-408432747
2. https://github.com/elixir-lang/elixir/releases/tag/v1.7.1