### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -4,21 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
-Tags: artful-curl, 17.10-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36
-Directory: artful/curl
-
-Tags: artful-scm, 17.10-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36018aca7e9637c9c04ff623625e59de12d7f161
-Directory: artful/scm
-
-Tags: artful, 17.10
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
-Directory: artful
-
 Tags: bionic-curl, 18.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36

--- a/library/julia
+++ b/library/julia
@@ -1,30 +1,50 @@
-# this file is generated via https://github.com/docker-library/julia/blob/d3bfa97a8dba3fd1085c017798d8d02f376f29e1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/4b1b740df34a21fc0edb10770d5991cb3c92d9e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
+Tags: 0.7.0-beta2-stretch, 0.7.0-stretch, 0.7-stretch, 0-rc-stretch
+SharedTags: 0.7.0-beta2, 0.7.0, 0.7, 0-rc
+Architectures: amd64, arm32v7, i386
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0-rc/stretch
+
+Tags: 0.7.0-beta2-windowsservercore-ltsc2016, 0.7.0-windowsservercore-ltsc2016, 0.7-windowsservercore-ltsc2016, 0-rc-windowsservercore-ltsc2016
+SharedTags: 0.7.0-beta2, 0.7.0, 0.7, 0-rc
+Architectures: windows-amd64
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 0.7.0-beta2-windowsservercore-1709, 0.7.0-windowsservercore-1709, 0.7-windowsservercore-1709, 0-rc-windowsservercore-1709
+SharedTags: 0.7.0-beta2, 0.7.0, 0.7, 0-rc
+Architectures: windows-amd64
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
 Tags: 0.6.4-stretch, 0.6-stretch, 0-stretch, stretch
 SharedTags: 0.6.4, 0.6, 0, latest
 Architectures: amd64, i386
-GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
-Directory: stretch
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0/stretch
 
 Tags: 0.6.4-jessie, 0.6-jessie, 0-jessie, jessie
 Architectures: amd64, i386
-GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
-Directory: jessie
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0/jessie
 
 Tags: 0.6.4-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 0.6.4, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
-Directory: windows/windowsservercore-ltsc2016
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 0.6.4-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
 SharedTags: 0.6.4, 0.6, 0, latest
 Architectures: windows-amd64
-GitCommit: d3bfa97a8dba3fd1085c017798d8d02f376f29e1
-Directory: windows/windowsservercore-1709
+GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+Directory: 0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-23-jdk-sid, 11-ea-23-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-23-jdk, 11-ea-23, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-24-jdk-sid, 11-ea-24-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-24-jdk, 11-ea-24, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
+GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
 Directory: 11/jdk
 
-Tags: 11-ea-23-jdk-slim-sid, 11-ea-23-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-23-jdk-slim, 11-ea-23-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-24-jdk-slim-sid, 11-ea-24-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-24-jdk-slim, 11-ea-24-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
+GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
 Directory: 11/jdk/slim
 
-Tags: 11-ea-23-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-23-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-24-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-24-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
+GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
 Directory: 11/jre
 
-Tags: 11-ea-23-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-23-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-24-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-24-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 300033e6ac3762f2fd3ec1a572f3dd66408b570b
+GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
 Directory: 11/jre/slim
 
 Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jdk/slim
 
-Tags: 10.0.1-jdk-windowsservercore-ltsc2016, 10.0.1-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
-SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 10.0.1-jdk-windowsservercore-1709, 10.0.1-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
-SharedTags: 10.0.1-jdk-windowsservercore, 10.0.1-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 10.0.1-jdk-nanoserver-sac2016, 10.0.1-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
-SharedTags: 10.0.1-jdk-nanoserver, 10.0.1-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
+Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
+SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
 Architectures: windows-amd64
-GitCommit: 59b305bb797b6cb60fa41e74448a68b4f0cdb813
+GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -80,24 +80,24 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jdk/alpine
 
-Tags: 8u171-jdk-windowsservercore-ltsc2016, 8u171-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 8u171-jdk-windowsservercore, 8u171-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 8u181-jdk-windowsservercore-ltsc2016, 8u181-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u171-jdk-windowsservercore-1709, 8u171-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 8u171-jdk-windowsservercore, 8u171-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 8u181-jdk-windowsservercore-1709, 8u181-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 8u171-jdk-nanoserver-sac2016, 8u171-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 8u171-jdk-nanoserver, 8u171-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
+Tags: 8u181-jdk-nanoserver-sac2016, 8u181-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 8u181-jdk-nanoserver, 8u181-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
+GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/percona
+++ b/library/percona
@@ -1,17 +1,20 @@
-# this file is generated via https://github.com/docker-library/percona/blob/11b6067c39e69db2c71f6c43edb902690dc5a132/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/percona/blob/2bc351a6c89c243851efc828d7ec19a21663df80/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.22, 5.7, 5, latest
-GitCommit: 01c136a28e68649b02fc2e00a580067e97f763c7
+Tags: 5.7.22-jessie, 5.7-jessie, 5-jessie, jessie, 5.7.22, 5.7, 5, latest
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.7
 
-Tags: 5.6.40, 5.6
-GitCommit: 24e0d02a91dd7880e2ac7991818887fd7df1303a
+Tags: 5.6.40-jessie, 5.6-jessie, 5.6.40, 5.6
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.6
 
-Tags: 5.5.60, 5.5
-GitCommit: 12afad5976f769f545bb9f85583e40e84109b80c
+Tags: 5.5.60-jessie, 5.5-jessie, 5.5.60, 5.5
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -11,7 +11,7 @@ Directory: 11
 
 Tags: 11-beta2-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: 6b2d9f0d5dde36d634d1bbcbd27a0b2ed7054f3c
 Directory: 11/alpine
 
 Tags: 10.4, 10, latest
@@ -21,7 +21,7 @@ Directory: 10
 
 Tags: 10.4-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: 6b2d9f0d5dde36d634d1bbcbd27a0b2ed7054f3c
 Directory: 10/alpine
 
 Tags: 9.6.9, 9.6, 9


### PR DESCRIPTION
- `buildpack-deps`: remove `artful` (EOL)
- `julia`: add 0.7.0-beta2
- `openjdk`: 11-ea+24, 10.0.2, 8u181 (Windows)
- `percona`: add arches (`i386`)
- `postgres`: add `icu-dev` (docker-library/postgres#470)