### PR TITLE
Traefik: Introduce the first windows image

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,4 +1,4 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v1.7.0-rc2, 1.7.0-rc2, v1.7, 1.7, maroilles
@@ -12,6 +12,12 @@ Tags: v1.7.0-rc2-alpine, 1.7.0-rc2-alpine, v1.7-alpine, 1.7-alpine, maroilles-al
 Architectures: amd64, arm64v8, arm32v6
 GitCommit: 7dec7b825ca16d0524626fbbca35284adfe3ef58
 Directory: alpine
+
+Tags: v1.7.0-rc2-nanoserver-sac2016, 1.7.0-rc2-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016
+Architectures: windows-amd64
+GitCommit: f04da6b99955ff13ad5f41b80f7d34d776ffd625
+Directory: windows
+Constraints: nanoserver-sac2016
 
 Tags: v1.6.5, 1.6.5, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm32v6, arm64v8


### PR DESCRIPTION
Following the issue https://github.com/containous/traefik/issues/3603 on the Træfik's issue tracker,
I am happy to introduce a first declination of a Windows Container image for Træfik.

This image is based on the `nanoserver-sac2016` variant: this is not the most recent, but it is a first start. Although we are planning to improve to other declination, some work have to be done on Golang and Træfik's sides as explained in https://github.com/containous/traefik/issues/3603#issuecomment-404329465 by @StefanScherer.

The related work can be found here: https://github.com/containous/traefik-library-image/pull/31 .

Let me know if anything else is needed !

PS: a big THANK YOU to @StefanScherer and @tianon for their help, guidance and explanations!

Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>