### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -5,40 +5,40 @@ GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 4.4.23, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 70795df9186772fe41659ef78dd68366fc84cb14
+GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
 Directory: 3.0

--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
+GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
 Directory: 2.1
 
 Tags: 2.2.12, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
+GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
 Directory: 2.2
 
 Tags: 3.0.16, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
+GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
 Directory: 3.0
 
 Tags: 3.11.2, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 3ab33070585d602d5403cb6ef655f30777046a43
+GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
 Directory: 3.11

--- a/library/ghost
+++ b/library/ghost
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.25.2, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb3933d8aacbc87c92ed7ae8bd550c2721dfdd6
+GitCommit: f4e1e58723ab0c2aac695aacf08a6fd54b4d2eee
 Directory: 1/debian
 
 Tags: 1.25.2-alpine, 1.25-alpine, 1-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f0cfbd2cd2bdbaea10a4f15cd05746397e84dd18
+GitCommit: f4e1e58723ab0c2aac695aacf08a6fd54b4d2eee
 Directory: 0/debian
 
 Tags: 0.11.13-alpine, 0.11-alpine, 0-alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
 Directory: 1.7/alpine
 
-Tags: 1.8.12, 1.8, 1, latest
+Tags: 1.8.13, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
+GitCommit: 50a14f801a7e7215c998969e5bdc923be8184646
 Directory: 1.8
 
-Tags: 1.8.12-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.13-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
+GitCommit: 50a14f801a7e7215c998969e5bdc923be8184646
 Directory: 1.8/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.34, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b814ed0f036c6084d67ce5d996b4648a9bda6275
+GitCommit: 38842a5d4cdd44ff4888e8540c0da99009790d01
 Directory: 2.4
 
 Tags: 2.4.34-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f3a5f0a505c3ffcd3ebcb6f06824fe912c00812
+GitCommit: 38842a5d4cdd44ff4888e8540c0da99009790d01
 Directory: 2.4/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ SharedTags: 3.2.20, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 753d566a83a4e9734227f186e554c87b4f08be51
+GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 3.2
 
 Tags: 3.2.20-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
@@ -31,7 +31,7 @@ SharedTags: 3.4.16, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: a499e81e743b05a5237e2fd700c0284b17d3d416
+GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 3.4
 
 Tags: 3.4.16-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
@@ -53,7 +53,7 @@ SharedTags: 3.6.6, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: e0735c07abced69a5d8945aace9285288d013a83
+GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
@@ -75,7 +75,7 @@ SharedTags: 4.0.0, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 274966255b326b17a4a351867ece4eaa0eefef28
+GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 4.0
 
 Tags: 4.0.0-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -104,7 +104,7 @@ SharedTags: 4.1.1, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 4.1
 
 Tags: 4.1.1-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/mysql
+++ b/library/mysql
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.11, 8.0, 8, latest
-GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
+Tags: 8.0.12, 8.0, 8, latest
+GitCommit: 333935aa6612376d58737a8cab0e3f5df370585a
 Directory: 8.0
 
-Tags: 5.7.22, 5.7, 5
-GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
+Tags: 5.7.23, 5.7, 5
+GitCommit: 333935aa6612376d58737a8cab0e3f5df370585a
 Directory: 5.7
 
-Tags: 5.6.40, 5.6
-GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
+Tags: 5.6.41, 5.6
+GitCommit: 333935aa6612376d58737a8cab0e3f5df370585a
 Directory: 5.6
 
-Tags: 5.5.60, 5.5
-GitCommit: 38a16645fb4bc3e537170d003581636ead265aef
+Tags: 5.5.61, 5.5
+GitCommit: 333935aa6612376d58737a8cab0e3f5df370585a
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/a5cc95a14480e9b30c674aa72257f6e4cf032b8d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/73d767bdc5525a71654cb3309f8338a5dd8f89d2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,94 +24,94 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
 Directory: 11/jre/slim
 
-Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10
+Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jdk
 
-Tags: 10.0.2-13-jdk-slim-sid, 10.0.2-13-slim-sid, 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.2-13-jdk-slim, 10.0.2-13-slim, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
+Tags: 10.0.2-13-jdk-slim-sid, 10.0.2-13-slim-sid, 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, jdk-slim-sid, slim-sid, 10.0.2-13-jdk-slim, 10.0.2-13-slim, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jdk/slim
 
-Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
-SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
+Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 10.0.2-13-jre-sid, 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.2-13-jre, 10.0.2-jre, 10.0-jre, 10-jre
+Tags: 10.0.2-13-jre-sid, 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, jre-sid, 10.0.2-13-jre, 10.0.2-jre, 10.0-jre, 10-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jre
 
-Tags: 10.0.2-13-jre-slim-sid, 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.2-13-jre-slim, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim
+Tags: 10.0.2-13-jre-slim-sid, 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, jre-slim-sid, 10.0.2-13-jre-slim, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
 Directory: 10/jre/slim
 
-Tags: 8u171-jdk-stretch, 8u171-stretch, 8-jdk-stretch, 8-stretch, jdk-stretch, stretch, 8u171-jdk, 8u171, 8-jdk, 8, jdk, latest
+Tags: 8u171-jdk-stretch, 8u171-stretch, 8-jdk-stretch, 8-stretch, 8u171-jdk, 8u171, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jdk
 
-Tags: 8u171-jdk-slim-stretch, 8u171-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, jdk-slim-stretch, slim-stretch, 8u171-jdk-slim, 8u171-slim, 8-jdk-slim, 8-slim, jdk-slim, slim
+Tags: 8u171-jdk-slim-stretch, 8u171-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u171-jdk-slim, 8u171-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jdk/slim
 
-Tags: 8u171-jdk-alpine3.8, 8u171-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, jdk-alpine3.8, alpine3.8, 8u171-jdk-alpine, 8u171-alpine, 8-jdk-alpine, 8-alpine, jdk-alpine, alpine
+Tags: 8u171-jdk-alpine3.8, 8u171-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u171-jdk-alpine, 8u171-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jdk/alpine
 
-Tags: 8u181-jdk-windowsservercore-ltsc2016, 8u181-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 8u181-jdk-windowsservercore-ltsc2016, 8u181-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
 GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u181-jdk-windowsservercore-1709, 8u181-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 8u181-jdk-windowsservercore-1709, 8u181-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
+SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
 GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 8u181-jdk-nanoserver-sac2016, 8u181-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 8u181-jdk-nanoserver, 8u181-nanoserver, 8-jdk-nanoserver, 8-nanoserver, jdk-nanoserver, nanoserver
+Tags: 8u181-jdk-nanoserver-sac2016, 8u181-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
+SharedTags: 8u181-jdk-nanoserver, 8u181-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
 GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u171-jre-stretch, 8-jre-stretch, jre-stretch, 8u171-jre, 8-jre, jre
+Tags: 8u171-jre-stretch, 8-jre-stretch, 8u171-jre, 8-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jre
 
-Tags: 8u171-jre-slim-stretch, 8-jre-slim-stretch, jre-slim-stretch, 8u171-jre-slim, 8-jre-slim, jre-slim
+Tags: 8u171-jre-slim-stretch, 8-jre-slim-stretch, 8u171-jre-slim, 8-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5cc95a14480e9b30c674aa72257f6e4cf032b8d
 Directory: 8/jre/slim
 
-Tags: 8u171-jre-alpine3.8, 8-jre-alpine3.8, jre-alpine3.8, 8u171-jre-alpine, 8-jre-alpine, jre-alpine
+Tags: 8u171-jre-alpine3.8, 8-jre-alpine3.8, 8u171-jre-alpine, 8-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jre/alpine

--- a/library/owncloud
+++ b/library/owncloud
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.9-apache, 10.0-apache, 10-apache, apache, 10.0.9, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e639fa023d91bdc7b60c56a19ad27343f7e4491c
+GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
 Directory: 10.0/apache
 
 Tags: 10.0.9-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e639fa023d91bdc7b60c56a19ad27343f7e4491c
+GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
+GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4e69c45fa3910d5e7f2f090cae185b58c6523dc
+GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
 Directory: 9.1/fpm

--- a/library/percona
+++ b/library/percona
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.22-jessie, 5.7-jessie, 5-jessie, jessie, 5.7.22, 5.7, 5, latest
-Architectures: amd64, i386
-GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
+Tags: 5.7.22-stretch, 5.7-stretch, 5-stretch, stretch, 5.7.22, 5.7, 5, latest
+Architectures: amd64
+GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
 Directory: 5.7
 
-Tags: 5.6.40-jessie, 5.6-jessie, 5.6.40, 5.6
-Architectures: amd64, i386
-GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
+Tags: 5.6.40-stretch, 5.6-stretch, 5.6.40, 5.6
+Architectures: amd64
+GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
 Directory: 5.6
 
-Tags: 5.5.60-jessie, 5.5-jessie, 5.5.60, 5.5
-Architectures: amd64, i386
-GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
+Tags: 5.5.60-stretch, 5.5-stretch, 5.5.60, 5.5
+Architectures: amd64
+GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
 Directory: 5.5

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta2, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: 56cf37a42a7647678a7e46b12e0df0942e26cc28
 Directory: 11
 
 Tags: 11-beta2-alpine, 11-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.7, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5b3f8a8f45623b03428f54d56426f129b9064a8
+GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
 Directory: 3.7/debian
 
 Tags: 3.7.7-management, 3.7-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.7/debian/management
 
 Tags: 3.7.7-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 32c80d4ef94250c981eb212756f9e95be6150b11
+GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
 Directory: 3.7/alpine
 
 Tags: 3.7.7-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.7/alpine/management
 
 Tags: 3.6.16, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17eebc8b38df47b8a45a46d3afb306a359f1e0d4
+GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
 Directory: 3.6/debian
 
 Tags: 3.6.16-management, 3.6-management
@@ -36,7 +36,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 32c80d4ef94250c981eb212756f9e95be6150b11
+GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
 Directory: 3.6/alpine
 
 Tags: 3.6.16-management-alpine, 3.6-management-alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.67.0, 0.67, 0, latest
-GitCommit: 54336806b95ef008fe593b2f6c439c2e3465ff3d
+Tags: 0.68.0, 0.68, 0, latest
+GitCommit: cf56e1fd3dea755339aaed44e0347c4e9877183c

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,110 +6,110 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.90-jre7, 7.0-jre7, 7-jre7, 7.0.90, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre7
 
 Tags: 7.0.90-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.90-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre7-slim
 
 Tags: 7.0.90-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.90-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d19b06d7ddb8964823867867b55cac2d2cd57a1
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre7-alpine
 
 Tags: 7.0.90-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre8
 
 Tags: 7.0.90-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7305c149df9cee83afb343c09fa4427d9842da2b
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre8-slim
 
 Tags: 7.0.90-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d19b06d7ddb8964823867867b55cac2d2cd57a1
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 7/jre8-alpine
 
 Tags: 8.0.53-jre7, 8.0-jre7, 8.0.53, 8.0
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre7
 
 Tags: 8.0.53-jre7-slim, 8.0-jre7-slim, 8.0.53-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre7-slim
 
 Tags: 8.0.53-jre7-alpine, 8.0-jre7-alpine, 8.0.53-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a0377566c7141395d74420b93c94f8fde72c7aa9
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.53-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre8
 
 Tags: 8.0.53-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c5ddb85c4d94a3d2e459ba83beb8a3207681d0
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre8-slim
 
 Tags: 8.0.53-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a0377566c7141395d74420b93c94f8fde72c7aa9
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre8-alpine
 
 Tags: 8.5.32-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.32, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.5/jre8
 
 Tags: 8.5.32-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.32-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.5/jre8-slim
 
 Tags: 8.5.32-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.32-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e4ee9a93be401c9c70aeda9f3c6ccf8a3ccdb8b
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.5/jre8-alpine
 
 Tags: 8.5.32-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.5/jre10
 
 Tags: 8.5.32-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d36a1cb80ddf73f37353460a5b1eb0f7a675779
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.5/jre10-slim
 
 Tags: 9.0.10-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 9.0/jre8
 
 Tags: 9.0.10-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 9.0/jre8-slim
 
 Tags: 9.0.10-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 52beaf7ad8bd55ae0b0f44031f370b5461209af8
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 9.0/jre8-alpine
 
 Tags: 9.0.10-jre10, 9.0-jre10, 9-jre10, 9.0.10, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 9.0/jre10
 
 Tags: 9.0.10-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.10-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5d0a055a85d851924093ed7f0ad702628f50650
+GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 9.0/jre10-slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,82 +6,82 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.7-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.7-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php5.6/apache
 
 Tags: 4.9.7-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php5.6/fpm
 
 Tags: 4.9.7-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.7-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.7-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.0/apache
 
 Tags: 4.9.7-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.0/fpm
 
 Tags: 4.9.7-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.7-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.7-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.1/apache
 
 Tags: 4.9.7-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.1/fpm
 
 Tags: 4.9.7-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.7-apache, 4.9-apache, 4-apache, apache, 4.9.7, 4.9, 4, latest, 4.9.7-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.7-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.2/apache
 
 Tags: 4.9.7-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.7-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.2/fpm
 
 Tags: 4.9.7-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.7-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b7198b18d92c016411c4bc3cdb31711065305605
+GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
+GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
 Directory: php5.6/cli
 
 Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
+GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
 Directory: php7.0/cli
 
 Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
+GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
 Directory: php7.1/cli
 
 Tags: cli-1.5.1, cli-1.5, cli-1, cli, cli-1.5.1-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b2f394ec850f4ac70e743a5017c634de719bdd42
+GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
 Directory: php7.2/cli


### PR DESCRIPTION
- `bash`: tianon/docker-bash#11
- `cassandra`: docker-library/cassandra#153
- `ghost`: docker-library/ghost#140
- `haproxy`: 1.8.13
- `httpd`: docker-library/httpd#106
- `mongo`: docker-library/mongo#289
- `mysql`: 5.7.23, 8.0.12, 5.5.61, 5.6.41, generate error on inability to read `initdb.d` files (docker-library/mysql#453)
- `openjdk`: update `latest` to OpenJDK 10 (docker-library/openjdk#220)
- `owncloud`: docker-library/owncloud#104
- `percona`: update to Stretch (docker-library/percona#67)
- `postgres`: `11~beta2-2.pgdg90+2`
- `rabbitmq`: docker-library/rabbitmq#270
- `rocket.chat`: 0.68.0
- `tomcat`: docker-library/tomcat#127
- `wordpress`: `WORDPRESS_CONFIG_EXTRA` (docker-library/wordpress#142), docker-library/wordpress#321

So, mostly instances of docker-library/php#666 with a few other changes mixed in.