### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,48 +1,48 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/0017af929f9a857f44a8c98615addc9b3889eaef/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/484912aeda0c3a52f87e063e7c903ac02006a397/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 0017af929f9a857f44a8c98615addc9b3889eaef
+GitCommit: 484912aeda0c3a52f87e063e7c903ac02006a397
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8b81d6b1feaefcff20c02de54bb5f0e74da041b5
+amd64-GitCommit: a36744245bff4234c130f994eee2e7ba4d3b745a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: a9520d2cd6ef8f060f374c2339f482475291f80c
+arm32v5-GitCommit: b4273a83999b4b1b6b5b2d0c37b54850fd0f3913
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 7f6b7393bd6c43762b49521efc2f80627da76db8
+arm32v6-GitCommit: d13c9a331721e43a5f482afa03df50248bd509f7
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 1dce26c350c13d3028dbae2f1e46c906f8ce101e
+arm32v7-GitCommit: dd41f16609c5b6742bf8c19da7915bb79130447b
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cdf10da58ffb5a686189b174e3831dad147fdcd6
+arm64v8-GitCommit: 377173e695adb0d1a0f81353a47af93e89e61614
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 816e37d000c05e78bc71ee48fd6384b8832711f8
+i386-GitCommit: 6eb9e5be868517a9849bd55766664a69600bdf45
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 87906c4c0274c7d6427f3ef6ce235f6050d066ea
+ppc64le-GitCommit: 962dbd69ca6c3e0345ca36fe69e81c9066772290
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: d85f098429f0040e08b36ad891eeaf031fd3e2bb
+s390x-GitCommit: c0249457fa478ad3cae0832e01c2ec3cd26f5525
 
-Tags: 1.29.1-uclibc, 1.29-uclibc, 1-uclibc, uclibc
+Tags: 1.29.2-uclibc, 1.29-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: uclibc
 
-Tags: 1.29.1-glibc, 1.29-glibc, 1-glibc, glibc
+Tags: 1.29.2-glibc, 1.29-glibc, 1-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: glibc
 
-Tags: 1.29.1-musl, 1.29-musl, 1-musl, musl
+Tags: 1.29.2-musl, 1.29-musl, 1-musl, musl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: musl
 
-Tags: 1.29.1, 1.29, 1, latest
+Tags: 1.29.2, 1.29, 1, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
 arm32v5-Directory: uclibc

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.25.2, 1.25, 1, latest
+Tags: 1.25.3, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4e1e58723ab0c2aac695aacf08a6fd54b4d2eee
+GitCommit: a42794cf630a480b873d0def8e69d0067f55017b
 Directory: 1/debian
 
-Tags: 1.25.2-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.3-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb3933d8aacbc87c92ed7ae8bd550c2721dfdd6
+GitCommit: a42794cf630a480b873d0def8e69d0067f55017b
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/mariadb
+++ b/library/mariadb
@@ -24,7 +24,7 @@ Architectures: amd64, arm64v8, i386, ppc64le
 GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
 Directory: 10.0
 
-Tags: 5.5.60-trusty, 5.5-trusty, 5-trusty, 5.5.60, 5.5, 5
+Tags: 5.5.61-trusty, 5.5-trusty, 5-trusty, 5.5.61, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
+GitCommit: 620856794361e738ab0fec89aa913b33a6af5f84
 Directory: 5.5

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/2d4b801444c569118f90ae288699b40338514102/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/6639ae9a138cc307b44b695aa42adee696af7123/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-6.0.0, 2-6.0, 2-6, 2
+Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
 GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 2
 
-Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim
+Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
 GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 2/slim
 
-Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest
+Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie
 Architectures: amd64, arm32v5, i386
 GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 3
 
-Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim
+Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim, 3-6.0.0-slim-jessie, 3-6.0-slim-jessie, 3-6-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, arm32v5, i386
 GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -12,7 +12,7 @@ Directory: 3.7/stretch
 
 Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
@@ -47,7 +47,7 @@ Directory: 3.6/stretch
 
 Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3.6.6-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.6-jessie, 3.6-jessie
@@ -57,7 +57,7 @@ Directory: 3.6/jessie
 
 Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
@@ -97,7 +97,7 @@ Directory: 3.5/stretch
 
 Tags: 3.5.5-slim-stretch, 3.5-slim-stretch, 3.5.5-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.5-jessie, 3.5-jessie
@@ -107,7 +107,7 @@ Directory: 3.5/jessie
 
 Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.5-alpine3.8, 3.5-alpine3.8, 3.5.5-alpine, 3.5-alpine
@@ -128,7 +128,7 @@ Directory: 3.4/stretch
 
 Tags: 3.4.8-slim-stretch, 3.4-slim-stretch, 3.4.8-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.8-jessie, 3.4-jessie
@@ -138,7 +138,7 @@ Directory: 3.4/jessie
 
 Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.8-wheezy, 3.4-wheezy
@@ -164,7 +164,7 @@ Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
@@ -174,7 +174,7 @@ Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.68.0, 0.68, 0, latest
-GitCommit: cf56e1fd3dea755339aaed44e0347c4e9877183c
+Tags: 0.68.1, 0.68, 0, latest
+GitCommit: b18736a72e0ecd1067705d6f63f2eb065a7dbf09


### PR DESCRIPTION
- `busybox`: 1.29.2, buildroot 2018.05.1
- `ghost`: 1.25.3
- `mariadb`: 5.5.61
- `pypy`: suite aliases (docker-library/pypy#27)
- `python`: fix APT list purging to purge `xz-utils` in `slim` variants properly (docker-library/python#323)
- `rocket.chat`: 0.68.1