### PR TITLE
library: mariadb: Disable ARM64 builds for Xenial

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -20,7 +20,7 @@ GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.1
 
 Tags: 10.0.35-xenial, 10.0-xenial, 10.0.35, 10.0
-Architectures: amd64, arm64v8, i386, ppc64le
+Architectures: amd64, i386, ppc64le
 GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
 Directory: 10.0
 


### PR DESCRIPTION
MariaDB do not supply the appropriate packages.

Signed-off-by: Lee Jones <lee.jones@linaro.org>