### PR TITLE
Bump Traefik to v1.7.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,4 +1,4 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v1.7.0-rc3, 1.7.0-rc3, v1.7, 1.7, maroilles

--- a/library/traefik
+++ b/library/traefik
@@ -1,17 +1,23 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.7.0-rc2, 1.7.0-rc2, v1.7, 1.7, maroilles
+Tags: v1.7.0-rc3, 1.7.0-rc3, v1.7, 1.7, maroilles
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 7dec7b825ca16d0524626fbbca35284adfe3ef58
+GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.7.0-rc2-alpine, 1.7.0-rc2-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.0-rc3-alpine, 1.7.0-rc3-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 7dec7b825ca16d0524626fbbca35284adfe3ef58
+GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
 Directory: alpine
+
+Tags: v1.7.0-rc3-nanoserver, 1.7.0-rc3-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.0-rc3-nanoserver-sac2016, 1.7.0-rc3-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016
+Architectures: windows-amd64
+GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
+Directory: windows
+Constraints: nanoserver-sac2016
 
 Tags: v1.6.5, 1.6.5, v1.6, 1.6, tetedemoine, latest
 Architectures: amd64, arm32v6, arm64v8


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.7.0-rc3.

And adds the windows docker image (superseeds #4650).

And adds @dduportal as maintainer

/cc @vdemeester @emilevauge @ldez

Cheers
