### PR TITLE
Add ARM64v8 support.

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,11 +1,14 @@
 # maintainer: Christophe Monniez <moc@odoo.com> (@d-fence)
 
+Architectures: amd64
 9.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
 9: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
 
+Architectures: amd64
 10.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
 10: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
 
+Architectures: amd64, arm64v8
 11.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
 11: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
 latest: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0

--- a/library/odoo
+++ b/library/odoo
@@ -1,5 +1,5 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
-GitRepo: git://github.com/odoo.docker
+GitRepo: https://github.com/odoo/docker
 GitCommit: 67e5ceb0fa3478a3e3c3428d8062a4dab45be29f
 
 Tags: 11.0, 11, latest

--- a/library/odoo
+++ b/library/odoo
@@ -1,14 +1,15 @@
-# maintainer: Christophe Monniez <moc@odoo.com> (@d-fence)
+Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
+GitRepo: git://github.com/odoo.docker
+GitCommit: 67e5ceb0fa3478a3e3c3428d8062a4dab45be29f
 
-Architectures: amd64
-9.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
-9: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
-
-Architectures: amd64
-10.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
-10: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
-
+Tags: 11.0, 11, latest
 Architectures: amd64, arm64v8
-11.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
-11: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
-latest: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
+Directory: 11.0
+
+Tags: 10.0, 10
+Architectures: amd64
+Directory: 10.0
+
+Tags: 9.0, 9
+Architectures: amd64
+Directory: 9.0


### PR DESCRIPTION
This PR has been raised in link with [this](https://github.com/odoo/docker/issues/195).

Odoo code is successfully building and running for ```arm64v8``` using ```tag-11```.
I can provide build and run logs too if required for confirmation.