### PR TITLE
Add ARM64v8 support

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -2,4 +2,5 @@ Maintainers: Nikolche Mihajlovski <nikolce.mihajlovski@gmail.com> (@nmihajlovski
 GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.4.6, 5.4, 5, latest
+Architectures: amd64, arm64v8
 GitCommit: 8fbb45c706fec5b0a015a37c24862127180ae9e9


### PR DESCRIPTION
This PR is raised in link to [this](https://github.com/rapidoid/docker-rapidoid/issues/3) to support ```arm64v8``` in official list of ```rapidoid```.

I can provide both build an run logs to confirm the working.
I would be happy to do experimentation/validation stuff if required for proper confirmation.

Regards,
