### PR TITLE
library: rapidoid: Enable support for ARM64v8

### DIFF
--- a/library/rapidoid
+++ b/library/rapidoid
@@ -3,3 +3,4 @@ GitRepo: https://github.com/rapidoid/docker-rapidoid.git
 
 Tags: 5.4.6, 5.4, 5, latest
 GitCommit: 8fbb45c706fec5b0a015a37c24862127180ae9e9
+Architectures: amd64, arm64v8


### PR DESCRIPTION
Rapidoid 'just works' on ARM64v8.

Tested-by: Odidev <odidev@puresoftware.com>
Signed-off-by: Lee Jones <lee.jones@linaro.org>