### PR TITLE
Add Multi-architecture support.

### DIFF
--- a/library/known
+++ b/library/known
@@ -1,6 +1,6 @@
-# maintainer: Known <hello@withknown.com> (@idno)
+Maintainers: Known <hello@withknown.com> (@idno)
+GitRepo: https://github.com/idno/Known-Docker.git
 
-0.9.2: git://github.com/idno/Known-Docker@986a2618080f32bbbcb9af3c8e7c15297d9658ea
-0.9: git://github.com/idno/Known-Docker@986a2618080f32bbbcb9af3c8e7c15297d9658ea
-0: git://github.com/idno/Known-Docker@986a2618080f32bbbcb9af3c8e7c15297d9658ea
-latest: git://github.com/idno/Known-Docker@986a2618080f32bbbcb9af3c8e7c15297d9658ea
+Tags: 0.9.9, 0.9, 0, latest
+Architectures: amd64, arm64v8
+GitCommit: 3454a52b4ad48e22b95e706dba9ff953cf84c2b1


### PR DESCRIPTION
This PR has been raised to add support for ```arm64v8``` and is linked with [this](https://github.com/idno/Known-Docker/issues/3#issuecomment-409834078).
