### PR TITLE
upgrade to node 10.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -53,24 +53,24 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
 Directory: 6/stretch
 
-Tags: 10.7.0-jessie, 10.7-jessie, 10-jessie, jessie, 10.7.0, 10.7, 10, latest
+Tags: 10.8.0-jessie, 10.8-jessie, 10-jessie, jessie, 10.8.0, 10.8, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
+GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
 Directory: 10/jessie
 
-Tags: 10.7.0-alpine, 10.7-alpine, 10-alpine, alpine
+Tags: 10.8.0-alpine, 10.8-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
+GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
 Directory: 10/alpine
 
-Tags: 10.7.0-slim, 10.7-slim, 10-slim, slim
+Tags: 10.8.0-slim, 10.8-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
+GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
 Directory: 10/slim
 
-Tags: 10.7.0-stretch, 10.7-stretch, 10-stretch, stretch
+Tags: 10.8.0-stretch, 10.8-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 58dbead97e921ff0497863d2cbbcc714f97e1d93
+GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
https://github.com/nodejs/docker-node/pull/835
https://nodejs.org/en/blog/release/v10.8.0/