### PR TITLE
OpenLiberty official image updates:

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,28 +1,9 @@
 Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 666b6fbbd7dc5f3a4387ff65eb584c4e8a6dd67d
+GitCommit: 06111774ceebc1ad5c0af4ba8354763d3dfcb693
+#GitRepo: https://github.com/NottyCode/ci.docker.git
+#GitCommit: 1967aab38a5c38e8f1a868c4d322f2c0547e51bb
 Architectures: amd64, i386, ppc64le, s390x
-
-Tags: kernel, kernel-java8-ibm
-Directory: release/kernel/java8/ibmjava
-
-Tags: kernel-java8-ibmsfj
-Directory: release/kernel/java8/ibmsfj
-Architectures: amd64
-
-Tags: webProfile7, webProfile7-java8-ibm
-Directory: release/webProfile7/java8/ibmjava
-
-Tags: webProfile7-java8-ibmsfj
-Directory: release/webProfile7/java8/ibmsfj
-Architectures: amd64
-
-Tags: javaee7, javaee7-java8-ibm
-Directory: release/javaee7/java8/ibmjava
-
-Tags: javaee7-java8-ibmsfj
-Directory: release/javaee7/java8/ibmsfj
-Architectures: amd64
 
 Tags: webProfile8, webProfile8-java8-ibm
 Directory: release/webProfile8/java8/ibmjava
@@ -45,16 +26,37 @@ Tags: microProfile1-java8-ibmsfj
 Directory: release/microProfile1/java8/ibmsfj
 Architectures: amd64
 
-Tags: springBoot1, springBoot1-java8-ibm
-Directory: release/springBoot1/java8/ibmjava
-
-Tags: springBoot1-java8-ibmsfj
-Directory: release/springBoot1/java8/ibmsfj
-Architectures: amd64
-
 Tags: springBoot2, springBoot2-java8-ibm
 Directory: release/springBoot2/java8/ibmjava
 
 Tags: springBoot2-java8-ibmsfj
 Directory: release/springBoot2/java8/ibmsfj
+Architectures: amd64
+
+Tags: kernel, kernel-java8-ibm
+Directory: release/kernel/java8/ibmjava
+
+Tags: kernel-java8-ibmsfj
+Directory: release/kernel/java8/ibmsfj
+Architectures: amd64
+
+Tags: webProfile7, webProfile7-java8-ibm
+Directory: release/webProfile7/java8/ibmjava
+
+Tags: webProfile7-java8-ibmsfj
+Directory: release/webProfile7/java8/ibmsfj
+Architectures: amd64
+
+Tags: javaee7, javaee7-java8-ibm
+Directory: release/javaee7/java8/ibmjava
+
+Tags: javaee7-java8-ibmsfj
+Directory: release/javaee7/java8/ibmsfj
+Architectures: amd64
+
+Tags: springBoot1, springBoot1-java8-ibm
+Directory: release/springBoot1/java8/ibmjava
+
+Tags: springBoot1-java8-ibmsfj
+Directory: release/springBoot1/java8/ibmsfj
 Architectures: amd64


### PR DESCRIPTION
1. Uninstall unzip after installing to save 1.2Mb
2. Move the copy of docker-server to the start since it rarely changes
3. Switch from runtime zip to webProfile8 and javaee8 where relevant to save space
4. Make sure we don't use the ssl keystore password generated at server create time
   so every image doesn't share a password
5. Update the order of images in the build file hoping that will affect the tags
   order on hub.docker.com