### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,17 +9,17 @@ Architectures: amd64, arm64v8, i386
 GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
 Directory: 2.1
 
-Tags: 2.2.12, 2.2, 2
+Tags: 2.2.13, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
+GitCommit: 9182976ad885af573aaefaabd99432d0c3c2fa6a
 Directory: 2.2
 
-Tags: 3.0.16, 3.0
+Tags: 3.0.17, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
+GitCommit: 290059ff8dfece6b7db18365c7172fac0f007c83
 Directory: 3.0
 
-Tags: 3.11.2, 3.11, 3, latest
+Tags: 3.11.3, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
+GitCommit: 4474c6c5cc2a81ee57c5615aae00555fca7e26a6
 Directory: 3.11

--- a/library/drupal
+++ b/library/drupal
@@ -19,19 +19,19 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
 Directory: 8.6-rc/fpm-alpine
 
-Tags: 8.5.5-apache, 8.5-apache, 8-apache, apache, 8.5.5, 8.5, 8, latest
+Tags: 8.5.6-apache, 8.5-apache, 8-apache, apache, 8.5.6, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
+GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
 Directory: 8.5/apache
 
-Tags: 8.5.5-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.6-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
+GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
 Directory: 8.5/fpm
 
-Tags: 8.5.5-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.6-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: aeb1d5ffd5fe222d4d89e51f94a9ef3b89454a56
+GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
 Directory: 8.5/fpm-alpine
 
 Tags: 7.59-apache, 7-apache, 7.59, 7

--- a/library/joomla
+++ b/library/joomla
@@ -3,62 +3,62 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.8.10-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.10-php5.6, 3.8-php5.6, 3-php5.6, php5.6
+Tags: 3.8.11-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.11-php5.6, 3.8-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php5.6/apache
 
-Tags: 3.8.10-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
+Tags: 3.8.11-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php5.6/fpm
 
-Tags: 3.8.10-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 3.8.11-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php5.6/fpm-alpine
 
-Tags: 3.8.10-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.10-php7.0, 3.8-php7.0, 3-php7.0, php7.0
+Tags: 3.8.11-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.11-php7.0, 3.8-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.0/apache
 
-Tags: 3.8.10-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
+Tags: 3.8.11-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.0/fpm
 
-Tags: 3.8.10-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 3.8.11-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.0/fpm-alpine
 
-Tags: 3.8.10-apache, 3.8-apache, 3-apache, apache, 3.8.10, 3.8, 3, latest, 3.8.10-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.10-php7.1, 3.8-php7.1, 3-php7.1, php7.1
+Tags: 3.8.11-apache, 3.8-apache, 3-apache, apache, 3.8.11, 3.8, 3, latest, 3.8.11-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.11-php7.1, 3.8-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.1/apache
 
-Tags: 3.8.10-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.10-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.8.11-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.11-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.1/fpm
 
-Tags: 3.8.10-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.10-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.8.11-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.11-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.1/fpm-alpine
 
-Tags: 3.8.10-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.10-php7.2, 3.8-php7.2, 3-php7.2, php7.2
+Tags: 3.8.11-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.11-php7.2, 3.8-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.2/apache
 
-Tags: 3.8.10-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.8.11-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.2/fpm
 
-Tags: 3.8.10-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.8.11-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 472c2d0db79afdbd0e7515728a998c01c6a6a81d
+GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
 Directory: php7.2/fpm-alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -10,8 +10,8 @@ GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.3
 
 Tags: 10.2.16-bionic, 10.2-bionic, 10.2.16, 10.2
-Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
 Directory: 10.2
 
 Tags: 10.1.34-bionic, 10.1-bionic, 10.1.34, 10.1
@@ -19,12 +19,12 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
 Directory: 10.1
 
-Tags: 10.0.35-xenial, 10.0-xenial, 10.0.35, 10.0
-Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: f8437ada7c617d2a6bb1c30bb30d0367b93e0ed2
+Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0
+Architectures: amd64, i386, ppc64le
+GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
 Directory: 10.0
 
 Tags: 5.5.61-trusty, 5.5-trusty, 5-trusty, 5.5.61, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 620856794361e738ab0fec89aa913b33a6af5f84
+GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
 Directory: 5.5

--- a/library/python
+++ b/library/python
@@ -17,12 +17,12 @@ Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -62,17 +62,17 @@ Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.6-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
@@ -89,71 +89,71 @@ GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.5.5-stretch, 3.5-stretch
-SharedTags: 3.5.5, 3.5
+Tags: 3.5.6-stretch, 3.5-stretch
+SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
 Directory: 3.5/stretch
 
-Tags: 3.5.5-slim-stretch, 3.5-slim-stretch, 3.5.5-slim, 3.5-slim
+Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
 Directory: 3.5/stretch/slim
 
-Tags: 3.5.5-jessie, 3.5-jessie
+Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 48284b41a887508cae25d1040bf44abcd1ed2c91
+GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
 Directory: 3.5/jessie
 
-Tags: 3.5.5-slim-jessie, 3.5-slim-jessie
+Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
 Directory: 3.5/jessie/slim
 
-Tags: 3.5.5-alpine3.8, 3.5-alpine3.8, 3.5.5-alpine, 3.5-alpine
+Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: bc999321f00459f8fedb9f42142395d211173713
 Directory: 3.5/alpine3.8
 
-Tags: 3.5.5-alpine3.7, 3.5-alpine3.7
+Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: bc999321f00459f8fedb9f42142395d211173713
 Directory: 3.5/alpine3.7
 
-Tags: 3.4.8-stretch, 3.4-stretch
-SharedTags: 3.4.8, 3.4
+Tags: 3.4.9-stretch, 3.4-stretch
+SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
 Directory: 3.4/stretch
 
-Tags: 3.4.8-slim-stretch, 3.4-slim-stretch, 3.4.8-slim, 3.4-slim
+Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
 Directory: 3.4/stretch/slim
 
-Tags: 3.4.8-jessie, 3.4-jessie
+Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
 Directory: 3.4/jessie
 
-Tags: 3.4.8-slim-jessie, 3.4-slim-jessie
+Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
 Directory: 3.4/jessie/slim
 
-Tags: 3.4.8-wheezy, 3.4-wheezy
+Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 34eb5b14953c4359205644790c3c8979a347f662
+GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
 Directory: 3.4/wheezy
 
-Tags: 3.4.8-alpine3.8, 3.4-alpine3.8, 3.4.8-alpine, 3.4-alpine
+Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: bc999321f00459f8fedb9f42142395d211173713
 Directory: 3.4/alpine3.8
 
-Tags: 3.4.8-alpine3.7, 3.4-alpine3.7
+Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: bc999321f00459f8fedb9f42142395d211173713
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
@@ -184,17 +184,17 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8d2323a87f82ab67a982ee00eca1a3a463d18e
+GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: bcb97451bbdf8c83457df42f6df7ffa1c439722c
+GitCommit: a28035fd89602f1e3573057ca7277d3e859fc7d7
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
@@ -19,5 +19,5 @@ GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: bcb97451bbdf8c83457df42f6df7ffa1c439722c
+GitCommit: a28035fd89602f1e3573057ca7277d3e859fc7d7
 Directory: 3.3/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.68.1, 0.68, 0, latest
-GitCommit: b18736a72e0ecd1067705d6f63f2eb065a7dbf09
+Tags: 0.68.3, 0.68, 0, latest
+GitCommit: c83ec239a61e05cafc42089cdeab3370df33dc20


### PR DESCRIPTION
- `cassandra`: 2.2.13, 3.0.17, 3.11.3
- `drupal`: 8.5.6
- `joomla`: 3.8.11
- `mariadb`: fix `arm64v8` detection (docker-library/mariadb#195)
- `python`: 3.4.9, 3.5.6, install `ca-certificates` again (docker-library/python#325)
- `redmine`: passenger 5.3.4
- `rocket.chat`: 0.68.3