### PR TITLE
update oraclelinux for yum-utils

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: be56ba6b16038485762f6058f48f6eaa018477b3
+amd64-GitCommit: bd5574b8e8dd22e33da67887578fcc2a37514859
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: dd5d83c3856f3facb5aa3a42b0163dcb43762721
+arm64v8-GitCommit: 6c3b5d9e42c63e619c55fe438a3f1bc9e9e3afa6
 Constraints: !aufs
 
 Tags: 7.5, 7, latest


### PR DESCRIPTION
    [AMD64 7.5] 2018-07-31-79
    [AMD64 7-slim] 2018-07-31-16
    [ARM 7.5] 2018-07-31-78
    [ARM 7-slim] 2018-07-31-15
    [AMD64 6.10] 2018-07-30-58
    [AMD64 6-slim] 2018-07-30-13

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>