### PR TITLE
Add Multiple architecture support for geonetwork

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -4,25 +4,31 @@ Maintainers: Joana Simoes <joana.simoes@geocat.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
 Tags: 3.0.5, 3.0
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: c2af30125f631f6357d3af3837ec4b80f04b5917
 Directory: 3.0.5
 
 Tags: 3.0.5-postgres, 3.0-postgres
+Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: e5cf5da76f557481c35b4a4d3e3cac77768a1302
 Directory: 3.0.5/postgres
 
 Tags: 3.2.2, 3.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a9d9f3f07c0f2b8badadb74206647d7f6dea4b24
 Directory: 3.2.2
 
 Tags: 3.2.2-postgres, 3.2-postgres
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7ba5f533d9ee31cf1a22d4d6a1a84fbb74f86466
 Directory: 3.2.2/postgres
 
 Tags: 3.4.3, 3.4, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21efb004beb5ee0675dd9ee0c807ca756b49b9a3
 Directory: 3.4.3
 
 Tags: 3.4.3-postgres, 3.4-postgres, postgres
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 21efb004beb5ee0675dd9ee0c807ca756b49b9a3
 Directory: 3.4.3/postgres


### PR DESCRIPTION
This PR is created in link with https://github.com/geonetwork/docker-geonetwork/issues/5

The support for multiple architecture has been added in continuation to conversation that as ```Tomcat ``` supports multiple architectures then same can be supported by ```geonetwork``` as well.

 https://github.com/docker-library/official-images/blob/83445dba81738f34d37e13fa811b34841d1d6def/library/tomcat#L38

I can provide build and run logs as required for confirmation as well.

Regards,