### PR TITLE
Update websphere-liberty beta to 2018.8.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 18197ebb67c98992535b0dd7ce992f9596d51b62
+GitCommit: de3f7503a0fbc27595bfe215d18f23117b5fb00b
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Update the websphere-liberty beta to 2018.8.0.0.