### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.0-alpha1-apache, 8.6-rc-apache, rc-apache, 8.6.0-alpha1, 8.6-rc, rc
+Tags: 8.6.0-beta2-apache, 8.6-rc-apache, rc-apache, 8.6.0-beta2, 8.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
 Directory: 8.6-rc/apache
 
-Tags: 8.6.0-alpha1-fpm, 8.6-rc-fpm, rc-fpm
+Tags: 8.6.0-beta2-fpm, 8.6-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
 Directory: 8.6-rc/fpm
 
-Tags: 8.6.0-alpha1-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.6.0-beta2-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b25abfd65a43d1955367f9b841898ab9f1585817
+GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
 Directory: 8.6-rc/fpm-alpine
 
 Tags: 8.5.6-apache, 8.5-apache, 8-apache, apache, 8.5.6, 8.5, 8, latest

--- a/library/golang
+++ b/library/golang
@@ -5,47 +5,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.11beta2-stretch, 1.11-rc-stretch, rc-stretch
-SharedTags: 1.11beta2, 1.11-rc, rc
+Tags: 1.11beta3-stretch, 1.11-rc-stretch, rc-stretch
+SharedTags: 1.11beta3, 1.11-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/stretch
 
-Tags: 1.11beta2-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11beta2-alpine, 1.11-rc-alpine, rc-alpine
+Tags: 1.11beta3-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11beta3-alpine, 1.11-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/alpine3.8
 
-Tags: 1.11beta2-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
+Tags: 1.11beta3-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/alpine3.7
 
-Tags: 1.11beta2-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
+Tags: 1.11beta3-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.11beta3-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta3, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.11beta2-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
+Tags: 1.11beta3-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.11beta3-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta3, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.11beta2-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.11beta2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta2, 1.11-rc, rc
+Tags: 1.11beta3-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.11beta3-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11beta3, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.11beta2-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.11beta2-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
+Tags: 1.11beta3-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.11beta3-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 9d80ad8bdf0abe15bdd3fbc77f92b17e69fe9284
+GitCommit: c45b9079fefae5aacf9f4ec16d01c27e85cccbdf
 Directory: 1.11-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/88e0e5bf726503c9805a1f4990096d6eb0aff6c5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/1ff34f6624a09ce06948728f1584ac41a8d99811/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -78,24 +78,24 @@ Architectures: amd64, arm64v8
 GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
 Directory: 4.0
 
-Tags: 4.0.0-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Tags: 4.0.1-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.0-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
-SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Tags: 4.0.1-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
+SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
 Directory: 4.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.0-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.0.0-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.0, 4.0, 4, latest
+Tags: 4.0.1-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/mysql
+++ b/library/mysql
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.12, 8.0, 8, latest
-GitCommit: 333935aa6612376d58737a8cab0e3f5df370585a
+GitCommit: ef9c8a4948f681c175f46c4fdcdc62dbbc528c07
 Directory: 8.0
 
 Tags: 5.7.23, 5.7, 5

--- a/library/python
+++ b/library/python
@@ -7,22 +7,22 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.0-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: 8601079d1f70b03c01408377716a3243ce75cec9
 Directory: 3.7/stretch
 
 Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: c5afee6efc8512af143b960d82b938bde623943f
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: c5afee6efc8512af143b960d82b938bde623943f
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: c5afee6efc8512af143b960d82b938bde623943f
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016

--- a/library/redis
+++ b/library/redis
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0-rc3, 5.0-rc, 5.0-rc3-stretch, 5.0-rc-stretch
+Tags: 5.0-rc4, 5.0-rc, 5.0-rc4-stretch, 5.0-rc-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 403f00a0ba7556f33850a88e27e70509aa2814dd
+GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
 Directory: 5.0-rc
 
-Tags: 5.0-rc3-32bit, 5.0-rc-32bit, 5.0-rc3-32bit-stretch, 5.0-rc-32bit-stretch
+Tags: 5.0-rc4-32bit, 5.0-rc-32bit, 5.0-rc4-32bit-stretch, 5.0-rc-32bit-stretch
 Architectures: amd64
-GitCommit: 403f00a0ba7556f33850a88e27e70509aa2814dd
+GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
 Directory: 5.0-rc/32bit
 
-Tags: 5.0-rc3-alpine, 5.0-rc-alpine, 5.0-rc3-alpine3.8, 5.0-rc-alpine3.8
+Tags: 5.0-rc4-alpine, 5.0-rc-alpine, 5.0-rc4-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f5671ebdc563464f5570a1d081a78c26b5e6ad3
+GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
 Directory: 5.0-rc/alpine
 
-Tags: 4.0.10, 4.0, 4, latest, 4.0.10-stretch, 4.0-stretch, 4-stretch, stretch
+Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53f86805506b103b503fd392e029929290fe5346
+GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
 Directory: 4.0
 
-Tags: 4.0.10-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.10-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
+Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: 53f86805506b103b503fd392e029929290fe5346
+GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
 Directory: 4.0/32bit
 
-Tags: 4.0.10-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.10-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
+Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
+GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
 Directory: 4.0/alpine
 
 Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch

--- a/library/redis
+++ b/library/redis
@@ -21,17 +21,17 @@ Directory: 5.0-rc/alpine
 
 Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
+GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
 Directory: 4.0
 
 Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
+GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
 Directory: 4.0/32bit
 
 Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7af8ab3f14bb72cacf8fa71af6a6f8e8a526bb9d
+GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
 Directory: 4.0/alpine
 
 Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -2,4 +2,4 @@ Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
 Tags: 0.68.3, 0.68, 0, latest
-GitCommit: c83ec239a61e05cafc42089cdeab3370df33dc20
+GitCommit: aa71f27e4e5dfe5ef39dd622b700565d910d579e

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.7-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.7-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php5.6/apache
 
-Tags: 4.9.7-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php5.6/fpm
 
-Tags: 4.9.7-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.7-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.7-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.0/apache
 
-Tags: 4.9.7-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.0/fpm
 
-Tags: 4.9.7-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.7-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.7-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.1/apache
 
-Tags: 4.9.7-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.1/fpm
 
-Tags: 4.9.7-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.7-apache, 4.9-apache, 4-apache, apache, 4.9.7, 4.9, 4, latest, 4.9.7-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.7-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.2/apache
 
-Tags: 4.9.7-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.7-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.2/fpm
 
-Tags: 4.9.7-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.7-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1ca45e311da0c79b543c1fad060a3e926a3aa409
+GitCommit: 875fcd986dbb97fb80ce7b88f2dd9f94d5173f6d
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `drupal`: 8.6.0-beta2
- `mysql`: install more utilities (docker-library/mysql#465)
- `python`: native `_uuid` (docker-library/python#326)
- `redis`: 4.0.11, 5.0-rc4
- `rocket.chat`: Node.js 8.11 (RocketChat/Docker.Official.Image#43)
- `wordpress`: 4.9.8