### PR TITLE
Add Multi-architecture support to backdrop

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -1,19 +1,14 @@
-# Maintainer: Mike Pirog <mike@kalabox.io> (@pirog)
-# Maintainer: Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy)
-# Maintainer: Jen Lampton <jen+docker@jeneration.com> (@jenlampton)           
-# GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
+Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
+             Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy),
+             Jen Lampton <jen+docker@jeneration.com> (@jenlampton)
+GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-1.10.1: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-1.10: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-1: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-latest: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
+Tags: 1.10.1, 1.10, 1, 1.10.1-apache, 1.10-apache, 1-apache, apache, latest
+Architectures: amd64, arm64v8
+GitCommit: e087df48230ef2ad3a7c7c3b135f412b112af6a0
+Directory: 1/apache
 
-1.10.1-apache: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-1.10-apache: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-1-apache: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-apache: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/apache
-
-1.10.1-fpm: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/fpm
-1.10-fpm: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/fpm
-1-fpm: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/fpm
-fpm: git://github.com/backdrop-ops/backdrop-docker@e087df48230ef2ad3a7c7c3b135f412b112af6a0 1/fpm
+Tags: 1.10.1-fpm, 1.10-fpm, 1-fpm, fpm
+Architectures: amd64, arm64v8
+GitCommit: e087df48230ef2ad3a7c7c3b135f412b112af6a0
+Directory: 1/fpm


### PR DESCRIPTION
 This **PR** has been raised in accordance with the ongoing discussion on https://github.com/backdrop-ops/backdrop-docker/issues/19

```Backdrop``` is based on ```php:5.6-apache ``` & ```php:5.6-fpm```, which have complete support for ```arm64v8``` architecture.

Please have a look and guide me further.

Regards,