### PR TITLE
Bump Rakudo-Star version to 2018.06

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,6 +1,6 @@
 Maintainers: Rob Hoelz <robAThoelz.ro> (@hoelzro)
 GitRepo: https://github.com/perl6/docker
 Architectures: amd64, arm64v8
-GitCommit: aff1beeb74853acb6d04c7335ef56c56f0270407
+GitCommit: f8a418d4d8d4a75f18af5d9b86c7e0a7cfe6bfd8
 
-Tags: latest, 2018.04
+Tags: latest, 2018.06


### PR DESCRIPTION
Update to new release: 2018.06