### PR TITLE
Update CouchDB for 2.2.0

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,20 +3,14 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: ca9b039d036d1482fd1e5ce67176f05cf959beed
+GitCommit: f429c1ccf22fe8cf7717383462fbf2f56e6d0301
 
-Tags: latest, 2.1.2, 2.1, 2
+Tags: latest, 2.2.0, 2.2, 2
 Architectures: amd64
-Directory: 2.1.2
+Directory: 2.2.0
 
-Tags: 1.7.2, 1.7, 1
-Architectures: amd64
-Directory: 1.7.2
-
-Tags: 1.7.2-couchperuser, 1.7-couchperuser, 1-couchperuser
-Architectures: amd64
-Directory: 1.7.2-couchperuser
-
+# 1.x is no longer supported by the Apache CouchDB team.
+#
 # dev, dev-cluster versions must not be published officially per
 # ASF release policy, see:
 # http://www.apache.org/dev/release-distribution.html#unreleased


### PR DESCRIPTION
Apache CouchDB have released version 2.2.0. This is an update for the official Docker image.

We've improved the Dockerfile with a few minor changes intended to make the resultant image smaller and for it to build more reliably in the event some PGP key servers are down.

1.x builds have not changed, FYI 1.x is now officially end-of-life.