### PR TITLE
Update Elixir to 1.7.2

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -3,19 +3,19 @@
 Maintainers: . <c0b@users.noreply.github.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
 
-Tags: 1.7.1, 1.7, latest
+Tags: 1.7.2, 1.7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+GitCommit: a502dfaf78efdf61ec82419c190741df293c0b29
 Directory: 1.7
 
-Tags: 1.7.1-slim, 1.7-slim, slim
+Tags: 1.7.2-slim, 1.7-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+GitCommit: a502dfaf78efdf61ec82419c190741df293c0b29
 Directory: 1.7/slim
 
-Tags: 1.7.1-alpine, 1.7-alpine, alpine
+Tags: 1.7.2-alpine, 1.7-alpine, alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: 634d315a5c6051a5858c25fbfdb37d0e655b971e
+GitCommit: a502dfaf78efdf61ec82419c190741df293c0b29
 Directory: 1.7/alpine
 
 Tags: 1.6.6, 1.6
@@ -40,7 +40,7 @@ Directory: 1.6/otp-21
 
 Tags: 1.6.6-otp-21-alpine, 1.6-otp-21-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
+GitCommit: 71f26c0a37a3d928f24021b14e23b88643c06280
 Directory: 1.6/otp-21-alpine
 
 Tags: 1.5.3, 1.5


### PR DESCRIPTION
Upstream:
1. https://github.com/c0b/docker-elixir/pull/86
2. https://github.com/elixir-lang/elixir/releases/tag/v1.7.2