### PR TITLE
Odoo 9.0-11.0: update to release 20180808

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,11 +1,15 @@
-# maintainer: Christophe Monniez <moc@odoo.com> (@d-fence)
+Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
+GitRepo: https://github.com/odoo/docker
+GitCommit: e34689bf67b64f7ee9fadaf984d0e532594ad4e5
 
-9.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
-9: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 9.0
+Tags: 11.0, 11, latest
+Architectures: amd64, arm64v8
+Directory: 11.0
 
-10.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
-10: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 10.0
+Tags: 10.0, 10
+Architectures: amd64
+Directory: 10.0
 
-11.0: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
-11: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
-latest: git://github.com/odoo/docker@67e5ceb0fa3478a3e3c3428d8062a4dab45be29f 11.0
+Tags: 9.0, 9
+Architectures: amd64
+Directory: 9.0


### PR DESCRIPTION
Also includes conversion to new library definition format and support for arm64v8 in 11.0, courtesy of @odidev (this supersedes #4666)

Thanks!
