### PR TITLE
Update GeoNetwork library

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,15 +1,7 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/af05aaf347c3cc33f2da2a45962fab46830f0d41/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/e9b8b6c0ca7cb2b4c4ae16b77a0ba3322a96eda0/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
-
-Tags: 3.2.2, 3.2
-GitCommit: a9d9f3f07c0f2b8badadb74206647d7f6dea4b24
-Directory: 3.2.2
-
-Tags: 3.2.2-postgres, 3.2-postgres
-GitCommit: 7ba5f533d9ee31cf1a22d4d6a1a84fbb74f86466
-Directory: 3.2.2/postgres
 
 Tags: 3.4.3, 3.4, latest
 GitCommit: 21efb004beb5ee0675dd9ee0c807ca756b49b9a3


### PR DESCRIPTION
- removed 3.2.2 tag (deprecated)