### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.25.3, 1.25, 1, latest
+Tags: 1.25.4, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a42794cf630a480b873d0def8e69d0067f55017b
+GitCommit: 199a610e78fc591c1988d3fc365bfdb6347a2818
 Directory: 1/debian
 
-Tags: 1.25.3-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.4-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a42794cf630a480b873d0def8e69d0067f55017b
+GitCommit: 199a610e78fc591c1988d3fc365bfdb6347a2818
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/irssi
+++ b/library/irssi
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.1.1-alpine, 1.1-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3166eac4730178900099a1e4fb255f25bbea6156
+GitCommit: 1c4c9fcc669d4c74d3aec3417b4d0e46de9e190e
 Directory: alpine

--- a/library/joomla
+++ b/library/joomla
@@ -5,60 +5,60 @@ GitRepo: https://github.com/joomla/docker-joomla.git
 
 Tags: 3.8.11-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.11-php5.6, 3.8-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php5.6/apache
 
 Tags: 3.8.11-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php5.6/fpm
 
 Tags: 3.8.11-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php5.6/fpm-alpine
 
 Tags: 3.8.11-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.11-php7.0, 3.8-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.0/apache
 
 Tags: 3.8.11-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.0/fpm
 
 Tags: 3.8.11-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.0/fpm-alpine
 
 Tags: 3.8.11-apache, 3.8-apache, 3-apache, apache, 3.8.11, 3.8, 3, latest, 3.8.11-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.11-php7.1, 3.8-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.1/apache
 
 Tags: 3.8.11-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.11-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.1/fpm
 
 Tags: 3.8.11-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.11-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.1/fpm-alpine
 
 Tags: 3.8.11-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.11-php7.2, 3.8-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.2/apache
 
 Tags: 3.8.11-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.2/fpm
 
 Tags: 3.8.11-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 64c3c0c13e2746e228e1bd935cd058b8f0ec81c1
+GitCommit: a6644c92553edc77699a31bbeec274287305284e
 Directory: php7.2/fpm-alpine

--- a/library/julia
+++ b/library/julia
@@ -1,50 +1,57 @@
-# this file is generated via https://github.com/docker-library/julia/blob/4b1b740df34a21fc0edb10770d5991cb3c92d9e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/9e8bb3426385de28cfac6576baef9bf580fe0e33/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 0.7.0-rc2-stretch, 0.7.0-stretch, 0.7-stretch, 0-rc-stretch
-SharedTags: 0.7.0-rc2, 0.7.0, 0.7, 0-rc
+Tags: 1.0.0-stretch, 1.0-stretch, stretch
+SharedTags: 1.0.0, 1.0, latest
 Architectures: amd64, arm32v7, i386
-GitCommit: 8f8fc18409a2a0454590776d3350b683850a5513
-Directory: 0-rc/stretch
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+Directory: 1.0/stretch
 
-Tags: 0.7.0-rc2-windowsservercore-ltsc2016, 0.7.0-windowsservercore-ltsc2016, 0.7-windowsservercore-ltsc2016, 0-rc-windowsservercore-ltsc2016
-SharedTags: 0.7.0-rc2, 0.7.0, 0.7, 0-rc
+Tags: 1.0.0-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.0.0, 1.0, latest
 Architectures: windows-amd64
-GitCommit: 8f8fc18409a2a0454590776d3350b683850a5513
-Directory: 0-rc/windows/windowsservercore-ltsc2016
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 0.7.0-rc2-windowsservercore-1709, 0.7.0-windowsservercore-1709, 0.7-windowsservercore-1709, 0-rc-windowsservercore-1709
-SharedTags: 0.7.0-rc2, 0.7.0, 0.7, 0-rc
+Tags: 1.0.0-windowsservercore-1709, 1.0-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.0.0, 1.0, latest
 Architectures: windows-amd64
-GitCommit: 8f8fc18409a2a0454590776d3350b683850a5513
-Directory: 0-rc/windows/windowsservercore-1709
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 0.6.4-stretch, 0.6-stretch, 0-stretch, stretch
-SharedTags: 0.6.4, 0.6, 0, latest
+Tags: 1.0.0-windowsservercore-1803, 1.0-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.0.0, 1.0, latest
+Architectures: windows-amd64
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+Directory: 1.0/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 0.7.0-stretch, 0.7-stretch, 0-stretch
+SharedTags: 0.7.0, 0.7, 0
 Architectures: amd64, i386
-GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 0/stretch
 
-Tags: 0.6.4-jessie, 0.6-jessie, 0-jessie, jessie
+Tags: 0.7.0-jessie, 0.7-jessie, 0-jessie
 Architectures: amd64, i386
-GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 0/jessie
 
-Tags: 0.6.4-windowsservercore-ltsc2016, 0.6-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.6.4, 0.6, 0, latest
+Tags: 0.7.0-windowsservercore-ltsc2016, 0.7-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016
+SharedTags: 0.7.0, 0.7, 0
 Architectures: windows-amd64
-GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 0.6.4-windowsservercore-1709, 0.6-windowsservercore-1709, 0-windowsservercore-1709, windowsservercore-1709
-SharedTags: 0.6.4, 0.6, 0, latest
+Tags: 0.7.0-windowsservercore-1709, 0.7-windowsservercore-1709, 0-windowsservercore-1709
+SharedTags: 0.7.0, 0.7, 0
 Architectures: windows-amd64
-GitCommit: 4b1b740df34a21fc0edb10770d5991cb3c92d9e8
+GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/julia
+++ b/library/julia
@@ -1,31 +1,31 @@
-# this file is generated via https://github.com/docker-library/julia/blob/9e8bb3426385de28cfac6576baef9bf580fe0e33/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/19c41722f3d366865377bd2679b026a0ab1192cb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.0.0-stretch, 1.0-stretch, stretch
-SharedTags: 1.0.0, 1.0, latest
+Tags: 1.0.0-stretch, 1.0-stretch, 1-stretch, stretch
+SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: amd64, arm32v7, i386
 GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 1.0/stretch
 
-Tags: 1.0.0-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.0.0, 1.0, latest
+Tags: 1.0.0-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
 GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.0.0-windowsservercore-1709, 1.0-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.0.0, 1.0, latest
+Tags: 1.0.0-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
 GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.0.0-windowsservercore-1803, 1.0-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.0.0, 1.0, latest
+Tags: 1.0.0-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
 GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
 Directory: 1.0/windows/windowsservercore-1803

--- a/library/mariadb
+++ b/library/mariadb
@@ -14,9 +14,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
 Directory: 10.2
 
-Tags: 10.1.34-bionic, 10.1-bionic, 10.1.34, 10.1
+Tags: 10.1.35-bionic, 10.1-bionic, 10.1.35, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 195c8432d2f434a50416dbb5ab2dec4b1978d89f
+GitCommit: 8a25691df08c6b6dede86a50411074f4f30e495d
 Directory: 10.1
 
 Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0

--- a/library/mongo
+++ b/library/mongo
@@ -70,12 +70,12 @@ GitCommit: 380200038360980631e362f964857d48489f99a2
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.0-xenial, 4.0-xenial, 4-xenial, xenial
-SharedTags: 4.0.0, 4.0, 4, latest
+Tags: 4.0.1-xenial, 4.0-xenial, 4-xenial, xenial
+SharedTags: 4.0.1, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
+GitCommit: f3e9e5d12f1515b20477bbe228951e62c62eb4f9
 Directory: 4.0
 
 Tags: 4.0.1-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016

--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 11-beta2, 11
+Tags: 11-beta3, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56cf37a42a7647678a7e46b12e0df0942e26cc28
+GitCommit: 988d8afbdbf5d3c9e28c78a33ccc6670de337eed
 Directory: 11
 
-Tags: 11-beta2-alpine, 11-alpine
+Tags: 11-beta3-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b2d9f0d5dde36d634d1bbcbd27a0b2ed7054f3c
+GitCommit: 7ea5efa503c6ec5d5ee2ebe52acd5eaa50ac75ca
 Directory: 11/alpine
 
-Tags: 10.4, 10, latest
+Tags: 10.5, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: 740fb98439e66c7a0e39a67880ee971c6d49e514
 Directory: 10
 
-Tags: 10.4-alpine, 10-alpine, alpine
+Tags: 10.5-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b2d9f0d5dde36d634d1bbcbd27a0b2ed7054f3c
+GitCommit: a78bff54b531d6ef106e43b020712086fff6a67f
 Directory: 10/alpine
 
-Tags: 9.6.9, 9.6, 9
+Tags: 9.6.10, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: fd76b238a51597fabb63d65191798d052e373636
 Directory: 9.6
 
-Tags: 9.6.9-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: 5673b8988b3d411f0ba6b9e73e48cf6986cc959d
 Directory: 9.6/alpine
 
-Tags: 9.5.13, 9.5
+Tags: 9.5.14, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: d424c8f180ed614184059a953639d0a420477846
 Directory: 9.5
 
-Tags: 9.5.13-alpine, 9.5-alpine
+Tags: 9.5.14-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: a72377975f328b42344dbefc5243f994f25ced22
 Directory: 9.5/alpine
 
-Tags: 9.4.18, 9.4
+Tags: 9.4.19, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: 6192edf44a557a7467d8f491899a9ac8f953d82c
 Directory: 9.4
 
-Tags: 9.4.18-alpine, 9.4-alpine
+Tags: 9.4.19-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: 1cf0f1b313b7dc14bfd9331efc45e96b8603f7d2
 Directory: 9.4/alpine
 
-Tags: 9.3.23, 9.3
+Tags: 9.3.24, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 635fd0bcb3ababc96871c9da52f10743fbae4742
+GitCommit: a0335993e11a1fba4dfea0665189dfa4423709cf
 Directory: 9.3
 
-Tags: 9.3.23-alpine, 9.3-alpine
+Tags: 9.3.24-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 34689e2a5ba1841fb09fd5a9c29ef47a022d48dc
+GitCommit: feaec8367b50af1707fc07da0643f77bd56aa912
 Directory: 9.3/alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -66,22 +66,22 @@ Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-1.5.1-php5.6, cli-1.5-php5.6, cli-1-php5.6, cli-php5.6
+Tags: cli-2.0.0-php5.6, cli-2.0-php5.6, cli-2-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
+GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
 Directory: php5.6/cli
 
-Tags: cli-1.5.1-php7.0, cli-1.5-php7.0, cli-1-php7.0, cli-php7.0
+Tags: cli-2.0.0-php7.0, cli-2.0-php7.0, cli-2-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
+GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
 Directory: php7.0/cli
 
-Tags: cli-1.5.1-php7.1, cli-1.5-php7.1, cli-1-php7.1, cli-php7.1
+Tags: cli-2.0.0-php7.1, cli-2.0-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
+GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
 Directory: php7.1/cli
 
-Tags: cli-1.5.1, cli-1.5, cli-1, cli, cli-1.5.1-php7.2, cli-1.5-php7.2, cli-1-php7.2, cli-php7.2
+Tags: cli-2.0.0, cli-2.0, cli-2, cli, cli-2.0.0-php7.2, cli-2.0-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7f6887ac9d040895eaa8f8ec9fb7f4d32ed614f9
+GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
 Directory: php7.2/cli


### PR DESCRIPTION
- `ghost`: 1.25.4
- `irssi`: `gpgconf --kill all`
- `joomla`: remove database details from entrypoint output
- `julia`: 0.7.0, 1.0.0, and Windows Server Core 1803
- `mariadb`: 10.1.35
- `mongo`: 4.0.1
- `postgres`: 9.4.19, 10.5, 9.5.14, 9.6.10, 9.3.24, 11beta3
- `wordpress`: WP-CLI 2.0.0