### PR TITLE
Use "tac|tac" pattern to fix a few racy tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apk add --no-cache \
 # go for compiling bashbrew
 		go libc-dev \
 # ssl for downloading files
-		libressl
+		libressl \
+# coreutils for real "tac" so it isn't busybox-buggy (where it seems to fail if the pipe is closed prematurely, which defeats the whole purpose of the "tac|tac" idiom)
+		coreutils
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -29,7 +29,7 @@ _request() {
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
 case "$ghostVersion" in
-	0.*) _request GET '/ghost/' -I | grep -q '^Location: .*setup' ;;
-	*)   _request GET '/ghost/api/v0.1/authentication/setup/' | grep -q 'status":false' ;;
+	0.*) _request GET '/ghost/' -I |tac|tac| grep -q '^Location: .*setup' ;;
+	*)   _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 esac
 

--- a/test/tests/haproxy-basics/run.sh
+++ b/test/tests/haproxy-basics/run.sh
@@ -42,5 +42,5 @@ _request() {
 . "$dir/../../retry.sh" '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
 
 # Check that we can request / (which is proxying example.com)
-_request GET http '/' | grep -q '<h1>Example Domain</h1>'
-_request GET https '/' | grep -q '<h1>Example Domain</h1>'
+_request GET http '/' |tac|tac| grep -q '<h1>Example Domain</h1>'
+_request GET https '/' |tac|tac| grep -q '<h1>Example Domain</h1>'

--- a/test/tests/mongo-basics/run.sh
+++ b/test/tests/mongo-basics/run.sh
@@ -4,7 +4,7 @@ set -e
 image="$1"
 
 haveSeccomp=
-if docker info --format '{{ join .SecurityOptions "\n" }}' 2>/dev/null | grep -q seccomp; then
+if docker info --format '{{ join .SecurityOptions "\n" }}' 2>/dev/null |tac|tac| grep -q seccomp; then
 	haveSeccomp=1
 
 	# get docker default seccomp profile

--- a/test/tests/no-hard-coded-passwords/run.sh
+++ b/test/tests/no-hard-coded-passwords/run.sh
@@ -4,7 +4,7 @@ set -e
 IFS=$'\n'
 userPasswds=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/passwd) )
 userShadows=()
-if echo "${userPasswds[*]}" | grep -qE ':x$'; then
+if grep -qE ':x$' <<<"${userPasswds[*]}"; then
 	userShadows=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/shadow || true) )
 fi
 unset IFS

--- a/test/tests/redmine-basics/run.sh
+++ b/test/tests/redmine-basics/run.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eo pipefail
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
@@ -28,7 +28,7 @@ _request() {
 . "$dir/../../retry.sh" --tries 40 '_request GET / --output /dev/null'
 
 # Check that / include the text "Redmine" somewhere
-_request GET '/' | grep -q Redmine
+_request GET '/' |tac|tac| grep -q Redmine
 
 # Check that /account/register include the text "Password" somewhere
-_request GET '/account/register' | grep -q Password
+_request GET '/account/register' |tac|tac| grep -q Password


### PR DESCRIPTION
See https://github.com/docker-library/redmine/issues/122 for a concrete example of the sort of errors this fixes.

> ```
> ...
> 	'redmine-basics' [5/5]....write /dev/stdout: broken pipe
> failed
> ...
> ```