### PR TITLE
Update sl containers to current (build-date=20180807)

### DIFF
--- a/library/sl
+++ b/library/sl
@@ -8,11 +8,11 @@ Tags: 7, latest
 Architectures: amd64
 GitFetch: refs/heads/7
 Directory: sl7
-GitCommit: 3671fb4018f190f7c8c39663d27062345ac6c2f8
+GitCommit: 1bc6a746a62e6ef13afc53aa585be9368fa3538b
 
 # For the SL6 container
 Tags: 6
 Architectures: amd64
 GitFetch: refs/heads/6
 Directory: sl6
-GitCommit: 4fbc57a5affd2462f4407de3e885b742e7b5b153
+GitCommit: 01b5d5d2b8430eae89b5782d9601bf41b262172b


### PR DESCRIPTION
This commit will obsolete the other two SL commits while I look at our internal generation process.