### PR TITLE
gradle: Remove unsupported openjdk architectures

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -15,7 +15,7 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: jdk7-alpine
 
 Tags: 4.9.0-jdk7-slim, 4.9-jdk7-slim, jdk7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jdk7-slim
 
 Tags: 4.9.0-jre7-alpine, 4.9-jre7-alpine, jre7-alpine
@@ -23,7 +23,7 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: jre7-alpine
 
 Tags: 4.9.0-jre7-slim, 4.9-jre7-slim, jre7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jre7-slim
 
 Tags: 4.9.0-jdk8, 4.9-jdk8, jdk8, 4.9.0-jdk, 4.9-jdk, jdk, 4.9.0, 4.9, latest


### PR DESCRIPTION
This should fix currently failing ARM64v8, PPC64LE and S390X builds.

Signed-off-by: Lee Jones <lee.jones@linaro.org>