### PR TITLE
Updating tag orders

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -5,29 +5,29 @@ GitRepo: https://github.com/WASdev/ci.docker.git
 GitCommit: de3f7503a0fbc27595bfe215d18f23117b5fb00b
 Architectures: amd64, i386, ppc64le, s390x
 
-Tags: kernel
-Directory: ga/developer/kernel
+Tags: javaee8, latest
+Directory: ga/developer/javaee8
+
+Tags: webProfile8
+Directory: ga/developer/webProfile8
 
 Tags: microProfile
 Directory: ga/developer/microProfile
 
-Tags: springBoot1
-Directory: ga/developer/springBoot1
-
 Tags: springBoot2
 Directory: ga/developer/springBoot2
+
+Tags: kernel
+Directory: ga/developer/kernel
+
+Tags: beta
+Directory: beta
+
+Tags: springBoot1
+Directory: ga/developer/springBoot1
 
 Tags: webProfile7
 Directory: ga/developer/webProfile7
 
 Tags: javaee7
 Directory: ga/developer/javaee7
-
-Tags: webProfile8
-Directory: ga/developer/webProfile8
-
-Tags: javaee8, latest
-Directory: ga/developer/javaee8
-
-Tags: beta
-Directory: beta


### PR DESCRIPTION
Simply a cosmetic change, but we would like to update the order in which the tags show up in Docker Hub so that we show the most popular used tags first.