### PR TITLE
Add test to verify Argon2 works in PHP

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -143,6 +143,7 @@ imageTests+=(
 	[php]='
 		php-ext-install
 		php-hello-world
+		php-argon2
 	'
 	[php:apache]='
 		php-apache-hello-web

--- a/test/tests/php-argon2/container.php
+++ b/test/tests/php-argon2/container.php
@@ -1,0 +1,26 @@
+<?php
+$success = true;
+
+// Argon2 is supported for PHP >= 7.2 on Debian >= 9 or Alpine >= 3.8
+if (file_exists('/etc/alpine-release')) {
+	$baseImage = version_compare(file_get_contents('/etc/alpine-release'), '3.8.0') >= 0;
+}
+else if (file_exists('/etc/debian_version')) {
+	$baseImage = version_compare(file_get_contents('/etc/debian_version'), '9.0') >= 0;
+}
+else {
+	echo "Unknown base image\n";
+	$success = false;
+}
+
+if ($baseImage && version_compare(PHP_VERSION, '7.2.0') >= 0) {
+	if (!defined('PASSWORD_ARGON2I')) {
+		echo "constant PASSWORD_ARGON2I is not defined\n";
+		$success = false;
+	}
+	if (!password_verify('password', '$argon2i$v=19$m=8,t=1,p=1$RWxaRlZ0d1FTa3RSY1c1OQ$c7a/rJlPgvH9ItPi74UGuh0tdCBhpdDF7b/nA3QweX8')) {
+		echo "Failed check test vector\n";
+		$success = false;
+	}
+}
+var_dump($success);

--- a/test/tests/php-argon2/expected-std-out.txt
+++ b/test/tests/php-argon2/expected-std-out.txt
@@ -1,0 +1,1 @@
+bool(true)

--- a/test/tests/php-argon2/run.sh
+++ b/test/tests/php-argon2/run.sh
@@ -1,0 +1,1 @@
+../run-php-in-container.sh


### PR DESCRIPTION
This test verifies that Argon2 actually works for PHP images where it should.
This is to ensure that the Argon2 from Buster does not magically change to
become incompatible.

see: https://github.com/docker-library/php/pull/677#issuecomment-408546100

-------------

```
[timwolla@/s/D/o/o/test (argon2-php)]./run.sh -t php-argon2 php:5
testing php:5
	'php-argon2' [1/1]...passed
[timwolla@/s/D/o/o/test (argon2-php)]./run.sh -t php-argon2 php:7
testing php:7
	'php-argon2' [1/1]...passed
```

Intentionally breaking the test hash fails php:7, but succeeds for php:5 as intended:
```
[timwolla@/s/D/o/o/test (argon2-php)]./run.sh -t php-argon2 php:7
testing php:7
	'php-argon2' [1/1]...failed; unexpected output:
--- /scratch/Dockerfiles/official/official-images/test/tests/php-argon2/expected-std-out.txt	2018-08-15 23:40:07.321339653 +0200
+++ -	2018-08-15 23:41:02.200583108 +0200
@@ -1 +1,2 @@
-bool(true)
+Failed check test vector
+bool(false)
[timwolla@/s/D/o/o/test (argon2-php) [1]]./run.sh -t php-argon2 php:5
testing php:5
	'php-argon2' [1/1]...passed
```