### PR TITLE
Update Node.js for August 2018 security releases

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,74 +3,74 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.11.3-jessie, 8.11-jessie, 8-jessie, carbon-jessie, 8.11.3, 8.11, 8, carbon
+Tags: 8.11.4-jessie, 8.11-jessie, 8-jessie, carbon-jessie, 8.11.4, 8.11, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 8/jessie
 
-Tags: 8.11.3-alpine, 8.11-alpine, 8-alpine, carbon-alpine
+Tags: 8.11.4-alpine, 8.11-alpine, 8-alpine, carbon-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 8/alpine
 
-Tags: 8.11.3-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.11.4-onbuild, 8.11-onbuild, 8-onbuild, carbon-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 8/onbuild
 
-Tags: 8.11.3-slim, 8.11-slim, 8-slim, carbon-slim
+Tags: 8.11.4-slim, 8.11-slim, 8-slim, carbon-slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 8/slim
 
-Tags: 8.11.3-stretch, 8.11-stretch, 8-stretch, carbon-stretch
+Tags: 8.11.4-stretch, 8.11-stretch, 8-stretch, carbon-stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 8/stretch
 
-Tags: 6.14.3-jessie, 6.14-jessie, 6-jessie, boron-jessie, 6.14.3, 6.14, 6, boron
+Tags: 6.14.4-jessie, 6.14-jessie, 6-jessie, boron-jessie, 6.14.4, 6.14, 6, boron
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/jessie
 
-Tags: 6.14.3-alpine, 6.14-alpine, 6-alpine, boron-alpine
+Tags: 6.14.4-alpine, 6.14-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/alpine
 
-Tags: 6.14.3-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.14.4-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/onbuild
 
-Tags: 6.14.3-slim, 6.14-slim, 6-slim, boron-slim
+Tags: 6.14.4-slim, 6.14-slim, 6-slim, boron-slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/slim
 
-Tags: 6.14.3-stretch, 6.14-stretch, 6-stretch, boron-stretch
+Tags: 6.14.4-stretch, 6.14-stretch, 6-stretch, boron-stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e3ec2111af089e31321e76641697e154b3b6a6c3
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/stretch
 
-Tags: 10.8.0-jessie, 10.8-jessie, 10-jessie, jessie, 10.8.0, 10.8, 10, latest
+Tags: 10.9.0-jessie, 10.9-jessie, 10-jessie, jessie, 10.9.0, 10.9, 10, latest
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 10/jessie
 
-Tags: 10.8.0-alpine, 10.8-alpine, 10-alpine, alpine
+Tags: 10.9.0-alpine, 10.9-alpine, 10-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 10/alpine
 
-Tags: 10.8.0-slim, 10.8-slim, 10-slim, slim
+Tags: 10.9.0-slim, 10.9-slim, 10-slim, slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 10/slim
 
-Tags: 10.8.0-stretch, 10.8-stretch, 10-stretch, stretch
+Tags: 10.9.0-stretch, 10.9-stretch, 10-stretch, stretch
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 387d4d9182566d0e10236d32f60d7a5b23196653
+GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
* v10.9.0
* v8.11.4
* v6.14.4

Ref: https://nodejs.org/en/blog/vulnerability/august-2018-security-releases/

@tianon
@yosifkit