### PR TITLE
Add ARM64v8 support to R-base

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -1,5 +1,8 @@
-# maintainer: "Carl Boettiger" <rocker-maintainers@eddelbuettel.com> (@cboettig)
-# maintainer: "Dirk Eddelbuettel" <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
+Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
+             Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
+GitRepo: https://github.com/rocker-org/rocker.git
 
-3.5.1: git://github.com/rocker-org/rocker@b9f9289ef27f07dc2f2b64d56d12646770b9b233 r-base
-latest: git://github.com/rocker-org/rocker@b9f9289ef27f07dc2f2b64d56d12646770b9b233 r-base
+Tags: 3.5.1, latest
+Architectures: amd64, arm64v8
+GitCommit: b9f9289ef27f07dc2f2b64d56d12646770b9b233
+Directory: r-base


### PR DESCRIPTION
This PR has been raised to support ```arm64v8``` architecture as official Docker build.

```R-Base``` is building and running successfully over ```arm64v8```.
I can provide build and run logs if required for confirmation.

In my view, we can add ```arm64v8``` to the official build list of ```r-base```.
DO let know, if any other test case needs to be done for further confirmation too.

Regards,