### PR TITLE
[gazebo] use long tag for gazebo base images

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -9,12 +9,12 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver4, gzserver4-trusty
 Architectures: amd64
-GitCommit: 1edae347ca21f301dd2396e621ed512859725924
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/4/ubuntu/trusty/gzserver4
 
 Tags: libgazebo4, libgazebo4-trusty
 Architectures: amd64
-GitCommit: 1edae347ca21f301dd2396e621ed512859725924
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 
@@ -26,12 +26,12 @@ Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 Tags: gzserver5, gzserver5-trusty
 Architectures: amd64
-GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/5/ubuntu/trusty/gzserver5
 
 Tags: libgazebo5, libgazebo5-trusty
 Architectures: amd64
-GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 
@@ -43,12 +43,12 @@ Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 Tags: gzserver6, gzserver6-trusty
 Architectures: amd64
-GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/6/ubuntu/trusty/gzserver6
 
 Tags: libgazebo6, libgazebo6-trusty
 Architectures: amd64
-GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 
@@ -60,12 +60,12 @@ Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 Tags: gzserver7, gzserver7-xenial
 Architectures: amd64
-GitCommit: e8f4c4d8ba96447121ca3b286c965feb0d293689
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/7/ubuntu/xenial/gzserver7
 
 Tags: libgazebo7, libgazebo7-xenial
 Architectures: amd64
-GitCommit: e8f4c4d8ba96447121ca3b286c965feb0d293689
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 
@@ -77,12 +77,12 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 Tags: gzserver8, gzserver8-xenial
 Architectures: amd64
-GitCommit: 84563884e54305fe02c38b5073c60fe3730fc8fa
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/8/ubuntu/xenial/gzserver8
 
 Tags: libgazebo8, libgazebo8-xenial
 Architectures: amd64
-GitCommit: 84563884e54305fe02c38b5073c60fe3730fc8fa
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 
@@ -94,12 +94,12 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: 59f76a64533a9c352b03919172ce0783bd1e583e
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: 59f76a64533a9c352b03919172ce0783bd1e583e
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -107,10 +107,10 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64
-GitCommit: 3ee19f3a71299da89891949d72206ca6056f3ced
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic, latest
 Architectures: amd64
-GitCommit: 3ee19f3a71299da89891949d72206ca6056f3ced
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/bionic/libgazebo9


### PR DESCRIPTION
Follow up of https://github.com/docker-library/official-images/pull/4728.
This fixes the name of the base images used, this will fix the Gazebo 9 xenial builds