### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.0-beta2-apache, 8.6-rc-apache, rc-apache, 8.6.0-beta2, 8.6-rc, rc
+Tags: 8.6.0-rc1-apache, 8.6-rc-apache, rc-apache, 8.6.0-rc1, 8.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
+GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
 Directory: 8.6-rc/apache
 
-Tags: 8.6.0-beta2-fpm, 8.6-rc-fpm, rc-fpm
+Tags: 8.6.0-rc1-fpm, 8.6-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
+GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
 Directory: 8.6-rc/fpm
 
-Tags: 8.6.0-beta2-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.6.0-rc1-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 87afd4a5acffb4f88ce4d6fdcc585fc4225ed8b1
+GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
 Directory: 8.6-rc/fpm-alpine
 
 Tags: 8.5.6-apache, 8.5-apache, 8-apache, apache, 8.5.6, 8.5, 8, latest

--- a/library/ghost
+++ b/library/ghost
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 1.25.5, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f76999e7bd50a37b59725c3ef848d5fdbce51d4
+GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
 Directory: 1/debian
 
 Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f76999e7bd50a37b59725c3ef848d5fdbce51d4
+GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/memcached
+++ b/library/memcached
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.5.10-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d87a2f33e826097cefdc3feec7f4a70ec8b047c
+GitCommit: ae7f6ef9e2e1d31b500ec843cbe4885876d7746a
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ SharedTags: 3.2.20, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
+GitCommit: eefc62ded2695ecf5e14193be7bc9640f79e1bd1
 Directory: 3.2
 
 Tags: 3.2.20-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
@@ -31,7 +31,7 @@ SharedTags: 3.4.16, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
+GitCommit: eefc62ded2695ecf5e14193be7bc9640f79e1bd1
 Directory: 3.4
 
 Tags: 3.4.16-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
@@ -48,34 +48,34 @@ GitCommit: 380200038360980631e362f964857d48489f99a2
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.6-jessie, 3.6-jessie, 3-jessie
-SharedTags: 3.6.6, 3.6, 3
+Tags: 3.6.7-jessie, 3.6-jessie, 3-jessie
+SharedTags: 3.6.7, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 21869963911a74ccc13697c3ad50cdc23cc79b15
+GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
 Directory: 3.6
 
-Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.6, 3.6, 3
+Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.7, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
-SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.6, 3.6, 3
+Tags: 3.6.7-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.7, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.1-xenial, 4.0-xenial, 4-xenial, xenial
+Tags: 4.0.1-bionic, 4.0-bionic, 4-bionic, bionic
 SharedTags: 4.0.1, 4.0, 4, latest
-# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
+# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: f3e9e5d12f1515b20477bbe228951e62c62eb4f9
+GitCommit: b9cf4ef8f09391e9cb50858fc3e0bf343caa4f91
 Directory: 4.0
 
 Tags: 4.0.1-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -99,12 +99,12 @@ GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.2-xenial, 4.1-xenial, unstable-xenial
+Tags: 4.1.2-bionic, 4.1-bionic, unstable-bionic
 SharedTags: 4.1.2, 4.1, unstable
-# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
+# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 4958ee0a8a6b1ac1c3734b161db67371720b31b5
+GitCommit: b9cf4ef8f09391e9cb50858fc3e0bf343caa4f91
 Directory: 4.1
 
 Tags: 4.1.2-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-24-jdk-sid, 11-ea-24-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-24-jdk, 11-ea-24, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-27-jdk-sid, 11-ea-27-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-27-jdk, 11-ea-27, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
+GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
 Directory: 11/jdk
 
-Tags: 11-ea-24-jdk-slim-sid, 11-ea-24-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-24-jdk-slim, 11-ea-24-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-27-jdk-slim-sid, 11-ea-27-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-27-jdk-slim, 11-ea-27-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
+GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
 Directory: 11/jdk/slim
 
-Tags: 11-ea-24-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-24-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-27-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-27-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
+GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
 Directory: 11/jre
 
-Tags: 11-ea-24-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-24-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-27-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-27-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c38dea4532ea7833b18b961e2bac37af85c9d064
+GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
 Directory: 11/jre/slim
 
 Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest

--- a/library/percona
+++ b/library/percona
@@ -9,12 +9,12 @@ Architectures: amd64
 GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
 Directory: 5.7
 
-Tags: 5.6.40-stretch, 5.6-stretch, 5.6.40, 5.6
+Tags: 5.6.41-stretch, 5.6-stretch, 5.6.41, 5.6
 Architectures: amd64
-GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
+GitCommit: e90d7a6c4dc7aa8317ec710095dce1bc848d9f5b
 Directory: 5.6
 
-Tags: 5.5.60-stretch, 5.5-stretch, 5.5.60, 5.5
+Tags: 5.5.61-stretch, 5.5-stretch, 5.5.61, 5.5
 Architectures: amd64
-GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
+GitCommit: 7eed6eb52668ecaca933e68898d63d6f28d51af9
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -1,112 +1,177 @@
-# this file is generated via https://github.com/docker-library/php/blob/0139cd64d90988807a460ca65c7867d9446ab08e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/0b2c6441b26bfb5f190a53c5781c641e9b6b8972/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.2.8-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.8-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.8-cli, 7.2-cli, 7-cli, cli, 7.2.8, 7.2, 7, latest
+Tags: 7.3.0beta2-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0beta2-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0beta2-cli, 7.3-rc-cli, rc-cli, 7.3.0beta2, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/stretch/cli
+
+Tags: 7.3.0beta2-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0beta2-apache, 7.3-rc-apache, rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/stretch/apache
+
+Tags: 7.3.0beta2-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0beta2-fpm, 7.3-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/stretch/fpm
+
+Tags: 7.3.0beta2-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0beta2-zts, 7.3-rc-zts, rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/stretch/zts
+
+Tags: 7.3.0beta2-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0beta2-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0beta2-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0beta2-alpine, 7.3-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/alpine3.8/cli
+
+Tags: 7.3.0beta2-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0beta2-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/alpine3.8/fpm
+
+Tags: 7.3.0beta2-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0beta2-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+Directory: 7.3-rc/alpine3.8/zts
+
+Tags: 7.2.9-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.9-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.9-cli, 7.2-cli, 7-cli, cli, 7.2.9, 7.2, 7, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.8-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.8-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.9-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.9-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.8-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.8-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.9-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.9-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.8-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.8-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.9-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.9-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.8-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.8-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7, 7.2.8-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.8-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.9-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.9-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.9-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.9-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+Directory: 7.2/alpine3.8/cli
+
+Tags: 7.2.9-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.9-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+Directory: 7.2/alpine3.8/fpm
+
+Tags: 7.2.9-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.9-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+Directory: 7.2/alpine3.8/zts
+
+Tags: 7.2.9-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.9-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.8-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7, 7.2.8-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.9-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.8-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7, 7.2.8-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.9-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.8-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.8-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
+Tags: 7.2.9-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.9-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.8-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
+Tags: 7.2.9-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.8-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
+Tags: 7.2.9-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 85af0c14e3f23689f0851d3164ab3b630e7f016f
+GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.20-cli-stretch, 7.1-cli-stretch, 7.1.20-stretch, 7.1-stretch, 7.1.20-cli, 7.1-cli, 7.1.20, 7.1
+Tags: 7.1.21-cli-stretch, 7.1-cli-stretch, 7.1.21-stretch, 7.1-stretch, 7.1.21-cli, 7.1-cli, 7.1.21, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.20-apache-stretch, 7.1-apache-stretch, 7.1.20-apache, 7.1-apache
+Tags: 7.1.21-apache-stretch, 7.1-apache-stretch, 7.1.21-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.20-fpm-stretch, 7.1-fpm-stretch, 7.1.20-fpm, 7.1-fpm
+Tags: 7.1.21-fpm-stretch, 7.1-fpm-stretch, 7.1.21-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.20-zts-stretch, 7.1-zts-stretch, 7.1.20-zts, 7.1-zts
+Tags: 7.1.21-zts-stretch, 7.1-zts-stretch, 7.1.21-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.20-cli-jessie, 7.1-cli-jessie, 7.1.20-jessie, 7.1-jessie
+Tags: 7.1.21-cli-jessie, 7.1-cli-jessie, 7.1.21-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.20-apache-jessie, 7.1-apache-jessie
+Tags: 7.1.21-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.20-fpm-jessie, 7.1-fpm-jessie
+Tags: 7.1.21-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.20-zts-jessie, 7.1-zts-jessie
+Tags: 7.1.21-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.20-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.20-alpine3.7, 7.1-alpine3.7, 7.1.20-cli-alpine, 7.1-cli-alpine, 7.1.20-alpine, 7.1-alpine
+Tags: 7.1.21-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.21-alpine3.8, 7.1-alpine3.8, 7.1.21-cli-alpine, 7.1-cli-alpine, 7.1.21-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+Directory: 7.1/alpine3.8/cli
+
+Tags: 7.1.21-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.21-fpm-alpine, 7.1-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+Directory: 7.1/alpine3.8/fpm
+
+Tags: 7.1.21-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.21-zts-alpine, 7.1-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+Directory: 7.1/alpine3.8/zts
+
+Tags: 7.1.21-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.21-alpine3.7, 7.1-alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.20-fpm-alpine3.7, 7.1-fpm-alpine3.7, 7.1.20-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.21-fpm-alpine3.7, 7.1-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.20-zts-alpine3.7, 7.1-zts-alpine3.7, 7.1.20-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.21-zts-alpine3.7, 7.1-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d6b950cc18b2977a96f472345024bed00cd07814
+GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.31-cli-stretch, 7.0-cli-stretch, 7.0.31-stretch, 7.0-stretch, 7.0.31-cli, 7.0-cli, 7.0.31, 7.0
@@ -204,17 +269,32 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.37-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.37-alpine3.7, 5.6-alpine3.7, 5-alpine3.7, 5.6.37-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.37-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.37-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.37-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.37-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.37-alpine, 5.6-alpine, 5-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+Directory: 5.6/alpine3.8/cli
+
+Tags: 5.6.37-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.37-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+Directory: 5.6/alpine3.8/fpm
+
+Tags: 5.6.37-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.37-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+Directory: 5.6/alpine3.8/zts
+
+Tags: 5.6.37-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.37-alpine3.7, 5.6-alpine3.7, 5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/cli
 
-Tags: 5.6.37-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7, 5.6.37-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.37-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/fpm
 
-Tags: 5.6.37-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7, 5.6.37-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.37-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
 Directory: 5.6/alpine3.7/zts

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta3, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9986244c45efe383456aa4116c6dfd5f5083871e
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 11
 
 Tags: 11-beta3-alpine, 11-alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.5, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 740fb98439e66c7a0e39a67880ee971c6d49e514
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 10
 
 Tags: 10.5-alpine, 10-alpine, alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.10, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fd76b238a51597fabb63d65191798d052e373636
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 9.6
 
 Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.14, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d424c8f180ed614184059a953639d0a420477846
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 9.5
 
 Tags: 9.5.14-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.19, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6192edf44a557a7467d8f491899a9ac8f953d82c
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 9.4
 
 Tags: 9.4.19-alpine, 9.4-alpine
@@ -56,7 +56,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.24, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a0335993e11a1fba4dfea0665189dfa4423709cf
+GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
 Directory: 9.3
 
 Tags: 9.3.24-alpine, 9.3-alpine

--- a/library/python
+++ b/library/python
@@ -17,12 +17,12 @@ Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5afee6efc8512af143b960d82b938bde623943f
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5afee6efc8512af143b960d82b938bde623943f
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -62,17 +62,17 @@ Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.6-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
@@ -112,12 +112,12 @@ Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc999321f00459f8fedb9f42142395d211173713
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.5/alpine3.8
 
 Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc999321f00459f8fedb9f42142395d211173713
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.9-stretch, 3.4-stretch
@@ -148,12 +148,12 @@ Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc999321f00459f8fedb9f42142395d211173713
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc999321f00459f8fedb9f42142395d211173713
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
@@ -184,17 +184,17 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6076ae65aced0eea263bd254c89311e66f4c8e64
+GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/ruby
+++ b/library/ruby
@@ -6,85 +6,85 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
+GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
+GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 57801cf4e9a2506e9c66380ab9e3ff9f63a669a7
+GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
+GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
+GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eca972d167cf4291de898e85aaf50d9a1929d4c7
+GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c43fef8a60cea31eb9e7d960a076d633cb62ba8d
+GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
+GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
+GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
+GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
+GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe47510c8d16c9a149c4b167a267ac18d5c5ae33
+GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/alpine3.7

--- a/library/tomcat
+++ b/library/tomcat
@@ -64,52 +64,52 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.32-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.32, 8.5, 8, latest
+Tags: 8.5.33-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.33, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
 Directory: 8.5/jre8
 
-Tags: 8.5.32-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.32-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.33-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.33-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.32-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.32-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.33-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.33-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: d485a5c4bfdb50a93ae36e212bbf6b2e6e1bdd9e
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.32-jre10, 8.5-jre10, 8-jre10, jre10
+Tags: 8.5.33-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
 Directory: 8.5/jre10
 
-Tags: 8.5.32-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Tags: 8.5.33-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
 Directory: 8.5/jre10-slim
 
-Tags: 9.0.10-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.11-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
 Directory: 9.0/jre8
 
-Tags: 9.0.10-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.11-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.10-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.11-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ba5a6d7b9fb9fa08480cc53a4ed707ea73cdc4ce
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.10-jre10, 9.0-jre10, 9-jre10, 9.0.10, 9.0, 9
+Tags: 9.0.11-jre10, 9.0-jre10, 9-jre10, 9.0.11, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
 Directory: 9.0/jre10
 
-Tags: 9.0.10-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.10-slim, 9.0-slim, 9-slim
+Tags: 9.0.11-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.11-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
 Directory: 9.0/jre10-slim


### PR DESCRIPTION
- `drupal`: 8.6.0-rc1
- `ghost`: ghost-cli 1.9.1
- `memcached`: Alpine 3.8 (docker-library/memcached#40)
- `mongo`: 3.6.7, `dbPath` fixes (docker-library/mongo#294)
- `openjdk`: 11-ea+27 (Debian)
- `percona`: 5.5.61, 5.6.41
- `php`: 7.1.21, Alpine 3.8 (docker-library/php#702, docker-library/php#688), 7.3.0beta2 (docker-library/php#677), 7.2.9
- `postgres`: fix `HOME` (docker-library/postgres#481)
- `python`: `apk add --no-cache` to combat new `apk` behavior (docker-library/python#330)
- `ruby`: bundler 1.16.4
- `tomcat`: 8.5.33, 9.0.11