### PR TITLE
Update Ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,39 +6,39 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 9f83c4db8b49a61ca009308966a8fc7a47bb65a3
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7a8f63add8a1003a6f77bbcf00e4d408ea96ca1b
+amd64-GitCommit: 59aa7dfef17153ecc812adbf26516675ce67e8aa
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: d25876a2dd51a5e428278a25d3c37d367411999d
+arm32v7-GitCommit: 4f5d8488115b418688863e3fd3b0128d56c0008b
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5bb7077f5a348a1227db7f6edf86e3eb0b34c24
+arm64v8-GitCommit: 57781e7b009bf52be6d7012f610d12790fe3e57e
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: fd6e82d6de4b5efd25e24479d0e325f191469ad4
+i386-GitCommit: 206bf81de358afe4d74bd9d53bf0d8646d33ff6e
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 8c8f22271f50813460665e9fa7d9d2a6e040ae5b
+ppc64le-GitCommit: c7f1f34f43657b97c95c9e10f12d168e66edb7a9
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 913968e3d9e668d90294d8d7fcdb091ca91e321a
+s390x-GitCommit: af969095cf606cd29e67670c3b96cec8b1990444
 
-# 20180724.1 (bionic)
-Tags: 18.04, bionic-20180724.1, bionic, latest, rolling
+# 20180821 (bionic)
+Tags: 18.04, bionic-20180821, bionic, latest, rolling
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20180725 (cosmic)
-Tags: 18.10, cosmic-20180725, cosmic, devel
+# 20180821 (cosmic)
+Tags: 18.10, cosmic-20180821, cosmic, devel
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: cosmic
 
-# 20180712 (trusty)
-Tags: 14.04, trusty-20180712, trusty
+# 20180807 (trusty)
+Tags: 14.04, trusty-20180807, trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: trusty
 
-# 20180726 (xenial)
-Tags: 16.04, xenial-20180726, xenial
+# 20180808 (xenial)
+Tags: 16.04, xenial-20180808, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: xenial


### PR DESCRIPTION
This fixes CVE-2017-7526 in Xenial.

20180821 (bionic)
20180821 (cosmic)
20180807 (trusty)
20180808 (xenial)