### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.06.1-ce-rc2, 18.06-rc, rc, test
+Tags: 18.06.1-ce, 18.06.1, 18.06, 18, edge, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5ca0a1b18ec5de602a668c760723e5ed27fc3382
-Directory: 18.06-rc
-
-Tags: 18.06.1-ce-rc2-dind, 18.06-rc-dind, rc-dind, test-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: fe9ffca05a3e29de69d7b2e8dd6c3d505e83412b
-Directory: 18.06-rc/dind
-
-Tags: 18.06.1-ce-rc2-git, 18.06-rc-git, rc-git, test-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: fe9ffca05a3e29de69d7b2e8dd6c3d505e83412b
-Directory: 18.06-rc/git
-
-Tags: 18.06.0-ce, 18.06.0, 18.06, 18, edge, stable, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5ca0a1b18ec5de602a668c760723e5ed27fc3382
+GitCommit: 75d265c97922a504c509dd01aaff17bd49072ea6
 Directory: 18.06
 
-Tags: 18.06.0-ce-dind, 18.06.0-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, dind
+Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/dind
 
-Tags: 18.06.0-ce-git, 18.06.0-git, 18.06-git, 18-git, edge-git, stable-git, git
+Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, 18-git, edge-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/git

--- a/library/ghost
+++ b/library/ghost
@@ -1,15 +1,25 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/8d1ed041ef46982fe5a15bed9e662c0045b23c75/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/3557ab61ea77fef9e6894ff5eff85c340ab5707e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 1.25.5, 1.25, 1, latest
+Tags: 2.0.3, 2.0, 2, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f683bbaf11e123d47b259e02c1272e64d5b08aa2
+Directory: 2/debian
+
+Tags: 2.0.3-alpine, 2.0-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: f683bbaf11e123d47b259e02c1272e64d5b08aa2
+Directory: 2/alpine
+
+Tags: 1.25.5, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
 Directory: 1/debian
 
-Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
 Directory: 1/alpine

--- a/library/golang
+++ b/library/golang
@@ -13,12 +13,12 @@ Directory: 1.11-rc/stretch
 
 Tags: 1.11rc1-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11rc1-alpine, 1.11-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.11-rc/alpine3.8
 
 Tags: 1.11rc1-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.11-rc/alpine3.7
 
 Tags: 1.11rc1-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
@@ -57,12 +57,12 @@ Directory: 1.10/stretch
 
 Tags: 1.10.3-alpine3.8, 1.10-alpine3.8, 1-alpine3.8, alpine3.8, 1.10.3-alpine, 1.10-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7a4a48a142ef2ada9c5794ba054fd008656c779
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.10/alpine3.8
 
 Tags: 1.10.3-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.10/alpine3.7
 
 Tags: 1.10.3-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -101,12 +101,12 @@ Directory: 1.9/stretch
 
 Tags: 1.9.7-alpine3.8, 1.9-alpine3.8, 1.9.7-alpine, 1.9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b7a4a48a142ef2ada9c5794ba054fd008656c779
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.9/alpine3.8
 
 Tags: 1.9.7-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
+GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
 Directory: 1.9/alpine3.7
 
 Tags: 1.9.7-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta3, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 11
 
 Tags: 11-beta3-alpine, 11-alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.5, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 10
 
 Tags: 10.5-alpine, 10-alpine, alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.10, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 9.6
 
 Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.14, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 9.5
 
 Tags: 9.5.14-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.19, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 9.4
 
 Tags: 9.4.19-alpine, 9.4-alpine
@@ -56,7 +56,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.24, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 726128b358cdc0efc1753475bbe502b07cbbb540
+GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
 Directory: 9.3
 
 Tags: 9.3.24-alpine, 9.3-alpine


### PR DESCRIPTION
- `docker`: 18.06.1-ce GA
- `ghost`: Ghost 2.0! (docker-library/ghost#145)
- `golang`: remove unused files (docker-library/golang#232)
- `postgres`: add `stretch-backports` when building 11+ from source (docker-library/postgres#485)