### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.06.1-ce, 18.06.1, 18.06, 18, edge, stable, test, latest
+Tags: 18.09.0-ce-tp3, 18.09-rc, rc, test
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 44e9b5c2823fe334e975c6cc0d2fbea3437e2c2b
+Directory: 18.09-rc
+
+Tags: 18.09.0-ce-tp3-dind, 18.09-rc-dind, rc-dind, test-dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
+Directory: 18.09-rc/dind
+
+Tags: 18.09.0-ce-tp3-git, 18.09-rc-git, rc-git, test-git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
+Directory: 18.09-rc/git
+
+Tags: 18.06.1-ce, 18.06.1, 18.06, 18, edge, stable, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 75d265c97922a504c509dd01aaff17bd49072ea6
 Directory: 18.06
 
-Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, test-dind, dind
+Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/dind
 
-Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, 18-git, edge-git, stable-git, test-git, git
+Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, 18-git, edge-git, stable-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/git

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.10, 5.6, 5, latest
-GitCommit: be1eb53a6a62a57d0ed17e4287d3fc51a7409a9f
+Tags: 5.6.11, 5.6, 5, latest
+GitCommit: 7e5d336cf3dc472756dd0e19c1d2cf62a011bcf4
 Directory: 5
 
-Tags: 5.6.10-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: be1eb53a6a62a57d0ed17e4287d3fc51a7409a9f
+Tags: 5.6.11-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 7e5d336cf3dc472756dd0e19c1d2cf62a011bcf4
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/golang
+++ b/library/golang
@@ -5,47 +5,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.11rc1-stretch, 1.11-rc-stretch, rc-stretch
-SharedTags: 1.11rc1, 1.11-rc, rc
+Tags: 1.11rc2-stretch, 1.11-rc-stretch, rc-stretch
+SharedTags: 1.11rc2, 1.11-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/stretch
 
-Tags: 1.11rc1-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11rc1-alpine, 1.11-rc-alpine, rc-alpine
+Tags: 1.11rc2-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11rc2-alpine, 1.11-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/alpine3.8
 
-Tags: 1.11rc1-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
+Tags: 1.11rc2-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/alpine3.7
 
-Tags: 1.11rc1-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.11rc1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc1, 1.11-rc, rc
+Tags: 1.11rc2-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.11rc1-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.11rc1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc1, 1.11-rc, rc
+Tags: 1.11rc2-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.11rc1-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.11rc1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc1, 1.11-rc, rc
+Tags: 1.11rc2-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
 Architectures: windows-amd64
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.11rc1-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.11rc1-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
+Tags: 1.11rc2-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.11rc2-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 5d648be144af4fb0ffa29cc7f21d84c610901703
+GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
 Directory: 1.11-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.10, 5.6, 5, latest
-GitCommit: c59bd9585cbe6d62e1bd56c7975d2eb350dc11fb
+Tags: 5.6.11, 5.6, 5, latest
+GitCommit: d87da97dff0d4510a841b866f8f4bddd8e0f5811
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.10, 5.6, 5, latest
-GitCommit: 7339f3d967a5e725c8c40c8b68d0e035b6005064
+Tags: 5.6.11, 5.6, 5, latest
+GitCommit: bac815b8aee26043274d82bfe9d11a1b6c6cc51f
 Directory: 5
 
-Tags: 5.6.10-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 7339f3d967a5e725c8c40c8b68d0e035b6005064
+Tags: 5.6.11-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: bac815b8aee26043274d82bfe9d11a1b6c6cc51f
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/mongo
+++ b/library/mongo
@@ -70,12 +70,12 @@ GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.1-bionic, 4.0-bionic, 4-bionic, bionic
+Tags: 4.0.1-xenial, 4.0-xenial, 4-xenial, xenial
 SharedTags: 4.0.1, 4.0, 4, latest
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.0/multiverse/
+# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: b9cf4ef8f09391e9cb50858fc3e0bf343caa4f91
+GitCommit: b2c38e6b34458edc9c7dbd15a669c7b3992e43d1
 Directory: 4.0
 
 Tags: 4.0.1-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -99,12 +99,12 @@ GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.2-bionic, 4.1-bionic, unstable-bionic
+Tags: 4.1.2-xenial, 4.1-xenial, unstable-xenial
 SharedTags: 4.1.2, 4.1, unstable
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.1/multiverse/
+# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: b9cf4ef8f09391e9cb50858fc3e0bf343caa4f91
+GitCommit: b2c38e6b34458edc9c7dbd15a669c7b3992e43d1
 Directory: 4.1
 
 Tags: 4.1.2-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.68.4, 0.68, 0, latest
-GitCommit: 294dc246d5a38b4143dbeb3435fbce501583bae7
+Tags: 0.68.5, 0.68, 0, latest
+GitCommit: f0395c98b3c374a978d401555c4f1a11f3afde76


### PR DESCRIPTION
- `docker`: 18.09.0-ce-tp3
- `elasticsearch`: 5.6.11
- `golang`: 1.11rc2
- `kibana`: 5.6.11
- `logstash`: 5.6.11
- `mongo`: revert back to xenial (docker-library/mongo#297)
- `rocket.chat`: 0.68.5