### PR TITLE
Switch mongo-express to Alpine, adding arm64v8 support

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -2,4 +2,5 @@ Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
 
 Tags: 0.49.0, 0.49, latest
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-GitCommit: bca900d7c6ce0fe0112c41709723b7cbc9198037
+GitCommit: b089fe7708d9dd619d648a6ec226fe0175b27740
+Architectures: amd64, arm64v8


### PR DESCRIPTION
This can probably go even further than just arm64v8, but I haven't tested other architectures yet.

See https://github.com/mongo-express/mongo-express-docker/pull/18.

cc @knickers