### PR TITLE
Update 1.11 and rm now EOL 1.9

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,138 +1,94 @@
-# this file is generated via https://github.com/docker-library/golang/blob/1f7e9415ec45eee984d67cd821609373e845e296/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/e06b00cbe4974436ee00eaec215d7fbb123cbc24/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.11rc2-stretch, 1.11-rc-stretch, rc-stretch
-SharedTags: 1.11rc2, 1.11-rc, rc
+Tags: 1.11.0-stretch, 1.11-stretch, 1-stretch, stretch
+SharedTags: 1.11.0, 1.11, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/stretch
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/stretch
 
-Tags: 1.11rc2-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11rc2-alpine, 1.11-rc-alpine, rc-alpine
+Tags: 1.11.0-alpine3.8, 1.11-alpine3.8, 1-alpine3.8, alpine3.8, 1.11.0-alpine, 1.11-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/alpine3.8
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/alpine3.8
 
-Tags: 1.11rc2-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
+Tags: 1.11.0-alpine3.7, 1.11-alpine3.7, 1-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/alpine3.7
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/alpine3.7
 
-Tags: 1.11rc2-windowsservercore-ltsc2016, 1.11-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
+Tags: 1.11.0-windowsservercore-ltsc2016, 1.11-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.11.0-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.0, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/windows/windowsservercore-ltsc2016
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.11rc2-windowsservercore-1709, 1.11-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
+Tags: 1.11.0-windowsservercore-1709, 1.11-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.11.0-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.0, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/windows/windowsservercore-1709
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.11rc2-windowsservercore-1803, 1.11-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.11rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore, 1.11rc2, 1.11-rc, rc
+Tags: 1.11.0-windowsservercore-1803, 1.11-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.11.0-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.0, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/windows/windowsservercore-1803
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.11rc2-nanoserver-sac2016, 1.11-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.11rc2-nanoserver, 1.11-rc-nanoserver, rc-nanoserver
+Tags: 1.11.0-nanoserver-sac2016, 1.11-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.11.0-nanoserver, 1.11-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 870d14b02b4c226eb57beb5f44e1b22c12121641
-Directory: 1.11-rc/windows/nanoserver-sac2016
+GitCommit: e06b00cbe4974436ee00eaec215d7fbb123cbc24
+Directory: 1.11/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.10.3-stretch, 1.10-stretch, 1-stretch, stretch
-SharedTags: 1.10.3, 1.10, 1, latest
+Tags: 1.10.4-stretch, 1.10-stretch
+SharedTags: 1.10.4, 1.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
+GitCommit: 1a7381c32220091f35bd76e34bc28af251954acb
 Directory: 1.10/stretch
 
-Tags: 1.10.3-alpine3.8, 1.10-alpine3.8, 1-alpine3.8, alpine3.8, 1.10.3-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.10.4-alpine3.8, 1.10-alpine3.8, 1.10.4-alpine, 1.10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
+GitCommit: 69f2d2a132565bf60afc91813801a3bdcc981526
 Directory: 1.10/alpine3.8
 
-Tags: 1.10.3-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7
+Tags: 1.10.4-alpine3.7, 1.10-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
+GitCommit: 69f2d2a132565bf60afc91813801a3bdcc981526
 Directory: 1.10/alpine3.7
 
-Tags: 1.10.3-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.10.3-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.3, 1.10, 1, latest
+Tags: 1.10.4-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016
+SharedTags: 1.10.4-windowsservercore, 1.10-windowsservercore, 1.10.4, 1.10
 Architectures: windows-amd64
-GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
+GitCommit: 1a7381c32220091f35bd76e34bc28af251954acb
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.10.3-windowsservercore-1709, 1.10-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.10.3-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.3, 1.10, 1, latest
+Tags: 1.10.4-windowsservercore-1709, 1.10-windowsservercore-1709
+SharedTags: 1.10.4-windowsservercore, 1.10-windowsservercore, 1.10.4, 1.10
 Architectures: windows-amd64
-GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
+GitCommit: 1a7381c32220091f35bd76e34bc28af251954acb
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.10.3-windowsservercore-1803, 1.10-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.10.3-windowsservercore, 1.10-windowsservercore, 1-windowsservercore, windowsservercore, 1.10.3, 1.10, 1, latest
+Tags: 1.10.4-windowsservercore-1803, 1.10-windowsservercore-1803
+SharedTags: 1.10.4-windowsservercore, 1.10-windowsservercore, 1.10.4, 1.10
 Architectures: windows-amd64
-GitCommit: e6528749f50809c858c6b9bad86be8541de6368e
+GitCommit: 1a7381c32220091f35bd76e34bc28af251954acb
 Directory: 1.10/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.10.3-nanoserver-sac2016, 1.10-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.10.3-nanoserver, 1.10-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.10.4-nanoserver-sac2016, 1.10-nanoserver-sac2016
+SharedTags: 1.10.4-nanoserver, 1.10-nanoserver
 Architectures: windows-amd64
-GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
+GitCommit: 1a7381c32220091f35bd76e34bc28af251954acb
 Directory: 1.10/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
-Tags: 1.9.7-stretch, 1.9-stretch
-SharedTags: 1.9.7, 1.9
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
-Directory: 1.9/stretch
-
-Tags: 1.9.7-alpine3.8, 1.9-alpine3.8, 1.9.7-alpine, 1.9-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
-Directory: 1.9/alpine3.8
-
-Tags: 1.9.7-alpine3.7, 1.9-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fd09bcfba2f2ec52318834df502b1a1907fa04f5
-Directory: 1.9/alpine3.7
-
-Tags: 1.9.7-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016
-SharedTags: 1.9.7-windowsservercore, 1.9-windowsservercore, 1.9.7, 1.9
-Architectures: windows-amd64
-GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
-Directory: 1.9/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 1.9.7-windowsservercore-1709, 1.9-windowsservercore-1709
-SharedTags: 1.9.7-windowsservercore, 1.9-windowsservercore, 1.9.7, 1.9
-Architectures: windows-amd64
-GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
-Directory: 1.9/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
-Tags: 1.9.7-windowsservercore-1803, 1.9-windowsservercore-1803
-SharedTags: 1.9.7-windowsservercore, 1.9-windowsservercore, 1.9.7, 1.9
-Architectures: windows-amd64
-GitCommit: e6528749f50809c858c6b9bad86be8541de6368e
-Directory: 1.9/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
-Tags: 1.9.7-nanoserver-sac2016, 1.9-nanoserver-sac2016
-SharedTags: 1.9.7-nanoserver, 1.9-nanoserver
-Architectures: windows-amd64
-GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
-Directory: 1.9/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016


### PR DESCRIPTION
https://github.com/docker-library/golang/pull/234, https://github.com/docker-library/golang/pull/235