### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-ce-tp3, 18.09-rc, rc, test
+Tags: 18.09.0-ce-tp4, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 44e9b5c2823fe334e975c6cc0d2fbea3437e2c2b
+GitCommit: 13958ae4bb03fdbd7bc29ae276a754ebee841572
 Directory: 18.09-rc
 
-Tags: 18.09.0-ce-tp3-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-ce-tp4-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/dind
 
-Tags: 18.09.0-ce-tp3-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-ce-tp4-git, 18.09-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/git

--- a/library/haproxy
+++ b/library/haproxy
@@ -6,40 +6,40 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.5/alpine
 
 Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.6
 
 Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.6/alpine
 
 Tags: 1.7.11, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 968e0bcfee8150b16a8e38fc3386de664ab9bfd1
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c811fc5a8d46d9a4086cc5e45b5232755768bd9
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.7/alpine
 
 Tags: 1.8.13, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 50a14f801a7e7215c998969e5bdc923be8184646
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.8
 
 Tags: 1.8.13-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 50a14f801a7e7215c998969e5bdc923be8184646
+GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.8/alpine

--- a/library/julia
+++ b/library/julia
@@ -13,21 +13,21 @@ Directory: 1.0/stretch
 Tags: 1.0.0-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.0.0-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
 SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
 Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 1.0.0-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
 SharedTags: 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
 Directory: 1.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/postgres
+++ b/library/postgres
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta3, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 11
 
 Tags: 11-beta3-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ea5efa503c6ec5d5ee2ebe52acd5eaa50ac75ca
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 11/alpine
 
 Tags: 10.5, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 10
 
 Tags: 10.5-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a78bff54b531d6ef106e43b020712086fff6a67f
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 10/alpine
 
 Tags: 9.6.10, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.6
 
 Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5673b8988b3d411f0ba6b9e73e48cf6986cc959d
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.6/alpine
 
 Tags: 9.5.14, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.5
 
 Tags: 9.5.14-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a72377975f328b42344dbefc5243f994f25ced22
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.5/alpine
 
 Tags: 9.4.19, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.4
 
 Tags: 9.4.19-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1cf0f1b313b7dc14bfd9331efc45e96b8603f7d2
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.4/alpine
 
 Tags: 9.3.24, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064113e0e481a1d0542846b81858e457fde02c90
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.3
 
 Tags: 9.3.24-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: feaec8367b50af1707fc07da0643f77bd56aa912
+GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
 Directory: 9.3/alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,82 +6,82 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: 57572ac281f3f77846aef85641ca36a02e71458f
 Directory: php5.6/apache
 
 Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php5.6/fpm
 
 Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.0/apache
 
 Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.0/fpm
 
 Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.1/apache
 
 Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.1/fpm
 
 Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.2/apache
 
 Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.2/fpm
 
 Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d640173bd9648c2efc2f9d9df8ae43def949a1b6
+GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-2.0.0-php5.6, cli-2.0-php5.6, cli-2-php5.6, cli-php5.6
+Tags: cli-2.0.1-php5.6, cli-2.0-php5.6, cli-2-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
+GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
 Directory: php5.6/cli
 
-Tags: cli-2.0.0-php7.0, cli-2.0-php7.0, cli-2-php7.0, cli-php7.0
+Tags: cli-2.0.1-php7.0, cli-2.0-php7.0, cli-2-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
+GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
 Directory: php7.0/cli
 
-Tags: cli-2.0.0-php7.1, cli-2.0-php7.1, cli-2-php7.1, cli-php7.1
+Tags: cli-2.0.1-php7.1, cli-2.0-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
+GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
 Directory: php7.1/cli
 
-Tags: cli-2.0.0, cli-2.0, cli-2, cli, cli-2.0.0-php7.2, cli-2.0-php7.2, cli-2-php7.2, cli-php7.2
+Tags: cli-2.0.1, cli-2.0, cli-2, cli, cli-2.0.1-php7.2, cli-2.0-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b4038d4400e3988854bef43d9790ea9a5973f469
+GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
 Directory: php7.2/cli


### PR DESCRIPTION
- `docker`: 18.09.0-ce-tp4
- `haproxy`: `SIGUSR1` (docker-library/haproxy#72)
- `julia`: update 1.0.0 Windows executable hashes (https://github.com/JuliaLang/julia/issues/28840#issuecomment-415632174)
- `postgres`: escape user input for `psql` invocations (docker-library/postgres#489)
- `wordpress`: add `WORDPRESS_DB_CHARSET` and `WORDPRESS_DB_COLLATE` vars (docker-library/wordpress#327), WP-CLI 2.0.1