### PR TITLE
Update websphere-liberty beta to 2018.8.0.1

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: de3f7503a0fbc27595bfe215d18f23117b5fb00b
+GitCommit: 48ea49879e8b070b70612386392c056970dcd85f
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: javaee8, latest


### PR DESCRIPTION
Update beta for websphere-liberty to the newly released version 2018.8.0.1.