### PR TITLE
openjdk: Add missing arm versions

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -71,12 +71,12 @@ GitCommit: 86918ee28d383e7af63f535a2558040dce141099
 Directory: 8/jdk
 
 Tags: 8u181-jdk-slim-stretch, 8u181-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u181-jdk-slim, 8u181-slim, 8-jdk-slim, 8-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 86918ee28d383e7af63f535a2558040dce141099
 Directory: 8/jdk/slim
 
 Tags: 8u171-jdk-alpine3.8, 8u171-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u171-jdk-alpine, 8u171-alpine, 8-jdk-alpine, 8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 8/jdk/alpine
 


### PR DESCRIPTION
* Adds arm32v6 architecture to `8-jdk-slim` image
* Adds arm32v7 architecture to `8-jdk-alpine` image