### PR TITLE
[nats-streaming] Release 0.11.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 
-Tags: 0.10.2-linux, linux
-SharedTags: 0.10.2, latest
+Tags: 0.11.0-linux, linux
+SharedTags: 0.11.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+amd64-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 amd64-Directory: amd64
-arm32v6-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+arm32v6-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+arm32v7-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+arm64v8-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 arm64v8-Directory: arm64v8
 
-Tags: 0.10.2-nanoserver, nanoserver
-SharedTags: 0.10.2, latest
+Tags: 0.11.0-nanoserver, nanoserver
+SharedTags: 0.11.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+windows-amd64-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.10.2-windowsservercore, windowsservercore
+Tags: 0.11.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 58d76a09cfa67441b9ea505fad29ad484b0e84c7
+windows-amd64-GitCommit: 342cc5fa3bb32adf2215ef789d2236978af48bf4
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.11.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>