### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-ce-tp4, 18.09-rc, rc, test
+Tags: 18.09.0-ce-tp6, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 13958ae4bb03fdbd7bc29ae276a754ebee841572
+GitCommit: 920059b3e2150aa2ebd053f5d28a8a5a15cfc227
 Directory: 18.09-rc
 
-Tags: 18.09.0-ce-tp4-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-ce-tp6-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/dind
 
-Tags: 18.09.0-ce-tp4-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-ce-tp6-git, 18.09-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/git

--- a/library/drupal
+++ b/library/drupal
@@ -19,19 +19,19 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
 Directory: 8.6-rc/fpm-alpine
 
-Tags: 8.5.6-apache, 8.5-apache, 8-apache, apache, 8.5.6, 8.5, 8, latest
+Tags: 8.5.7-apache, 8.5-apache, 8-apache, apache, 8.5.7, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
+GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/apache
 
-Tags: 8.5.6-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.7-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
+GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/fpm
 
-Tags: 8.5.6-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.7-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ff4da791fcf656569964f1c3fa046028d3562448
+GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/fpm-alpine
 
 Tags: 7.59-apache, 7-apache, 7.59, 7

--- a/library/ghost
+++ b/library/ghost
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.0.3, 2.0, 2, latest
+Tags: 2.1.1, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f683bbaf11e123d47b259e02c1272e64d5b08aa2
+GitCommit: ccae14e2681176e0b098f918c417cd8d7f6618b5
 Directory: 2/debian
 
-Tags: 2.0.3-alpine, 2.0-alpine, 2-alpine, alpine
+Tags: 2.1.1-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f683bbaf11e123d47b259e02c1272e64d5b08aa2
+GitCommit: ccae14e2681176e0b098f918c417cd8d7f6618b5
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
+GitCommit: c39ad569186086a1c6c53110803737e74566a4a2
 Directory: 1/debian
 
 Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45aaec28dbf650199d283c1ce4998764b6bc24ee
+GitCommit: c39ad569186086a1c6c53110803737e74566a4a2
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -8,38 +8,38 @@ GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 amd64-Directory: amd64/hello-seattle
-arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v5-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v5-Directory: arm32v5/hello-seattle
-arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v7-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v7-Directory: arm32v7/hello-seattle
-arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm64v8-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm64v8-Directory: arm64v8/hello-seattle
-i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+i386-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 i386-Directory: i386/hello-seattle
-ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+ppc64le-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 ppc64le-Directory: ppc64le/hello-seattle
-s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+s390x-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 s390x-Directory: s390x/hello-seattle
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1803
 Constraints: nanoserver-1803

--- a/library/hello-world
+++ b/library/hello-world
@@ -8,38 +8,38 @@ GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 amd64-Directory: amd64/hello-world
-arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v5-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v5-Directory: arm32v5/hello-world
-arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v7-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v7-Directory: arm32v7/hello-world
-arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm64v8-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm64v8-Directory: arm64v8/hello-world
-i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+i386-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 i386-Directory: i386/hello-world
-ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+ppc64le-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 ppc64le-Directory: ppc64le/hello-world
-s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+s390x-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 s390x-Directory: s390x/hello-world
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-world/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hello-world/nanoserver-1803
 Constraints: nanoserver-1803

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -8,38 +8,38 @@ GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
 Tags: linux
 SharedTags: latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-amd64-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 amd64-Directory: amd64/hola-mundo
-arm32v5-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v5-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v5-Directory: arm32v5/hola-mundo
-arm32v7-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm32v7-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v7-Directory: arm32v7/hola-mundo
-arm64v8-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+arm64v8-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm64v8-Directory: arm64v8/hola-mundo
-i386-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+i386-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 i386-Directory: i386/hola-mundo
-ppc64le-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+ppc64le-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 ppc64le-Directory: ppc64le/hola-mundo
-s390x-GitCommit: b0a34596994b120f5456f08992ef9a75ed56f34e
+s390x-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 s390x-Directory: s390x/hola-mundo
 
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1803
 Constraints: nanoserver-1803

--- a/library/mongo
+++ b/library/mongo
@@ -4,47 +4,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.2.20-jessie, 3.2-jessie
-SharedTags: 3.2.20, 3.2
+Tags: 3.2.21-jessie, 3.2-jessie
+SharedTags: 3.2.21, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: eefc62ded2695ecf5e14193be7bc9640f79e1bd1
+GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
 Directory: 3.2
 
-Tags: 3.2.20-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
-SharedTags: 3.2.20-windowsservercore, 3.2-windowsservercore, 3.2.20, 3.2
+Tags: 3.2.21-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
+SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
 Directory: 3.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.2.20-windowsservercore-1709, 3.2-windowsservercore-1709
-SharedTags: 3.2.20-windowsservercore, 3.2-windowsservercore, 3.2.20, 3.2
+Tags: 3.2.21-windowsservercore-1709, 3.2-windowsservercore-1709
+SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.4.16-jessie, 3.4-jessie
-SharedTags: 3.4.16, 3.4
+Tags: 3.4.17-jessie, 3.4-jessie
+SharedTags: 3.4.17, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: eefc62ded2695ecf5e14193be7bc9640f79e1bd1
+GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
 Directory: 3.4
 
-Tags: 3.4.16-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
-SharedTags: 3.4.16-windowsservercore, 3.4-windowsservercore, 3.4.16, 3.4
+Tags: 3.4.17-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.16-windowsservercore-1709, 3.4-windowsservercore-1709
-SharedTags: 3.4.16-windowsservercore, 3.4-windowsservercore, 3.4.16, 3.4
+Tags: 3.4.17-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
 Architectures: windows-amd64
-GitCommit: 380200038360980631e362f964857d48489f99a2
+GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -53,7 +53,7 @@ SharedTags: 3.6.7, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
+GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
 Directory: 3.6
 
 Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
@@ -70,32 +70,32 @@ GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.1-xenial, 4.0-xenial, 4-xenial, xenial
-SharedTags: 4.0.1, 4.0, 4, latest
+Tags: 4.0.2-xenial, 4.0-xenial, 4-xenial, xenial
+SharedTags: 4.0.2, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: b2c38e6b34458edc9c7dbd15a669c7b3992e43d1
+GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
 Directory: 4.0
 
-Tags: 4.0.1-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
+Tags: 4.0.2-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
+GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.1-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
-SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
+Tags: 4.0.2-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
+SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
+GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
 Directory: 4.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.1-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.0.1-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.1, 4.0, 4, latest
+Tags: 4.0.2-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 87b691c1e7d585d5b6f3ca00b6006d33ff74dabb
+GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -104,7 +104,7 @@ SharedTags: 4.1.2, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: b2c38e6b34458edc9c7dbd15a669c7b3992e43d1
+GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
 Directory: 4.1
 
 Tags: 4.1.2-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 11-ea-27-jdk-sid, 11-ea-27-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-27-jdk, 11-ea-27, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-ea-28-jdk-sid, 11-ea-28-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-28-jdk, 11-ea-28, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
+GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jdk
 
-Tags: 11-ea-27-jdk-slim-sid, 11-ea-27-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-27-jdk-slim, 11-ea-27-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-ea-28-jdk-slim-sid, 11-ea-28-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-28-jdk-slim, 11-ea-28-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
+GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jdk/slim
 
-Tags: 11-ea-27-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-27-jre, 11-ea-jre, 11-jre
+Tags: 11-ea-28-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-28-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
+GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jre
 
-Tags: 11-ea-27-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-27-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-ea-28-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-28-jre-slim, 11-ea-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6274e014e788701bc5d427e992b1fa66f5aa5ad5
+GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jre/slim
 
 Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest

--- a/library/php
+++ b/library/php
@@ -4,297 +4,297 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0beta2-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0beta2-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0beta2-cli, 7.3-rc-cli, rc-cli, 7.3.0beta2, 7.3-rc, rc
+Tags: 7.3.0beta3-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0beta3-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0beta3-cli, 7.3-rc-cli, rc-cli, 7.3.0beta3, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/stretch/cli
 
-Tags: 7.3.0beta2-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0beta2-apache, 7.3-rc-apache, rc-apache
+Tags: 7.3.0beta3-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0beta3-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/stretch/apache
 
-Tags: 7.3.0beta2-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0beta2-fpm, 7.3-rc-fpm, rc-fpm
+Tags: 7.3.0beta3-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0beta3-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/stretch/fpm
 
-Tags: 7.3.0beta2-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0beta2-zts, 7.3-rc-zts, rc-zts
+Tags: 7.3.0beta3-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0beta3-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/stretch/zts
 
-Tags: 7.3.0beta2-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0beta2-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0beta2-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0beta2-alpine, 7.3-rc-alpine, rc-alpine
+Tags: 7.3.0beta3-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0beta3-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0beta3-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0beta3-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/alpine3.8/cli
 
-Tags: 7.3.0beta2-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0beta2-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.3.0beta3-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0beta3-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/alpine3.8/fpm
 
-Tags: 7.3.0beta2-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0beta2-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Tags: 7.3.0beta3-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0beta3-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 42b75056a11e7b1e767a680acab96369d5a45010
+GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
 Directory: 7.3-rc/alpine3.8/zts
 
 Tags: 7.2.9-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.9-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.9-cli, 7.2-cli, 7-cli, cli, 7.2.9, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.9-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.9-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.9-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.9-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.9-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.9-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.9-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.9-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.9-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.9-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.8/cli
 
 Tags: 7.2.9-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.9-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.8/fpm
 
 Tags: 7.2.9-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.9-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.2.9-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.9-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.7/cli
 
 Tags: 7.2.9-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.7/fpm
 
 Tags: 7.2.9-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.7/zts
 
 Tags: 7.2.9-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.9-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.6/cli
 
 Tags: 7.2.9-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.6/fpm
 
 Tags: 7.2.9-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e92dfe4847c9fe74ea309e66f9d3ef0217f8525d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.2/alpine3.6/zts
 
 Tags: 7.1.21-cli-stretch, 7.1-cli-stretch, 7.1.21-stretch, 7.1-stretch, 7.1.21-cli, 7.1-cli, 7.1.21, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.21-apache-stretch, 7.1-apache-stretch, 7.1.21-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.21-fpm-stretch, 7.1-fpm-stretch, 7.1.21-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.21-zts-stretch, 7.1-zts-stretch, 7.1.21-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.21-cli-jessie, 7.1-cli-jessie, 7.1.21-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.21-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.21-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.21-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.21-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.21-alpine3.8, 7.1-alpine3.8, 7.1.21-cli-alpine, 7.1-cli-alpine, 7.1.21-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.8/cli
 
 Tags: 7.1.21-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.21-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.8/fpm
 
 Tags: 7.1.21-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.21-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.8/zts
 
 Tags: 7.1.21-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.21-alpine3.7, 7.1-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.7/cli
 
 Tags: 7.1.21-fpm-alpine3.7, 7.1-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.7/fpm
 
 Tags: 7.1.21-zts-alpine3.7, 7.1-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 74b59e1cf7e5a356b5d4ee5eaeffe5f70f5ebd4c
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.31-cli-stretch, 7.0-cli-stretch, 7.0.31-stretch, 7.0-stretch, 7.0.31-cli, 7.0-cli, 7.0.31, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/stretch/cli
 
 Tags: 7.0.31-apache-stretch, 7.0-apache-stretch, 7.0.31-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/stretch/apache
 
 Tags: 7.0.31-fpm-stretch, 7.0-fpm-stretch, 7.0.31-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/stretch/fpm
 
 Tags: 7.0.31-zts-stretch, 7.0-zts-stretch, 7.0.31-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/stretch/zts
 
 Tags: 7.0.31-cli-jessie, 7.0-cli-jessie, 7.0.31-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.31-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.31-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.31-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.31-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.31-alpine3.7, 7.0-alpine3.7, 7.0.31-cli-alpine, 7.0-cli-alpine, 7.0.31-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/alpine3.7/cli
 
 Tags: 7.0.31-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.31-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/alpine3.7/fpm
 
 Tags: 7.0.31-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.31-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d413e2dff930b1ac261a587cb8911df2c6bd355
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 7.0/alpine3.7/zts
 
 Tags: 5.6.37-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.37-stretch, 5.6-stretch, 5-stretch, 5.6.37-cli, 5.6-cli, 5-cli, 5.6.37, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/stretch/cli
 
 Tags: 5.6.37-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.37-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/stretch/apache
 
 Tags: 5.6.37-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.37-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/stretch/fpm
 
 Tags: 5.6.37-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.37-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/stretch/zts
 
 Tags: 5.6.37-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.37-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.37-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.37-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.37-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.37-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.37-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.37-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.37-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.8/cli
 
 Tags: 5.6.37-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.37-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.8/fpm
 
 Tags: 5.6.37-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.37-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a370a1ed553bddbae08f2aa1364b45b60d6f54fa
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.8/zts
 
 Tags: 5.6.37-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.37-alpine3.7, 5.6-alpine3.7, 5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.7/cli
 
 Tags: 5.6.37-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.7/fpm
 
 Tags: 5.6.37-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 655d427e50f99968a154691d2569d7ecc4736d3d
+GitCommit: 88189f016803224152e3b1d96b11a573b3762559
 Directory: 5.6/alpine3.7/zts

--- a/library/redis
+++ b/library/redis
@@ -16,7 +16,7 @@ Directory: 5.0-rc/32bit
 
 Tags: 5.0-rc4-alpine, 5.0-rc-alpine, 5.0-rc4-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
+GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch
@@ -31,7 +31,7 @@ Directory: 4.0/32bit
 
 Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
+GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
 Directory: 4.0/alpine
 
 Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch
@@ -46,5 +46,5 @@ Directory: 3.2/32bit
 
 Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine, 3.2.12-alpine3.8, 3.2-alpine3.8, 3-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cd19a816a89c3ec00586e6d02da28802af11a958
+GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
 Directory: 3.2/alpine

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.68.5, 0.68, 0, latest
-GitCommit: f0395c98b3c374a978d401555c4f1a11f3afde76
+Tags: 0.69.1, 0.69, 0, latest
+GitCommit: f3cd9120e9a8c0c5f8512f39d94d4f2a0aef1343


### PR DESCRIPTION
- `docker`: 18.09.0-ce-tp6
- `drupal`: 8.5.7
- `ghost`: 2.1.1
- `hello-seattle`: update URL (docker-library/hello-world#51)
- `hello-world`: update URL (docker-library/hello-world#51)
- `hola-mundo`: update URL (docker-library/hello-world#51)
- `mongo`: 3.4.17, 3.2.21, fix duplicated `--pidfile` (docker-library/mongo#298)
- `openjdk`: 11-ea+28 (debian)
- `php`: 7.3.0beta3, ship `php.ini-production` and `php.ini-development` in `$PHP_INI_DIR` (docker-library/php#711)
- `redis`: add `tzdata` to Alpine variants (docker-library/redis#162)
- `rocket.chat`: 0.69.1