### PR TITLE
Bump Traefik to v1.7.0-rc4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,33 +1,33 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.7.0-rc3, 1.7.0-rc3, v1.7, 1.7, maroilles
+Tags: v1.7.0-rc4, 1.7.0-rc4, v1.7, 1.7, maroilles
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
+GitCommit: c8cd5891b67c3915959841be314ab1b655ed830d
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.7.0-rc3-alpine, 1.7.0-rc3-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.0-rc4-alpine, 1.7.0-rc4-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
+GitCommit: c8cd5891b67c3915959841be314ab1b655ed830d
 Directory: alpine
 
-Tags: v1.7.0-rc3-nanoserver, 1.7.0-rc3-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.0-rc3-nanoserver-sac2016, 1.7.0-rc3-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016
+Tags: v1.7.0-rc4-nanoserver, 1.7.0-rc4-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.0-rc4-nanoserver-sac2016, 1.7.0-rc4-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 6dadcaf64497da64d2283f2e86302798554f1539
+GitCommit: c8cd5891b67c3915959841be314ab1b655ed830d
 Directory: windows
 Constraints: nanoserver-sac2016
 
 Tags: v1.6.6, 1.6.6, v1.6, 1.6, tetedemoine, latest
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: d95245ee706fbe031fe4d62564015cb4fb1f076d
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v1.6.6-alpine, 1.6.6-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
-Architectures: amd64, arm64v8, arm32v6
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: d95245ee706fbe031fe4d62564015cb4fb1f076d
 Directory: alpine
 


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.7.0-rc4.

/cc @vdemeester @emilevauge

Cheers
