### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-ce-tp6, 18.09-rc, rc, test
+Tags: 18.09.0-ce-beta1, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 920059b3e2150aa2ebd053f5d28a8a5a15cfc227
+GitCommit: 6c9844cf7bc73d87cf884f7e347c6a7b060f8530
 Directory: 18.09-rc
 
-Tags: 18.09.0-ce-tp6-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-ce-beta1-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/dind
 
-Tags: 18.09.0-ce-tp6-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-ce-beta1-git, 18.09-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/git

--- a/library/drupal
+++ b/library/drupal
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/c1dc3e34b48fc47c8f8a893e67b8eaba5db9d5ed/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/a97122faee2234e22f990e8c942b357e806511e1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.0-rc1-apache, 8.6-rc-apache, rc-apache, 8.6.0-rc1, 8.6-rc, rc
+Tags: 8.6.0-apache, 8.6-apache, 8-apache, apache, 8.6.0, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
-Directory: 8.6-rc/apache
+GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+Directory: 8.6/apache
 
-Tags: 8.6.0-rc1-fpm, 8.6-rc-fpm, rc-fpm
+Tags: 8.6.0-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
-Directory: 8.6-rc/fpm
+GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+Directory: 8.6/fpm
 
-Tags: 8.6.0-rc1-fpm-alpine, 8.6-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.6.0-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7e10c55eadc2c2c94685bd21aa8528fbae9b1878
-Directory: 8.6-rc/fpm-alpine
+GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+Directory: 8.6/fpm-alpine
 
-Tags: 8.5.7-apache, 8.5-apache, 8-apache, apache, 8.5.7, 8.5, 8, latest
+Tags: 8.5.7-apache, 8.5-apache, 8.5.7, 8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/apache
 
-Tags: 8.5.7-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.7-fpm, 8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/fpm
 
-Tags: 8.5.7-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.7-fpm-alpine, 8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
 Directory: 8.5/fpm-alpine

--- a/library/mongo
+++ b/library/mongo
@@ -48,12 +48,12 @@ GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.7-jessie, 3.6-jessie, 3-jessie
+Tags: 3.6.7-stretch, 3.6-stretch, 3-stretch
 SharedTags: 3.6.7, 3.6, 3
-# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.6/main/
+# see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
+GitCommit: 2fdc4a20575449775346b5c56bfc478cdba0caa9
 Directory: 3.6
 
 Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016

--- a/library/postgres
+++ b/library/postgres
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11-beta3, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 11
 
 Tags: 11-beta3-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 11/alpine
 
 Tags: 10.5, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 10
 
 Tags: 10.5-alpine, 10-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 10/alpine
 
 Tags: 9.6.10, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.6
 
 Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.6/alpine
 
 Tags: 9.5.14, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.5
 
 Tags: 9.5.14-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.5/alpine
 
 Tags: 9.4.19, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.4
 
 Tags: 9.4.19-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.4/alpine
 
 Tags: 9.3.24, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.3
 
 Tags: 9.3.24-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 36294f464a4253017c4d9e04657d5469556f27f8
+GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 9.3/alpine


### PR DESCRIPTION
- `docker`: 18.09.0-ce-beta1
- `drupal`: 8.6 GA (docker-library/drupal#132)
- `mongo`: update 3.6 to Debian Stretch (docker-library/mongo#301)
- `postgres`: use `initdb` more directly to allow `--auth-local=md5` (docker-library/postgres#493)