### PR TITLE
Add multi-arch support to Apache Storm

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,17 +1,15 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 
 Tags: 1.0.6, 1.0
-Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
 Directory: 1.0.6
 
 Tags: 1.1.3, 1.1
-Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
 Directory: 1.1.3
 
 Tags: 1.2.2, 1.2, latest
-Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
 Directory: 1.2.2

--- a/library/storm
+++ b/library/storm
@@ -1,6 +1,6 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
-Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 1.0.6, 1.0
 GitCommit: 9986213e09356e2d5230e6af9338052ce858b224

--- a/library/storm
+++ b/library/storm
@@ -2,13 +2,16 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
 
 Tags: 1.0.6, 1.0
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
 Directory: 1.0.6
 
 Tags: 1.1.3, 1.1
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
 Directory: 1.1.3
 
 Tags: 1.2.2, 1.2, latest
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
 Directory: 1.2.2


### PR DESCRIPTION
Since Zookeeper has been muti-arch for a while now and both Zookeeper and Storm are based on the same `openjdk:8-jre-alpine` image I hope we should be fine 🤞 