### PR TITLE
Update Solr to 6.6.5

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -64,19 +64,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 48c50a7b2746470baa9b3e3573033e600dac75e9
 Directory: 7.1/slim
 
-Tags: 6.6.4, 6.6, 6
+Tags: 6.6.5, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88259161626bc9f6803076024f35c681feffa275
+GitCommit: d4ee8786131f1271be0b725aa2ab298ec66f4e22
 Directory: 6.6
 
-Tags: 6.6.4-alpine, 6.6-alpine, 6-alpine
+Tags: 6.6.5-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88259161626bc9f6803076024f35c681feffa275
+GitCommit: d4ee8786131f1271be0b725aa2ab298ec66f4e22
 Directory: 6.6/alpine
 
-Tags: 6.6.4-slim, 6.6-slim, 6-slim
+Tags: 6.6.5-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88259161626bc9f6803076024f35c681feffa275
+GitCommit: d4ee8786131f1271be0b725aa2ab298ec66f4e22
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5


### PR DESCRIPTION
See [announcement](https://lists.apache.org/thread.html/%3CCAHPRk5Fo0VHMFvasPUWqd8f22t11bidQj_zVWoUePr7_oNdO1Q@mail.gmail.com%3E). Note that this includes a security fix, see [CVE-2018-8026: XXE vulnerability due to Apache Solr configset upload](https://lists.apache.org/thread.html/%3C0cdc01d413b7$f97ba580$ec72f080$@apache.org%3E).

Fixes https://github.com/docker-solr/docker-solr/issues/184