### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.0-apache, 8.6-apache, 8-apache, apache, 8.6.0, 8.6, 8, latest
+Tags: 8.6.1-apache, 8.6-apache, 8-apache, apache, 8.6.1, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
 Directory: 8.6/apache
 
-Tags: 8.6.0-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.1-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
 Directory: 8.6/fpm
 
-Tags: 8.6.0-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.1-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3ca3d46b77e95f9a7fe70a5032a16adef9e8e0b6
+GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
 Directory: 8.6/fpm-alpine
 
 Tags: 8.5.7-apache, 8.5-apache, 8.5.7, 8.5

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.1.1, 2.1, 2, latest
+Tags: 2.1.2, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccae14e2681176e0b098f918c417cd8d7f6618b5
+GitCommit: ce00cfb3b3b27187354961b9efb5f81e41c38bf2
 Directory: 2/debian
 
-Tags: 2.1.1-alpine, 2.1-alpine, 2-alpine, alpine
+Tags: 2.1.2-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccae14e2681176e0b098f918c417cd8d7f6618b5
+GitCommit: ce00cfb3b3b27187354961b9efb5f81e41c38bf2
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1

--- a/library/mariadb
+++ b/library/mariadb
@@ -14,9 +14,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: f5c3481f84205d7601cde45777f0c939c01eb7d6
 Directory: 10.2
 
-Tags: 10.1.35-bionic, 10.1-bionic, 10.1.35, 10.1
+Tags: 10.1.36-bionic, 10.1-bionic, 10.1.36, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8a25691df08c6b6dede86a50411074f4f30e495d
+GitCommit: b678346ca1c832c93ecf0969f2738268d065dd8f
 Directory: 10.1
 
 Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,8 +1,29 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/73d767bdc5525a71654cb3309f8338a5dd8f89d2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/bf06437449e8ae1782905f6c2df744805498874b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
+
+Tags: 12-ea-10-jdk-windowsservercore-ltsc2016, 12-ea-10-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Architectures: windows-amd64
+GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+Directory: 12/jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 12-ea-10-jdk-windowsservercore-1709, 12-ea-10-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Architectures: windows-amd64
+GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+Directory: 12/jdk/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 12-ea-10-jdk-windowsservercore-1803, 12-ea-10-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Architectures: windows-amd64
+GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+Directory: 12/jdk/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
 
 Tags: 11-ea-28-jdk-sid, 11-ea-28-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-28-jdk, 11-ea-28, 11-ea-jdk, 11-ea, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -13,6 +34,27 @@ Tags: 11-ea-28-jdk-slim-sid, 11-ea-28-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-s
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jdk/slim
+
+Tags: 11-28-jdk-windowsservercore-ltsc2016, 11-28-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Architectures: windows-amd64
+GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+Directory: 11/jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 11-28-jdk-windowsservercore-1709, 11-28-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
+SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Architectures: windows-amd64
+GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+Directory: 11/jdk/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 11-28-jdk-windowsservercore-1803, 11-28-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Architectures: windows-amd64
+GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+Directory: 11/jdk/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
 
 Tags: 11-ea-28-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-28-jre, 11-ea-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/percona
+++ b/library/percona
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.22-stretch, 5.7-stretch, 5-stretch, stretch, 5.7.22, 5.7, 5, latest
+Tags: 5.7.23-stretch, 5.7-stretch, 5-stretch, stretch, 5.7.23, 5.7, 5, latest
 Architectures: amd64
-GitCommit: dacba4148dfdda9f0ff28cd2a42117c0ee3b86b2
+GitCommit: 0f9f131aaff61dd735195ca44e190d4ef4995335
 Directory: 5.7
 
 Tags: 5.6.41-stretch, 5.6-stretch, 5.6.41, 5.6

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.69.1, 0.69, 0, latest
-GitCommit: f3cd9120e9a8c0c5f8512f39d94d4f2a0aef1343
+Tags: 0.69.2, 0.69, 0, latest
+GitCommit: bc47cba5626cfbc2eb78973fe15bfab2964d4e1b

--- a/library/ruby
+++ b/library/ruby
@@ -16,7 +16,7 @@ Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
+GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
@@ -31,7 +31,7 @@ Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
+GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
@@ -56,12 +56,12 @@ Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
@@ -86,5 +86,5 @@ Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
+GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
 Directory: 2.3/alpine3.7

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,110 +6,110 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.90-jre7, 7.0-jre7, 7-jre7, 7.0.90, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre7
 
 Tags: 7.0.90-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.90-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre7-slim
 
 Tags: 7.0.90-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.90-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre7-alpine
 
 Tags: 7.0.90-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre8
 
 Tags: 7.0.90-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre8-slim
 
 Tags: 7.0.90-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 7/jre8-alpine
 
 Tags: 8.0.53-jre7, 8.0-jre7, 8.0.53, 8.0
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre7
 
 Tags: 8.0.53-jre7-slim, 8.0-jre7-slim, 8.0.53-slim, 8.0-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre7-slim
 
 Tags: 8.0.53-jre7-alpine, 8.0-jre7-alpine, 8.0.53-alpine, 8.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre7-alpine
 
 Tags: 8.0.53-jre8, 8.0-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre8
 
 Tags: 8.0.53-jre8-slim, 8.0-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre8-slim
 
 Tags: 8.0.53-jre8-alpine, 8.0-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1383c5549ee60522e76b37667c38b4cddc8bbc6d
+GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
 Directory: 8.0/jre8-alpine
 
-Tags: 8.5.33-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.33, 8.5, 8, latest
+Tags: 8.5.34-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.34, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
+GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
 Directory: 8.5/jre8
 
-Tags: 8.5.33-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.33-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.34-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.34-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
+GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.33-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.33-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.34-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.34-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d485a5c4bfdb50a93ae36e212bbf6b2e6e1bdd9e
+GitCommit: af1646c18d6398e6cf27a29d32ff58b994d2566e
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.33-jre10, 8.5-jre10, 8-jre10, jre10
+Tags: 8.5.34-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
+GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
 Directory: 8.5/jre10
 
-Tags: 8.5.33-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Tags: 8.5.34-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1043df616963648dd50d5d18310f4826b32d995c
+GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
 Directory: 8.5/jre10-slim
 
-Tags: 9.0.11-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.12-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
+GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre8
 
-Tags: 9.0.11-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.12-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
+GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.11-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.12-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ba5a6d7b9fb9fa08480cc53a4ed707ea73cdc4ce
+GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.11-jre10, 9.0-jre10, 9-jre10, 9.0.11, 9.0, 9
+Tags: 9.0.12-jre10, 9.0-jre10, 9-jre10, 9.0.12, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
+GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre10
 
-Tags: 9.0.11-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.11-slim, 9.0-slim, 9-slim
+Tags: 9.0.12-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.12-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eebf2f8b88db28cbeee79b7c6b1411401283c4bd
+GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre10-slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -68,20 +68,20 @@ Directory: php7.2/fpm-alpine
 
 Tags: cli-2.0.1-php5.6, cli-2.0-php5.6, cli-2-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
+GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
 Directory: php5.6/cli
 
 Tags: cli-2.0.1-php7.0, cli-2.0-php7.0, cli-2-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
+GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
 Directory: php7.0/cli
 
 Tags: cli-2.0.1-php7.1, cli-2.0-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
+GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
 Directory: php7.1/cli
 
 Tags: cli-2.0.1, cli-2.0, cli-2, cli, cli-2.0.1-php7.2, cli-2.0-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c5dbd211c852158ba5e396f056172a317dc9a5cc
+GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
 Directory: php7.2/cli


### PR DESCRIPTION
- `drupal`: 8.6.1
- `ghost`: 2.1.2
- `mariadb`: 10.1.36
- `openjdk`: Windows builds of 11 and 12 from jdk.java.net (docker-library/openjdk#227)
- `percona`: 5.7.23
- `rocket.chat`: 0.69.2
- `ruby`: remove `libressl-dev` from runtime deps (docker-library/ruby#230)
- `tomcat`: 8.5.34
- `wordpress`: add `bash` to WP-CLI for `wp shell` (docker-library/wordpress#335)