### PR TITLE
Upgrade rust to 1.29

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,24 +1,14 @@
-# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/da8bc5716ede5f18748e4daa92f85e9a9d9c1454/generate-stackbrew-library.sh
+# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/b039f64c9fbfc679ff1f72d97466f58ebf509790/generate-stackbrew-library.sh
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
 GitRepo: https://github.com/rust-lang-nursery/docker-rust.git
 
-Tags: 1.28.0-stretch, 1-stretch, 1.28-stretch, stretch, 1.28.0, 1, 1.28, latest
+Tags: 1.29.0-stretch, 1-stretch, 1.28-stretch, stretch, 1.29.0, 1, 1.28, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: da8bc5716ede5f18748e4daa92f85e9a9d9c1454
-Directory: 1.28.0/stretch
+GitCommit: 46d75fee52b77161355ce8a4623d6afbfec0e63f
+Directory: 1.29.0/stretch
 
-Tags: 1.28.0-slim-stretch, 1-slim-stretch, 1.28-slim-stretch, slim-stretch, 1.28.0-slim, 1-slim, 1.28-slim, slim
+Tags: 1.29.0-slim-stretch, 1-slim-stretch, 1.28-slim-stretch, slim-stretch, 1.29.0-slim, 1-slim, 1.28-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: da8bc5716ede5f18748e4daa92f85e9a9d9c1454
-Directory: 1.28.0/stretch/slim
-
-Tags: 1.28.0-jessie, 1-jessie, 1.28-jessie, jessie
-Architectures: amd64, arm32v7, i386
-GitCommit: da8bc5716ede5f18748e4daa92f85e9a9d9c1454
-Directory: 1.28.0/jessie
-
-Tags: 1.28.0-slim-jessie, 1-slim-jessie, 1.28-slim-jessie, slim-jessie
-Architectures: amd64, arm32v7, i386
-GitCommit: da8bc5716ede5f18748e4daa92f85e9a9d9c1454
-Directory: 1.28.0/jessie/slim
+GitCommit: 46d75fee52b77161355ce8a4623d6afbfec0e63f
+Directory: 1.29.0/stretch/slim


### PR DESCRIPTION
We're dropping support for jessie images since that release is
obsoleted.