### PR TITLE
Update to current images for SL6 and SL7

### DIFF
--- a/library/sl
+++ b/library/sl
@@ -8,11 +8,11 @@ Tags: 7, latest
 Architectures: amd64
 GitFetch: refs/heads/7
 Directory: sl7
-GitCommit: 1bc6a746a62e6ef13afc53aa585be9368fa3538b
+GitCommit: b1a2cb1c4a0efc1965f3344f8bdf1c949c7b79c2
 
 # For the SL6 container
 Tags: 6
 Architectures: amd64
 GitFetch: refs/heads/6
 Directory: sl6
-GitCommit: 7c20e5b10d389e51577c54dd858bae0917620797
+GitCommit: 020b3e367c934ee9ce9987e2875fdd5d0761e82a


### PR DESCRIPTION
This commit should update SL6 and SL7 to the latest images.

Our commits clean up a missing signature on the SL6 image and slims SL7 down to a smaller history.