### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 2.1.2, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce00cfb3b3b27187354961b9efb5f81e41c38bf2
+GitCommit: 9d29c5d929829dc623e04ca8cc522fba2d6f87de
 Directory: 2/debian
 
 Tags: 2.1.2-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ce00cfb3b3b27187354961b9efb5f81e41c38bf2
+GitCommit: 9d29c5d929829dc623e04ca8cc522fba2d6f87de
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c39ad569186086a1c6c53110803737e74566a4a2
+GitCommit: 7b323446256b8d18a09233c83001cb1c2b4046bb
 Directory: 1/debian
 
 Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c39ad569186086a1c6c53110803737e74566a4a2
+GitCommit: 7b323446256b8d18a09233c83001cb1c2b4046bb
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/memcached
+++ b/library/memcached
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.5.10, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d87a2f33e826097cefdc3feec7f4a70ec8b047c
+GitCommit: 04dbe5166ad88cca06885b68bd44efedc9a13771
 Directory: debian
 
 Tags: 1.5.10-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ae7f6ef9e2e1d31b500ec843cbe4885876d7746a
+GitCommit: 04dbe5166ad88cca06885b68bd44efedc9a13771
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -99,31 +99,31 @@ GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.2-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.2, 4.1, unstable
+Tags: 4.1.3-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.3, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
+GitCommit: 95be7b40a25fdf699af4e2b04b7de7e6e107b7e9
 Directory: 4.1
 
-Tags: 4.1.2-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.2-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.2, 4.1, unstable
+Tags: 4.1.3-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 4958ee0a8a6b1ac1c3734b161db67371720b31b5
+GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.2-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.2-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.2, 4.1, unstable
+Tags: 4.1.3-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 4958ee0a8a6b1ac1c3734b161db67371720b31b5
+GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.2-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.2-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.2, 4.1, unstable
+Tags: 4.1.3-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 4958ee0a8a6b1ac1c3734b161db67371720b31b5
+GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/php
+++ b/library/php
@@ -4,297 +4,297 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0beta3-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0beta3-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0beta3-cli, 7.3-rc-cli, rc-cli, 7.3.0beta3, 7.3-rc, rc
+Tags: 7.3.0RC1-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC1-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC1-cli, 7.3-rc-cli, rc-cli, 7.3.0RC1, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/stretch/cli
 
-Tags: 7.3.0beta3-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0beta3-apache, 7.3-rc-apache, rc-apache
+Tags: 7.3.0RC1-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC1-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/stretch/apache
 
-Tags: 7.3.0beta3-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0beta3-fpm, 7.3-rc-fpm, rc-fpm
+Tags: 7.3.0RC1-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC1-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/stretch/fpm
 
-Tags: 7.3.0beta3-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0beta3-zts, 7.3-rc-zts, rc-zts
+Tags: 7.3.0RC1-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC1-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/stretch/zts
 
-Tags: 7.3.0beta3-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0beta3-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0beta3-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0beta3-alpine, 7.3-rc-alpine, rc-alpine
+Tags: 7.3.0RC1-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC1-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC1-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC1-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/alpine3.8/cli
 
-Tags: 7.3.0beta3-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0beta3-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.3.0RC1-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC1-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/alpine3.8/fpm
 
-Tags: 7.3.0beta3-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0beta3-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Tags: 7.3.0RC1-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC1-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 40176806407cec87a3d253067e83d2d0ceb2664d
+GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
 Directory: 7.3-rc/alpine3.8/zts
 
-Tags: 7.2.9-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.9-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.9-cli, 7.2-cli, 7-cli, cli, 7.2.9, 7.2, 7, latest
+Tags: 7.2.10-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.10-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.10-cli, 7.2-cli, 7-cli, cli, 7.2.10, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.9-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.9-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.10-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.10-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.9-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.9-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.10-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.10-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.9-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.9-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.10-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.10-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.9-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.9-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.9-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.9-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.10-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.10-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.10-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.10-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.9-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.9-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.10-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.10-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.9-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.9-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.10-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.10-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.8/zts
 
-Tags: 7.2.9-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.9-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.10-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.10-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.9-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.10-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.9-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.10-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.9-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.9-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
+Tags: 7.2.10-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.10-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.9-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
+Tags: 7.2.10-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.9-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
+Tags: 7.2.10-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.21-cli-stretch, 7.1-cli-stretch, 7.1.21-stretch, 7.1-stretch, 7.1.21-cli, 7.1-cli, 7.1.21, 7.1
+Tags: 7.1.22-cli-stretch, 7.1-cli-stretch, 7.1.22-stretch, 7.1-stretch, 7.1.22-cli, 7.1-cli, 7.1.22, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.21-apache-stretch, 7.1-apache-stretch, 7.1.21-apache, 7.1-apache
+Tags: 7.1.22-apache-stretch, 7.1-apache-stretch, 7.1.22-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.21-fpm-stretch, 7.1-fpm-stretch, 7.1.21-fpm, 7.1-fpm
+Tags: 7.1.22-fpm-stretch, 7.1-fpm-stretch, 7.1.22-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.21-zts-stretch, 7.1-zts-stretch, 7.1.21-zts, 7.1-zts
+Tags: 7.1.22-zts-stretch, 7.1-zts-stretch, 7.1.22-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.21-cli-jessie, 7.1-cli-jessie, 7.1.21-jessie, 7.1-jessie
+Tags: 7.1.22-cli-jessie, 7.1-cli-jessie, 7.1.22-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.21-apache-jessie, 7.1-apache-jessie
+Tags: 7.1.22-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.21-fpm-jessie, 7.1-fpm-jessie
+Tags: 7.1.22-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.21-zts-jessie, 7.1-zts-jessie
+Tags: 7.1.22-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.21-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.21-alpine3.8, 7.1-alpine3.8, 7.1.21-cli-alpine, 7.1-cli-alpine, 7.1.21-alpine, 7.1-alpine
+Tags: 7.1.22-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.22-alpine3.8, 7.1-alpine3.8, 7.1.22-cli-alpine, 7.1-cli-alpine, 7.1.22-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.8/cli
 
-Tags: 7.1.21-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.21-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.22-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.22-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.8/fpm
 
-Tags: 7.1.21-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.21-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.22-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.22-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.8/zts
 
-Tags: 7.1.21-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.21-alpine3.7, 7.1-alpine3.7
+Tags: 7.1.22-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.22-alpine3.7, 7.1-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.21-fpm-alpine3.7, 7.1-fpm-alpine3.7
+Tags: 7.1.22-fpm-alpine3.7, 7.1-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.21-zts-alpine3.7, 7.1-zts-alpine3.7
+Tags: 7.1.22-zts-alpine3.7, 7.1-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
 Directory: 7.1/alpine3.7/zts
 
-Tags: 7.0.31-cli-stretch, 7.0-cli-stretch, 7.0.31-stretch, 7.0-stretch, 7.0.31-cli, 7.0-cli, 7.0.31, 7.0
+Tags: 7.0.32-cli-stretch, 7.0-cli-stretch, 7.0.32-stretch, 7.0-stretch, 7.0.32-cli, 7.0-cli, 7.0.32, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/stretch/cli
 
-Tags: 7.0.31-apache-stretch, 7.0-apache-stretch, 7.0.31-apache, 7.0-apache
+Tags: 7.0.32-apache-stretch, 7.0-apache-stretch, 7.0.32-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/stretch/apache
 
-Tags: 7.0.31-fpm-stretch, 7.0-fpm-stretch, 7.0.31-fpm, 7.0-fpm
+Tags: 7.0.32-fpm-stretch, 7.0-fpm-stretch, 7.0.32-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/stretch/fpm
 
-Tags: 7.0.31-zts-stretch, 7.0-zts-stretch, 7.0.31-zts, 7.0-zts
+Tags: 7.0.32-zts-stretch, 7.0-zts-stretch, 7.0.32-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/stretch/zts
 
-Tags: 7.0.31-cli-jessie, 7.0-cli-jessie, 7.0.31-jessie, 7.0-jessie
+Tags: 7.0.32-cli-jessie, 7.0-cli-jessie, 7.0.32-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/jessie/cli
 
-Tags: 7.0.31-apache-jessie, 7.0-apache-jessie
+Tags: 7.0.32-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/jessie/apache
 
-Tags: 7.0.31-fpm-jessie, 7.0-fpm-jessie
+Tags: 7.0.32-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/jessie/fpm
 
-Tags: 7.0.31-zts-jessie, 7.0-zts-jessie
+Tags: 7.0.32-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/jessie/zts
 
-Tags: 7.0.31-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.31-alpine3.7, 7.0-alpine3.7, 7.0.31-cli-alpine, 7.0-cli-alpine, 7.0.31-alpine, 7.0-alpine
+Tags: 7.0.32-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.32-alpine3.7, 7.0-alpine3.7, 7.0.32-cli-alpine, 7.0-cli-alpine, 7.0.32-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/alpine3.7/cli
 
-Tags: 7.0.31-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.31-fpm-alpine, 7.0-fpm-alpine
+Tags: 7.0.32-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.32-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/alpine3.7/fpm
 
-Tags: 7.0.31-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.31-zts-alpine, 7.0-zts-alpine
+Tags: 7.0.32-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.32-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: 2e12f1a8b59960c71b1dae4b5593bcc15aa8b05c
 Directory: 7.0/alpine3.7/zts
 
-Tags: 5.6.37-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.37-stretch, 5.6-stretch, 5-stretch, 5.6.37-cli, 5.6-cli, 5-cli, 5.6.37, 5.6, 5
+Tags: 5.6.38-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.38-stretch, 5.6-stretch, 5-stretch, 5.6.38-cli, 5.6-cli, 5-cli, 5.6.38, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/stretch/cli
 
-Tags: 5.6.37-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.37-apache, 5.6-apache, 5-apache
+Tags: 5.6.38-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.38-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/stretch/apache
 
-Tags: 5.6.37-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.37-fpm, 5.6-fpm, 5-fpm
+Tags: 5.6.38-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.38-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/stretch/fpm
 
-Tags: 5.6.37-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.37-zts, 5.6-zts, 5-zts
+Tags: 5.6.38-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.38-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/stretch/zts
 
-Tags: 5.6.37-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.37-jessie, 5.6-jessie, 5-jessie
+Tags: 5.6.38-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.38-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/jessie/cli
 
-Tags: 5.6.37-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
+Tags: 5.6.38-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/jessie/apache
 
-Tags: 5.6.37-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
+Tags: 5.6.38-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/jessie/fpm
 
-Tags: 5.6.37-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
+Tags: 5.6.38-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/jessie/zts
 
-Tags: 5.6.37-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.37-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.37-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.37-alpine, 5.6-alpine, 5-alpine
+Tags: 5.6.38-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.38-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.38-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.38-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.8/cli
 
-Tags: 5.6.37-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.37-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
+Tags: 5.6.38-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.38-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.8/fpm
 
-Tags: 5.6.37-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.37-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
+Tags: 5.6.38-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.38-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.8/zts
 
-Tags: 5.6.37-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.37-alpine3.7, 5.6-alpine3.7, 5-alpine3.7
+Tags: 5.6.38-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.38-alpine3.7, 5.6-alpine3.7, 5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.7/cli
 
-Tags: 5.6.37-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7
+Tags: 5.6.38-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.7/fpm
 
-Tags: 5.6.37-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7
+Tags: 5.6.38-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 88189f016803224152e3b1d96b11a573b3762559
+GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.7/zts

--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0-rc4, 5.0-rc, 5.0-rc4-stretch, 5.0-rc-stretch
+Tags: 5.0-rc5, 5.0-rc, 5.0-rc5-stretch, 5.0-rc-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
+GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
 Directory: 5.0-rc
 
-Tags: 5.0-rc4-32bit, 5.0-rc-32bit, 5.0-rc4-32bit-stretch, 5.0-rc-32bit-stretch
+Tags: 5.0-rc5-32bit, 5.0-rc-32bit, 5.0-rc5-32bit-stretch, 5.0-rc-32bit-stretch
 Architectures: amd64
-GitCommit: e95c0cf4ffd9a52aa48d05b93fe3b42069c05032
+GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
 Directory: 5.0-rc/32bit
 
-Tags: 5.0-rc4-alpine, 5.0-rc-alpine, 5.0-rc4-alpine3.8, 5.0-rc-alpine3.8
+Tags: 5.0-rc5-alpine, 5.0-rc-alpine, 5.0-rc5-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
+GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/b9e495c8e400363e6cc2d4db6d944235b7989584/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/bb5c7101e13cfa3632dfc21245b172c205d90353/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -14,7 +14,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
 Directory: 2.6-rc/stretch/slim
 
-Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: e7d27d514f15f3bffdc7fac383a8b83494317d47
+Directory: 2.6-rc/alpine3.8
+
+Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.6-rc/alpine3.7
@@ -84,7 +89,12 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
 Directory: 2.3/jessie/slim
 
-Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
+Tags: 2.3.7-alpine3.8, 2.3-alpine3.8, 2.3.7-alpine, 2.3-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: e7d27d514f15f3bffdc7fac383a8b83494317d47
+Directory: 2.3/alpine3.8
+
+Tags: 2.3.7-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.3/alpine3.7

--- a/library/ruby
+++ b/library/ruby
@@ -16,7 +16,7 @@ Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
+GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
@@ -31,7 +31,7 @@ Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
+GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
@@ -56,12 +56,12 @@ Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
+GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
+GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
@@ -86,5 +86,5 @@ Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 55b509b397ec2bc7d0e626fcca08310eb5f59981
+GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `ghost`: ghost-cli 1.9.3
- `memcached`: update UID to 11211 (docker-library/memcached#41)
- `mongo`: 4.1.3
- `php`: 7.1.22, 5.6.38, 7.2.10, 7.3.0RC1, 7.0.32
- `redis`: 5.0-rc5
- `ruby`: use `apk --no-network` (docker-library/ruby#231), add some Alpine 3.8 (https://github.com/docker-library/ruby/pull/232)