### PR TITLE
Add arm64v8 support to silverpeas

### DIFF
--- a/library/silverpeas
+++ b/library/silverpeas
@@ -1,7 +1,8 @@
 # This file is generated via https://github.com/Silverpeas/docker-silverpeas-prod/blob/master/generate-docker-library.sh
 Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
+Architectures: amd64, arm64v8
 
 Tags: 6.0.1, latest
-GitCommit: 43daef47765ff3acc21c4d856a0bc3e09f2e9de3
+GitCommit: 3e3e2ce680e57828a145151a2ee609b34e1501d2
 


### PR DESCRIPTION
Silverpeas already supports ```arm64v8``` architecture in GitHub code.
This **PR** has been raised to add ```arm64v8``` support for ```silverpeas``` in Docker-Hub.

Regards,
