### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 5.6.11, 5.6, 5, latest
-GitCommit: 7e5d336cf3dc472756dd0e19c1d2cf62a011bcf4
+Tags: 5.6.12, 5.6, 5, latest
+GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
 Directory: 5
 
-Tags: 5.6.11-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: 7e5d336cf3dc472756dd0e19c1d2cf62a011bcf4
+Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
 Directory: 5/alpine
 
 Tags: 2.4.6, 2.4, 2

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.1.2, 2.1, 2, latest
+Tags: 2.1.3, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d29c5d929829dc623e04ca8cc522fba2d6f87de
+GitCommit: 7566f8c9733df6b86732779cab40bd7b2807e654
 Directory: 2/debian
 
-Tags: 2.1.2-alpine, 2.1-alpine, 2-alpine, alpine
+Tags: 2.1.3-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9d29c5d929829dc623e04ca8cc522fba2d6f87de
+GitCommit: 7566f8c9733df6b86732779cab40bd7b2807e654
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 5.6.11, 5.6, 5, latest
-GitCommit: d87da97dff0d4510a841b866f8f4bddd8e0f5811
+Tags: 5.6.12, 5.6, 5, latest
+GitCommit: 958ce4b1abe560d2cbbe6a74168d13031cb1e106
 Directory: 5
 
 Tags: 4.6.6, 4.6, 4

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.11, 5.6, 5, latest
-GitCommit: bac815b8aee26043274d82bfe9d11a1b6c6cc51f
+Tags: 5.6.12, 5.6, 5, latest
+GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
 Directory: 5
 
-Tags: 5.6.11-alpine, 5.6-alpine, 5-alpine, alpine
-GitCommit: bac815b8aee26043274d82bfe9d11a1b6c6cc51f
+Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine, alpine
+GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
 Directory: 5/alpine
 
 Tags: 2.4.1, 2.4, 2

--- a/library/matomo
+++ b/library/matomo
@@ -1,18 +1,18 @@
-# This file is generated via https://github.com/matomo-org/docker/blob/fd6d19b262068216213f41162e3b33bed54847fe/generate-stackbrew-library.sh
+# This file is generated via https://github.com/matomo-org/docker/blob/d1f85155be775e20bd66346db2ea5025d40e275d/generate-stackbrew-library.sh
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.5.1-apache, 3.5-apache, 3-apache, apache, 3.5.1, 3.5, 3, latest
+Tags: 3.6.0-apache, 3.6-apache, 3-apache, apache, 3.6.0, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: apache
 
-Tags: 3.5.1-fpm, 3.5-fpm, 3-fpm, fpm
+Tags: 3.6.0-fpm, 3.6-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: fpm
 
-Tags: 3.5.1-fpm-alpine, 3.5-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.6.0-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: fpm-alpine

--- a/library/mongo
+++ b/library/mongo
@@ -9,20 +9,20 @@ SharedTags: 3.2.21, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
+GitCommit: 0d81416797611e471ec456ec99306c987a224418
 Directory: 3.2
 
 Tags: 3.2.21-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
 SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
 Architectures: windows-amd64
-GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.2.21-windowsservercore-1709, 3.2-windowsservercore-1709
 SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
 Architectures: windows-amd64
-GitCommit: 00c36756db79ec88574eb7543832c8fb298fb4fc
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -31,42 +31,42 @@ SharedTags: 3.4.17, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
+GitCommit: 0d81416797611e471ec456ec99306c987a224418
 Directory: 3.4
 
 Tags: 3.4.17-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
 SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
 Architectures: windows-amd64
-GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.4.17-windowsservercore-1709, 3.4-windowsservercore-1709
 SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
 Architectures: windows-amd64
-GitCommit: 3b897b8fcac8482bb6a3e5b6617371ec2e84da07
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.7-stretch, 3.6-stretch, 3-stretch
-SharedTags: 3.6.7, 3.6, 3
+Tags: 3.6.8-stretch, 3.6-stretch, 3-stretch
+SharedTags: 3.6.8, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 2fdc4a20575449775346b5c56bfc478cdba0caa9
+GitCommit: 8a8bab64bb7e70e230da6217651155747a5d3974
 Directory: 3.6
 
-Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.7, 3.6, 3
+Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.8, 3.6, 3
 Architectures: windows-amd64
-GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.7-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
-SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.7, 3.6, 3
+Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.8, 3.6, 3
 Architectures: windows-amd64
-GitCommit: c47466bb5eaecfa3b6fcf54a492b2e1c57182af7
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -75,27 +75,27 @@ SharedTags: 4.0.2, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 36a011c5f198ad05c47310284795ad029d8340ba
+GitCommit: 0d81416797611e471ec456ec99306c987a224418
 Directory: 4.0
 
 Tags: 4.0.2-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 4.0.2-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
 SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 4.0.2-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
 SharedTags: 4.0.2-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.2, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: f4e1d147084c6c7479782f68c8e392ec8b5da19a
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -104,26 +104,26 @@ SharedTags: 4.1.3, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 95be7b40a25fdf699af4e2b04b7de7e6e107b7e9
+GitCommit: 0d81416797611e471ec456ec99306c987a224418
 Directory: 4.1
 
 Tags: 4.1.3-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
 SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 4.1.3-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
 SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 4.1.3-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
 SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: ba0482d1a0906a5f3463b0e7411b66805e9489da
+GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-10-jdk-windowsservercore-ltsc2016, 12-ea-10-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-11-jdk-windowsservercore-ltsc2016, 12-ea-11-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-10-jdk-windowsservercore-1709, 12-ea-10-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-11-jdk-windowsservercore-1709, 12-ea-11-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-10-jdk-windowsservercore-1803, 12-ea-10-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-10-jdk-windowsservercore, 12-ea-10-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-11-jdk-windowsservercore-1803, 12-ea-11-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 918514c9b313f8f60580b1e3638eb2ae60ef5e7f
+GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -35,24 +35,24 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
 Directory: 11/jdk/slim
 
-Tags: 11-28-jdk-windowsservercore-ltsc2016, 11-28-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-ea-28-jdk-windowsservercore-ltsc2016, 11-ea-28-windowsservercore-ltsc2016, 11-ea-jdk-windowsservercore-ltsc2016, 11-ea-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11-28-jdk-windowsservercore-1709, 11-28-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
-SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-ea-28-jdk-windowsservercore-1709, 11-ea-28-windowsservercore-1709, 11-ea-jdk-windowsservercore-1709, 11-ea-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
+SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11-28-jdk-windowsservercore-1803, 11-28-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11-28-jdk-windowsservercore, 11-28-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-ea-28-jdk-windowsservercore-1803, 11-ea-28-windowsservercore-1803, 11-ea-jdk-windowsservercore-1803, 11-ea-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bf06437449e8ae1782905f6c2df744805498874b
+GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/owncloud
+++ b/library/owncloud
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/owncloud.git
 
-Tags: 10.0.9-apache, 10.0-apache, 10-apache, apache, 10.0.9, 10.0, 10, latest
+Tags: 10.0.10-apache, 10.0-apache, 10-apache, apache, 10.0.10, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
+GitCommit: b70c794c5b9f437c14331772873cf49e668c7042
 Directory: 10.0/apache
 
-Tags: 10.0.9-fpm, 10.0-fpm, 10-fpm, fpm
+Tags: 10.0.10-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
+GitCommit: b70c794c5b9f437c14331772873cf49e668c7042
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9

--- a/library/piwik
+++ b/library/piwik
@@ -1,18 +1,18 @@
-# This file is generated via https://github.com/matomo-org/docker/blob/fd6d19b262068216213f41162e3b33bed54847fe/generate-stackbrew-library.sh
+# This file is generated via https://github.com/matomo-org/docker/blob/d1f85155be775e20bd66346db2ea5025d40e275d/generate-stackbrew-library.sh
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.5.1-apache, 3.5-apache, 3-apache, apache, 3.5.1, 3.5, 3, latest
+Tags: 3.6.0-apache, 3.6-apache, 3-apache, apache, 3.6.0, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: apache
 
-Tags: 3.5.1-fpm, 3.5-fpm, 3-fpm, fpm
+Tags: 3.6.0-fpm, 3.6-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: fpm
 
-Tags: 3.5.1-fpm-alpine, 3.5-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.6.0-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 89d38796efe1063e84d8dee3e7c74d04cb240abc
+GitCommit: b711c66be5de3caade38361bd974134e1291a929
 Directory: fpm-alpine

--- a/library/ruby
+++ b/library/ruby
@@ -6,95 +6,95 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
+GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e4d795f70df296f79b1272b665cc0c970e58fe2
+GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e7d27d514f15f3bffdc7fac383a8b83494317d47
+GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
+GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
+GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a04dd5259eaef8d682dae2bb709f03219a6e5905
+GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
+GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7ccc7ba6924a2abb902da99dae82aadde9b0581
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
+GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 4fa4c114e81bf8bdb653262c033da1d3fafa9141
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.8, 2.3-alpine3.8, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e7d27d514f15f3bffdc7fac383a8b83494317d47
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96967d8295f1b26a784e5893f41b5f5ccd8318eb
+GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `elasticsearch`: 5.6.12
- `ghost`: 2.1.3
- `kibana`: 5.6.12
- `logstash`: 5.6.12
- `matomo`: 3.6.0
- `mongo`: fix Windows TLS
- `openjdk`: 12-ea+11, fix Windows version numbers for 11
- `owncloud`: 10.0.10
- `piwik`: 3.6.0
- `ruby`: bundler 1.16.5