### PR TITLE
Update haproxy to 1.8.14

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,12 +34,12 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
 Directory: 1.7/alpine
 
-Tags: 1.8.13, 1.8, 1, latest
+Tags: 1.8.14, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
+GitCommit: 9da24940385e6178f987737305ff499734437c90
 Directory: 1.8
 
-Tags: 1.8.13-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.14-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
+GitCommit: 9da24940385e6178f987737305ff499734437c90
 Directory: 1.8/alpine


### PR DESCRIPTION
This fixes CVE-2018-14645.