### PR TITLE
Bump Traefik to v1.7.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,38 +1,20 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v1.7.0-rc5, 1.7.0-rc5, v1.7, 1.7, maroilles
+Tags: v1.7.0, 1.7.0, v1.7, 1.7, maroilles, latest
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 46ca01f945229d77d8cdf1ee7345508460ef99bd
+GitCommit: cd926d586b87791aca0cebe2eb51889b678a84e0
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v1.7.0-rc5-alpine, 1.7.0-rc5-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.0-alpine, 1.7.0-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine, alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 46ca01f945229d77d8cdf1ee7345508460ef99bd
+GitCommit: cd926d586b87791aca0cebe2eb51889b678a84e0
 Directory: alpine
 
-Tags: v1.7.0-rc5-nanoserver, 1.7.0-rc5-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.0-rc5-nanoserver-sac2016, 1.7.0-rc5-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016
+Tags: v1.7.0-nanoserver, 1.7.0-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.0-nanoserver-sac2016, 1.7.0-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016, nanoserver, nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 46ca01f945229d77d8cdf1ee7345508460ef99bd
-Directory: windows
-Constraints: nanoserver-sac2016
-
-Tags: v1.6.6, 1.6.6, v1.6, 1.6, tetedemoine, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: d95245ee706fbe031fe4d62564015cb4fb1f076d
-amd64-Directory: scratch/amd64
-arm32v6-Directory: scratch/arm
-arm64v8-Directory: scratch/arm64
-
-Tags: v1.6.6-alpine, 1.6.6-alpine, v1.6-alpine, 1.6-alpine, tetedemoine-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: d95245ee706fbe031fe4d62564015cb4fb1f076d
-Directory: alpine
-
-Tags: v1.6.6-nanoserver, 1.6.6-nanoserver, v1.6-nanoserver, 1.6-nanoserver, tetedemoine-nanoserver, v1.6.6-nanoserver-sac2016, 1.6.6-nanoserver-sac2016, v1.6-nanoserver-sac2016, 1.6-nanoserver-sac2016, tetedemoine-nanoserver-sac2016, nanoserver, nanoserver-sac2016
-Architectures: windows-amd64
-GitCommit: d95245ee706fbe031fe4d62564015cb4fb1f076d
+GitCommit: cd926d586b87791aca0cebe2eb51889b678a84e0
 Directory: windows
 Constraints: nanoserver-sac2016


### PR DESCRIPTION

Hello,

This PR updates Traefik to v1.7.0.

/cc @vdemeester @emilevauge

Cheers
