### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -1,11 +1,16 @@
-# this file is generated via https://github.com/tianon/docker-bash/blob/81f17babadb63ed497cb43c48442633a15989fef/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-bash/blob/bbffeabe24a9edabc79ef2e5f6418a70e09abafc/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
+Tags: 5.0-beta, 5.0-rc, rc
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: bbffeabe24a9edabc79ef2e5f6418a70e09abafc
+Directory: 5.0-rc
+
 Tags: 4.4.23, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9ff9f21578dc27e4dc1ce3ed1136394bbb461e5b
 Directory: 4.4
 
 Tags: 4.3.48, 4.3

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.1.3, 2.1, 2, latest
+Tags: 2.1.4, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7566f8c9733df6b86732779cab40bd7b2807e654
+GitCommit: b55768081c3382215bc6a7c166ae217abaecd636
 Directory: 2/debian
 
-Tags: 2.1.3-alpine, 2.1-alpine, 2-alpine, alpine
+Tags: 2.1.4-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7566f8c9733df6b86732779cab40bd7b2807e654
+GitCommit: b55768081c3382215bc6a7c166ae217abaecd636
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1

--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.34, 2.4, 2, latest
+Tags: 2.4.35, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 38842a5d4cdd44ff4888e8540c0da99009790d01
+GitCommit: 152fc858992b2d8edb91794864e531664ca39c05
 Directory: 2.4
 
-Tags: 2.4.34-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.35-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 38842a5d4cdd44ff4888e8540c0da99009790d01
+GitCommit: 4d73c6a3b77f6175c50f51fdfe5243b1ae3ddca8
 Directory: 2.4/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -9,9 +9,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 4891ee2e3bd2dc6b07db634a39433ad579764a4b
 Directory: 10.3
 
-Tags: 10.2.17-bionic, 10.2-bionic, 10.2.17, 10.2
+Tags: 10.2.18-bionic, 10.2-bionic, 10.2.18, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f5c3481f84205d7601cde45777f0c939c01eb7d6
+GitCommit: d42959d5f5772f70f71d433f843836a7401a07fd
 Directory: 10.2
 
 Tags: 10.1.36-bionic, 10.1-bionic, 10.1.36, 10.1
@@ -20,8 +20,8 @@ GitCommit: b678346ca1c832c93ecf0969f2738268d065dd8f
 Directory: 10.1
 
 Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0
-Architectures: amd64, i386, ppc64le
-GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
+Architectures: amd64, arm64v8, i386, ppc64le
+GitCommit: cf769b4ec7ce7b343bd3b04225ab2a9bdd6bdc6e
 Directory: 10.0
 
 Tags: 5.5.61-trusty, 5.5-trusty, 5-trusty, 5.5.61, 5.5, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-11-jdk-windowsservercore-ltsc2016, 12-ea-11-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-12-jdk-windowsservercore-ltsc2016, 12-ea-12-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
+GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-11-jdk-windowsservercore-1709, 12-ea-11-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-12-jdk-windowsservercore-1709, 12-ea-12-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
+GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-11-jdk-windowsservercore-1803, 12-ea-11-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-11-jdk-windowsservercore, 12-ea-11-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-12-jdk-windowsservercore-1803, 12-ea-12-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0ec2a0d41bebbff50f9537b58d258b6e551b0dce
+GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.7/alpine/management
 
 Tags: 3.6.16, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
+GitCommit: 406d5ee14aec24f9012ce204dc6aa0e5400a649d
 Directory: 3.6/debian
 
 Tags: 3.6.16-management, 3.6-management
@@ -36,7 +36,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 13c512c0250e86d1b1a48200daa8d041d24b1894
+GitCommit: 406d5ee14aec24f9012ce204dc6aa0e5400a649d
 Directory: 3.6/alpine
 
 Tags: 3.6.16-management-alpine, 3.6-management-alpine

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: a28035fd89602f1e3573057ca7277d3e859fc7d7
+GitCommit: 3620c44581073acbafa5ee848025122e350b39e0
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
@@ -19,5 +19,5 @@ GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: a28035fd89602f1e3573057ca7277d3e859fc7d7
+GitCommit: 3620c44581073acbafa5ee848025122e350b39e0
 Directory: 3.3/passenger


### PR DESCRIPTION
- `bash`: 5.0-beta
- `ghost`: 2.1.4
- `httpd`: 2.4.35
- `mariadb`: 10.2.18, add `arm64v8` to 10.0
- `openjdk`: 12-ea+12 (windows)
- `rabbitmq`: minor comment update
- `redmine`: passenger 5.3.5