### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,76 +4,76 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-12-jdk-windowsservercore-ltsc2016, 12-ea-12-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-13-jdk-windowsservercore-ltsc2016, 12-ea-13-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
+GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-12-jdk-windowsservercore-1709, 12-ea-12-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-13-jdk-windowsservercore-1709, 12-ea-13-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
+GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-12-jdk-windowsservercore-1803, 12-ea-12-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-12-jdk-windowsservercore, 12-ea-12-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-13-jdk-windowsservercore-1803, 12-ea-13-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: ea58310ec57fed8d5eedc7ed30eb7d0a26ebc574
+GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-ea-28-jdk-sid, 11-ea-28-sid, 11-ea-jdk-sid, 11-ea-sid, 11-jdk-sid, 11-sid, 11-ea-28-jdk, 11-ea-28, 11-ea-jdk, 11-ea, 11-jdk, 11
+Tags: 11-jdk-sid, 11-sid, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jdk
 
-Tags: 11-ea-28-jdk-slim-sid, 11-ea-28-slim-sid, 11-ea-jdk-slim-sid, 11-ea-slim-sid, 11-jdk-slim-sid, 11-slim-sid, 11-ea-28-jdk-slim, 11-ea-28-slim, 11-ea-jdk-slim, 11-ea-slim, 11-jdk-slim, 11-slim
+Tags: 11-jdk-slim-sid, 11-slim-sid, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jdk/slim
 
-Tags: 11-ea-28-jdk-windowsservercore-ltsc2016, 11-ea-28-windowsservercore-ltsc2016, 11-ea-jdk-windowsservercore-ltsc2016, 11-ea-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11-ea-28-jdk-windowsservercore-1709, 11-ea-28-windowsservercore-1709, 11-ea-jdk-windowsservercore-1709, 11-ea-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
-SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11-ea-28-jdk-windowsservercore-1803, 11-ea-28-windowsservercore-1803, 11-ea-jdk-windowsservercore-1803, 11-ea-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11-ea-28-jdk-windowsservercore, 11-ea-28-windowsservercore, 11-ea-jdk-windowsservercore, 11-ea-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: a7b5f34846cbad5712619ea11d686ad6be56e922
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-ea-28-jre-sid, 11-ea-jre-sid, 11-jre-sid, 11-ea-28-jre, 11-ea-jre, 11-jre
+Tags: 11-jre-sid, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jre
 
-Tags: 11-ea-28-jre-slim-sid, 11-ea-jre-slim-sid, 11-jre-slim-sid, 11-ea-28-jre-slim, 11-ea-jre-slim, 11-jre-slim
+Tags: 11-jre-slim-sid, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecb81629f5d5f226491e9f3e0a5be11662f72870
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jre/slim
 
-Tags: 10.0.2-13-jdk-sid, 10.0.2-13-sid, 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-13-jdk, 10.0.2-13, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest
+Tags: 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jdk
 
-Tags: 10.0.2-13-jdk-slim-sid, 10.0.2-13-slim-sid, 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, jdk-slim-sid, slim-sid, 10.0.2-13-jdk-slim, 10.0.2-13-slim, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim, jdk-slim, slim
+Tags: 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, jdk-slim-sid, slim-sid, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jdk/slim
 
 Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -97,14 +97,14 @@ GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 10.0.2-13-jre-sid, 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, jre-sid, 10.0.2-13-jre, 10.0.2-jre, 10.0-jre, 10-jre, jre
+Tags: 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, jre-sid, 10.0.2-jre, 10.0-jre, 10-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jre
 
-Tags: 10.0.2-13-jre-slim-sid, 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, jre-slim-sid, 10.0.2-13-jre-slim, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim, jre-slim
+Tags: 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, jre-slim-sid, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d143fd9932ee055c5658adea2f263eed48d04ad
+GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jre/slim
 
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.69.2, 0.69, 0, latest
-GitCommit: bc47cba5626cfbc2eb78973fe15bfab2964d4e1b
+Tags: 0.70.0, 0.70, 0, latest
+GitCommit: 2749acc385aa6f2a394eec075d305707e4611d1c


### PR DESCRIPTION
- `openjdk`: 11 GA, 12-ea+13
- `rocket.chat`: 0.70.0