### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,48 +1,48 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/484912aeda0c3a52f87e063e7c903ac02006a397/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/70624b0473d43006ecb72ed0301608567a27abce/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 484912aeda0c3a52f87e063e7c903ac02006a397
+GitCommit: 70624b0473d43006ecb72ed0301608567a27abce
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a36744245bff4234c130f994eee2e7ba4d3b745a
+amd64-GitCommit: 0b299265b6140985a88913133261b93d5a2c2c19
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: b4273a83999b4b1b6b5b2d0c37b54850fd0f3913
+arm32v5-GitCommit: e3d0eb49bc2e66ef25202849d09e7d8baa120845
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: d13c9a331721e43a5f482afa03df50248bd509f7
+arm32v6-GitCommit: eb985e24967902bfdf6a5ec3fabaf49251e2d76d
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: dd41f16609c5b6742bf8c19da7915bb79130447b
+arm32v7-GitCommit: 238ae1cff3074d4358e8671056b43ac3f6f8e93f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 377173e695adb0d1a0f81353a47af93e89e61614
+arm64v8-GitCommit: 1a8a22485bd77156c946eaa1d534110d75c24514
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6eb9e5be868517a9849bd55766664a69600bdf45
+i386-GitCommit: 1be2d6ee59fe9b585f81ec965defe62608206950
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 962dbd69ca6c3e0345ca36fe69e81c9066772290
+ppc64le-GitCommit: 4aded97ae4afd237eb89bd7db14c4ca6a5f48570
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: c0249457fa478ad3cae0832e01c2ec3cd26f5525
+s390x-GitCommit: 971c57858d77ed05c79773f7976ee997527829ce
 
-Tags: 1.29.2-uclibc, 1.29-uclibc, 1-uclibc, uclibc
+Tags: 1.29.3-uclibc, 1.29-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: uclibc
 
-Tags: 1.29.2-glibc, 1.29-glibc, 1-glibc, glibc
+Tags: 1.29.3-glibc, 1.29-glibc, 1-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: glibc
 
-Tags: 1.29.2-musl, 1.29-musl, 1-musl, musl
+Tags: 1.29.3-musl, 1.29-musl, 1-musl, musl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: musl
 
-Tags: 1.29.2, 1.29, 1, latest
+Tags: 1.29.3, 1.29, 1, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
 arm32v5-Directory: uclibc

--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: 986cea9cdfbf38ae611bdfbd14f1b1cc17194e0c
+GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
 Directory: 2.1
 
 Tags: 2.2.13, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 9182976ad885af573aaefaabd99432d0c3c2fa6a
+GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
 Directory: 2.2
 
 Tags: 3.0.17, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 290059ff8dfece6b7db18365c7172fac0f007c83
+GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
 Directory: 3.0
 
 Tags: 3.11.3, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 4474c6c5cc2a81ee57c5615aae00555fca7e26a6
+GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
 Directory: 3.11

--- a/library/ghost
+++ b/library/ghost
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 2.1.4, 2.1, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b55768081c3382215bc6a7c166ae217abaecd636
+GitCommit: fe5b8950bbb0127df35421b8d801fff3f7a94ca1
 Directory: 2/debian
 
 Tags: 2.1.4-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b55768081c3382215bc6a7c166ae217abaecd636
+GitCommit: fe5b8950bbb0127df35421b8d801fff3f7a94ca1
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b323446256b8d18a09233c83001cb1c2b4046bb
+GitCommit: 9fc9c0a2009ab4302a80c88618a0e3640b2b78c6
 Directory: 1/debian
 
 Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b323446256b8d18a09233c83001cb1c2b4046bb
+GitCommit: 9fc9c0a2009ab4302a80c88618a0e3640b2b78c6
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4e1e58723ab0c2aac695aacf08a6fd54b4d2eee
+GitCommit: d14e83ced34cd574b9473023e2765683f4e99e65
 Directory: 0/debian
 
 Tags: 0.11.13-alpine, 0.11-alpine, 0-alpine
 Architectures: amd64
-GitCommit: f0cfbd2cd2bdbaea10a4f15cd05746397e84dd18
+GitCommit: 9fc9c0a2009ab4302a80c88618a0e3640b2b78c6
 Directory: 0/alpine

--- a/library/julia
+++ b/library/julia
@@ -4,30 +4,30 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.0.0-stretch, 1.0-stretch, 1-stretch, stretch
-SharedTags: 1.0.0, 1.0, 1, latest
-Architectures: amd64, arm32v7, i386
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+Tags: 1.0.1-stretch, 1.0-stretch, 1-stretch, stretch
+SharedTags: 1.0.1, 1.0, 1, latest
+Architectures: amd64, i386
+GitCommit: bc6c8bde792335ec4b97ae58bbad10e965ecfaed
 Directory: 1.0/stretch
 
-Tags: 1.0.0-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.0.0, 1.0, 1, latest
+Tags: 1.0.1-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.0.1, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
+GitCommit: bc6c8bde792335ec4b97ae58bbad10e965ecfaed
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.0.0-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.0.0, 1.0, 1, latest
+Tags: 1.0.1-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.0.1, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
+GitCommit: bc6c8bde792335ec4b97ae58bbad10e965ecfaed
 Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.0.0-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.0.0, 1.0, 1, latest
+Tags: 1.0.1-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.0.1, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 5407cd3df30c7c0a5f416f5d61341cf960f8139f
+GitCommit: bc6c8bde792335ec4b97ae58bbad10e965ecfaed
 Directory: 1.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,25 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.3.9-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.9, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4891ee2e3bd2dc6b07db634a39433ad579764a4b
+GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
 Directory: 10.3
 
 Tags: 10.2.18-bionic, 10.2-bionic, 10.2.18, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: d42959d5f5772f70f71d433f843836a7401a07fd
+GitCommit: 81ad56cf6bdf82666da60d828247684fda142c03
 Directory: 10.2
 
 Tags: 10.1.36-bionic, 10.1-bionic, 10.1.36, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b678346ca1c832c93ecf0969f2738268d065dd8f
+GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
 Directory: 10.1
 
 Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: cf769b4ec7ce7b343bd3b04225ab2a9bdd6bdc6e
+GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
 Directory: 10.0
 
 Tags: 5.5.61-trusty, 5.5-trusty, 5-trusty, 5.5.61, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 350bb5974b3cb5ee71805d2b29812a76d7c6d393
+GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
 Directory: 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ SharedTags: 3.2.21, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 0d81416797611e471ec456ec99306c987a224418
+GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
 Directory: 3.2
 
 Tags: 3.2.21-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
@@ -31,7 +31,7 @@ SharedTags: 3.4.17, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 0d81416797611e471ec456ec99306c987a224418
+GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
 Directory: 3.4
 
 Tags: 3.4.17-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
@@ -53,7 +53,7 @@ SharedTags: 3.6.8, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 8a8bab64bb7e70e230da6217651155747a5d3974
+GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
 Directory: 3.6
 
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
@@ -75,7 +75,7 @@ SharedTags: 4.0.2, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 0d81416797611e471ec456ec99306c987a224418
+GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
 Directory: 4.0
 
 Tags: 4.0.2-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -104,7 +104,7 @@ SharedTags: 4.1.3, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 0d81416797611e471ec456ec99306c987a224418
+GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
 Directory: 4.1
 
 Tags: 4.1.3-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,29 +1,44 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/bf06437449e8ae1782905f6c2df744805498874b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/7d6b0528da55c7b74feff4f565c9dbb8907b8c9a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
+Tags: 12-ea-13-jdk-oraclelinux7, 12-ea-13-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-13-jdk-oracle, 12-ea-13-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+Architectures: amd64
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+Directory: 12/jdk/oracle
+
+Tags: 12-ea-12-jdk-alpine3.8, 12-ea-12-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-12-jdk-alpine, 12-ea-12-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Architectures: amd64
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+Directory: 12/jdk/alpine
+
 Tags: 12-ea-13-jdk-windowsservercore-ltsc2016, 12-ea-13-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
 SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 12-ea-13-jdk-windowsservercore-1709, 12-ea-13-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
 SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 12-ea-13-jdk-windowsservercore-1803, 12-ea-13-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
 SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 2eedac4afe8e587cb02cb7739d70e2c33c2b1421
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 11-jdk-oraclelinux7, 11-oraclelinux7, 11-jdk-oracle, 11-oracle
+Architectures: amd64
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+Directory: 11/jdk/oracle
 
 Tags: 11-jdk-sid, 11-sid, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -38,21 +53,21 @@ Directory: 11/jdk/slim
 Tags: 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
 SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
 SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
-GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -65,6 +80,11 @@ Tags: 11-jre-slim-sid, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 11/jre/slim
+
+Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle, jdk-oracle, oracle
+Architectures: amd64
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+Directory: 10/jdk/oracle
 
 Tags: 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -79,21 +99,21 @@ Directory: 10/jdk/slim
 Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 40a23ac72e90b05469c881a6fa9139476d3fa2a4
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -125,21 +145,21 @@ Directory: 8/jdk/alpine
 Tags: 8u181-jdk-windowsservercore-ltsc2016, 8u181-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u181-jdk-windowsservercore-1709, 8u181-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
 SharedTags: 8u181-jdk-windowsservercore, 8u181-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 8u181-jdk-nanoserver-sac2016, 8u181-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
 SharedTags: 8u181-jdk-nanoserver, 8u181-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 5527e8e319a1451b9e302af846b9939da36d8992
+GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/owncloud
+++ b/library/owncloud
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.10-apache, 10.0-apache, 10-apache, apache, 10.0.10, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b70c794c5b9f437c14331772873cf49e668c7042
+GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
 Directory: 10.0/apache
 
 Tags: 10.0.10-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b70c794c5b9f437c14331772873cf49e668c7042
+GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
+GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f7e38b9b8cc2cc22ddaec513f8a9b08f8e4578
+GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
 Directory: 9.1/fpm

--- a/library/percona
+++ b/library/percona
@@ -6,15 +6,15 @@ GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.23-stretch, 5.7-stretch, 5-stretch, stretch, 5.7.23, 5.7, 5, latest
 Architectures: amd64
-GitCommit: 0f9f131aaff61dd735195ca44e190d4ef4995335
+GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
 Directory: 5.7
 
 Tags: 5.6.41-stretch, 5.6-stretch, 5.6.41, 5.6
 Architectures: amd64
-GitCommit: e90d7a6c4dc7aa8317ec710095dce1bc848d9f5b
+GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
 Directory: 5.6
 
 Tags: 5.5.61-stretch, 5.5-stretch, 5.5.61, 5.5
 Architectures: amd64
-GitCommit: 7eed6eb52668ecaca933e68898d63d6f28d51af9
+GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0RC1-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC1-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC1-cli, 7.3-rc-cli, rc-cli, 7.3.0RC1, 7.3-rc, rc
+Tags: 7.3.0RC2-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC2-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC2-cli, 7.3-rc-cli, rc-cli, 7.3.0RC2, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/stretch/cli
 
-Tags: 7.3.0RC1-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC1-apache, 7.3-rc-apache, rc-apache
+Tags: 7.3.0RC2-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC2-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/stretch/apache
 
-Tags: 7.3.0RC1-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC1-fpm, 7.3-rc-fpm, rc-fpm
+Tags: 7.3.0RC2-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC2-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/stretch/fpm
 
-Tags: 7.3.0RC1-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC1-zts, 7.3-rc-zts, rc-zts
+Tags: 7.3.0RC2-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC2-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/stretch/zts
 
-Tags: 7.3.0RC1-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC1-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC1-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC1-alpine, 7.3-rc-alpine, rc-alpine
+Tags: 7.3.0RC2-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC2-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC2-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC2-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/alpine3.8/cli
 
-Tags: 7.3.0RC1-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC1-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.3.0RC2-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC2-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/alpine3.8/fpm
 
-Tags: 7.3.0RC1-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC1-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Tags: 7.3.0RC2-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC2-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 8982189eac80c6b0a427df33811a4a4e9f3e735d
+GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
 Directory: 7.3-rc/alpine3.8/zts
 
 Tags: 7.2.10-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.10-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.10-cli, 7.2-cli, 7-cli, cli, 7.2.10, 7.2, 7, latest

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.8, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d566a9b72ee43d891757a8515704ff87aef22d72
+GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
 Directory: 3.7/debian
 
 Tags: 3.7.8-management, 3.7-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.7/debian/management
 
 Tags: 3.7.8-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a57996987ef2d277ffbf101eff00649990bd72b
+GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
 Directory: 3.7/alpine
 
 Tags: 3.7.8-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.7/alpine/management
 
 Tags: 3.6.16, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 406d5ee14aec24f9012ce204dc6aa0e5400a649d
+GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
 Directory: 3.6/debian
 
 Tags: 3.6.16-management, 3.6-management
@@ -36,7 +36,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 406d5ee14aec24f9012ce204dc6aa0e5400a649d
+GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
 Directory: 3.6/alpine
 
 Tags: 3.6.16-management-alpine, 3.6-management-alpine

--- a/library/redis
+++ b/library/redis
@@ -6,45 +6,45 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 5.0-rc5, 5.0-rc, 5.0-rc5-stretch, 5.0-rc-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 5.0-rc
 
 Tags: 5.0-rc5-32bit, 5.0-rc-32bit, 5.0-rc5-32bit-stretch, 5.0-rc-32bit-stretch
 Architectures: amd64
-GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 5.0-rc/32bit
 
 Tags: 5.0-rc5-alpine, 5.0-rc-alpine, 5.0-rc5-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 10a0d470b8debe15540437e2395ad7c0525886f0
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0
 
 Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: 7900c5d31e0b3a4c463c57a8d69cc497d58fbe70
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0/32bit
 
 Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0/alpine
 
 Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53f86805506b103b503fd392e029929290fe5346
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 3.2
 
 Tags: 3.2.12-32bit, 3.2-32bit, 3-32bit, 3.2.12-32bit-stretch, 3.2-32bit-stretch, 3-32bit-stretch
 Architectures: amd64
-GitCommit: 53f86805506b103b503fd392e029929290fe5346
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 3.2/32bit
 
 Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine, 3.2.12-alpine3.8, 3.2-alpine3.8, 3-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f71b77c76b524260b9edd2397cacec51e87c4d33
+GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 3.2/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
+GitCommit: ba719a0b180982a45d994e0ab66ac7a4ea106bfe
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69082edc899cdbc69a00c4dd30d01f83fb59048f
+GitCommit: ba719a0b180982a45d994e0ab66ac7a4ea106bfe
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger

--- a/library/ruby
+++ b/library/ruby
@@ -16,12 +16,12 @@ Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
@@ -36,7 +36,7 @@ Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
@@ -61,12 +61,12 @@ Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
@@ -91,10 +91,10 @@ Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.8, 2.3-alpine3.8, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
 Directory: 2.3/alpine3.7

--- a/library/tomcat
+++ b/library/tomcat
@@ -34,36 +34,6 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: e0cfc71038fca93f3e1b54ef4a4db58fb506d5be
 Directory: 7/jre8-alpine
 
-Tags: 8.0.53-jre7, 8.0-jre7, 8.0.53, 8.0
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre7
-
-Tags: 8.0.53-jre7-slim, 8.0-jre7-slim, 8.0.53-slim, 8.0-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre7-slim
-
-Tags: 8.0.53-jre7-alpine, 8.0-jre7-alpine, 8.0.53-alpine, 8.0-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre7-alpine
-
-Tags: 8.0.53-jre8, 8.0-jre8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre8
-
-Tags: 8.0.53-jre8-slim, 8.0-jre8-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre8-slim
-
-Tags: 8.0.53-jre8-alpine, 8.0-jre8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf0fa74f05274f8e00e2a27ca0cc8e04d28f0ec
-Directory: 8.0/jre8-alpine
-
 Tags: 8.5.34-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.34, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd


### PR DESCRIPTION
- `busybox`: 1.29.3, Buildroot 2018.08, Alpine 3.8
- `cassandra`: fix `cassandra.yaml` modification (docker-library/cassandra#160), `chown` fixes (docker-library/cassandra#158)
- `ghost`: `chown` fixes (docker-library/ghost#153)
- `julia`: 1.0.1
- `mariadb`: `chown` fixes (docker-library/mariadb#203)
- `mongo`: `chown` fixes (docker-library/mongo#305)
- `openjdk`: Oracle variants (docker-library/openjdk#235), 11 GA
- `owncloud`: `chown` fixes (docker-library/owncloud#105)
- `percona`: `chown` fixes (docker-library/percona#69)
- `php`: 7.3.0RC2
- `rabbitmq`: `chown` fixes (docker-library/rabbitmq#281)
- `redis`: `chown` fixes (docker-library/redis#166)
- `redmine`: `chown` fixes (docker-library/redmine#128)
- `ruby`: Alpine thread stack size fix (docker-library/ruby#237)
- `tomcat`: add JRE 11, remove EOL Tomcat 8.0 (docker-library/tomcat#133)