### PR TITLE
Update elasticsearch

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,8 +1,20 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/47a72b6f1962df04a62616b1c3c32e85b5410639/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/d22dc8b36939ab325763fa92e4e6ee3059aaea59/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
+
+Tags: 6.4.1
+GitCommit: 41ec004d537b2d5d1a4bdd5664fbee018f8cb98e
+Directory: 6.4.1
+
+Tags: 6.4.0
+GitCommit: 936f5c437c1509a8ee090868b030ca2f89cc0021
+Directory: 6.4.0
+
+Tags: 6.4.2
+GitCommit: 41ec004d537b2d5d1a4bdd5664fbee018f8cb98e
+Directory: 6
 
 Tags: 5.6.12, 5.6, 5, latest
 GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
@@ -11,11 +23,3 @@ Directory: 5
 Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine, alpine
 GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
 Directory: 5/alpine
-
-Tags: 2.4.6, 2.4, 2
-GitCommit: 8e87587ac5d6b44a8382a229162c88e65618c30a
-Directory: 2.4
-
-Tags: 2.4.6-alpine, 2.4-alpine, 2-alpine
-GitCommit: 8e87587ac5d6b44a8382a229162c88e65618c30a
-Directory: 2.4/alpine


### PR DESCRIPTION
In the interest of providing the best and most reliable support for the official Elasticsearch Docker images, Elastic performs a rigorous set of automated and manual tests as part of the Elasticsearch release process.  Beyond testing our own software, these tests have historically uncovered other items such as JVM issues and OS-dependent issues that the Elasticsearch software relied on.

In order to provide the Docker Library community with the same level of support for any Elastic images which are pulled from Docker Hub, it is necessary that these images are equivalent with those which come from the Elastic build system. This equivalence allows us to address issues in a specific version of Elasticsearch with a full understanding of exactly what exists in that version, allowing us to support and troubleshoot any issues effectively and efficiently. It also allows Elastic to respond to issues with any necessary updates rapidly, and without the risk of divergent image content.

After extensive discussions and collaboration with Docker, it has been determined that the easiest, fastest, and most stable way to accomplish this is to use the Elastic images directly rather than rely on setting up an exact replica of Elastic’s build and testing systems. The code contained within this image is open (references to the code and the referenced image can be viewed within the image Dockerfile). 