### PR TITLE
Update Kibana

### DIFF
--- a/library/kibana
+++ b/library/kibana
@@ -1,13 +1,21 @@
-# this file is generated via https://github.com/docker-library/kibana/blob/03f657e02f2fc3f3487dfe98cc98f9870eaaa5c4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/kibana/blob/6e72574c0ad4c1b6aa9aa9c2dcb86175b87f5467/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
+Tags: 6.4.1
+GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+Directory: 6.4.1
+
+Tags: 6.4.0
+GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+Directory: 6.4.0
+
+Tags: 6.4.2
+GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+Directory: 6
+
 Tags: 5.6.12, 5.6, 5, latest
 GitCommit: 958ce4b1abe560d2cbbe6a74168d13031cb1e106
 Directory: 5
-
-Tags: 4.6.6, 4.6, 4
-GitCommit: febc4b766dabfc5a30f04373337cd0a0ec997bb2
-Directory: 4.6


### PR DESCRIPTION
In the interest of providing the best and most reliable support for the official Elastic Docker images, Elastic performs a rigorous set of automated and manual tests as part of the release process.  Beyond testing our own software, these tests have historically uncovered other items such as JVM issues and OS-dependent issues that the Elastic software relied on.

In order to provide the Docker Library community with the same level of support for any Elastic images which are pulled from Docker Hub, it is necessary that these images are equivalent with those which come from the Elastic build system. This equivalence allows us to address issues in a specific version of Elasticsearch with a full understanding of exactly what exists in that version, allowing us to support and troubleshoot any issues effectively and efficiently. It also allows Elastic to respond to issues with any necessary updates rapidly, and without the risk of divergent image content.

After extensive discussions and collaboration with Docker, it has been determined that the easiest, fastest, and most stable way to accomplish this is to use the Elastic images directly rather than rely on setting up an exact replica of Elastic’s build and testing systems. The code contained within this image is open (references to the code and the referenced image can be viewed within the image Dockerfile). 