### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 18.09.0-ce-beta1, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 6c9844cf7bc73d87cf884f7e347c6a7b060f8530
+GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.09-rc
 
 Tags: 18.09.0-ce-beta1-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
+GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.09-rc/dind
 
 Tags: 18.09.0-ce-beta1-git, 18.09-rc-git, rc-git, test-git
@@ -21,12 +21,12 @@ Directory: 18.09-rc/git
 
 Tags: 18.06.1-ce, 18.06.1, 18.06, 18, edge, stable, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 75d265c97922a504c509dd01aaff17bd49072ea6
+GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.06
 
 Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
+GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.06/dind
 
 Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, 18-git, edge-git, stable-git, git

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-13-jdk-oraclelinux7, 12-ea-13-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-13-jdk-oracle, 12-ea-13-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+Tags: 12-ea-14-jdk-oraclelinux7, 12-ea-14-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-14-jdk-oracle, 12-ea-14-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
 Architectures: amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-12-jdk-alpine3.8, 12-ea-12-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-12-jdk-alpine, 12-ea-12-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-13-jdk-windowsservercore-ltsc2016, 12-ea-13-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-14-jdk-windowsservercore-ltsc2016, 12-ea-14-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-13-jdk-windowsservercore-1709, 12-ea-13-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-14-jdk-windowsservercore-1709, 12-ea-14-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-13-jdk-windowsservercore-1803, 12-ea-13-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-13-jdk-windowsservercore, 12-ea-13-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-14-jdk-windowsservercore-1803, 12-ea-14-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/ruby
+++ b/library/ruby
@@ -6,95 +6,95 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
+GitCommit: a6559bd074b19055a37f7bdac7f40ae5d79010ed
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 929ba8718f380644aaaa38047508256d1e7c5a3c
+GitCommit: a6559bd074b19055a37f7bdac7f40ae5d79010ed
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: a6559bd074b19055a37f7bdac7f40ae5d79010ed
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: a6559bd074b19055a37f7bdac7f40ae5d79010ed
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
+GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
 Directory: 2.5/stretch
 
 Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 38e06eaab48f587fca9993a6c7124a11512ac65c
+GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/stretch
 
 Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.4-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/jessie
 
 Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3149de350c3bc540492a4331881b925e608c3abd
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/alpine3.7
 
 Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
 Directory: 2.4/alpine3.6
 
 Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/stretch
 
 Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.7-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/jessie
 
 Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: bba73b8fbe85081da0362b8e5224e6dc336ac0d6
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.7-alpine3.8, 2.3-alpine3.8, 2.3.7-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.7-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 87ab073c1cdb82c043eba4f144df5fa108031a5b
+GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
 Directory: 2.3/alpine3.7

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/f93ce2df63e03c2467dedde31fdc6b08f84c0155/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/185917c653a1a7504e5cc82c0a8ceb6a8a171bc8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -59,6 +59,16 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
 Directory: 8.5/jre10-slim
 
+Tags: 8.5.34-jre11, 8.5-jre11, 8-jre11, jre11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+Directory: 8.5/jre11
+
+Tags: 8.5.34-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+Directory: 8.5/jre11-slim
+
 Tags: 9.0.12-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
@@ -83,3 +93,13 @@ Tags: 9.0.12-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.12-slim, 9.0-slim, 9-
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
 Directory: 9.0/jre10-slim
+
+Tags: 9.0.12-jre11, 9.0-jre11, 9-jre11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+Directory: 9.0/jre11
+
+Tags: 9.0.12-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+Directory: 9.0/jre11-slim


### PR DESCRIPTION
- `docker`: swap from `curl` back to `wget` (docker-library/docker#126)
- `openjdk`: 12-ea+14
- `ruby`: bundler 1.16.6
- `tomcat`: publish missing `jre11` tags (docker-library/tomcat#133)