### PR TITLE
Odoo: Remove 9.0 and update 10.0-12.0 to release 20181008

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: a7e2eb4193e9e1de98ce9e3e7462593a49c191a8
+GitCommit: f71a22239e062719b202fb339f5983af88b2d1c8
 
 Tags: 12.0, 12, latest
 Architectures: amd64, arm64v8
@@ -13,7 +13,3 @@ Directory: 11.0
 Tags: 10.0, 10
 Architectures: amd64
 Directory: 10.0
-
-Tags: 9.0, 9
-Architectures: amd64
-Directory: 9.0


### PR DESCRIPTION
Hello,

this is an update of all Odoo supported versions.
Also, this removes the deprecated 9.0 version.

Thanks