### PR TITLE
Remove "latest" from Elasticsearch and Kibana

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/d22dc8b36939ab325763fa92e4e6ee3059aaea59/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/7de84d3d08d1544e90e3a2e9cacda3f3e17037e2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,10 +16,10 @@ Tags: 6.4.2
 GitCommit: 41ec004d537b2d5d1a4bdd5664fbee018f8cb98e
 Directory: 6
 
-Tags: 5.6.12, 5.6, 5, latest
+Tags: 5.6.12, 5.6, 5
 GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
 Directory: 5
 
-Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine, alpine
+Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine
 GitCommit: b30b4e51e77c6289be522b1d5c3d64918b9d77d9
 Directory: 5/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/kibana/blob/6e72574c0ad4c1b6aa9aa9c2dcb86175b87f5467/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/kibana/blob/b8795b8333c3ba6b5f0ae43ef4f119afe9a67910/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,6 +16,6 @@ Tags: 6.4.2
 GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
 Directory: 6
 
-Tags: 5.6.12, 5.6, 5, latest
+Tags: 5.6.12, 5.6, 5
 GitCommit: 958ce4b1abe560d2cbbe6a74168d13031cb1e106
 Directory: 5


### PR DESCRIPTION
Elastic does not intend to support the "latest" tag, so these will be removed from the Hub shortly after this merges.