### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/70624b0473d43006ecb72ed0301608567a27abce/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/2ed68abfaed6ec75caeedd3c61af1038975ae9d1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 70624b0473d43006ecb72ed0301608567a27abce
+GitCommit: 2ed68abfaed6ec75caeedd3c61af1038975ae9d1
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 0b299265b6140985a88913133261b93d5a2c2c19

--- a/library/cirros
+++ b/library/cirros
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/tianon/docker-brew-cirros/blob/ee542009d503007fe76276b6b3f66ec55d1f9289//home/tianon/docker/hub/cirros/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-brew-cirros/blob/b039392ba51709b7b461ec4eaef45bd722ae4c69//home/tianon/docker/hub/cirros/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-brew-cirros.git

--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-ce-beta1, 18.09-rc, rc, test
+Tags: 18.09.0-beta3, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
+GitCommit: 9820a073c73cded1d189bc8f7b067b1b4c6f9fb2
 Directory: 18.09-rc
 
-Tags: 18.09.0-ce-beta1-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-beta3-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.09-rc/dind
 
-Tags: 18.09.0-ce-beta1-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-beta3-git, 18.09-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/git

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
 Tags: 6.4.1
-GitCommit: 41ec004d537b2d5d1a4bdd5664fbee018f8cb98e
+GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
 Directory: 6.4.1
 
 Tags: 6.4.0
-GitCommit: 936f5c437c1509a8ee090868b030ca2f89cc0021
+GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
 Directory: 6.4.0
 
 Tags: 6.4.2
-GitCommit: 41ec004d537b2d5d1a4bdd5664fbee018f8cb98e
+GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
 Directory: 6
 
 Tags: 5.6.12, 5.6, 5

--- a/library/kibana
+++ b/library/kibana
@@ -5,15 +5,15 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/kibana.git
 
 Tags: 6.4.1
-GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
 Directory: 6.4.1
 
 Tags: 6.4.0
-GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
 Directory: 6.4.0
 
 Tags: 6.4.2
-GitCommit: b6711c0af6435630493ac92be1de5c319ae835cf
+GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
 Directory: 6
 
 Tags: 5.6.12, 5.6, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -9,9 +9,9 @@ Architectures: amd64
 GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-12-jdk-alpine3.8, 12-ea-12-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-12-jdk-alpine, 12-ea-12-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-14-jdk-alpine3.8, 12-ea-14-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-14-jdk-alpine, 12-ea-14-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 57de518e280c26fa8a9f602e76c3f3ea95f8296c
 Directory: 12/jdk/alpine
 
 Tags: 12-ea-14-jdk-windowsservercore-ltsc2016, 12-ea-14-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016

--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: cad275d97df1d056fca6731e6293d687bc7b5e80
+GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: cad275d97df1d056fca6731e6293d687bc7b5e80
+GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
+GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
 Directory: 3
 
 Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim, 3-6.0.0-slim-jessie, 3-6.0-slim-jessie, 3-6-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: d813837c73e726c0b5568297eff2f5a4b00c123f
+GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -7,206 +7,206 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.0-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8601079d1f70b03c01408377716a3243ce75cec9
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/stretch
 
 Tags: 3.7.0-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.0-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c5afee6efc8512af143b960d82b938bde623943f
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.0-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.0-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.0-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.0-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.0-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.0, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: ccfb4c011e1db901c167c8d4c3611263bd68e65c
+GitCommit: 38dcdb4320c8668416205e044ee50489c059da18
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.6-stretch, 3.6-stretch
 SharedTags: 3.6.6, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/stretch
 
 Tags: 3.6.6-slim-stretch, 3.6-slim-stretch, 3.6.6-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.6-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/jessie
 
 Tags: 3.6.6-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.6-alpine3.8, 3.6-alpine3.8, 3.6.6-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.6-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.6-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.6-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.6-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.6-windowsservercore, 3.6-windowsservercore, 3.6.6, 3.6
 Architectures: windows-amd64
-GitCommit: 878ffe36c2391279e673a44a011f5c65943b5eb8
+GitCommit: 88812635c8ad7ff06a8a3755616a1040df222f3c
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/stretch
 
 Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/jessie
 
 Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2acdb940ae75704be5892378b4ff498861d74d64
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/alpine3.8
 
 Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/stretch
 
 Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/jessie
 
 Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 88faa24df29998ef7840efd3bb204aa7ab9bf0b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8350b865d28bc0f4a05111398392ec701d449058
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c0365d804c2ef4ee8edef652e6a39cdf461e3b2
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 1565b7e3d9f9084dc141e8e75fd02bf49fe7f79a
+GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.70.0, 0.70, 0, latest
-GitCommit: 2749acc385aa6f2a394eec075d305707e4611d1c
+Tags: 0.70.3, 0.70, 0, latest
+GitCommit: 7ff0833b6dc718d2b35c3301e975093a770a54ad


### PR DESCRIPTION
- `busybox`: remove use of rawgit.com (https://twitter.com/rawgit/status/1049360165030567937)
- `cirros`: remove use of rawgit.com (https://twitter.com/rawgit/status/1049360165030567937)
- `docker`: 18.09.0-beta3
- `elasticsearch`: PR link
- `kibana`: PR link
- `openjdk`: 12-ea+14
- `pypy`: pip 18.1
- `python`: pip 18.1
- `rocket.chat`: 0.70.3