### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.2.0, 2.2, 2, latest
+Tags: 2.2.2, 2.2, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e91e6026c4437fcd11482f4f500a88c5b7d5be96
+GitCommit: ae3cc785ed9f54b70cd4d8fe983eeb1980843683
 Directory: 2/debian
 
-Tags: 2.2.0-alpine, 2.2-alpine, 2-alpine, alpine
+Tags: 2.2.2-alpine, 2.2-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e91e6026c4437fcd11482f4f500a88c5b7d5be96
+GitCommit: ae3cc785ed9f54b70cd4d8fe983eeb1980843683
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1

--- a/library/joomla
+++ b/library/joomla
@@ -3,62 +3,62 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.8.12-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.12-php5.6, 3.8-php5.6, 3-php5.6, php5.6
+Tags: 3.8.13-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.13-php5.6, 3.8-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php5.6/apache
 
-Tags: 3.8.12-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
+Tags: 3.8.13-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php5.6/fpm
 
-Tags: 3.8.12-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 3.8.13-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php5.6/fpm-alpine
 
-Tags: 3.8.12-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.12-php7.0, 3.8-php7.0, 3-php7.0, php7.0
+Tags: 3.8.13-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.13-php7.0, 3.8-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.0/apache
 
-Tags: 3.8.12-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
+Tags: 3.8.13-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.0/fpm
 
-Tags: 3.8.12-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 3.8.13-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.0/fpm-alpine
 
-Tags: 3.8.12-apache, 3.8-apache, 3-apache, apache, 3.8.12, 3.8, 3, latest, 3.8.12-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.12-php7.1, 3.8-php7.1, 3-php7.1, php7.1
+Tags: 3.8.13-apache, 3.8-apache, 3-apache, apache, 3.8.13, 3.8, 3, latest, 3.8.13-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.13-php7.1, 3.8-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.1/apache
 
-Tags: 3.8.12-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.12-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.8.13-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.13-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.1/fpm
 
-Tags: 3.8.12-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.12-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.8.13-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.13-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.1/fpm-alpine
 
-Tags: 3.8.12-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.12-php7.2, 3.8-php7.2, 3-php7.2, php7.2
+Tags: 3.8.13-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.13-php7.2, 3.8-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.2/apache
 
-Tags: 3.8.12-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.8.13-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.2/fpm
 
-Tags: 3.8.12-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.8.13-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 2eeb03d4fc3126b2985afc59fc1636ad7e28be98
+GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
 Directory: php7.2/fpm-alpine

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.10, 1.5, 1, latest
+Tags: 1.5.11, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04dbe5166ad88cca06885b68bd44efedc9a13771
+GitCommit: 66cbfc84fd2a8a08bc43d065bc6d74e0b48e972d
 Directory: debian
 
-Tags: 1.5.10-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.11-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 04dbe5166ad88cca06885b68bd44efedc9a13771
+GitCommit: 66cbfc84fd2a8a08bc43d065bc6d74e0b48e972d
 Directory: alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-14-jdk-oraclelinux7, 12-ea-14-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-14-jdk-oracle, 12-ea-14-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+Tags: 12-ea-15-jdk-oraclelinux7, 12-ea-15-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-15-jdk-oracle, 12-ea-15-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
 Architectures: amd64
-GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
+GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-14-jdk-alpine3.8, 12-ea-14-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-14-jdk-alpine, 12-ea-14-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 57de518e280c26fa8a9f602e76c3f3ea95f8296c
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-14-jdk-windowsservercore-ltsc2016, 12-ea-14-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-15-jdk-windowsservercore-ltsc2016, 12-ea-15-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
+GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-14-jdk-windowsservercore-1709, 12-ea-14-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-15-jdk-windowsservercore-1709, 12-ea-15-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
+GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-14-jdk-windowsservercore-1803, 12-ea-14-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-14-jdk-windowsservercore, 12-ea-14-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-15-jdk-windowsservercore-1803, 12-ea-15-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 1c341f869e22b2db077c4f36f9f5d4c407d33c84
+GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/php
+++ b/library/php
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0RC2-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC2-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC2-cli, 7.3-rc-cli, rc-cli, 7.3.0RC2, 7.3-rc, rc
+Tags: 7.3.0RC3-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC3-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC3-cli, 7.3-rc-cli, rc-cli, 7.3.0RC3, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/stretch/cli
 
-Tags: 7.3.0RC2-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC2-apache, 7.3-rc-apache, rc-apache
+Tags: 7.3.0RC3-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC3-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/stretch/apache
 
-Tags: 7.3.0RC2-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC2-fpm, 7.3-rc-fpm, rc-fpm
+Tags: 7.3.0RC3-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC3-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/stretch/fpm
 
-Tags: 7.3.0RC2-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC2-zts, 7.3-rc-zts, rc-zts
+Tags: 7.3.0RC3-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC3-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/stretch/zts
 
-Tags: 7.3.0RC2-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC2-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC2-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC2-alpine, 7.3-rc-alpine, rc-alpine
+Tags: 7.3.0RC3-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC3-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC3-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC3-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/alpine3.8/cli
 
-Tags: 7.3.0RC2-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC2-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.3.0RC3-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC3-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/alpine3.8/fpm
 
-Tags: 7.3.0RC2-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC2-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Tags: 7.3.0RC3-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC3-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d3beb19a515cde39a7953e278feed441fcef472c
+GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/alpine3.8/zts
 
 Tags: 7.2.10-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.10-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.10-cli, 7.2-cli, 7-cli, cli, 7.2.10, 7.2, 7, latest

--- a/library/postgres
+++ b/library/postgres
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 11-beta4, 11
+Tags: 11-rc1, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1acd5e225abead13b3f264e9e5a7c68598a33c67
+GitCommit: 4b94743e2ef5ead3ce8c66f96e43f6dc9d877025
 Directory: 11
 
-Tags: 11-beta4-alpine, 11-alpine
+Tags: 11-rc1-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f99f10cb564f0a8b5c1de8a9a00a8095a587fb
+GitCommit: eed67ed0f33435bffd1e78d27b389e0492d30599
 Directory: 11/alpine
 
 Tags: 10.5, 10, latest

--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0-rc5, 5.0-rc, 5.0-rc5-stretch, 5.0-rc-stretch
+Tags: 5.0-rc6, 5.0-rc, 5.0-rc6-stretch, 5.0-rc-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
 Directory: 5.0-rc
 
-Tags: 5.0-rc5-32bit, 5.0-rc-32bit, 5.0-rc5-32bit-stretch, 5.0-rc-32bit-stretch
+Tags: 5.0-rc6-32bit, 5.0-rc-32bit, 5.0-rc6-32bit-stretch, 5.0-rc-32bit-stretch
 Architectures: amd64
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
 Directory: 5.0-rc/32bit
 
-Tags: 5.0-rc5-alpine, 5.0-rc-alpine, 5.0-rc5-alpine3.8, 5.0-rc-alpine3.8
+Tags: 5.0-rc6-alpine, 5.0-rc-alpine, 5.0-rc6-alpine3.8, 5.0-rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
 Directory: 5.0-rc/alpine
 
 Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.70.3, 0.70, 0, latest
-GitCommit: 7ff0833b6dc718d2b35c3301e975093a770a54ad
+Tags: 0.70.4, 0.70, 0, latest
+GitCommit: 717015e57e3ae10d3da1bcf26c50462b7dd57edb

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57572ac281f3f77846aef85641ca36a02e71458f
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php5.6/apache
 
 Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php5.6/fpm
 
 Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.0/apache
 
 Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.0/fpm
 
 Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.1/apache
 
 Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.1/fpm
 
 Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.2/apache
 
 Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.2/fpm
 
 Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cb50cbaabba8eea67ea6a1f7702a7a1e238f10b9
+GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost`: 2.2.2
- `joomla`: 3.8.13
- `memcached`: 1.5.11
- `openjdk`: 12-ea+15
- `php`: 7.3.0RC3
- `postgres`: 11rc1
- `redis`: 5.0-rc6
- `rocket.chat`: 0.70.4
- `wordpress`: `WORDPRESS_CONFIG_EXTRA` warning (docker-library/wordpress#342)