### PR TITLE
Update docker-library images

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -99,31 +99,31 @@ GitCommit: 90f043506151539585d7894e3ade7fde6960674a
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.3-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.3, 4.1, unstable
+Tags: 4.1.4-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.4, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
+GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
 Directory: 4.1
 
-Tags: 4.1.3-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
+Tags: 4.1.4-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.3-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
+Tags: 4.1.4-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.3-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.3-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.3, 4.1, unstable
+Tags: 4.1.4-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/7d6b0528da55c7b74feff4f565c9dbb8907b8c9a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/b334897770e2d249ac0d14d4425892dda675fd43/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-15-jdk-oraclelinux7, 12-ea-15-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-15-jdk-oracle, 12-ea-15-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+Tags: 12-ea-15-jdk-oraclelinux7, 12-ea-15-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-15-jdk-oracle, 12-ea-15-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-15-jdk, 12-ea-15, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
 GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/oracle
@@ -35,94 +35,94 @@ GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-jdk-oraclelinux7, 11-oraclelinux7, 11-jdk-oracle, 11-oracle
+Tags: 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/oracle
 
-Tags: 11-jdk-sid, 11-sid, 11-jdk, 11
+Tags: 11-jdk-sid, 11-sid, jdk-sid, sid, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
 Directory: 11/jdk
 
-Tags: 11-jdk-slim-sid, 11-slim-sid, 11-jdk-slim, 11-slim
+Tags: 11-jdk-slim-sid, 11-slim-sid, jdk-slim-sid, slim-sid, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
 Directory: 11/jdk/slim
 
-Tags: 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore
+Tags: 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-jre-sid, 11-jre
+Tags: 11-jre-sid, jre-sid, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
 Directory: 11/jre
 
-Tags: 11-jre-slim-sid, 11-jre-slim
+Tags: 11-jre-slim-sid, jre-slim-sid, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
 Directory: 11/jre/slim
 
-Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle, jdk-oracle, oracle
+Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle
 Architectures: amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/oracle
 
-Tags: 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, jdk-sid, sid, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10, jdk, latest
+Tags: 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jdk
 
-Tags: 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, jdk-slim-sid, slim-sid, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim, jdk-slim, slim
+Tags: 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jdk/slim
 
-Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
+SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver, jdk-nanoserver, nanoserver
+Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
+SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
 Architectures: windows-amd64
 GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
 Directory: 10/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, jre-sid, 10.0.2-jre, 10.0-jre, 10-jre, jre
+Tags: 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.2-jre, 10.0-jre, 10-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jre
 
-Tags: 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, jre-slim-sid, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim, jre-slim
+Tags: 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bca955fe8c80ff7272e9f4a4ffa8b822a27a0aef
 Directory: 10/jre/slim

--- a/library/php
+++ b/library/php
@@ -39,139 +39,139 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
 Directory: 7.3-rc/alpine3.8/zts
 
-Tags: 7.2.10-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.10-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.10-cli, 7.2-cli, 7-cli, cli, 7.2.10, 7.2, 7, latest
+Tags: 7.2.11-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.11-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.11-cli, 7.2-cli, 7-cli, cli, 7.2.11, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.10-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.10-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.11-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.11-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.10-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.10-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.11-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.11-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.10-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.10-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.11-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.11-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.10-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.10-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.10-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.10-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.11-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.11-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.11-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.11-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.10-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.10-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.11-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.11-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.10-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.10-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.11-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.11-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.8/zts
 
-Tags: 7.2.10-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.10-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
+Tags: 7.2.11-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.11-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.7/cli
 
-Tags: 7.2.10-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
+Tags: 7.2.11-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.7/fpm
 
-Tags: 7.2.10-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
+Tags: 7.2.11-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.7/zts
 
-Tags: 7.2.10-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.10-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
+Tags: 7.2.11-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.11-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.6/cli
 
-Tags: 7.2.10-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
+Tags: 7.2.11-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.6/fpm
 
-Tags: 7.2.10-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
+Tags: 7.2.11-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d97098c8c6af46ae1211e65ff052278ab39ba45c
+GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.6/zts
 
-Tags: 7.1.22-cli-stretch, 7.1-cli-stretch, 7.1.22-stretch, 7.1-stretch, 7.1.22-cli, 7.1-cli, 7.1.22, 7.1
+Tags: 7.1.23-cli-stretch, 7.1-cli-stretch, 7.1.23-stretch, 7.1-stretch, 7.1.23-cli, 7.1-cli, 7.1.23, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.22-apache-stretch, 7.1-apache-stretch, 7.1.22-apache, 7.1-apache
+Tags: 7.1.23-apache-stretch, 7.1-apache-stretch, 7.1.23-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.22-fpm-stretch, 7.1-fpm-stretch, 7.1.22-fpm, 7.1-fpm
+Tags: 7.1.23-fpm-stretch, 7.1-fpm-stretch, 7.1.23-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.22-zts-stretch, 7.1-zts-stretch, 7.1.22-zts, 7.1-zts
+Tags: 7.1.23-zts-stretch, 7.1-zts-stretch, 7.1.23-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.22-cli-jessie, 7.1-cli-jessie, 7.1.22-jessie, 7.1-jessie
+Tags: 7.1.23-cli-jessie, 7.1-cli-jessie, 7.1.23-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.22-apache-jessie, 7.1-apache-jessie
+Tags: 7.1.23-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.22-fpm-jessie, 7.1-fpm-jessie
+Tags: 7.1.23-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.22-zts-jessie, 7.1-zts-jessie
+Tags: 7.1.23-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.22-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.22-alpine3.8, 7.1-alpine3.8, 7.1.22-cli-alpine, 7.1-cli-alpine, 7.1.22-alpine, 7.1-alpine
+Tags: 7.1.23-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.23-alpine3.8, 7.1-alpine3.8, 7.1.23-cli-alpine, 7.1-cli-alpine, 7.1.23-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.8/cli
 
-Tags: 7.1.22-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.22-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.23-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.23-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.8/fpm
 
-Tags: 7.1.22-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.22-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.23-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.23-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.8/zts
 
-Tags: 7.1.22-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.22-alpine3.7, 7.1-alpine3.7
+Tags: 7.1.23-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.23-alpine3.7, 7.1-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.7/cli
 
-Tags: 7.1.22-fpm-alpine3.7, 7.1-fpm-alpine3.7
+Tags: 7.1.23-fpm-alpine3.7, 7.1-fpm-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.7/fpm
 
-Tags: 7.1.22-zts-alpine3.7, 7.1-zts-alpine3.7
+Tags: 7.1.23-zts-alpine3.7, 7.1-zts-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c856411d1c21111855a54c5d29f2bfe099d63ce7
+GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.32-cli-stretch, 7.0-cli-stretch, 7.0.32-stretch, 7.0-stretch, 7.0.32-cli, 7.0-cli, 7.0.32, 7.0

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba719a0b180982a45d994e0ab66ac7a4ea106bfe
+GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba719a0b180982a45d994e0ab66ac7a4ea106bfe
+GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger


### PR DESCRIPTION
- `mongo`: 4.1.4
- `openjdk`: fix tags (`openjdk:11` is now latest, 12+ will consider Oracle variants to be `latest`)
- `php`: 7.2.11, 7.1.23
- `redmine`: add `gsfonts` package to fix Gannt to PNG generation (docker-library/redmine#133)