### PR TITLE
update oraclelinux for openssl

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9e0f94328f32f3decebad720ed2978c2bf481359
+amd64-GitCommit: a1b19a9db117829b4096bcba68da381dbda62a61
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 9c7fef4b2c1e58a450e217c6c48b76845d5b2e2d


### PR DESCRIPTION
	[AMD64 6.10] 2018-10-15-60
	[AMD64 6-slim] 2018-10-15-16
	[AMD64 7.5] 2018-10-15-82
	[AMD64 7-slim] 2018-10-15-18

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>