### PR TITLE
Run WebSphere Liberty as non-root

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 0751657f005a03a1d81f995d51af06c463ba42c6
+GitCommit: b8d21d7bcc0401fc7f5d014a3a7ff41e3e6a49b2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: javaee8, latest


### PR DESCRIPTION
Updating WebSphere Liberty's container to run as non-root by default.