### PR TITLE
Haxe: install missing runtime dependencies

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -3,12 +3,12 @@ GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
 Tags: 3.4.7-stretch, 3.4-stretch, 3.4.7, 3.4, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
+GitCommit: e60ab8c2df98de16d9abfaf90b9227059433fd2e
 Directory: 3.4/stretch
 
 Tags: 3.4.7-jessie, 3.4-jessie
 Architectures: amd64
-GitCommit: 87941e0d428dfe0b54be5b2ad80ab6699c95058a
+GitCommit: 93a25ea07ddfedad53fc77d522b9b8e703518030
 Directory: 3.4/jessie
 
 Tags: 3.4.7-onbuild, 3.4-onbuild
@@ -24,27 +24,27 @@ Constraints: windowsservercore
 
 Tags: 3.4.7-alpine3.8, 3.4-alpine3.8, 3.4.7-alpine, 3.4-alpine
 Architectures: amd64, arm64v8
-GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.7-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.4/alpine3.7
 
 Tags: 3.4.7-alpine3.6, 3.4-alpine3.6
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.4/alpine3.6
 
 Tags: 3.3.0-rc.1-stretch, 3.3.0-stretch, 3.3-stretch, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: e60ab8c2df98de16d9abfaf90b9227059433fd2e
 Directory: 3.3/stretch
 
 Tags: 3.3.0-rc.1-jessie, 3.3.0-jessie, 3.3-jessie
 Architectures: amd64
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: 93a25ea07ddfedad53fc77d522b9b8e703518030
 Directory: 3.3/jessie
 
 Tags: 3.3.0-rc.1-onbuild, 3.3.0-onbuild, 3.3-onbuild
@@ -60,27 +60,27 @@ Constraints: windowsservercore
 
 Tags: 3.3.0-rc.1-alpine3.8, 3.3.0-rc.1-alpine, 3.3.0-alpine3.8, 3.3-alpine3.8, 3.3.0-alpine, 3.3-alpine
 Architectures: amd64, arm64v8
-GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.3/alpine3.8
 
 Tags: 3.3.0-rc.1-alpine3.7, 3.3.0-alpine3.7, 3.3-alpine3.7
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.3/alpine3.7
 
 Tags: 3.3.0-rc.1-alpine3.6, 3.3.0-alpine3.6, 3.3-alpine3.6
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.3/alpine3.6
 
 Tags: 3.2.1-stretch, 3.2-stretch, 3.2.1, 3.2
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: e60ab8c2df98de16d9abfaf90b9227059433fd2e
 Directory: 3.2/stretch
 
 Tags: 3.2.1-jessie, 3.2-jessie
 Architectures: amd64
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: 93a25ea07ddfedad53fc77d522b9b8e703518030
 Directory: 3.2/jessie
 
 Tags: 3.2.1-onbuild, 3.2-onbuild
@@ -96,27 +96,27 @@ Constraints: windowsservercore
 
 Tags: 3.2.1-alpine3.8, 3.2-alpine3.8, 3.2.1-alpine, 3.2-alpine
 Architectures: amd64, arm64v8
-GitCommit: fb51ba61bf670297a1d443cb0a4906447969edad
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.2/alpine3.8
 
 Tags: 3.2.1-alpine3.7, 3.2-alpine3.7
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.2/alpine3.7
 
 Tags: 3.2.1-alpine3.6, 3.2-alpine3.6
 Architectures: amd64, arm64v8
-GitCommit: 80fa879a04aef26ca1a6ced627a87d86fa5763df
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 3.2/alpine3.6
 
 Tags: 3.1.3-stretch, 3.1-stretch, 3.1.3, 3.1
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: e60ab8c2df98de16d9abfaf90b9227059433fd2e
 Directory: 3.1/stretch
 
 Tags: 3.1.3-jessie, 3.1-jessie
 Architectures: amd64
-GitCommit: b53c8f548757e9c9ef2fa6895762ddc538d94a7e
+GitCommit: 93a25ea07ddfedad53fc77d522b9b8e703518030
 Directory: 3.1/jessie
 
 Tags: 3.1.3-onbuild, 3.1-onbuild
@@ -132,12 +132,12 @@ Constraints: windowsservercore
 
 Tags: 4.0.0-preview.5-stretch, 4.0.0-preview.5, 4.0.0-stretch, 4.0-stretch, 4.0.0, 4.0
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: bd2e624cf881e72c42434922808199f70054a19e
+GitCommit: e60ab8c2df98de16d9abfaf90b9227059433fd2e
 Directory: 4.0/stretch
 
 Tags: 4.0.0-preview.5-jessie, 4.0.0-jessie, 4.0-jessie
 Architectures: amd64
-GitCommit: bd2e624cf881e72c42434922808199f70054a19e
+GitCommit: 93a25ea07ddfedad53fc77d522b9b8e703518030
 Directory: 4.0/jessie
 
 Tags: 4.0.0-preview.5-onbuild, 4.0.0-onbuild, 4.0-onbuild
@@ -153,16 +153,16 @@ Constraints: windowsservercore
 
 Tags: 4.0.0-preview.5-alpine3.8, 4.0.0-preview.5-alpine, 4.0.0-alpine3.8, 4.0-alpine3.8, 4.0.0-alpine, 4.0-alpine
 Architectures: amd64, arm64v8
-GitCommit: bd2e624cf881e72c42434922808199f70054a19e
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 4.0/alpine3.8
 
 Tags: 4.0.0-preview.5-alpine3.7, 4.0.0-alpine3.7, 4.0-alpine3.7
 Architectures: amd64, arm64v8
-GitCommit: bd2e624cf881e72c42434922808199f70054a19e
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 4.0/alpine3.7
 
 Tags: 4.0.0-preview.5-alpine3.6, 4.0.0-alpine3.6, 4.0-alpine3.6
 Architectures: amd64, arm64v8
-GitCommit: bd2e624cf881e72c42434922808199f70054a19e
+GitCommit: 63ce668557c6f5afe60bac087ec24f19390f2707
 Directory: 4.0/alpine3.6
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -93,6 +93,7 @@ imageTests+=(
 	'
 	[haxe]='
 		haxe-hello-world
+		haxe-haxelib-install
 	'
 	[hylang]='
 		hylang-sh

--- a/test/tests/haxe-haxelib-install/Container.hx
+++ b/test/tests/haxe-haxelib-install/Container.hx
@@ -1,9 +1,5 @@
 class Container {
     static function main():Void {
-        switch (Sys.command("haxelib", ["newrepo"])) {
-            case 0: //pass
-            case code: Sys.exit(code);
-        }
         switch (Sys.command("haxelib", ["install", "jQueryExtern"])) {
             case 0: //pass
             case code: Sys.exit(code);

--- a/test/tests/haxe-haxelib-install/Container.hx
+++ b/test/tests/haxe-haxelib-install/Container.hx
@@ -1,0 +1,12 @@
+class Container {
+    static function main():Void {
+        switch (Sys.command("haxelib", ["newrepo"])) {
+            case 0: //pass
+            case code: Sys.exit(code);
+        }
+        switch (Sys.command("haxelib", ["install", "jQueryExtern"])) {
+            case 0: //pass
+            case code: Sys.exit(code);
+        }
+    }
+}

--- a/test/tests/haxe-haxelib-install/run.sh
+++ b/test/tests/haxe-haxelib-install/run.sh
@@ -1,0 +1,1 @@
+../run-haxe-in-container.sh


### PR DESCRIPTION
 * jessie/stretch: install missing runtime dependencies
 * alpine: renamed the misnamed virtual package .python-rundeps to .haxe-rundeps (minor)