### PR TITLE
Reflect Mediawiki folder changes and upgrade lts to 1.31

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,14 +2,14 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 41edcc8020aa47823d30c1b35f216b0a2834b2b6
+GitCommit: 41b4758701e47c363a49ff2ef8835be5f69cf383
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: stable, latest, 1.31, 1.31.1
-Directory: stable
+Tags: lts, stable, latest, 1.31, 1.31.1
+Directory: 1.31
 
 Tags: legacy, 1.30, 1.30.1
-Directory: legacy
+Directory: 1.30
 
-Tags: lts, 1.27, 1.27.5
-Directory: lts
+Tags: legacylts, 1.27, 1.27.5
+Directory: 1.27


### PR DESCRIPTION
This reflects the folder structure change in https://github.com/wikimedia/mediawiki-docker/pull/53 and  updates the `lts` tag to use 1.31.