### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,47 +4,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.1-apache, 8.6-apache, 8-apache, apache, 8.6.1, 8.6, 8, latest
+Tags: 8.6.2-apache, 8.6-apache, 8-apache, apache, 8.6.2, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
+GitCommit: 48eb0d321cb472d76de0cf552192ee044f568ebe
 Directory: 8.6/apache
 
-Tags: 8.6.1-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.2-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
+GitCommit: 48eb0d321cb472d76de0cf552192ee044f568ebe
 Directory: 8.6/fpm
 
-Tags: 8.6.1-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.2-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d3c158bd114f9041ecf25a80b8b8b62deb249833
+GitCommit: 48eb0d321cb472d76de0cf552192ee044f568ebe
 Directory: 8.6/fpm-alpine
 
-Tags: 8.5.7-apache, 8.5-apache, 8.5.7, 8.5
+Tags: 8.5.8-apache, 8.5-apache, 8.5.8, 8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
+GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
 Directory: 8.5/apache
 
-Tags: 8.5.7-fpm, 8.5-fpm
+Tags: 8.5.8-fpm, 8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
+GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
 Directory: 8.5/fpm
 
-Tags: 8.5.7-fpm-alpine, 8.5-fpm-alpine
+Tags: 8.5.8-fpm-alpine, 8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 37b255dbb119fb78221dab4ea2e9ebdb3c2cc263
+GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
 Directory: 8.5/fpm-alpine
 
-Tags: 7.59-apache, 7-apache, 7.59, 7
+Tags: 7.60-apache, 7-apache, 7.60, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff8962fc943001457c6919fa42e3d875b9fab9f7
+GitCommit: 978f4a2b3b187dcf105d9c40cfd6b84ea8597850
 Directory: 7/apache
 
-Tags: 7.59-fpm, 7-fpm
+Tags: 7.60-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff8962fc943001457c6919fa42e3d875b9fab9f7
+GitCommit: 978f4a2b3b187dcf105d9c40cfd6b84ea8597850
 Directory: 7/fpm
 
-Tags: 7.59-fpm-alpine, 7-fpm-alpine
+Tags: 7.60-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ff8962fc943001457c6919fa42e3d875b9fab9f7
+GitCommit: 978f4a2b3b187dcf105d9c40cfd6b84ea8597850
 Directory: 7/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.2.2, 2.2, 2, latest
+Tags: 2.2.4, 2.2, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae3cc785ed9f54b70cd4d8fe983eeb1980843683
+GitCommit: 7bbf37e816bb52b50472238fdf8da245129c1863
 Directory: 2/debian
 
-Tags: 2.2.2-alpine, 2.2-alpine, 2-alpine, alpine
+Tags: 2.2.4-alpine, 2.2-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ae3cc785ed9f54b70cd4d8fe983eeb1980843683
+GitCommit: 7bbf37e816bb52b50472238fdf8da245129c1863
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1

--- a/library/matomo
+++ b/library/matomo
@@ -2,17 +2,17 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.6.0-apache, 3.6-apache, 3-apache, apache, 3.6.0, 3.6, 3, latest
+Tags: 3.6.1-apache, 3.6-apache, 3-apache, apache, 3.6.1, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b711c66be5de3caade38361bd974134e1291a929
+GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
 Directory: apache
 
-Tags: 3.6.0-fpm, 3.6-fpm, 3-fpm, fpm
+Tags: 3.6.1-fpm, 3.6-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b711c66be5de3caade38361bd974134e1291a929
+GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
 Directory: fpm
 
-Tags: 3.6.0-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.6.1-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b711c66be5de3caade38361bd974134e1291a929
+GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
 Directory: fpm-alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -35,50 +35,50 @@ GitCommit: 8502712f6e80904b766505805c894c2008afa700
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
+Tags: 11.0.1-jdk-oraclelinux7, 11.0.1-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.1-jdk-oracle, 11.0.1-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/oracle
 
-Tags: 11-jdk-sid, 11-sid, jdk-sid, sid, 11-jdk, 11, jdk, latest
+Tags: 11.0.1-jdk-sid, 11.0.1-sid, 11.0-jdk-sid, 11.0-sid, 11-jdk-sid, 11-sid, jdk-sid, sid, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
+GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
 Directory: 11/jdk
 
-Tags: 11-jdk-slim-sid, 11-slim-sid, jdk-slim-sid, slim-sid, 11-jdk-slim, 11-slim, jdk-slim, slim
+Tags: 11.0.1-jdk-slim-sid, 11.0.1-slim-sid, 11.0-jdk-slim-sid, 11.0-slim-sid, 11-jdk-slim-sid, 11-slim-sid, jdk-slim-sid, slim-sid, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
+GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
 Directory: 11/jdk/slim
 
-Tags: 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.1-jdk-windowsservercore-1709, 11.0.1-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.1-jdk-windowsservercore-1803, 11.0.1-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
+GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11-jre-sid, jre-sid, 11-jre, jre
+Tags: 11.0.1-jre-sid, 11.0-jre-sid, 11-jre-sid, jre-sid, 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
+GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
 Directory: 11/jre
 
-Tags: 11-jre-slim-sid, jre-slim-sid, 11-jre-slim, jre-slim
+Tags: 11.0.1-jre-slim-sid, 11.0-jre-slim-sid, 11-jre-slim-sid, jre-slim-sid, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e23069b35737d02166d86d25088a02330a7ac96
+GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
 Directory: 11/jre/slim
 
 Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle

--- a/library/php
+++ b/library/php
@@ -16,7 +16,7 @@ Directory: 7.3-rc/stretch/apache
 
 Tags: 7.3.0RC3-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC3-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
+GitCommit: 87c85e43ff8fd9ebeb913e7929987ab540c61197
 Directory: 7.3-rc/stretch/fpm
 
 Tags: 7.3.0RC3-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC3-zts, 7.3-rc-zts, rc-zts
@@ -31,7 +31,7 @@ Directory: 7.3-rc/alpine3.8/cli
 
 Tags: 7.3.0RC3-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC3-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 7717f268f785e290a52a6cf67551d88c35a1d1ae
+GitCommit: 87c85e43ff8fd9ebeb913e7929987ab540c61197
 Directory: 7.3-rc/alpine3.8/fpm
 
 Tags: 7.3.0RC3-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC3-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine

--- a/library/postgres
+++ b/library/postgres
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/32caee4c0be1529a58d42e873ffcb5504844191e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/7f3fd17214f5ff59feaec6126cf562710b545c73/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 11-rc1, 11
+Tags: 11.0, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b94743e2ef5ead3ce8c66f96e43f6dc9d877025
+GitCommit: 88341a435106ea0c9a805ff305bf486f81f56e0c
 Directory: 11
 
-Tags: 11-rc1-alpine, 11-alpine
+Tags: 11.0-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eed67ed0f33435bffd1e78d27b389e0492d30599
+GitCommit: 3402e9731098e1cba778c0af82b8d6fdfc698f27
 Directory: 11/alpine
 
-Tags: 10.5, 10, latest
+Tags: 10.5, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 6f6968e4a2ee82cc7893e12414cbb221044ed3bd
 Directory: 10
 
-Tags: 10.5-alpine, 10-alpine, alpine
+Tags: 10.5-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
 Directory: 10/alpine

--- a/library/redis
+++ b/library/redis
@@ -1,50 +1,35 @@
-# this file is generated via https://github.com/docker-library/redis/blob/8adb3f1eb87687ab1ce96ed1b5db3764c8f9024c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/dc6dc737baa434528ce31948b22b4c6ccc78793a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0-rc6, 5.0-rc, 5.0-rc6-stretch, 5.0-rc-stretch
+Tags: 5.0.0, 5.0, 5, latest, 5.0.0-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
-Directory: 5.0-rc
+GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+Directory: 5.0
 
-Tags: 5.0-rc6-32bit, 5.0-rc-32bit, 5.0-rc6-32bit-stretch, 5.0-rc-32bit-stretch
+Tags: 5.0.0-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.0-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
-Directory: 5.0-rc/32bit
+GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+Directory: 5.0/32bit
 
-Tags: 5.0-rc6-alpine, 5.0-rc-alpine, 5.0-rc6-alpine3.8, 5.0-rc-alpine3.8
+Tags: 5.0.0-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.0-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 792574dfa561c5c9e8b6bcc48aad76637b49e96c
-Directory: 5.0-rc/alpine
+GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+Directory: 5.0/alpine
 
-Tags: 4.0.11, 4.0, 4, latest, 4.0.11-stretch, 4.0-stretch, 4-stretch, stretch
+Tags: 4.0.11, 4.0, 4, 4.0.11-stretch, 4.0-stretch, 4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0
 
-Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch, 32bit-stretch
+Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
 Architectures: amd64
 GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0/32bit
 
-Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8, alpine3.8
+Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
 Directory: 4.0/alpine
-
-Tags: 3.2.12, 3.2, 3, 3.2.12-stretch, 3.2-stretch, 3-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
-Directory: 3.2
-
-Tags: 3.2.12-32bit, 3.2-32bit, 3-32bit, 3.2.12-32bit-stretch, 3.2-32bit-stretch, 3-32bit-stretch
-Architectures: amd64
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
-Directory: 3.2/32bit
-
-Tags: 3.2.12-alpine, 3.2-alpine, 3-alpine, 3.2.12-alpine3.8, 3.2-alpine3.8, 3-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
-Directory: 3.2/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -24,77 +24,77 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: a6559bd074b19055a37f7bdac7f40ae5d79010ed
 Directory: 2.6-rc/alpine3.7
 
-Tags: 2.5.1-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.1, 2.5, 2, latest
+Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
+GitCommit: 0bdbbff7475155c90a5945f13daf7067a7bd9f11
 Directory: 2.5/stretch
 
-Tags: 2.5.1-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.1-slim, 2.5-slim, 2-slim, slim
+Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
+GitCommit: 0bdbbff7475155c90a5945f13daf7067a7bd9f11
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.1-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.1-alpine, 2.5-alpine, 2-alpine, alpine
+Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccf00a6b31abe14d27bdda498707a2ce338ef019
+GitCommit: 0bdbbff7475155c90a5945f13daf7067a7bd9f11
 Directory: 2.5/alpine3.7
 
-Tags: 2.4.4-stretch, 2.4-stretch, 2.4.4, 2.4
+Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/stretch
 
-Tags: 2.4.4-slim-stretch, 2.4-slim-stretch, 2.4.4-slim, 2.4-slim
+Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.4-jessie, 2.4-jessie
+Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/jessie
 
-Tags: 2.4.4-slim-jessie, 2.4-slim-jessie
+Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.4-alpine3.7, 2.4-alpine3.7, 2.4.4-alpine, 2.4-alpine
+Tags: 2.4.5-alpine3.7, 2.4-alpine3.7, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/alpine3.7
 
-Tags: 2.4.4-alpine3.6, 2.4-alpine3.6
+Tags: 2.4.5-alpine3.6, 2.4-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ccacdf5eb9e69b6f249a890c87621679410e7d74
+GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/alpine3.6
 
-Tags: 2.3.7-stretch, 2.3-stretch, 2.3.7, 2.3
+Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/stretch
 
-Tags: 2.3.7-slim-stretch, 2.3-slim-stretch, 2.3.7-slim, 2.3-slim
+Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/stretch/slim
 
-Tags: 2.3.7-jessie, 2.3-jessie
+Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/jessie
 
-Tags: 2.3.7-slim-jessie, 2.3-slim-jessie
+Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/jessie/slim
 
-Tags: 2.3.7-alpine3.8, 2.3-alpine3.8, 2.3.7-alpine, 2.3-alpine
+Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/alpine3.8
 
-Tags: 2.3.7-alpine3.7, 2.3-alpine3.7
+Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 676eadd43f87bdb1d3f033ea31ae69e45d11ee5b
+GitCommit: 36c87bb64362de2e6e9ea003104030ca2a5fc4e5
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `drupal`: 8.5.8, 7.60, 8.6.2
- `ghost`: 2.2.4
- `matomo`: 3.6.1
- `openjdk`: 11.0.1
- `php`: remove FPM log decoration on 7.3+ (docker-library/php#725)
- `postgres`: 11.0 GA, 10.5-2.pgdg90+1
- `redis`: EOL 3.2, 5.0.0 GA
- `ruby`: 2.5.3, 2.3.8, 2.4.5