### PR TITLE
Update docker-library images

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -5,11 +5,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.35, 2.4, 2, latest
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 152fc858992b2d8edb91794864e531664ca39c05
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c1891301f0941fab9a2b4004b99bd6abc912bde5
 Directory: 2.4
 
 Tags: 2.4.35-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d73c6a3b77f6175c50f51fdfe5243b1ae3ddca8
+GitCommit: c1891301f0941fab9a2b4004b99bd6abc912bde5
 Directory: 2.4/alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-15-jdk-oraclelinux7, 12-ea-15-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-15-jdk-oracle, 12-ea-15-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-15-jdk, 12-ea-15, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-16-jdk-oraclelinux7, 12-ea-16-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-16-jdk-oracle, 12-ea-16-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-16-jdk, 12-ea-16, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 8502712f6e80904b766505805c894c2008afa700
+GitCommit: 1db004031219f5428cdf6d39425b1db8241e80e1
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-14-jdk-alpine3.8, 12-ea-14-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-14-jdk-alpine, 12-ea-14-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 57de518e280c26fa8a9f602e76c3f3ea95f8296c
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-15-jdk-windowsservercore-ltsc2016, 12-ea-15-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-16-jdk-windowsservercore-ltsc2016, 12-ea-16-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-16-jdk-windowsservercore, 12-ea-16-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 8502712f6e80904b766505805c894c2008afa700
+GitCommit: 1db004031219f5428cdf6d39425b1db8241e80e1
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-15-jdk-windowsservercore-1709, 12-ea-15-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-16-jdk-windowsservercore-1709, 12-ea-16-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-16-jdk-windowsservercore, 12-ea-16-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 8502712f6e80904b766505805c894c2008afa700
+GitCommit: 1db004031219f5428cdf6d39425b1db8241e80e1
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-15-jdk-windowsservercore-1803, 12-ea-15-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-15-jdk-windowsservercore, 12-ea-15-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-16-jdk-windowsservercore-1803, 12-ea-16-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-16-jdk-windowsservercore, 12-ea-16-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 8502712f6e80904b766505805c894c2008afa700
+GitCommit: 1db004031219f5428cdf6d39425b1db8241e80e1
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/php
+++ b/library/php
@@ -74,36 +74,6 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
 Directory: 7.2/alpine3.8/zts
 
-Tags: 7.2.11-cli-alpine3.7, 7.2-cli-alpine3.7, 7-cli-alpine3.7, cli-alpine3.7, 7.2.11-alpine3.7, 7.2-alpine3.7, 7-alpine3.7, alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.7/cli
-
-Tags: 7.2.11-fpm-alpine3.7, 7.2-fpm-alpine3.7, 7-fpm-alpine3.7, fpm-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.7/fpm
-
-Tags: 7.2.11-zts-alpine3.7, 7.2-zts-alpine3.7, 7-zts-alpine3.7, zts-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.7/zts
-
-Tags: 7.2.11-cli-alpine3.6, 7.2-cli-alpine3.6, 7-cli-alpine3.6, cli-alpine3.6, 7.2.11-alpine3.6, 7.2-alpine3.6, 7-alpine3.6, alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.6/cli
-
-Tags: 7.2.11-fpm-alpine3.6, 7.2-fpm-alpine3.6, 7-fpm-alpine3.6, fpm-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.6/fpm
-
-Tags: 7.2.11-zts-alpine3.6, 7.2-zts-alpine3.6, 7-zts-alpine3.6, zts-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
-Directory: 7.2/alpine3.6/zts
-
 Tags: 7.1.23-cli-stretch, 7.1-cli-stretch, 7.1.23-stretch, 7.1-stretch, 7.1.23-cli, 7.1-cli, 7.1.23, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
@@ -158,21 +128,6 @@ Tags: 7.1.23-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.23-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
 Directory: 7.1/alpine3.8/zts
-
-Tags: 7.1.23-cli-alpine3.7, 7.1-cli-alpine3.7, 7.1.23-alpine3.7, 7.1-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
-Directory: 7.1/alpine3.7/cli
-
-Tags: 7.1.23-fpm-alpine3.7, 7.1-fpm-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
-Directory: 7.1/alpine3.7/fpm
-
-Tags: 7.1.23-zts-alpine3.7, 7.1-zts-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f3220a0aa5992cdc08128cbbe0f2490694d6be9
-Directory: 7.1/alpine3.7/zts
 
 Tags: 7.0.32-cli-stretch, 7.0-cli-stretch, 7.0.32-stretch, 7.0-stretch, 7.0.32-cli, 7.0-cli, 7.0.32, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -283,18 +238,3 @@ Tags: 5.6.38-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.38-zts-alpin
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
 Directory: 5.6/alpine3.8/zts
-
-Tags: 5.6.38-cli-alpine3.7, 5.6-cli-alpine3.7, 5-cli-alpine3.7, 5.6.38-alpine3.7, 5.6-alpine3.7, 5-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
-Directory: 5.6/alpine3.7/cli
-
-Tags: 5.6.38-fpm-alpine3.7, 5.6-fpm-alpine3.7, 5-fpm-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
-Directory: 5.6/alpine3.7/fpm
-
-Tags: 5.6.38-zts-alpine3.7, 5.6-zts-alpine3.7, 5-zts-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c04d025eaceae20315156a458ae31d5f0e77ba65
-Directory: 5.6/alpine3.7/zts

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/bb5c7101e13cfa3632dfc21245b172c205d90353/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/0b4ab84ebb15d80b591a5610200cf537fc4740ad/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -34,7 +34,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0bdbbff7475155c90a5945f13daf7067a7bd9f11
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
+Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 06192e37c6daec1d2f2a516c04c7bcc97174b1e2
+Directory: 2.5/alpine3.8
+
+Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 0bdbbff7475155c90a5945f13daf7067a7bd9f11
 Directory: 2.5/alpine3.7
@@ -59,15 +64,15 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.5-alpine3.7, 2.4-alpine3.7, 2.4.5-alpine, 2.4-alpine
+Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 06192e37c6daec1d2f2a516c04c7bcc97174b1e2
+Directory: 2.4/alpine3.8
+
+Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
 Directory: 2.4/alpine3.7
-
-Tags: 2.4.5-alpine3.6, 2.4-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 58cbeeb8ea937737eeb8f358472add230b6ded30
-Directory: 2.4/alpine3.6
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
- `httpd`: update to Debian Stretch (docker-library/httpd#113)
- `openjdk`: 12-ea+16
- `php`: remove old Alpine versions (docker-library/php#730)
- `ruby`: add more Alpine 3.8 (docker-library/ruby#241) and drop Alpine 3.6