### PR TITLE
Bump sonarqube to latest commit for newer urls to fix failing builds

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,6 +1,6 @@
 Maintainers: Evgeny Mandrikov <mandrikov@gmail.com> (@Godin)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 4d76dfe9fb4c5d41ba1852cd5072dbff15ca5a20
+GitCommit: 5d738964cc4b857ca5b399d6f0bb626b6710bac6
 
 Tags: 6.7.5, lts
 Directory: 6.7.5


### PR DESCRIPTION
Using newest commit available on repo: https://github.com/SonarSource/docker-sonarqube/commit/5d738964cc4b857ca5b399d6f0bb626b6710bac6 which still has the same version numbers.

cc @Godin 