### PR TITLE
Add support for "File:" in manifest files

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -90,7 +90,7 @@ func cmdBuild(c *cli.Context) error {
 					}
 					defer archive.Close()
 
-					err = dockerBuild(cacheTag, archive)
+					err = dockerBuild(cacheTag, entry.ArchFile(arch), archive)
 					if err != nil {
 						return cli.NewMultiError(fmt.Errorf(`failed building %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 					}

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -28,7 +28,7 @@ func (r Repo) ArchDockerFrom(arch string, entry *manifest.Manifest2822Entry) (st
 		return "", err
 	}
 
-	dockerfileFile := path.Join(entry.ArchDirectory(arch), "Dockerfile")
+	dockerfileFile := path.Join(entry.ArchDirectory(arch), entry.ArchFile(arch))
 
 	cacheKey := strings.Join([]string{
 		commit,
@@ -113,7 +113,7 @@ func dockerInspect(format string, args ...string) (string, error) {
 			return "", fmt.Errorf("%v\ncommand: docker inspect -f %q %q\n%s", ee, format, args, string(ee.Stderr))
 		}
 	}
-	return string(out), nil
+	return strings.TrimSpace(string(out)), nil
 }
 
 var dockerFromIdCache = map[string]string{
@@ -138,12 +138,13 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 		entry.ArchGitRepo(arch),
 		entry.ArchGitCommit(arch),
 		entry.ArchDirectory(arch),
+		entry.ArchFile(arch),
 		fromId,
 	}, nil
 }
 
-func dockerBuild(tag string, context io.Reader) error {
-	args := []string{"build", "-t", tag, "--rm", "--force-rm"}
+func dockerBuild(tag string, file string, context io.Reader) error {
+	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm"}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = context

--- a/bashbrew/go/vendor/manifest
+++ b/bashbrew/go/vendor/manifest
@@ -10,7 +10,7 @@
 		{
 			"importpath": "github.com/docker-library/go-dockerlibrary",
 			"repository": "https://github.com/docker-library/go-dockerlibrary",
-			"revision": "994859128ef56db39a0e164a348a249733b9ec91",
+			"revision": "dd7d405dfece72f87c382d7c0495ad44235f9ebb",
 			"branch": "master"
 		},
 		{

--- a/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/example_test.go
+++ b/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/example_test.go
@@ -54,10 +54,18 @@ s390x-GitCommit: b6c460e7cd79b595267870a98013ec3078b490df
 i386-GitFetch: refs/heads/i386
 ppc64le-Directory: 1.5/ppc64le
 
+Tags: 1.5-alpine
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5
+File: Dockerfile.alpine
+s390x-File: Dockerfile.alpine.s390x.bad-boy
+
 SharedTags: raspbian
 GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 Tags: raspbian-s390x
 Architectures: s390x, i386
+File: Dockerfile-raspbian
+s390x-File: Dockerfile
 
 
 `)))
@@ -113,15 +121,24 @@ i: g@h j
 	// ppc64le-Directory: 1.5/ppc64le
 	// s390x-GitCommit: b6c460e7cd79b595267870a98013ec3078b490df
 	//
+	// Tags: 1.5-alpine
+	// GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+	// Directory: 1.5
+	// File: Dockerfile.alpine
+	// s390x-File: Dockerfile.alpine.s390x.bad-boy
+	//
 	// Tags: raspbian-s390x
 	// SharedTags: raspbian
 	// Architectures: i386, s390x
 	// GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+	// File: Dockerfile-raspbian
+	// s390x-File: Dockerfile
 	//
 	// Shared Tag Groups:
 	//
 	//   - latest
 	//     - 1.6.1, 1.6, 1
+	//     - 1.5-alpine
 	//
 	//   - 1.5.3-debian, 1.5-debian
 	//     - 1.5.3, 1.5

--- a/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/rfc2822.go
+++ b/bashbrew/go/vendor/src/github.com/docker-library/go-dockerlibrary/manifest/rfc2822.go
@@ -38,6 +38,7 @@ type Manifest2822Entry struct {
 	GitFetch  string
 	GitCommit string
 	Directory string
+	File      string
 
 	// architecture-specific versions of the above fields
 	ArchValues map[string]string
@@ -56,6 +57,7 @@ var (
 
 		GitFetch:  "refs/heads/master",
 		Directory: ".",
+		File:      "Dockerfile",
 	}
 )
 
@@ -81,7 +83,7 @@ func (entry Manifest2822Entry) Clone() Manifest2822Entry {
 
 func (entry *Manifest2822Entry) SeedArchValues() {
 	for field, val := range entry.Paragraph.Values {
-		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") {
+		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") || strings.HasSuffix(field, "-File") {
 			entry.ArchValues[field] = val
 		}
 	}
@@ -118,7 +120,7 @@ func (a Manifest2822Entry) SameBuildArtifacts(b Manifest2822Entry) bool {
 		}
 	}
 
-	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.ConstraintsString() == b.ConstraintsString()
+	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.File == b.File && a.ConstraintsString() == b.ConstraintsString()
 }
 
 // returns a list of architecture-specific fields in an Entry
@@ -160,6 +162,9 @@ func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifes
 	if entry.Directory == defaults.Directory {
 		entry.Directory = ""
 	}
+	if entry.File == defaults.File {
+		entry.File = ""
+	}
 	for _, key := range defaults.archFields() {
 		if defaults.ArchValues[key] == entry.ArchValues[key] {
 			delete(entry.ArchValues, key)
@@ -196,6 +201,9 @@ func (entry Manifest2822Entry) String() string {
 	}
 	if str := entry.Directory; str != "" {
 		ret = append(ret, "Directory: "+str)
+	}
+	if str := entry.File; str != "" {
+		ret = append(ret, "File: "+str)
 	}
 	for _, key := range entry.archFields() {
 		ret = append(ret, key+": "+entry.ArchValues[key])
@@ -261,6 +269,13 @@ func (entry Manifest2822Entry) ArchDirectory(arch string) string {
 		return val
 	}
 	return entry.Directory
+}
+
+func (entry Manifest2822Entry) ArchFile(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-File"]; ok && val != "" {
+		return val
+	}
+	return entry.File
 }
 
 func (entry Manifest2822Entry) HasTag(tag string) bool {


### PR DESCRIPTION
See https://github.com/docker-library/go-dockerlibrary/pull/16 for format implementation details.

This feature is intended to be used extremely sparingly, but allows for specifying the `-f` argument to `docker build` relative to `Directory:` (via a new `File:` field), especially so multiple builds can share build context.