### PR TITLE
Updating tags

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,35 +2,35 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: b8d21d7bcc0401fc7f5d014a3a7ff41e3e6a49b2
+GitCommit: 3e8b75f57f92f23f4d5d599d713c9a2d1c8e5c3d
 Architectures: amd64, i386, ppc64le, s390x
 
-Tags: javaee8, latest
-Directory: ga/developer/javaee8
+Tags: 18.0.0.3-javaee8, javaee8, latest
+Directory: ga/18.0.0.3/javaee8
 
-Tags: webProfile8
-Directory: ga/developer/webProfile8
+Tags: 18.0.0.3-webProfile8, webProfile8
+Directory: ga/18.0.0.3/webProfile8
 
-Tags: microProfile1
-Directory: ga/developer/microProfile1
+Tags: 18.0.0.3-microProfile1, microProfile1
+Directory: ga/18.0.0.3/microProfile1
 
-Tags: microProfile2, microProfile
-Directory: ga/developer/microProfile2
+Tags: 18.0.0.3-microProfile2, microProfile2, microProfile
+Directory: ga/18.0.0.3/microProfile2
 
-Tags: springBoot2
-Directory: ga/developer/springBoot2
+Tags: 18.0.0.3-springBoot2, springBoot2
+Directory: ga/18.0.0.3/springBoot2
 
-Tags: kernel
-Directory: ga/developer/kernel
+Tags: 18.0.0.3-kernel, kernel
+Directory: ga/18.0.0.3/kernel
 
 Tags: beta
 Directory: beta
 
-Tags: springBoot1
-Directory: ga/developer/springBoot1
+Tags: 18.0.0.3-springBoot1, springBoot1
+Directory: ga/18.0.0.3/springBoot1
 
-Tags: webProfile7
-Directory: ga/developer/webProfile7
+Tags: 18.0.0.3-webProfile7, webProfile7
+Directory: ga/18.0.0.3/webProfile7
 
-Tags: javaee7
-Directory: ga/developer/javaee7
+Tags: 18.0.0.3-javaee7, javaee7
+Directory: ga/18.0.0.3/javaee7


### PR DESCRIPTION
Adding versions to Liberty's tags.  This has been a very requested featured from customers that want to move up to newer versions on their own.  

We plan on keeping tags for N - 2 versions.

The `versionless` tags (like `javaee8`) will always point to the latest versions.  