### PR TITLE
Update Eclipse Mosquitto to 1.5.3.

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,7 +1,7 @@
-Maintainers: David Audet <david.audet@ca.com> (@daudetCA)
+Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
+GitCommit: 1853bfc678c255367e7c2c2f138da7bf47054117
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 1.4.12, latest
-GitCommit: 0bb602ed7a89da80d25e6b959a130fdcf0556be5
-GitFetch:  refs/heads/develop
-Directory: docker/1.4.12
+Tags: 1.5.3, 1.5, latest
+Directory: docker/1.5


### PR DESCRIPTION
This is an update for the Eclipse Mosquitto image. I'm the upstream lead and am taking on the direct maintainership now.

Changes:
* Multiple architecture support
* The new Dockerfile builds from source instead of using an Alpine package
* The downloads have sha256 and gpg checks.

It is a fairly substantial rewrite and my Docker experience isn't as broad as I'd like, so I'd be grateful for a keen review.