### PR TITLE
Add a 1.4.0-rc1 tag

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -5,3 +5,9 @@ Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 3e9120657c15e2f208e3cf16a698f1bb3bee3cdd
 Directory: 0.X
+
+Tags: 1.4.0-rc1
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 3f040bac0f335116e264334d64c9f4fec524fe61
+Directory: 0.X


### PR DESCRIPTION
The latest tag still will use version 1.3.0