### PR TITLE
ZNC: update Alpine to 3.8

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,6 +1,6 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
-GitCommit: 202305e54e2e2c4d22a6a234bc74c5bbb209b129
+GitCommit: e1b3356c689e2b6171252770a17ffb662fdb4d8c
 Architectures: amd64, arm32v6, arm64v8
 
 Tags: 1.7.1, 1.7, latest


### PR DESCRIPTION
Accidentally, fix https://github.com/znc/znc-docker/issues/18