### PR TITLE
drop 17, add rebar3 into alpine, update base os to stretch, update to 20.3.8.14, 18.3.8.11, 21.1.2

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,64 +1,54 @@
-# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/5c50e67e89a5d26233fb650c13bc9caecc865cf5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/ba81527544daf50d27a85b1a6001cc541b742089/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/erlang/docker-erlang-otp.git
 
-Tags: 21.1.1, 21.1, 21, latest
+Tags: 21.1.2, 21.1, 21, latest
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: de48e7c91b8a293770c6fcccdd30d2329fcc0414
+GitCommit: 7e059488ae8eaaffd3a98ee1816796f445a19721
 Directory: 21
 
-Tags: 21.1.1-slim, 21.1-slim, 21-slim, slim
+Tags: 21.1.2-slim, 21.1-slim, 21-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: de48e7c91b8a293770c6fcccdd30d2329fcc0414
+GitCommit: 7e059488ae8eaaffd3a98ee1816796f445a19721
 Directory: 21/slim
 
-Tags: 21.1.1-alpine, 21.1-alpine, 21-alpine, alpine
+Tags: 21.1.2-alpine, 21.1-alpine, 21-alpine, alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: de48e7c91b8a293770c6fcccdd30d2329fcc0414
+GitCommit: 7e059488ae8eaaffd3a98ee1816796f445a19721
 Directory: 21/alpine
 
-Tags: 20.3.8.13, 20.3.8, 20.3, 20
+Tags: 20.3.8.14, 20.3.8, 20.3, 20
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
+GitCommit: 1ab28c7de349f59cdf03ad3303d50eee0a039c1f
 Directory: 20
 
-Tags: 20.3.8.13-slim, 20.3.8-slim, 20.3-slim, 20-slim
+Tags: 20.3.8.14-slim, 20.3.8-slim, 20.3-slim, 20-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
+GitCommit: 1ab28c7de349f59cdf03ad3303d50eee0a039c1f
 Directory: 20/slim
 
-Tags: 20.3.8.13-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine
+Tags: 20.3.8.14-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
+GitCommit: 1ab28c7de349f59cdf03ad3303d50eee0a039c1f
 Directory: 20/alpine
 
 Tags: 19.3.6.12, 19.3.6, 19.3, 19
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: dc54fb8d1737f493748176df10c4af1b42e1e7b5
+GitCommit: ba81527544daf50d27a85b1a6001cc541b742089
 Directory: 19
 
 Tags: 19.3.6.12-slim, 19.3.6-slim, 19.3-slim, 19-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: dc54fb8d1737f493748176df10c4af1b42e1e7b5
+GitCommit: ba81527544daf50d27a85b1a6001cc541b742089
 Directory: 19/slim
 
-Tags: 18.3.4.10, 18.3.4, 18.3, 18
+Tags: 18.3.4.11, 18.3.4, 18.3, 18
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: 4fe4caa8ebd01748b50bac745f5e96d872e1db4c
+GitCommit: 06d4d38a4fc360a8718d78d163e36d6777cd2528
 Directory: 18
 
-Tags: 18.3.4.10-slim, 18.3.4-slim, 18.3-slim, 18-slim
+Tags: 18.3.4.11-slim, 18.3.4-slim, 18.3-slim, 18-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x
-GitCommit: 4fe4caa8ebd01748b50bac745f5e96d872e1db4c
+GitCommit: 06d4d38a4fc360a8718d78d163e36d6777cd2528
 Directory: 18/slim
-
-Tags: 17.5.6.9, 17.5.6, 17.5, 17
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: a75738f344af1f177f828cbaa6e8a44d15749d5a
-Directory: 17
-
-Tags: 17.5.6.9-slim, 17.5.6-slim, 17.5-slim, 17-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: a75738f344af1f177f828cbaa6e8a44d15749d5a
-Directory: 17/slim


### PR DESCRIPTION
a solution for erlang/docker-erlang-otp#130 , code discussion see erlang/docker-erlang-otp#153