### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -7,27 +7,27 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
+GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
 Directory: 5
 # Docker EOL: 2018-10-10
 
-# Last Modified: 2017-07-04
-Tags: 6.4.0, 6.4, 6
+# Last Modified: 2018-10-26
+Tags: 6.5.0, 6.5, 6
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
+GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
 Directory: 6
-# Docker EOL: 2018-07-04
+# Docker EOL: 2019-10-26
 
 # Last Modified: 2018-01-25
 Tags: 7.3.0, 7.3, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a7f7464baaa3a24cdd35e1173d84ab94e32a14d
+GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
 Directory: 7
 # Docker EOL: 2019-01-25
 
 # Last Modified: 2018-07-26
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ca5b263c1028b3a4fbdb8c2d800544ab43d524a0
+GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
 Directory: 8
 # Docker EOL: 2019-07-26

--- a/library/mariadb
+++ b/library/mariadb
@@ -24,7 +24,7 @@ Architectures: amd64, arm64v8, i386, ppc64le
 GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
 Directory: 10.0
 
-Tags: 5.5.61-trusty, 5.5-trusty, 5-trusty, 5.5.61, 5.5, 5
+Tags: 5.5.62-trusty, 5.5-trusty, 5-trusty, 5.5.62, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
+GitCommit: 4ffbde76c75a49456d1729bb142d1c0c9c51f574
 Directory: 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -129,12 +129,12 @@ Directory: 10/jre/slim
 
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86918ee28d383e7af63f535a2558040dce141099
+GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
 Directory: 8/jdk
 
 Tags: 8u181-jdk-slim-stretch, 8u181-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u181-jdk-slim, 8u181-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86918ee28d383e7af63f535a2558040dce141099
+GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
 Directory: 8/jdk/slim
 
 Tags: 8u181-jdk-alpine3.8, 8u181-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u181-jdk-alpine, 8u181-alpine, 8-jdk-alpine, 8-alpine
@@ -165,12 +165,12 @@ Constraints: nanoserver-sac2016
 
 Tags: 8u181-jre-stretch, 8-jre-stretch, 8u181-jre, 8-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86918ee28d383e7af63f535a2558040dce141099
+GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
 Directory: 8/jre
 
 Tags: 8u181-jre-slim-stretch, 8-jre-slim-stretch, 8u181-jre-slim, 8-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86918ee28d383e7af63f535a2558040dce141099
+GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
 Directory: 8/jre/slim
 
 Tags: 8u181-jre-alpine3.8, 8-jre-alpine3.8, 8u181-jre-alpine, 8-jre-alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.7.8, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
+GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
 Directory: 3.7/debian
 
 Tags: 3.7.8-management, 3.7-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.7/debian/management
 
 Tags: 3.7.8-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
+GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
 Directory: 3.7/alpine
 
 Tags: 3.7.8-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.7/alpine/management
 
 Tags: 3.6.16, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
+GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
 Directory: 3.6/debian
 
 Tags: 3.6.16-management, 3.6-management
@@ -36,7 +36,7 @@ Directory: 3.6/debian/management
 
 Tags: 3.6.16-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fa42cf263ead1671e1aa6dc3495173609173cadb
+GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
 Directory: 3.6/alpine
 
 Tags: 3.6.16-management-alpine, 3.6-management-alpine

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebcb6b03454b1ca0c61407523f549a7bd669763
+GitCommit: 11b069f7a672f1900534901d50debae8e2770559
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebcb6b03454b1ca0c61407523f549a7bd669763
+GitCommit: 11b069f7a672f1900534901d50debae8e2770559
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebcb6b03454b1ca0c61407523f549a7bd669763
+GitCommit: 11b069f7a672f1900534901d50debae8e2770559
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebcb6b03454b1ca0c61407523f549a7bd669763
+GitCommit: 11b069f7a672f1900534901d50debae8e2770559
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94c61b83026af46f7909aed29269a56247110485
+GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94c61b83026af46f7909aed29269a56247110485
+GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 94c61b83026af46f7909aed29269a56247110485
+GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 94c61b83026af46f7909aed29269a56247110485
+GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 95a644170764312bec299ca00c933bafdd1c9c64
+GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ec28789af73f3a02ec675ee49172cc3cd1bfce2
+GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `gcc`: 6.5.0
- `mariadb`: 5.5.62
- `openjdk`: debian `8u181-b13-2~deb9u1`
- `rabbitmq`: copy SSL certificates with a warning if necessary (docker-library/rabbitmq#285)
- `ruby`: bundler 1.17.1