### PR TITLE
Ditch "neurodebian:artful" now that it's EOL

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: 88af27888a5aee76924c3b6840fc47f9cd8f63cb
+GitCommit: 3af4359d1781af273f5fbc5aa8e6ff1055eb4aa4
 
 Tags: trusty, nd14.04
 Directory: dockerfiles/trusty
@@ -13,12 +13,6 @@ Directory: dockerfiles/xenial
 
 Tags: xenial-non-free, nd16.04-non-free
 Directory: dockerfiles/xenial-non-free
-
-Tags: artful, nd17.10
-Directory: dockerfiles/artful
-
-Tags: artful-non-free, nd17.10-non-free
-Directory: dockerfiles/artful-non-free
 
 Tags: bionic, nd18.04
 Directory: dockerfiles/bionic


### PR DESCRIPTION
It's that time again, @yarikoptic. :sweat_smile: :heart: