### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
+GitCommit: c80b2d6a3f5668f01246e44883e851ae37114194
 Directory: 2.1
 
 Tags: 2.2.13, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
+GitCommit: c80b2d6a3f5668f01246e44883e851ae37114194
 Directory: 2.2
 
 Tags: 3.0.17, 3.0

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.4.1
-GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
-Directory: 6.4.1
-
-Tags: 6.4.0
-GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
-Directory: 6.4.0
-
 Tags: 6.4.2
 GitCommit: cf9cba0a1590cfd894d51bc7998d9d36b2d47afd
 Directory: 6

--- a/library/gcc
+++ b/library/gcc
@@ -7,27 +7,27 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
+GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
 Directory: 5
-# Docker EOL: 2018-10-10
+# Docker EOL: 2019-04-10
 
-# Last Modified: 2018-10-26
+# Last Modified: 2018-10-30
 Tags: 6.5.0, 6.5, 6
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
+GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
 Directory: 6
-# Docker EOL: 2019-10-26
+# Docker EOL: 2020-04-30
 
 # Last Modified: 2018-01-25
 Tags: 7.3.0, 7.3, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
+GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
 Directory: 7
-# Docker EOL: 2019-01-25
+# Docker EOL: 2019-07-25
 
 # Last Modified: 2018-07-26
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 03f749f3db89492de30407fb33bab9f5af55a62b
+GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
 Directory: 8
-# Docker EOL: 2019-07-26
+# Docker EOL: 2020-01-26

--- a/library/ghost
+++ b/library/ghost
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.3.0, 2.3, 2, latest
+Tags: 2.4.0, 2.4, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1522c9e45bc73c26b5d7a05b37d310fadd13ef9e
+GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
 Directory: 2/debian
 
-Tags: 2.3.0-alpine, 2.3-alpine, 2-alpine, alpine
+Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1522c9e45bc73c26b5d7a05b37d310fadd13ef9e
+GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4792c91799bca4e41a5f8439cf068f05e2341662
+GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
 Directory: 1/debian
 
 Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4792c91799bca4e41a5f8439cf068f05e2341662
+GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0

--- a/library/joomla
+++ b/library/joomla
@@ -3,62 +3,62 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.8.13-php5.6-apache, 3.8-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.8.13-php5.6, 3.8-php5.6, 3-php5.6, php5.6
+Tags: 3.9.0-php5.6-apache, 3.9-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.9.0-php5.6, 3.9-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php5.6/apache
 
-Tags: 3.8.13-php5.6-fpm, 3.8-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
+Tags: 3.9.0-php5.6-fpm, 3.9-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php5.6/fpm
 
-Tags: 3.8.13-php5.6-fpm-alpine, 3.8-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 3.9.0-php5.6-fpm-alpine, 3.9-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php5.6/fpm-alpine
 
-Tags: 3.8.13-php7.0-apache, 3.8-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.8.13-php7.0, 3.8-php7.0, 3-php7.0, php7.0
+Tags: 3.9.0-php7.0-apache, 3.9-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.9.0-php7.0, 3.9-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.0/apache
 
-Tags: 3.8.13-php7.0-fpm, 3.8-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
+Tags: 3.9.0-php7.0-fpm, 3.9-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.0/fpm
 
-Tags: 3.8.13-php7.0-fpm-alpine, 3.8-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 3.9.0-php7.0-fpm-alpine, 3.9-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.0/fpm-alpine
 
-Tags: 3.8.13-apache, 3.8-apache, 3-apache, apache, 3.8.13, 3.8, 3, latest, 3.8.13-php7.1-apache, 3.8-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.8.13-php7.1, 3.8-php7.1, 3-php7.1, php7.1
+Tags: 3.9.0-apache, 3.9-apache, 3-apache, apache, 3.9.0, 3.9, 3, latest, 3.9.0-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.0-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.1/apache
 
-Tags: 3.8.13-fpm, 3.8-fpm, 3-fpm, fpm, 3.8.13-php7.1-fpm, 3.8-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.9.0-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.0-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.1/fpm
 
-Tags: 3.8.13-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.8.13-php7.1-fpm-alpine, 3.8-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.9.0-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.0-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.1/fpm-alpine
 
-Tags: 3.8.13-php7.2-apache, 3.8-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.8.13-php7.2, 3.8-php7.2, 3-php7.2, php7.2
+Tags: 3.9.0-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.0-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.2/apache
 
-Tags: 3.8.13-php7.2-fpm, 3.8-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.0-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.2/fpm
 
-Tags: 3.8.13-php7.2-fpm-alpine, 3.8-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.0-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 23d27541b491bb4b259e1941ec48a9c6e495b70d
+GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
 Directory: php7.2/fpm-alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.4.1
-GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
-Directory: 6.4.1
-
-Tags: 6.4.0
-GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
-Directory: 6.4.0
-
 Tags: 6.4.2
 GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
 Directory: 6

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.70.4, 0.70, 0, latest
-GitCommit: 717015e57e3ae10d3da1bcf26c50462b7dd57edb
+Tags: 0.71.0, 0.71, 0, latest
+GitCommit: 4b769135c538f251d595008d82462ef712bd9f6a


### PR DESCRIPTION
- `cassandra`: stretch (docker-library/cassandra#166)
- `elasticsearch`: remove backfilled tags (docker-library/elasticsearch#184)
- `gcc`: increase EOL window to 18 months (docker-library/gcc#49)
- `ghost`: 2.4.0
- `joomla`: 3.9.0
- `kibana`: remove backfilled tags (docker-library/kibana#87)
- `rocket.chat`: 0.71.0