### PR TITLE
Maven 3.6.0

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -1,72 +1,72 @@
 Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
 GitRepo: https://github.com/carlossg/docker-maven.git
 
-Tags: 3.5.4-jdk-10-slim, 3.5-jdk-10-slim, 3-jdk-10-slim
+Tags: 3.6.0-jdk-10-slim, 3.6-jdk-10-slim, 3-jdk-10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-10-slim
 
-Tags: 3.5.4-jdk-10, 3.5-jdk-10, 3-jdk-10
+Tags: 3.6.0-jdk-10, 3.6-jdk-10, 3-jdk-10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-10
 
-Tags: 3.5.4-jdk-11-slim, 3.5-jdk-11-slim, 3-jdk-11-slim
+Tags: 3.6.0-jdk-11-slim, 3.6-jdk-11-slim, 3-jdk-11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-11-slim
 
-Tags: 3.5.4-jdk-11, 3.5-jdk-11, 3-jdk-11
+Tags: 3.6.0-jdk-11, 3.6-jdk-11, 3-jdk-11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-11
 
-Tags: 3.5.4-jdk-7-alpine, 3.5-jdk-7-alpine, 3-jdk-7-alpine
+Tags: 3.6.0-jdk-12-alpine, 3.6-jdk-12-alpine, 3-jdk-12-alpine
+Architectures: amd64
+GitCommit: 0607c2d00e31df3d2166bb0ab4f5097bdf2ede0e
+Directory: jdk-12-alpine
+
+Tags: 3.6.0-jdk-12, 3.6-jdk-12, 3-jdk-12
+Architectures: amd64
+GitCommit: 0607c2d00e31df3d2166bb0ab4f5097bdf2ede0e
+Directory: jdk-12
+
+Tags: 3.6.0-jdk-7-alpine, 3.6-jdk-7-alpine, 3-jdk-7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-7-alpine
 
-Tags: 3.5.4-jdk-7-slim, 3.5-jdk-7-slim, 3-jdk-7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+Tags: 3.6.0-jdk-7-slim, 3.6-jdk-7-slim, 3-jdk-7-slim
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-7-slim
 
-Tags: 3.5.4-jdk-7, 3.5-jdk-7, 3-jdk-7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+Tags: 3.6.0-jdk-7, 3.6-jdk-7, 3-jdk-7
+Architectures: amd64, arm32v5, arm32v7, i386
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-7
 
-Tags: 3.5.4-jdk-8-alpine, 3.5.4-alpine, 3.5-jdk-8-alpine, 3.5-alpine, 3-jdk-8-alpine, alpine
+Tags: 3.6.0-jdk-8-alpine, 3.6.0-alpine, 3.6-jdk-8-alpine, 3.6-alpine, 3-jdk-8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-8-alpine
 
-Tags: 3.5.4-jdk-8-slim, 3.5.4-slim, 3.5-jdk-8-slim, 3.5-slim, 3-jdk-8-slim, slim
+Tags: 3.6.0-jdk-8-slim, 3.6.0-slim, 3.6-jdk-8-slim, 3.6-slim, 3-jdk-8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-8-slim
 
-Tags: 3.5.4-jdk-8, 3.5.4, 3.5-jdk-8, 3.5, 3-jdk-8, 3, latest
+Tags: 3.6.0-jdk-8, 3.6.0, 3.6-jdk-8, 3.6, 3-jdk-8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: jdk-8
 
-Tags: 3.5.4-jdk-9-slim, 3.5-jdk-9-slim, 3-jdk-9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
-Directory: jdk-9-slim
-
-Tags: 3.5.4-jdk-9, 3.5-jdk-9, 3-jdk-9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
-Directory: jdk-9
-
-Tags: 3.5.4-ibmjava-8-alpine, 3.5.4-ibmjava-alpine, 3.5-ibmjava-8-alpine, 3.5-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
+Tags: 3.6.0-ibmjava-8-alpine, 3.6.0-ibmjava-alpine, 3.6-ibmjava-8-alpine, 3.6-ibmjava-alpine, 3-ibmjava-8-alpine, ibmjava-alpine
 Architectures: amd64
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: ibmjava-8-alpine
 
-Tags: 3.5.4-ibmjava-8, 3.5.4-ibmjava, 3.5-ibmjava-8, 3.5-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
+Tags: 3.6.0-ibmjava-8, 3.6.0-ibmjava, 3.6-ibmjava-8, 3.6-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: f581ea002e5d067deb6213c00a4d217297cad469
+GitCommit: 05f4802aa5c253dcf75fe967c6f45b3fb1e2f26e
 Directory: ibmjava-8


### PR DESCRIPTION
Remove jdk-9 images as parent images have been removed (docker-library/openjdk#199)
Add jdk-12 and jdk-12-alpine images