### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-beta5, 18.09-rc, rc, test
+Tags: 18.09.0-rc1, 18.09-rc, rc, test
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9da077a794cffbea8461b128286a9acb69a3c54d
+GitCommit: 89c711a9c06628611a8ac28b18b965bdadccf146
 Directory: 18.09-rc
 
-Tags: 18.09.0-beta5-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-rc1-dind, 18.09-rc-dind, rc-dind, test-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.09-rc/dind
 
-Tags: 18.09.0-beta5-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-rc1-git, 18.09-rc-git, rc-git, test-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
 Directory: 18.09-rc/git

--- a/library/ghost
+++ b/library/ghost
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 2.4.0, 2.4, 2, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, i386
 GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
 Directory: 2/debian
 
@@ -15,7 +15,7 @@ GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
 Directory: 2/alpine
 
 Tags: 1.25.5, 1.25, 1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, i386
 GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
 Directory: 1/debian
 
@@ -25,7 +25,7 @@ GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
 Directory: 1/alpine
 
 Tags: 0.11.13, 0.11, 0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, i386
 GitCommit: d14e83ced34cd574b9473023e2765683f4e99e65
 Directory: 0/debian
 

--- a/library/mariadb
+++ b/library/mariadb
@@ -14,14 +14,14 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 81ad56cf6bdf82666da60d828247684fda142c03
 Directory: 10.2
 
-Tags: 10.1.36-bionic, 10.1-bionic, 10.1.36, 10.1
+Tags: 10.1.37-bionic, 10.1-bionic, 10.1.37, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
+GitCommit: 36024883027e6ec5ff0d2fb43c0ce4f6f77ea4cc
 Directory: 10.1
 
-Tags: 10.0.36-xenial, 10.0-xenial, 10.0.36, 10.0
+Tags: 10.0.37-xenial, 10.0-xenial, 10.0.37, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: c65dccaa72d6030429ebb764b10a13c955c92314
+GitCommit: 63a00c827dd02c5ede7957d96d0ffc0d020ef03e
 Directory: 10.0
 
 Tags: 5.5.62-trusty, 5.5-trusty, 5-trusty, 5.5.62, 5.5, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-17-jdk-oraclelinux7, 12-ea-17-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-17-jdk-oracle, 12-ea-17-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-17-jdk, 12-ea-17, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-18-jdk-oraclelinux7, 12-ea-18-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-18-jdk-oracle, 12-ea-18-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-18-jdk, 12-ea-18, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 3850f26ecddd3dc1626e7fbc7ec29a61a9c67fd6
+GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-14-jdk-alpine3.8, 12-ea-14-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-14-jdk-alpine, 12-ea-14-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 57de518e280c26fa8a9f602e76c3f3ea95f8296c
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-17-jdk-windowsservercore-ltsc2016, 12-ea-17-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-17-jdk-windowsservercore, 12-ea-17-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-18-jdk-windowsservercore-ltsc2016, 12-ea-18-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3850f26ecddd3dc1626e7fbc7ec29a61a9c67fd6
+GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-17-jdk-windowsservercore-1709, 12-ea-17-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-17-jdk-windowsservercore, 12-ea-17-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-18-jdk-windowsservercore-1709, 12-ea-18-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3850f26ecddd3dc1626e7fbc7ec29a61a9c67fd6
+GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-17-jdk-windowsservercore-1803, 12-ea-17-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-17-jdk-windowsservercore, 12-ea-17-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-18-jdk-windowsservercore-1803, 12-ea-18-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3850f26ecddd3dc1626e7fbc7ec29a61a9c67fd6
+GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/owncloud
+++ b/library/owncloud
@@ -5,21 +5,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.10-apache, 10.0-apache, 10-apache, apache, 10.0.10, 10.0, 10, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
 Directory: 10.0/apache
 
 Tags: 10.0.10-fpm, 10.0-fpm, 10-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
+GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933c3f68a282c9612e565a8421ced10e19614e76
+GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
 Directory: 9.1/fpm

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 3620c44581073acbafa5ee848025122e350b39e0
+GitCommit: 4f5873e66fb775da334d8902c02ecb6d579fc3e8
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
@@ -19,5 +19,5 @@ GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: 3620c44581073acbafa5ee848025122e350b39e0
+GitCommit: 4f5873e66fb775da334d8902c02ecb6d579fc3e8
 Directory: 3.3/passenger

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.71.0, 0.71, 0, latest
-GitCommit: 4b769135c538f251d595008d82462ef712bd9f6a
+Tags: 0.71.1, 0.71, 0, latest
+GitCommit: 45ab9367ba7ad36779ee0348e8489276e0a96323

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 11b069f7a672f1900534901d50debae8e2770559
+GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 11b069f7a672f1900534901d50debae8e2770559
+GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 11b069f7a672f1900534901d50debae8e2770559
+GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 11b069f7a672f1900534901d50debae8e2770559
+GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
+GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
+GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
+GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac
+GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a1c2d5ce79ea8f0c381e24fbe535bd090043c393
+GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9e6a656108d5227e5788dcf5f0e4c63e726dc3e6
+GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
 Directory: 2.3/alpine3.7

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php5.6/apache
 
 Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php5.6/fpm
 
 Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.0/apache
 
 Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.0/fpm
 
 Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.1/apache
 
 Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.1/fpm
 
 Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.2/apache
 
 Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.2/fpm
 
 Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 913115b209407ae0ed9d38a13e8e5d8b909b431f
+GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker`: 18.09.0-rc1
- `ghost`: fixed architectures (`node:8-slim` is `debian:jessie`-based)
- `mariadb`: 10.1.37
- `openjdk`: 12-ea+18
- `owncloud`: PHP 7.2 (docker-library/owncloud#107)
- `redmine`: pre-build `passenger_native_support.so` (docker-library/redmine#135)
- `rocket.chat`: 0.71.1
- `ruby`: rubygems 2.7.8
- `wordpress`: remove `--one-file-system` (docker-library/wordpress#345)