### PR TITLE
Fixes in eclipse-mosquitto image

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,6 +1,6 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 1853bfc678c255367e7c2c2f138da7bf47054117
+GitCommit: da2879c33b6baf00b8b50a38da8d7f176cd85afa
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 1.5.3, 1.5, latest


### PR DESCRIPTION
- Don't remove apk files
- Install mosquitto_passwd binary.