### PR TITLE
Update Logstash to 6.x upstream images

### DIFF
--- a/library/logstash
+++ b/library/logstash
@@ -1,21 +1,33 @@
-# this file is generated via https://github.com/docker-library/logstash/blob/ed8e1d89a264eed50f857601c7b4364af66155cd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/logstash/blob/18d3da965bb702a12edd9d387afd16bd965c5b1c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 5.6.12, 5.6, 5, latest
+Tags: 6.4.1
+GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
+Directory: 6.4.1
+
+Tags: 6.4.0
+GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
+Directory: 6.4.0
+
+Tags: 6.4.2
+GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
+Directory: 6
+
+Tags: 5.6.12, 5.6, 5
 GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
 Directory: 5
 
-Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine, alpine
+Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine
 GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
 Directory: 5/alpine
 
-Tags: 2.4.1, 2.4, 2
+Tags: 2.4.1, 2.4
 GitCommit: 4f425e9008de3d0375d1749d390029808aed8d96
 Directory: 2.4
 
-Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine
+Tags: 2.4.1-alpine, 2.4-alpine
 GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
 Directory: 2.4/alpine


### PR DESCRIPTION
In the interest of providing the best and most reliable support for the official Logstash Docker images, Elastic performs a rigorous set of automated and manual tests as part of the Logstash release process. Beyond testing our own software, these tests have historically uncovered other items such as JVM issues and OS-dependent issues that the Logstash software relies on.

In order to provide the Docker Library community with the same level of support for any Elastic images which are pulled from Docker Hub, it is necessary that these images are equivalent to those which come from the Elastic build system. This equivalence allows us to address issues in a specific version of Logstash with a full understanding of exactly what exists in that version, allowing us to support and troubleshoot any issues effectively and efficiently. It also allows Elastic to respond to issues with any necessary updates rapidly, and without the risk of divergent image content.

After extensive discussions and collaboration with Docker, it has been determined that the easiest, fastest, and most stable way to accomplish this is to use the Elastic images directly rather than rely on setting up an exact replica of Elastic’s build and testing systems. The code contained within this image is open (references to the code and the referenced image can be viewed within the image Dockerfile).

Relates: docker-library/logstash#91