### PR TITLE
Update oraclelinux for Oracle Linux 7.6

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,15 +4,15 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a1b19a9db117829b4096bcba68da381dbda62a61
+amd64-GitCommit: 54ab6edcc7e8ec45613d34456093da338b537267
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9c7fef4b2c1e58a450e217c6c48b76845d5b2e2d
+arm64v8-GitCommit: 0b50b405c53879218587393cad77cf6bf2d44d9e
 Constraints: !aufs
 
-Tags: 7.5, 7, latest
+Tags: 7.6, 7, latest
 Architectures: amd64, arm64v8
-Directory: 7.5
+Directory: 7.6
 
 Tags: 7-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
    [AMD64 7.6] 2018-11-06-86
    [AMD64 7-slim] 2018-11-06-20
    [ARM64v8 7.6] 2018-11-07-8
    [ARM64v8 7-slim] 2018-11-07-8

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>