### PR TITLE
Update docker library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0-rc1, 18.09-rc, rc, test
+Tags: 18.09.0, 18.09, 18, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 89c711a9c06628611a8ac28b18b965bdadccf146
-Directory: 18.09-rc
+GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
+Directory: 18.09
 
-Tags: 18.09.0-rc1-dind, 18.09-rc-dind, rc-dind, test-dind
+Tags: 18.09.0-dind, 18.09-dind, 18-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
-Directory: 18.09-rc/dind
+GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
+Directory: 18.09/dind
 
-Tags: 18.09.0-rc1-git, 18.09-rc-git, rc-git, test-git
+Tags: 18.09.0-git, 18.09-git, 18-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 5dd425e5b74a02bde63257e56c2bb67cbae74686
-Directory: 18.09-rc/git
+GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
+Directory: 18.09/git
 
-Tags: 18.06.1-ce, 18.06.1, 18.06, 18, edge, stable, latest
+Tags: 18.06.1-ce, 18.06.1, 18.06, edge
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.06
 
-Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, 18-dind, edge-dind, stable-dind, dind
+Tags: 18.06.1-ce-dind, 18.06.1-dind, 18.06-dind, edge-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: fe2ca76a21fdc02cbb4974246696ee1b4a7839dd
 Directory: 18.06/dind
 
-Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, 18-git, edge-git, stable-git, git
+Tags: 18.06.1-ce-git, 18.06.1-git, 18.06-git, edge-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.4.0, 2.4, 2, latest
+Tags: 2.5.0, 2.5, 2, latest
 Architectures: amd64, arm32v7, i386
-GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
+GitCommit: 9274b77aede29ff0e7595023b5160d7bc7ffb3e0
 Directory: 2/debian
 
-Tags: 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 171d72c30f798944d6efad4919834e5817c49ada
+GitCommit: 9274b77aede29ff0e7595023b5160d7bc7ffb3e0
 Directory: 2/alpine
 
-Tags: 1.25.5, 1.25, 1
+Tags: 1.25.6, 1.25, 1
 Architectures: amd64, arm32v7, i386
-GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
+GitCommit: 94e82489166b6d44f590306402492df09bbfbcbd
 Directory: 1/debian
 
-Tags: 1.25.5-alpine, 1.25-alpine, 1-alpine
+Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e4ebbc57745f336eceec48df12490d7cbf720b3
+GitCommit: 94e82489166b6d44f590306402492df09bbfbcbd
 Directory: 1/alpine
 
-Tags: 0.11.13, 0.11, 0
+Tags: 0.11.14, 0.11, 0
 Architectures: amd64, arm32v7, i386
-GitCommit: d14e83ced34cd574b9473023e2765683f4e99e65
+GitCommit: e1880db3c56f85410ad3342cbd33e7f98f24bcac
 Directory: 0/debian
 
-Tags: 0.11.13-alpine, 0.11-alpine, 0-alpine
+Tags: 0.11.14-alpine, 0.11-alpine, 0-alpine
 Architectures: amd64
-GitCommit: 9fc9c0a2009ab4302a80c88618a0e3640b2b78c6
+GitCommit: e1880db3c56f85410ad3342cbd33e7f98f24bcac
 Directory: 0/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -8,6 +8,6 @@ Tags: 6.4.2
 GitCommit: b8eac6fd9374fdb607b226603c13f180d4040588
 Directory: 6
 
-Tags: 5.6.12, 5.6, 5
-GitCommit: 958ce4b1abe560d2cbbe6a74168d13031cb1e106
+Tags: 5.6.13, 5.6, 5
+GitCommit: 7728998a85333ed87f14fc224db081f6c10602f9
 Directory: 5

--- a/library/logstash
+++ b/library/logstash
@@ -16,18 +16,10 @@ Tags: 6.4.2
 GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
 Directory: 6
 
-Tags: 5.6.12, 5.6, 5
-GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
+Tags: 5.6.13, 5.6, 5
+GitCommit: d5ef01551cfeae4e9aa45796689911485172dd68
 Directory: 5
 
-Tags: 5.6.12-alpine, 5.6-alpine, 5-alpine
-GitCommit: 606dfc2ead6902c11a0d809d7d66b192b87177e6
+Tags: 5.6.13-alpine, 5.6-alpine, 5-alpine
+GitCommit: d5ef01551cfeae4e9aa45796689911485172dd68
 Directory: 5/alpine
-
-Tags: 2.4.1, 2.4
-GitCommit: 4f425e9008de3d0375d1749d390029808aed8d96
-Directory: 2.4
-
-Tags: 2.4.1-alpine, 2.4-alpine
-GitCommit: 19330c802e6f198f015c0c4723a6d86ed449d93f
-Directory: 2.4/alpine

--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.11, 1.5, 1, latest
+Tags: 1.5.12, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66cbfc84fd2a8a08bc43d065bc6d74e0b48e972d
+GitCommit: c7bc33a596845a439051bbe32357b4b0e6e9dddc
 Directory: debian
 
-Tags: 1.5.11-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.12-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 66cbfc84fd2a8a08bc43d065bc6d74e0b48e972d
+GitCommit: c7bc33a596845a439051bbe32357b4b0e6e9dddc
 Directory: alpine

--- a/library/mongo
+++ b/library/mongo
@@ -26,25 +26,25 @@ GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.2/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.4.17-jessie, 3.4-jessie
-SharedTags: 3.4.17, 3.4
+Tags: 3.4.18-jessie, 3.4-jessie
+SharedTags: 3.4.18, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
+GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
 Directory: 3.4
 
-Tags: 3.4.17-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
-SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
+Tags: 3.4.18-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: 3.4.18-windowsservercore, 3.4-windowsservercore, 3.4.18, 3.4
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.17-windowsservercore-1709, 3.4-windowsservercore-1709
-SharedTags: 3.4.17-windowsservercore, 3.4-windowsservercore, 3.4.17, 3.4
+Tags: 3.4.18-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: 3.4.18-windowsservercore, 3.4-windowsservercore, 3.4.18, 3.4
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -70,60 +70,60 @@ GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.3-xenial, 4.0-xenial, 4-xenial, xenial
-SharedTags: 4.0.3, 4.0, 4, latest
+Tags: 4.0.4-xenial, 4.0-xenial, 4-xenial, xenial
+SharedTags: 4.0.4, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 90f043506151539585d7894e3ade7fde6960674a
+GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
 Directory: 4.0
 
-Tags: 4.0.3-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.0.3-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.3, 4.0, 4, latest
+Tags: 4.0.4-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.0.4-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.4, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 90f043506151539585d7894e3ade7fde6960674a
+GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.3-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
-SharedTags: 4.0.3-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.3, 4.0, 4, latest
+Tags: 4.0.4-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
+SharedTags: 4.0.4-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.4, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 90f043506151539585d7894e3ade7fde6960674a
+GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
 Directory: 4.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.3-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.0.3-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.3, 4.0, 4, latest
+Tags: 4.0.4-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.0.4-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.4, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 90f043506151539585d7894e3ade7fde6960674a
+GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.4-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.4, 4.1, unstable
+Tags: 4.1.5-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.5, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
+GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
 Directory: 4.1
 
-Tags: 4.1.4-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
+Tags: 4.1.5-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
+GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.4-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
+Tags: 4.1.5-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
+GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.4-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.4-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.4, 4.1, unstable
+Tags: 4.1.5-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: fb4e5958a22f8b5c7a65dba70ad53f6b08aeb8c8
+GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-18-jdk-oraclelinux7, 12-ea-18-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-18-jdk-oracle, 12-ea-18-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-18-jdk, 12-ea-18, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-19-jdk-oraclelinux7, 12-ea-19-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-19-jdk-oracle, 12-ea-19-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-19-jdk, 12-ea-19, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
+GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-14-jdk-alpine3.8, 12-ea-14-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-14-jdk-alpine, 12-ea-14-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-18-jdk-alpine3.8, 12-ea-18-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-18-jdk-alpine, 12-ea-18-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 57de518e280c26fa8a9f602e76c3f3ea95f8296c
+GitCommit: 37ac51ae06458726bfd2d5e2286232d9ca07a8a5
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-18-jdk-windowsservercore-ltsc2016, 12-ea-18-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-19-jdk-windowsservercore-ltsc2016, 12-ea-19-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
+GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-18-jdk-windowsservercore-1709, 12-ea-18-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-19-jdk-windowsservercore-1709, 12-ea-19-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
+GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-18-jdk-windowsservercore-1803, 12-ea-18-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-18-jdk-windowsservercore, 12-ea-18-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-19-jdk-windowsservercore-1803, 12-ea-19-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: b75355761b3630f01ee19832486c04b5faa8c652
+GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/php
+++ b/library/php
@@ -4,74 +4,74 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0RC4-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC4-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC4-cli, 7.3-rc-cli, rc-cli, 7.3.0RC4, 7.3-rc, rc
+Tags: 7.3.0RC5-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC5-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC5-cli, 7.3-rc-cli, rc-cli, 7.3.0RC5, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/stretch/cli
 
-Tags: 7.3.0RC4-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC4-apache, 7.3-rc-apache, rc-apache
+Tags: 7.3.0RC5-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC5-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/stretch/apache
 
-Tags: 7.3.0RC4-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC4-fpm, 7.3-rc-fpm, rc-fpm
+Tags: 7.3.0RC5-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC5-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/stretch/fpm
 
-Tags: 7.3.0RC4-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC4-zts, 7.3-rc-zts, rc-zts
+Tags: 7.3.0RC5-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC5-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/stretch/zts
 
-Tags: 7.3.0RC4-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC4-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC4-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC4-alpine, 7.3-rc-alpine, rc-alpine
+Tags: 7.3.0RC5-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC5-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC5-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC5-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/alpine3.8/cli
 
-Tags: 7.3.0RC4-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC4-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
+Tags: 7.3.0RC5-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC5-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/alpine3.8/fpm
 
-Tags: 7.3.0RC4-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC4-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
+Tags: 7.3.0RC5-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC5-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1d4332513f5906d568d0ca29d5ef5610b5ca066b
+GitCommit: 2dd8abbedbed070137e91333cab2fc0d351acbbb
 Directory: 7.3-rc/alpine3.8/zts
 
-Tags: 7.2.11-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.11-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.11-cli, 7.2-cli, 7-cli, cli, 7.2.11, 7.2, 7, latest
+Tags: 7.2.12-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.12-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.12-cli, 7.2-cli, 7-cli, cli, 7.2.12, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.11-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.11-apache, 7.2-apache, 7-apache, apache
+Tags: 7.2.12-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.12-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.11-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.11-fpm, 7.2-fpm, 7-fpm, fpm
+Tags: 7.2.12-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.12-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.11-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.11-zts, 7.2-zts, 7-zts, zts
+Tags: 7.2.12-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.12-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.11-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.11-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.11-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.11-alpine, 7.2-alpine, 7-alpine, alpine
+Tags: 7.2.12-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.12-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.12-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.12-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.11-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.11-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.2.12-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.12-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.11-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.11-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.2.12-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.12-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: f363b9f8a0e23e79faaa624ff5bf160b9dec18f4
+GitCommit: 985de7a6d4b12c5f10f9e79496cdc1cdcad47d14
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.23-cli-stretch, 7.1-cli-stretch, 7.1.23-stretch, 7.1-stretch, 7.1.23-cli, 7.1-cli, 7.1.23, 7.1

--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 11.0, 11, latest
+Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 88341a435106ea0c9a805ff305bf486f81f56e0c
+GitCommit: 2d40c8a89bfc888fb99463e919ac748cd54c0fcc
 Directory: 11
 
-Tags: 11.0-alpine, 11-alpine, alpine
+Tags: 11.1-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3402e9731098e1cba778c0af82b8d6fdfc698f27
+GitCommit: 112bf5ee8455f930354bc90f32d6a1c830525ed9
 Directory: 11/alpine
 
-Tags: 10.5, 10
+Tags: 10.6, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f6968e4a2ee82cc7893e12414cbb221044ed3bd
+GitCommit: f5a7e06b42aa14cad6edfaeefa676a5312d27618
 Directory: 10
 
-Tags: 10.5-alpine, 10-alpine
+Tags: 10.6-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 7c287e7800dc08743da8d6372ab752e5438f662b
 Directory: 10/alpine
 
-Tags: 9.6.10, 9.6, 9
+Tags: 9.6.11, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 0dfe0ba571b8aa2319474548403489ebdd80c52e
 Directory: 9.6
 
-Tags: 9.6.10-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: cb8d873277a533b2f1140a3f3624321a0c53f45d
 Directory: 9.6/alpine
 
-Tags: 9.5.14, 9.5
+Tags: 9.5.15, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 34af727d7b54676c48c2f4c5f144cd395f9f93da
 Directory: 9.5
 
-Tags: 9.5.14-alpine, 9.5-alpine
+Tags: 9.5.15-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: d48c7ca3c7b8c573a33b9f0598839aa7a06318ff
 Directory: 9.5/alpine
 
-Tags: 9.4.19, 9.4
+Tags: 9.4.20, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: d28670df74380893a098d9e08c80e9507af5ffff
 Directory: 9.4
 
-Tags: 9.4.19-alpine, 9.4-alpine
+Tags: 9.4.20-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: d564da5142b2e5fa235707b05d8aa0fc76250418
 Directory: 9.4/alpine
 
-Tags: 9.3.24, 9.3
+Tags: 9.3.25, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 64bec4b1617291e3646e4e7dbbae1174404c3fd9
 Directory: 9.3
 
-Tags: 9.3.24-alpine, 9.3-alpine
+Tags: 9.3.25-alpine, 9.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f585c58df93e93b730c09a13e8904b96fa20c58
+GitCommit: 4955a99b600fa0badb1e707285617a23315421af
 Directory: 9.3/alpine

--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0.0, 5.0, 5, latest, 5.0.0-stretch, 5.0-stretch, 5-stretch, stretch
+Tags: 5.0.1, 5.0, 5, latest, 5.0.1-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
 Directory: 5.0
 
-Tags: 5.0.0-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.0-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
+Tags: 5.0.1-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.1-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
 Directory: 5.0/32bit
 
-Tags: 5.0.0-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.0-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
+Tags: 5.0.1-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.1-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dc6dc737baa434528ce31948b22b4c6ccc78793a
+GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
 Directory: 5.0/alpine
 
 Tags: 4.0.11, 4.0, 4, 4.0.11-stretch, 4.0-stretch, 4-stretch

--- a/library/redmine
+++ b/library/redmine
@@ -6,18 +6,18 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
+GitCommit: a3845e002703544622a7b9afb0cb2a7bc07aa68a
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: 4f5873e66fb775da334d8902c02ecb6d579fc3e8
+GitCommit: 2674d8dd6f63ca0977752c022c28dd66849bce16
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aa9d653e472f2993d8b61a92d32eb9848952cbac
+GitCommit: a3845e002703544622a7b9afb0cb2a7bc07aa68a
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: 4f5873e66fb775da334d8902c02ecb6d579fc3e8
+GitCommit: 2674d8dd6f63ca0977752c022c28dd66849bce16
 Directory: 3.3/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-preview2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview2, 2.6-rc, rc
+Tags: 2.6.0-preview3-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview3, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
+GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
 Directory: 2.6-rc/stretch
 
-Tags: 2.6.0-preview2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview2-slim, 2.6-rc-slim, rc-slim
+Tags: 2.6.0-preview3-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview3-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
+GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
 Directory: 2.6-rc/stretch/slim
 
-Tags: 2.6.0-preview2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview2-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-preview3-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview3-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
+GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
 Directory: 2.6-rc/alpine3.8
 
-Tags: 2.6.0-preview2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
+Tags: 2.6.0-preview3-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a70e975dc5b8f643d2a3918e2b1f50629a27220
+GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest

--- a/library/tomcat
+++ b/library/tomcat
@@ -34,72 +34,72 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: e0cfc71038fca93f3e1b54ef4a4db58fb506d5be
 Directory: 7/jre8-alpine
 
-Tags: 8.5.34-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.34, 8.5, 8, latest
+Tags: 8.5.35-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.35, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre8
 
-Tags: 8.5.34-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.34-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.35-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.35-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.34-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.34-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.35-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.35-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: af1646c18d6398e6cf27a29d32ff58b994d2566e
+GitCommit: 0e7ff602f64ffc447c210dcf72ffa073d17ffed4
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.34-jre10, 8.5-jre10, 8-jre10, jre10
+Tags: 8.5.35-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre10
 
-Tags: 8.5.34-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
+Tags: 8.5.35-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dec5126a93c8b4bdbb7480e3bccdc4ca13c024fd
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre10-slim
 
-Tags: 8.5.34-jre11, 8.5-jre11, 8-jre11, jre11
+Tags: 8.5.35-jre11, 8.5-jre11, 8-jre11, jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre11
 
-Tags: 8.5.34-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
+Tags: 8.5.35-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
 Directory: 8.5/jre11-slim
 
-Tags: 9.0.12-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.13-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre8
 
-Tags: 9.0.12-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.13-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.12-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.13-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
+GitCommit: 8bf3981234ee391fede358b76f43dabefa1bdc7c
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.12-jre10, 9.0-jre10, 9-jre10, 9.0.12, 9.0, 9
+Tags: 9.0.13-jre10, 9.0-jre10, 9-jre10, 9.0.13, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre10
 
-Tags: 9.0.12-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.12-slim, 9.0-slim, 9-slim
+Tags: 9.0.13-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.13-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56e65662f0e151aed90bd255aa97a10de17b8316
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre10-slim
 
-Tags: 9.0.12-jre11, 9.0-jre11, 9-jre11
+Tags: 9.0.13-jre11, 9.0-jre11, 9-jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre11
 
-Tags: 9.0.12-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
+Tags: 9.0.13-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92bd4324e50c57fc1779ccc97c61aaa53bc0020d
+GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
 Directory: 9.0/jre11-slim


### PR DESCRIPTION
 - `docker` `18.09` GA
 - `ghost` bump to `2.5.0`, `1.25.6`, and `0.11.14`
 - `kibana` bump to `5.6.13`
 - `logstash` bump to `5.6.13`, drop `2.4` https://github.com/docker-library/logstash/pull/92
 - `memcached` bump to `1.5.12`
 - `mongo` bump to `3.4.18`, `4.0.4`, and `4.1.5`
 - `openjdk` bump to `12-ea-19-oraclelinux7`, `12-ea-18-alpine`, `12-ea-19-windowsservercore`
 - `php` bump to `7.3.0RC5`, and `7.2.12`
 - `postgres` bump to `11.1`, `10.6`, `9.6.11`, `9.5.15`, `9.4.20`, and `9.3.25`
 - `redis` bump to `5.0.1`
 - `redmine` arbitrary user support: https://github.com/docker-library/redmine/pull/136, passenger `5.3.6`
 - `ruby` bump to `2.6.0-preview3`
 - `tomcat` bump to `8.5.35`, and `9.0.13`