### PR TITLE
Bump Rakudo-Star version to 2018.10

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,6 +1,6 @@
 Maintainers: Rob Hoelz <robAThoelz.ro> (@hoelzro)
 GitRepo: https://github.com/perl6/docker
 Architectures: amd64, arm64v8
-GitCommit: f8a418d4d8d4a75f18af5d9b86c7e0a7cfe6bfd8
+GitCommit: 960c26271cbb4b5df7251f4f0e0ed94b1f59cc7d
 
-Tags: latest, 2018.06
+Tags: latest, 2018.10


### PR DESCRIPTION
Update to new release: 2018.10