### PR TITLE
Disable "bootstrap checks" in Elasticsearch tests

### DIFF
--- a/test/tests/elasticsearch-basics/run.sh
+++ b/test/tests/elasticsearch-basics/run.sh
@@ -13,7 +13,8 @@ clientImage='buildpack-deps:stretch-curl'
 
 # Create an instance of the container-under-test
 # (explicitly setting a low memory limit since the image defaults to 2GB)
-cid="$(docker run -d -e ES_JAVA_OPTS='-Xms128m -Xmx128m' "$image")"
+# (disable "bootstrap checks" by setting discovery.type option)
+cid="$(docker run -d -e ES_JAVA_OPTS='-Xms128m -Xmx128m' -e discovery.type=single-node "$image")"
 trap "docker rm -vf $cid > /dev/null" EXIT
 
 _request() {


### PR DESCRIPTION
Relates: https://github.com/docker-library/logstash/issues/93#issuecomment-438075913