### PR TITLE
Update docker-library images, esp for https://bugs.debian.org/913614

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -5,45 +5,45 @@ GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 5.0-beta, 5.0-rc, rc
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bbffeabe24a9edabc79ef2e5f6418a70e09abafc
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 5.0-rc
 
 Tags: 4.4.23, 4.4, 4, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ff9f21578dc27e4dc1ce3ed1136394bbb461e5b
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b2e7308f6bacbbe929241174b8b205f40cfdd2f
+GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 3.0

--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.20, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: c80b2d6a3f5668f01246e44883e851ae37114194
+GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
 Directory: 2.1
 
 Tags: 2.2.13, 2.2, 2
 Architectures: amd64, i386
-GitCommit: c80b2d6a3f5668f01246e44883e851ae37114194
+GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
 Directory: 2.2
 
 Tags: 3.0.17, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
+GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
 Directory: 3.0
 
 Tags: 3.11.3, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 0e270a93b53119818f9c71fa273cda3a07d0bf5c
+GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
 Directory: 3.11

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.4.3
-GitCommit: 4cb8fc9d672f2b43feaf1e9178755fa0def4cff0
+Tags: 6.5.0
+GitCommit: 7d09a4ec10b02fa8ec5d396436209e4ab885aa87
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5
-GitCommit: 9a765c385f3b18e890e50eb21ff60465208726cf
+GitCommit: a912899428b3c0854a463a30a3d7c5d52a088759
 Directory: 5
 
 Tags: 5.6.13-alpine, 5.6-alpine, 5-alpine
-GitCommit: 9a765c385f3b18e890e50eb21ff60465208726cf
+GitCommit: a912899428b3c0854a463a30a3d7c5d52a088759
 Directory: 5/alpine

--- a/library/gcc
+++ b/library/gcc
@@ -7,27 +7,27 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
+GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
 Directory: 5
 # Docker EOL: 2019-04-10
 
 # Last Modified: 2018-10-30
 Tags: 6.5.0, 6.5, 6
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
+GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
 Directory: 6
 # Docker EOL: 2020-04-30
 
 # Last Modified: 2018-01-25
 Tags: 7.3.0, 7.3, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
+GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
 Directory: 7
 # Docker EOL: 2019-07-25
 
 # Last Modified: 2018-07-26
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0915d9f7df75b3e37336e3d3bdacb64fbf2ecf88
+GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
 Directory: 8
 # Docker EOL: 2020-01-26

--- a/library/ghost
+++ b/library/ghost
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.5.0, 2.5, 2, latest
+Tags: 2.6.0, 2.6, 2, latest
 Architectures: amd64, arm32v7, i386
-GitCommit: 9274b77aede29ff0e7595023b5160d7bc7ffb3e0
+GitCommit: 10a935f258430d00157b430c3a2aeebf35973685
 Directory: 2/debian
 
-Tags: 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
+Tags: 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9274b77aede29ff0e7595023b5160d7bc7ffb3e0
+GitCommit: 81aad92c56ab5cbfbdde4e381c6642a3a3fbb368
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1
 Architectures: amd64, arm32v7, i386
-GitCommit: 94e82489166b6d44f590306402492df09bbfbcbd
+GitCommit: f1dde8050d6994a8df9564e50bffd4549c9c9305
 Directory: 1/debian
 
 Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
@@ -26,7 +26,7 @@ Directory: 1/alpine
 
 Tags: 0.11.14, 0.11, 0
 Architectures: amd64, arm32v7, i386
-GitCommit: e1880db3c56f85410ad3342cbd33e7f98f24bcac
+GitCommit: f1dde8050d6994a8df9564e50bffd4549c9c9305
 Directory: 0/debian
 
 Tags: 0.11.14-alpine, 0.11-alpine, 0-alpine

--- a/library/httpd
+++ b/library/httpd
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.37, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d90aa98c2f7e4dea3374490788681a1f69635c1
+GitCommit: a426e299988c48f4937dfb4a9a67ac479ca011e1
 Directory: 2.4
 
 Tags: 2.4.37-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b2e7d2868e2f92660469ac66187f8f83fe449c65
+GitCommit: a426e299988c48f4937dfb4a9a67ac479ca011e1
 Directory: 2.4/alpine

--- a/library/julia
+++ b/library/julia
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/julia.git
 Tags: 1.0.2-stretch, 1.0-stretch, 1-stretch, stretch
 SharedTags: 1.0.2, 1.0, 1, latest
 Architectures: amd64, i386
-GitCommit: 739386e833cc5e839a7bf8e42c4f2e3eed3eb11e
+GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
 Directory: 1.0/stretch
 
 Tags: 1.0.2-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -34,12 +34,12 @@ Constraints: windowsservercore-1803
 Tags: 0.7.0-stretch, 0.7-stretch, 0-stretch
 SharedTags: 0.7.0, 0.7, 0
 Architectures: amd64, i386
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
 Directory: 0/stretch
 
 Tags: 0.7.0-jessie, 0.7-jessie, 0-jessie
 Architectures: amd64, i386
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
+GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
 Directory: 0/jessie
 
 Tags: 0.7.0-windowsservercore-ltsc2016, 0.7-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.4.3
-GitCommit: df4d4cad6dfa5a5edd9dc8682e4bb21e95ca4cf7
+Tags: 6.5.0
+GitCommit: ae7ac749f927d0afe82c44571e019be677fc3b15
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5
-GitCommit: 7728998a85333ed87f14fc224db081f6c10602f9
+GitCommit: 52bb5b8b2f675befe52e370153dda288c83d09e9
 Directory: 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,22 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.4.1
-GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
-Directory: 6.4.1
-
-Tags: 6.4.0
-GitCommit: 18d3da965bb702a12edd9d387afd16bd965c5b1c
-Directory: 6.4.0
-
-Tags: 6.4.3
-GitCommit: 4fd742915018388ae0f050331760019bad7876f7
+Tags: 6.5.0
+GitCommit: 38921903645d7bb218a7aeca8eabb301408bd8bf
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5
-GitCommit: d5ef01551cfeae4e9aa45796689911485172dd68
+GitCommit: babe058abf92da5091d976173639663f7fea0d59
 Directory: 5
 
 Tags: 5.6.13-alpine, 5.6-alpine, 5-alpine
-GitCommit: d5ef01551cfeae4e9aa45796689911485172dd68
+GitCommit: babe058abf92da5091d976173639663f7fea0d59
 Directory: 5/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,27 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
+Tags: 10.4.0-bionic, 10.4-bionic, 10.4.0, 10.4
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 7384b25a0196d8a7e62173781df5a5bed1eb88d2
+Directory: 10.4
+
 Tags: 10.3.10-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.10, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 44cfe68144976ce0ec135593ffe15c4bcca0dc6f
+GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 10.3
 
-Tags: 10.2.18-bionic, 10.2-bionic, 10.2.18, 10.2
+Tags: 10.2.19-bionic, 10.2-bionic, 10.2.19, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 81ad56cf6bdf82666da60d828247684fda142c03
+GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 10.2
 
 Tags: 10.1.37-bionic, 10.1-bionic, 10.1.37, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 36024883027e6ec5ff0d2fb43c0ce4f6f77ea4cc
+GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 10.1
 
 Tags: 10.0.37-xenial, 10.0-xenial, 10.0.37, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 63a00c827dd02c5ede7957d96d0ffc0d020ef03e
+GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 10.0
 
 Tags: 5.5.62-trusty, 5.5-trusty, 5-trusty, 5.5.62, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 4ffbde76c75a49456d1729bb142d1c0c9c51f574
+GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 5.5

--- a/library/mongo
+++ b/library/mongo
@@ -9,7 +9,7 @@ SharedTags: 3.2.21, 3.2
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
+GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
 Directory: 3.2
 
 Tags: 3.2.21-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
@@ -31,7 +31,7 @@ SharedTags: 3.4.18, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
+GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
 Directory: 3.4
 
 Tags: 3.4.18-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
@@ -48,25 +48,25 @@ GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.8-stretch, 3.6-stretch, 3-stretch
-SharedTags: 3.6.8, 3.6, 3
+Tags: 3.6.9-stretch, 3.6-stretch, 3-stretch
+SharedTags: 3.6.9, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 974dbf4a5f951f4bc627dc59761dab19585edcc4
+GitCommit: cb722bcc413b6789064d874b5231f9e23cc81540
 Directory: 3.6
 
-Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.8, 3.6, 3
+Tags: 3.6.9-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.9-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.9, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: 2674c80f0674f29484c4ccb4aff7d076227d5bc9
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
-SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.8, 3.6, 3
+Tags: 3.6.9-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.9-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.9, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
+GitCommit: 2674c80f0674f29484c4ccb4aff7d076227d5bc9
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -75,7 +75,7 @@ SharedTags: 4.0.4, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
+GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
 Directory: 4.0
 
 Tags: 4.0.4-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -104,7 +104,7 @@ SharedTags: 4.1.5, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
+GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
 Directory: 4.1
 
 Tags: 4.1.5-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016

--- a/library/mysql
+++ b/library/mysql
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.0.13, 8.0, 8, latest
-GitCommit: 223f0be1213bbd8647b841243a3114e8b34022f4
+GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
 Directory: 8.0
 
 Tags: 5.7.24, 5.7, 5
-GitCommit: b7c899673a214df4c8027a498c64eec7145ba479
+GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
 Directory: 5.7
 
 Tags: 5.6.42, 5.6
-GitCommit: 37aee3a187904f07d41ce5fa3cc0fb43c08ffaf5
+GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
 Directory: 5.6
 
 Tags: 5.5.62, 5.5
-GitCommit: 7ca585ee4356dd2c912708f24d877967dab51cdd
+GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
 Directory: 5.5

--- a/library/owncloud
+++ b/library/owncloud
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/owncloud.git
 
 Tags: 10.0.10-apache, 10.0-apache, 10-apache, apache, 10.0.10, 10.0, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
+GitCommit: df96d12ed616ac6d1e58a3e879d42dbb4f4ea3cb
 Directory: 10.0/apache
 
 Tags: 10.0.10-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
+GitCommit: df96d12ed616ac6d1e58a3e879d42dbb4f4ea3cb
 Directory: 10.0/fpm
 
 Tags: 9.1.8-apache, 9.1-apache, 9-apache, 9.1.8, 9.1, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
+GitCommit: df96d12ed616ac6d1e58a3e879d42dbb4f4ea3cb
 Directory: 9.1/apache
 
 Tags: 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29ad327272bcec6e95d728e37453f4acfcf052f7
+GitCommit: df96d12ed616ac6d1e58a3e879d42dbb4f4ea3cb
 Directory: 9.1/fpm

--- a/library/percona
+++ b/library/percona
@@ -6,15 +6,15 @@ GitRepo: https://github.com/docker-library/percona.git
 
 Tags: 5.7.23-stretch, 5.7-stretch, 5-stretch, stretch, 5.7.23, 5.7, 5, latest
 Architectures: amd64
-GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
+GitCommit: 3cc4caa4d34bf744283d48af4b11f19e28217e3f
 Directory: 5.7
 
 Tags: 5.6.41-stretch, 5.6-stretch, 5.6.41, 5.6
 Architectures: amd64
-GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
+GitCommit: c21319e084e50e831f33767d8ee1110711f93472
 Directory: 5.6
 
 Tags: 5.5.61-stretch, 5.5-stretch, 5.5.61, 5.5
 Architectures: amd64
-GitCommit: 0f4b22adef232551c763308367d3b54d586a4a38
+GitCommit: c21319e084e50e831f33767d8ee1110711f93472
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -6,235 +6,235 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.3.0RC5-cli-stretch, 7.3-rc-cli-stretch, rc-cli-stretch, 7.3.0RC5-stretch, 7.3-rc-stretch, rc-stretch, 7.3.0RC5-cli, 7.3-rc-cli, rc-cli, 7.3.0RC5, 7.3-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/stretch/cli
 
 Tags: 7.3.0RC5-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC5-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.3-rc/stretch/apache
 
 Tags: 7.3.0RC5-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC5-fpm, 7.3-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/stretch/fpm
 
 Tags: 7.3.0RC5-zts-stretch, 7.3-rc-zts-stretch, rc-zts-stretch, 7.3.0RC5-zts, 7.3-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/stretch/zts
 
 Tags: 7.3.0RC5-cli-alpine3.8, 7.3-rc-cli-alpine3.8, rc-cli-alpine3.8, 7.3.0RC5-alpine3.8, 7.3-rc-alpine3.8, rc-alpine3.8, 7.3.0RC5-cli-alpine, 7.3-rc-cli-alpine, rc-cli-alpine, 7.3.0RC5-alpine, 7.3-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/alpine3.8/cli
 
 Tags: 7.3.0RC5-fpm-alpine3.8, 7.3-rc-fpm-alpine3.8, rc-fpm-alpine3.8, 7.3.0RC5-fpm-alpine, 7.3-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/alpine3.8/fpm
 
 Tags: 7.3.0RC5-zts-alpine3.8, 7.3-rc-zts-alpine3.8, rc-zts-alpine3.8, 7.3.0RC5-zts-alpine, 7.3-rc-zts-alpine, rc-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.3-rc/alpine3.8/zts
 
 Tags: 7.2.12-cli-stretch, 7.2-cli-stretch, 7-cli-stretch, cli-stretch, 7.2.12-stretch, 7.2-stretch, 7-stretch, stretch, 7.2.12-cli, 7.2-cli, 7-cli, cli, 7.2.12, 7.2, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.12-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.12-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.12-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.12-fpm, 7.2-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.12-zts-stretch, 7.2-zts-stretch, 7-zts-stretch, zts-stretch, 7.2.12-zts, 7.2-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.12-cli-alpine3.8, 7.2-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.2.12-alpine3.8, 7.2-alpine3.8, 7-alpine3.8, alpine3.8, 7.2.12-cli-alpine, 7.2-cli-alpine, 7-cli-alpine, cli-alpine, 7.2.12-alpine, 7.2-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/alpine3.8/cli
 
 Tags: 7.2.12-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.2.12-fpm-alpine, 7.2-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/alpine3.8/fpm
 
 Tags: 7.2.12-zts-alpine3.8, 7.2-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.2.12-zts-alpine, 7.2-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.24-cli-stretch, 7.1-cli-stretch, 7.1.24-stretch, 7.1-stretch, 7.1.24-cli, 7.1-cli, 7.1.24, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.24-apache-stretch, 7.1-apache-stretch, 7.1.24-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.24-fpm-stretch, 7.1-fpm-stretch, 7.1.24-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.24-zts-stretch, 7.1-zts-stretch, 7.1.24-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.24-cli-jessie, 7.1-cli-jessie, 7.1.24-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.24-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.24-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.24-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.24-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.24-alpine3.8, 7.1-alpine3.8, 7.1.24-cli-alpine, 7.1-cli-alpine, 7.1.24-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/alpine3.8/cli
 
 Tags: 7.1.24-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.24-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/alpine3.8/fpm
 
 Tags: 7.1.24-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.24-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 189782763ee925cba4c4e2e6255a558c2f8b5f16
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.1/alpine3.8/zts
 
 Tags: 7.0.32-cli-stretch, 7.0-cli-stretch, 7.0.32-stretch, 7.0-stretch, 7.0.32-cli, 7.0-cli, 7.0.32, 7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/stretch/cli
 
 Tags: 7.0.32-apache-stretch, 7.0-apache-stretch, 7.0.32-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.0/stretch/apache
 
 Tags: 7.0.32-fpm-stretch, 7.0-fpm-stretch, 7.0.32-fpm, 7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/stretch/fpm
 
 Tags: 7.0.32-zts-stretch, 7.0-zts-stretch, 7.0.32-zts, 7.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/stretch/zts
 
 Tags: 7.0.32-cli-jessie, 7.0-cli-jessie, 7.0.32-jessie, 7.0-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/jessie/cli
 
 Tags: 7.0.32-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.32-fpm-jessie, 7.0-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/jessie/fpm
 
 Tags: 7.0.32-zts-jessie, 7.0-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/jessie/zts
 
 Tags: 7.0.32-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.32-alpine3.7, 7.0-alpine3.7, 7.0.32-cli-alpine, 7.0-cli-alpine, 7.0.32-alpine, 7.0-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/alpine3.7/cli
 
 Tags: 7.0.32-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.32-fpm-alpine, 7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/alpine3.7/fpm
 
 Tags: 7.0.32-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.32-zts-alpine, 7.0-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 7.0/alpine3.7/zts
 
 Tags: 5.6.38-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.38-stretch, 5.6-stretch, 5-stretch, 5.6.38-cli, 5.6-cli, 5-cli, 5.6.38, 5.6, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/stretch/cli
 
 Tags: 5.6.38-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.38-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 5.6/stretch/apache
 
 Tags: 5.6.38-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.38-fpm, 5.6-fpm, 5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/stretch/fpm
 
 Tags: 5.6.38-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.38-zts, 5.6-zts, 5-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/stretch/zts
 
 Tags: 5.6.38-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.38-jessie, 5.6-jessie, 5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/jessie/cli
 
 Tags: 5.6.38-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.38-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/jessie/fpm
 
 Tags: 5.6.38-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/jessie/zts
 
 Tags: 5.6.38-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.38-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.38-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.38-alpine, 5.6-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/alpine3.8/cli
 
 Tags: 5.6.38-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.38-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/alpine3.8/fpm
 
 Tags: 5.6.38-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.38-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d5bdcd6f8ca2f71db83d556b90e5c2802fa01ede
+GitCommit: b99209cc078ebb7bf4614e870c2d69e0b3bed399
 Directory: 5.6/alpine3.8/zts

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d40c8a89bfc888fb99463e919ac748cd54c0fcc
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.6, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f5a7e06b42aa14cad6edfaeefa676a5312d27618
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 10
 
 Tags: 10.6-alpine, 10-alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.11, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0dfe0ba571b8aa2319474548403489ebdd80c52e
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 9.6
 
 Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.15, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34af727d7b54676c48c2f4c5f144cd395f9f93da
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 9.5
 
 Tags: 9.5.15-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.20, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d28670df74380893a098d9e08c80e9507af5ffff
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 9.4
 
 Tags: 9.4.20-alpine, 9.4-alpine
@@ -56,7 +56,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.25, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 64bec4b1617291e3646e4e7dbbae1174404c3fd9
+GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
 Directory: 9.3
 
 Tags: 9.3.25-alpine, 9.3-alpine

--- a/library/python
+++ b/library/python
@@ -7,22 +7,22 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.1-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.1, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.7/stretch
 
 Tags: 3.7.1-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.1-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.1-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.1-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.1-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -42,37 +42,37 @@ Constraints: windowsservercore-1709
 Tags: 3.6.7-stretch, 3.6-stretch
 SharedTags: 3.6.7, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/stretch
 
 Tags: 3.6.7-slim-stretch, 3.6-slim-stretch, 3.6.7-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.7-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/jessie
 
 Tags: 3.6.7-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.7-alpine3.8, 3.6-alpine3.8, 3.6.7-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.7-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.7-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
@@ -92,109 +92,109 @@ Constraints: windowsservercore-1709
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/stretch
 
 Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/jessie
 
 Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/alpine3.8
 
 Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 005dda958e7fdf517214d950c0ef8eb0201ab3a1
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/stretch
 
 Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/jessie
 
 Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b45793d90a50e2263b28ab9161d313706949b3d7
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/redis
+++ b/library/redis
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 5.0.1, 5.0, 5, latest, 5.0.1-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
+GitCommit: a5d019077b46494751482512c200c4df34463dc6
 Directory: 5.0
 
 Tags: 5.0.1-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.1-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
+GitCommit: a5d019077b46494751482512c200c4df34463dc6
 Directory: 5.0/32bit
 
 Tags: 5.0.1-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.1-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
@@ -21,12 +21,12 @@ Directory: 5.0/alpine
 
 Tags: 4.0.11, 4.0, 4, 4.0.11-stretch, 4.0-stretch, 4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: a5d019077b46494751482512c200c4df34463dc6
 Directory: 4.0
 
 Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
 Architectures: amd64
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: a5d019077b46494751482512c200c4df34463dc6
 Directory: 4.0/32bit
 
 Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3845e002703544622a7b9afb0cb2a7bc07aa68a
+GitCommit: c3e897609621001076c6410c0f177e9bd783e45b
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3845e002703544622a7b9afb0cb2a7bc07aa68a
+GitCommit: c3e897609621001076c6410c0f177e9bd783e45b
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.91-jre7, 7.0-jre7, 7-jre7, 7.0.91, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 92855dba2d4edffc55bc04f9b779a0826747ff4c
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre7
 
 Tags: 7.0.91-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.91-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 92855dba2d4edffc55bc04f9b779a0826747ff4c
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre7-slim
 
 Tags: 7.0.91-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.91-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e0cfc71038fca93f3e1b54ef4a4db58fb506d5be
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre7-alpine
 
 Tags: 7.0.91-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92855dba2d4edffc55bc04f9b779a0826747ff4c
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre8
 
 Tags: 7.0.91-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92855dba2d4edffc55bc04f9b779a0826747ff4c
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre8-slim
 
 Tags: 7.0.91-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e0cfc71038fca93f3e1b54ef4a4db58fb506d5be
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 7/jre8-alpine
 
 Tags: 8.5.35-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.35, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre8
 
 Tags: 8.5.35-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.35-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre8-slim
 
 Tags: 8.5.35-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.35-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7ff602f64ffc447c210dcf72ffa073d17ffed4
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre8-alpine
 
 Tags: 8.5.35-jre10, 8.5-jre10, 8-jre10, jre10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre10
 
 Tags: 8.5.35-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre10-slim
 
 Tags: 8.5.35-jre11, 8.5-jre11, 8-jre11, jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre11
 
 Tags: 8.5.35-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63d1d9301744525ccb96a016be29aaec19d0a5c3
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre11-slim
 
 Tags: 9.0.13-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre8
 
 Tags: 9.0.13-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre8-slim
 
 Tags: 9.0.13-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bf3981234ee391fede358b76f43dabefa1bdc7c
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre8-alpine
 
 Tags: 9.0.13-jre10, 9.0-jre10, 9-jre10, 9.0.13, 9.0, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre10
 
 Tags: 9.0.13-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.13-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre10-slim
 
 Tags: 9.0.13-jre11, 9.0-jre11, 9-jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre11
 
 Tags: 9.0.13-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d78c9c4369915a4f9c087e85f7d79ed51e1f8dd9
+GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre11-slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -68,20 +68,20 @@ Directory: php7.2/fpm-alpine
 
 Tags: cli-2.0.1-php5.6, cli-2.0-php5.6, cli-2-php5.6, cli-php5.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
+GitCommit: 08b057215dd2c8fbacdc39cee5b3b58d0f87af63
 Directory: php5.6/cli
 
 Tags: cli-2.0.1-php7.0, cli-2.0-php7.0, cli-2-php7.0, cli-php7.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
+GitCommit: 08b057215dd2c8fbacdc39cee5b3b58d0f87af63
 Directory: php7.0/cli
 
 Tags: cli-2.0.1-php7.1, cli-2.0-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
+GitCommit: 08b057215dd2c8fbacdc39cee5b3b58d0f87af63
 Directory: php7.1/cli
 
 Tags: cli-2.0.1, cli-2.0, cli-2, cli, cli-2.0.1-php7.2, cli-2.0-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c5dcf1a2d8d894a5b1ed1c7218e444dc342bd7b4
+GitCommit: 08b057215dd2c8fbacdc39cee5b3b58d0f87af63
 Directory: php7.2/cli


### PR DESCRIPTION
Also includes version bumps for elasticsearch `6.5.0`, ghost `2.6.0`, kibana `6.5.0`, logstash `6.5.0`, mariadb `10.4.0` alpha + `10.2.19`, mongo `3.6.9`
Drop backfilled logstash versions: https://github.com/docker-library/logstash/pull/95

 - https://github.com/tianon/docker-bash/pull/14
 - https://github.com/docker-library/cassandra/pull/170
 - https://github.com/docker-library/elasticsearch/pull/185
 - https://github.com/docker-library/gcc/pull/50
 - https://github.com/docker-library/ghost/pull/164
 - https://github.com/docker-library/httpd/pull/117
 - https://github.com/docker-library/julia/pull/26
 - https://github.com/docker-library/kibana/pull/88
 - https://github.com/docker-library/logstash/pull/94
 - https://github.com/docker-library/mariadb/pull/212
 - https://github.com/docker-library/mongo/pull/314
 - https://github.com/docker-library/mysql/pull/515
 - https://github.com/docker-library/owncloud/pull/108
 - https://github.com/docker-library/percona/pull/73
 - https://github.com/docker-library/php/pull/747
 - https://github.com/docker-library/postgres/pull/527
 - https://github.com/docker-library/python/pull/351
 - https://github.com/docker-library/redis/pull/171
 - https://github.com/docker-library/redmine/pull/140
 - https://github.com/docker-library/tomcat/pull/137
 - https://github.com/docker-library/wordpress/pull/348