### PR TITLE
erlang/otp 20.3.8.13

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/e28cf72b126849095d33892f1000950eb8e3277f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/5c50e67e89a5d26233fb650c13bc9caecc865cf5/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/erlang/docker-erlang-otp.git
@@ -18,19 +18,19 @@ Architectures: amd64, arm64v8, i386, s390x, ppc64le
 GitCommit: de48e7c91b8a293770c6fcccdd30d2329fcc0414
 Directory: 21/alpine
 
-Tags: 20.3.8.11, 20.3.8, 20.3, 20
+Tags: 20.3.8.13, 20.3.8, 20.3, 20
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 01bc5270a30887e3b57c5c50bcdefe375b2e5123
+GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
 Directory: 20
 
-Tags: 20.3.8.11-slim, 20.3.8-slim, 20.3-slim, 20-slim
+Tags: 20.3.8.13-slim, 20.3.8-slim, 20.3-slim, 20-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 01bc5270a30887e3b57c5c50bcdefe375b2e5123
+GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
 Directory: 20/slim
 
-Tags: 20.3.8.11-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine
+Tags: 20.3.8.13-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine
 Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: 01bc5270a30887e3b57c5c50bcdefe375b2e5123
+GitCommit: d299e24c934b01a46af119ca2b139eb4dc648237
 Directory: 20/alpine
 
 Tags: 19.3.6.12, 19.3.6, 19.3, 19


### PR DESCRIPTION
Only update the erlang 20.3.8.13, I think this one can be merged in a short time.