### PR TITLE
notary: Update to 0.6.1 and add multi-arch support

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,9 +1,10 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: ff7ae14c71fa0f87f9e6bd8de81a78c20db66664
+GitCommit: 6db20782a52c71a48e33a9f075ba632054c0112d
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: server-0.5.0, server
+Tags: server-0.6.1, server
 Directory: notary-server
 
-Tags: signer-0.5.0, signer
+Tags: signer-0.6.1, signer
 Directory: notary-signer


### PR DESCRIPTION
Sent with @justincormack's blessing.

Signed-off-by: Lee Jones <lee.jones@linaro.org>