### PR TITLE
 Update node v11 to v11.2.0 with Yarn v1.12.3

### DIFF
--- a/library/node
+++ b/library/node
@@ -53,19 +53,19 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
 Directory: 6/stretch
 
-Tags: 11.1.0-alpine, 11.1-alpine, 11-alpine, alpine
+Tags: 11.2.0-alpine, 11.2-alpine, 11-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 120b465c249cf08d7939a3a0c07fec897cfcf91d
+GitCommit: 241b2cfaca1ba225f312d439365d4410c94737fb
 Directory: 11/alpine
 
-Tags: 11.1.0-slim, 11.1-slim, 11-slim, slim
+Tags: 11.2.0-slim, 11.2-slim, 11-slim, slim
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 120b465c249cf08d7939a3a0c07fec897cfcf91d
+GitCommit: 241b2cfaca1ba225f312d439365d4410c94737fb
 Directory: 11/slim
 
-Tags: 11.1.0-stretch, 11.1-stretch, 11-stretch, stretch, 11.1.0, 11.1, 11, latest
+Tags: 11.2.0-stretch, 11.2-stretch, 11-stretch, stretch, 11.2.0, 11.2, 11, latest
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 120b465c249cf08d7939a3a0c07fec897cfcf91d
+GitCommit: 241b2cfaca1ba225f312d439365d4410c94737fb
 Directory: 11/stretch
 
 Tags: 10.13.0-jessie, 10.13-jessie, 10-jessie, dubnium-jessie, 10.13.0, 10.13, 10, dubnium


### PR DESCRIPTION
Please note that this is not an automatically generated update as we want to keep some changes to be deployed in later future, so only update v11 manually here.

- https://github.com/nodejs/docker-node/pull/911
- https://github.com/nodejs/node/releases/tag/v11.2.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.2.0