### PR TITLE
Update websphere-liberty:javaee8

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 051f60c8158806ddaf3a1a1e1f4fd75fa826ab8a
+GitCommit: 8fa7f1efc7afea1fe4b82f8b9eee28f4dfb71938
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: 18.0.0.3-javaee8, javaee8, latest


### PR DESCRIPTION
Updating the `javaee8` tag to contain a few features that customers said are often needed.