### PR TITLE
Update swipl to 7.7.22

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,10 +1,10 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 1d06a09d029ed545f01076049408c1dee081d045
+GitCommit: ca31851cdd4101aefd5e8172e7fe33e062be2ee7
 
-Tags: latest, 7.7.21
+Tags: latest, 7.7.22
 Architectures: amd64, arm32v7, arm64v8
-Directory: 7.7.21/stretch
+Directory: 7.7.22/stretch
 
 Tags: stable, 7.6.4
 Directory: 7.6.4/stretch


### PR DESCRIPTION
This patch adds SWI-Prolog 7.7.22. It replaces the autoconf/make based build with cmake/make. Otherwise it adds a hack (LANG=C.UTF8) and removes an obsolete one (linking configure.ac to configure.in).

7.7.22 fixes two fatal crashes and a file handle leak in addition to minor updates.