### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/2ed68abfaed6ec75caeedd3c61af1038975ae9d1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3b5d707612c934b2196d91f1ddda5faf7cf8521d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 2ed68abfaed6ec75caeedd3c61af1038975ae9d1
+GitCommit: 3b5d707612c934b2196d91f1ddda5faf7cf8521d
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 0b299265b6140985a88913133261b93d5a2c2c19

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.5.0
-GitCommit: 7d09a4ec10b02fa8ec5d396436209e4ab885aa87
+Tags: 6.5.1
+GitCommit: 649743f29f4f3e9b54959cced3e059c5c4aaa444
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.6.0, 2.6, 2, latest
+Tags: 2.6.1, 2.6, 2, latest
 Architectures: amd64, arm32v7, i386
-GitCommit: 10a935f258430d00157b430c3a2aeebf35973685
+GitCommit: 2dded8903da71e4a1bbc12cdc703c62416fedcc8
 Directory: 2/debian
 
-Tags: 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 81aad92c56ab5cbfbdde4e381c6642a3a3fbb368
+GitCommit: 2dded8903da71e4a1bbc12cdc703c62416fedcc8
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/irssi
+++ b/library/irssi
@@ -6,10 +6,10 @@ GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.1.1, 1.1, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af8cf0bce6614ed1b6cd4f3c691359f573da4193
+GitCommit: 6b35dbff64c5d8eeaab7d75f456ffa7378279455
 Directory: debian
 
 Tags: 1.1.1-alpine, 1.1-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c4c9fcc669d4c74d3aec3417b4d0e46de9e190e
+GitCommit: 6b35dbff64c5d8eeaab7d75f456ffa7378279455
 Directory: alpine

--- a/library/joomla
+++ b/library/joomla
@@ -5,60 +5,60 @@ GitRepo: https://github.com/joomla/docker-joomla.git
 
 Tags: 3.9.0-php5.6-apache, 3.9-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.9.0-php5.6, 3.9-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php5.6/apache
 
 Tags: 3.9.0-php5.6-fpm, 3.9-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php5.6/fpm
 
 Tags: 3.9.0-php5.6-fpm-alpine, 3.9-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php5.6/fpm-alpine
 
 Tags: 3.9.0-php7.0-apache, 3.9-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.9.0-php7.0, 3.9-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.0/apache
 
 Tags: 3.9.0-php7.0-fpm, 3.9-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.0/fpm
 
 Tags: 3.9.0-php7.0-fpm-alpine, 3.9-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.0/fpm-alpine
 
 Tags: 3.9.0-apache, 3.9-apache, 3-apache, apache, 3.9.0, 3.9, 3, latest, 3.9.0-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.0-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.1/apache
 
 Tags: 3.9.0-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.0-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.1/fpm
 
 Tags: 3.9.0-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.0-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.1/fpm-alpine
 
 Tags: 3.9.0-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.0-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.2/apache
 
 Tags: 3.9.0-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.2/fpm
 
 Tags: 3.9.0-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 91196cdf1107b97225e6d19262b7fc8f29579a13
+GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
 Directory: php7.2/fpm-alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.5.0
-GitCommit: ae7ac749f927d0afe82c44571e019be677fc3b15
+Tags: 6.5.1
+GitCommit: 09f59b3a0fe8771b12797be6158f99dec0be654e
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.5.0
-GitCommit: 38921903645d7bb218a7aeca8eabb301408bd8bf
+Tags: 6.5.1
+GitCommit: 60f93194c822ef6eefa62b46448521b1b01d3ef3
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/852044c20cd24a94bb15d8fcdb7b0784a40110d9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/8832650f4b1a00dab55d8a66cf282cdc3b142af3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -9,9 +9,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 7384b25a0196d8a7e62173781df5a5bed1eb88d2
 Directory: 10.4
 
-Tags: 10.3.10-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.10, 10.3, 10, latest
+Tags: 10.3.11-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.11, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
+GitCommit: 4d2df7be30fb608fd4ad743b74e7df80203a7dc0
 Directory: 10.3
 
 Tags: 10.2.19-bionic, 10.2-bionic, 10.2.19, 10.2

--- a/library/matomo
+++ b/library/matomo
@@ -2,17 +2,17 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.6.1-apache, 3.6-apache, 3-apache, apache, 3.6.1, 3.6, 3, latest
+Tags: 3.7.0-apache, 3.7-apache, 3-apache, apache, 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
+GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
 Directory: apache
 
-Tags: 3.6.1-fpm, 3.6-fpm, 3-fpm, fpm
+Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
+GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
 Directory: fpm
 
-Tags: 3.6.1-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.7.0-fpm-alpine, 3.7-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fde849de55fa31f0676de532ce14b3e08acaa796
+GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
 Directory: fpm-alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-19-jdk-oraclelinux7, 12-ea-19-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-19-jdk-oracle, 12-ea-19-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-19-jdk, 12-ea-19, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-20-jdk-oraclelinux7, 12-ea-20-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-20-jdk-oracle, 12-ea-20-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-20-jdk, 12-ea-20, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
+GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-18-jdk-alpine3.8, 12-ea-18-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-18-jdk-alpine, 12-ea-18-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-20-jdk-alpine3.8, 12-ea-20-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-20-jdk-alpine, 12-ea-20-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 37ac51ae06458726bfd2d5e2286232d9ca07a8a5
+GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-19-jdk-windowsservercore-ltsc2016, 12-ea-19-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-20-jdk-windowsservercore-ltsc2016, 12-ea-20-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-20-jdk-windowsservercore, 12-ea-20-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
+GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-19-jdk-windowsservercore-1709, 12-ea-19-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-20-jdk-windowsservercore-1709, 12-ea-20-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-20-jdk-windowsservercore, 12-ea-20-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
+GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-19-jdk-windowsservercore-1803, 12-ea-19-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-19-jdk-windowsservercore, 12-ea-19-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-20-jdk-windowsservercore-1803, 12-ea-20-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-20-jdk-windowsservercore, 12-ea-20-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0d60b6626ac530dfc39febf84416d96ca52aad8e
+GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -155,6 +155,13 @@ Architectures: windows-amd64
 GitCommit: fdf3bb8d168120655fe39e4098713e704db809df
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Architectures: windows-amd64
+GitCommit: 0cdf33bad33f7297e125b5ae8625299654eb34ae
+Directory: 8/jdk/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
 
 Tags: 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
 SharedTags: 8u191-jdk-nanoserver, 8u191-nanoserver, 8-jdk-nanoserver, 8-nanoserver

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 3.4.6, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3e897609621001076c6410c0f177e9bd783e45b
+GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3e897609621001076c6410c0f177e9bd783e45b
+GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.91-jre7, 7.0-jre7, 7-jre7, 7.0.91, 7.0, 7
+Tags: 7.0.92-jre7, 7.0-jre7, 7-jre7, 7.0.92, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
 Directory: 7/jre7
 
-Tags: 7.0.91-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.91-slim, 7.0-slim, 7-slim
+Tags: 7.0.92-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.92-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
 Directory: 7/jre7-slim
 
-Tags: 7.0.91-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.91-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.92-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.92-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
 Directory: 7/jre7-alpine
 
-Tags: 7.0.91-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.92-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
 Directory: 7/jre8
 
-Tags: 7.0.91-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
+Tags: 7.0.92-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
 Directory: 7/jre8-slim
 
-Tags: 7.0.91-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.92-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
 Directory: 7/jre8-alpine
 
 Tags: 8.5.35-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.35, 8.5, 8, latest


### PR DESCRIPTION
- `elasticsearch`: 6.5.1
- `ghost`: 2.6.1
- `irssi`: `gpg --batch` (jessfraz/irssi#21)
- `joomla`: https://github.com/joomla/docker-joomla/pull/69
- `kibana`: 6.5.1
- `logstash`: 6.5.1
- `mariadb`: 10.3.11
- `matomo`: 3.7.0
- `openjdk`: 12-ea+20, windowsservercore-1803 for jdk8
- `redmine`: arbitrary user fixes (docker-library/redmine#141, docker-library/redmine#142)
- `tomcat`: 7.0.92