### PR TITLE
SonarQube 7.4 and 6.7.6

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -2,10 +2,16 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Julien Lancelot <julien.lancelot@sonarsource.com> (@julienlancelot),
              Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: cbc60794178859a867d572d3a5d386f38df87333
+GitCommit: b3cb018a78ad7879bf1e07e2516f1497eb15a0c2
 
-Tags: 6.7.6-community, 6.7-community, lts
+Tags: 6.7.6-community-alpine, 6.7-community-alpine, lts
+Directory: 6.7.6-community-alpine
+
+Tags: 6.7.6-community, 6.7-community
 Directory: 6.7.6-community
 
-Tags: 7.4-community, latest
+Tags: 7.4-community-alpine, latest
+Directory: 7.4-community-alpine
+
+Tags: 7.4-community
 Directory: 7.4-community

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,15 +1,11 @@
-Maintainers: Evgeny Mandrikov <mandrikov@gmail.com> (@Godin)
+Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
+             Julien Lancelot <julien.lancelot@sonarsource.com> (@julienlancelot),
+             Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 5d738964cc4b857ca5b399d6f0bb626b6710bac6
+GitCommit: cbc60794178859a867d572d3a5d386f38df87333
 
-Tags: 6.7.5, lts
-Directory: 6.7.5
+Tags: 6.7.6-community, 6.7-community, lts
+Directory: 6.7.6-community
 
-Tags: 6.7.5-alpine, lts-alpine
-Directory: 6.7.5-alpine
-
-Tags: 7.1, latest
-Directory: 7.1
-
-Tags: 7.1-alpine, alpine
-Directory: 7.1-alpine
+Tags: 7.4-community, latest
+Directory: 7.4-community

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,14 +4,8 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 GitCommit: b3cb018a78ad7879bf1e07e2516f1497eb15a0c2
 
-Tags: 6.7.6-community-alpine, 6.7-community-alpine, lts
-Directory: 6.7.6-community-alpine
-
-Tags: 6.7.6-community, 6.7-community
+Tags: 6.7.6-community, 6.7-community, lts
 Directory: 6.7.6-community
 
-Tags: 7.4-community-alpine, latest
-Directory: 7.4-community-alpine
-
-Tags: 7.4-community
+Tags: 7.4-community, latest
 Directory: 7.4-community


### PR DESCRIPTION
At SonarSource we are finally officially supporting the SonarQube images for the Community Edition, taking over from @Godin who was doing it in his personal time.

See also [the PR on docs](https://github.com/docker-library/docs/pull/1367).