### PR TITLE
Odoo: update 10.0-12.0 to release 20181126

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 3b5c6ae6aa21ea4d590a5d305fc9b0f4a447e218
+GitCommit: d0360678214b8f70970a2369a5a6b37981ab2c45
 
 Tags: 12.0, 12, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Hello,

Here are the latest updates of the supported Odoo versions.
It  includes some important missing packages fixes and an important third party update (wkhtmltopdf).

Thanks