### PR TITLE
Update WebSphere Liberty beta to 2018.11.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 8fa7f1efc7afea1fe4b82f8b9eee28f4dfb71938
+GitCommit: d581464c90b50722f1aaa59357cc15648a7f1313
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: 18.0.0.3-javaee8, javaee8, latest


### PR DESCRIPTION
Update to the latest beta of WebSphere Liberty.