### PR TITLE
BLD-1187 rollback sql_mode after migration to centos

### DIFF
--- a/library/percona
+++ b/library/percona
@@ -15,6 +15,6 @@ Directory: percona-server.57
 File: Dockerfile-dockerhub
 
 Tags: 5.6.41-centos, 5.6-centos, 5.6.41, 5.6
-GitCommit: 9f4a229bf338497d47b7216929a53f715fdade17
+GitCommit: bd9111fa72764033b89e4beaaa71e0523231069b
 Directory: percona-server.56
 File: Dockerfile-dockerhub


### PR DESCRIPTION
Hi @tianon,

I have received the first feedback after migration to centos, here - https://github.com/percona/percona-docker/pull/50#issuecomment-441214218

could you review?
change itself - https://github.com/percona/percona-docker/pull/61