### PR TITLE
Library definition files for onboarding Amazon Corretto as an official docker image.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -1,0 +1,8 @@
+Maintainers: Amazon Corretto Team (@corretto),
+             Eric Edens (@ericedens),
+             iliana weller (@ilianaw)
+GitRepo: https://github.com/corretto/corretto-8-docker.git
+
+Tags: 8, 8u192, 8-al2-full, latest
+GitFetch: refs/heads/8-al2-full
+GitCommit: ca83f84faf06f5ca115ac922926e37fb183a2126

--- a/test/config.sh
+++ b/test/config.sh
@@ -17,6 +17,7 @@ imageTests[:onbuild]+='
 '
 
 testAlias+=(
+	[amazoncorretto]='openjdk'
 	[iojs]='node'
 	[jruby]='ruby'
 	[pypy]='python'


### PR DESCRIPTION
This PR adds a new official image containing [Amazon Corretto 8](https://aws.amazon.com/corretto/) installed into [Amazon Linux 2](https://hub.docker.com/_/amazonlinux/).

The image contains the full JDK 8, at the latest security update 8u192, with common commands such as `java` and `javac` symlinked into the user's path. 