### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,18 +4,18 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.6.1, 2.6, 2, latest
-Architectures: amd64, arm32v7, i386
-GitCommit: 2dded8903da71e4a1bbc12cdc703c62416fedcc8
+Tags: 2.6.2, 2.6, 2, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: bcd3f1c810dc3bed5be1306ef3f1c89659d9ceac
 Directory: 2/debian
 
-Tags: 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.2-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2dded8903da71e4a1bbc12cdc703c62416fedcc8
+GitCommit: bcd3f1c810dc3bed5be1306ef3f1c89659d9ceac
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f1dde8050d6994a8df9564e50bffd4549c9c9305
 Directory: 1/debian
 

--- a/library/joomla
+++ b/library/joomla
@@ -3,62 +3,62 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.9.0-php5.6-apache, 3.9-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.9.0-php5.6, 3.9-php5.6, 3-php5.6, php5.6
+Tags: 3.9.1-php5.6-apache, 3.9-php5.6-apache, 3-php5.6-apache, php5.6-apache, 3.9.1-php5.6, 3.9-php5.6, 3-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php5.6/apache
 
-Tags: 3.9.0-php5.6-fpm, 3.9-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
+Tags: 3.9.1-php5.6-fpm, 3.9-php5.6-fpm, 3-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php5.6/fpm
 
-Tags: 3.9.0-php5.6-fpm-alpine, 3.9-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 3.9.1-php5.6-fpm-alpine, 3.9-php5.6-fpm-alpine, 3-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php5.6/fpm-alpine
 
-Tags: 3.9.0-php7.0-apache, 3.9-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.9.0-php7.0, 3.9-php7.0, 3-php7.0, php7.0
+Tags: 3.9.1-php7.0-apache, 3.9-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.9.1-php7.0, 3.9-php7.0, 3-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.0/apache
 
-Tags: 3.9.0-php7.0-fpm, 3.9-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
+Tags: 3.9.1-php7.0-fpm, 3.9-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.0/fpm
 
-Tags: 3.9.0-php7.0-fpm-alpine, 3.9-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 3.9.1-php7.0-fpm-alpine, 3.9-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.0/fpm-alpine
 
-Tags: 3.9.0-apache, 3.9-apache, 3-apache, apache, 3.9.0, 3.9, 3, latest, 3.9.0-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.0-php7.1, 3.9-php7.1, 3-php7.1, php7.1
+Tags: 3.9.1-apache, 3.9-apache, 3-apache, apache, 3.9.1, 3.9, 3, latest, 3.9.1-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.1-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.1/apache
 
-Tags: 3.9.0-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.0-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.9.1-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.1-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.1/fpm
 
-Tags: 3.9.0-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.0-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.9.1-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.1-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.1/fpm-alpine
 
-Tags: 3.9.0-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.0-php7.2, 3.9-php7.2, 3-php7.2, php7.2
+Tags: 3.9.1-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.1-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.2/apache
 
-Tags: 3.9.0-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.1-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.2/fpm
 
-Tags: 3.9.0-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.1-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: e4fb5df2e19bb237b158e77ae2dcdb21422eaae2
+GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php7.2/fpm-alpine

--- a/library/matomo
+++ b/library/matomo
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.7.0-apache, 3.7-apache, 3-apache, apache, 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
+GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
 Directory: apache
 
 Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
+GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
 Directory: fpm
 
 Tags: 3.7.0-fpm-alpine, 3.7-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d1838e0fffbb95c387ae9318bc5fb91302eb1d2
+GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
 Directory: fpm-alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -187,12 +187,12 @@ Directory: 8/jre/alpine
 
 Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2057305e0474ebf6461daea607ff02874d690914
+GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk
 
 Tags: 7u181-jdk-slim-jessie, 7u181-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u181-jdk-slim, 7u181-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2057305e0474ebf6461daea607ff02874d690914
+GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk/slim
 
 Tags: 7u181-jdk-alpine3.8, 7u181-alpine3.8, 7-jdk-alpine3.8, 7-alpine3.8, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
@@ -202,12 +202,12 @@ Directory: 7/jdk/alpine
 
 Tags: 7u181-jre-jessie, 7-jre-jessie, 7u181-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2057305e0474ebf6461daea607ff02874d690914
+GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre
 
 Tags: 7u181-jre-slim-jessie, 7-jre-slim-jessie, 7u181-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 2057305e0474ebf6461daea607ff02874d690914
+GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre/slim
 
 Tags: 7u181-jre-alpine3.8, 7-jre-alpine3.8, 7u181-jre-alpine, 7-jre-alpine

--- a/library/php
+++ b/library/php
@@ -11,7 +11,7 @@ Directory: 7.3-rc/stretch/cli
 
 Tags: 7.3.0RC6-apache-stretch, 7.3-rc-apache-stretch, rc-apache-stretch, 7.3.0RC6-apache, 7.3-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ee78d7883237754eb68ffb281f5835f851797e05
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.3-rc/stretch/apache
 
 Tags: 7.3.0RC6-fpm-stretch, 7.3-rc-fpm-stretch, rc-fpm-stretch, 7.3.0RC6-fpm, 7.3-rc-fpm, rc-fpm
@@ -46,7 +46,7 @@ Directory: 7.2/stretch/cli
 
 Tags: 7.2.12-apache-stretch, 7.2-apache-stretch, 7-apache-stretch, apache-stretch, 7.2.12-apache, 7.2-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.12-fpm-stretch, 7.2-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.2.12-fpm, 7.2-fpm, 7-fpm, fpm
@@ -81,7 +81,7 @@ Directory: 7.1/stretch/cli
 
 Tags: 7.1.24-apache-stretch, 7.1-apache-stretch, 7.1.24-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.24-fpm-stretch, 7.1-fpm-stretch, 7.1.24-fpm, 7.1-fpm
@@ -101,7 +101,7 @@ Directory: 7.1/jessie/cli
 
 Tags: 7.1.24-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.24-fpm-jessie, 7.1-fpm-jessie
@@ -136,7 +136,7 @@ Directory: 7.0/stretch/cli
 
 Tags: 7.0.32-apache-stretch, 7.0-apache-stretch, 7.0.32-apache, 7.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.0/stretch/apache
 
 Tags: 7.0.32-fpm-stretch, 7.0-fpm-stretch, 7.0.32-fpm, 7.0-fpm
@@ -156,7 +156,7 @@ Directory: 7.0/jessie/cli
 
 Tags: 7.0.32-apache-jessie, 7.0-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 7.0/jessie/apache
 
 Tags: 7.0.32-fpm-jessie, 7.0-fpm-jessie
@@ -191,7 +191,7 @@ Directory: 5.6/stretch/cli
 
 Tags: 5.6.38-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.38-apache, 5.6-apache, 5-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 5.6/stretch/apache
 
 Tags: 5.6.38-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.38-fpm, 5.6-fpm, 5-fpm
@@ -211,7 +211,7 @@ Directory: 5.6/jessie/cli
 
 Tags: 5.6.38-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 67efd89c36bf15cb5ba096213e0536b2cab5eb38
+GitCommit: c77c579341cfbfee90e669535ea3057679a1005b
 Directory: 5.6/jessie/apache
 
 Tags: 5.6.38-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.6, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 10
 
 Tags: 10.6-alpine, 10-alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.11, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 9.6
 
 Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.15, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 9.5
 
 Tags: 9.5.15-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.20, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 9.4
 
 Tags: 9.4.20-alpine, 9.4-alpine
@@ -56,7 +56,7 @@ Directory: 9.4/alpine
 
 Tags: 9.3.25, 9.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61fd19b699b2c380da08c3a95f7272137a182bb
+GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
 Directory: 9.3
 
 Tags: 9.3.25-alpine, 9.3-alpine

--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0.1, 5.0, 5, latest, 5.0.1-stretch, 5.0-stretch, 5-stretch, stretch
+Tags: 5.0.2, 5.0, 5, latest, 5.0.2-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5d019077b46494751482512c200c4df34463dc6
+GitCommit: f1a8498333ae3ab340b5b39fbac1d7e1dc0d628c
 Directory: 5.0
 
-Tags: 5.0.1-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.1-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
+Tags: 5.0.2-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.2-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: a5d019077b46494751482512c200c4df34463dc6
+GitCommit: f1a8498333ae3ab340b5b39fbac1d7e1dc0d628c
 Directory: 5.0/32bit
 
-Tags: 5.0.1-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.1-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
+Tags: 5.0.2-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.2-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cad514bada42abbaba0092c5c94e94553b19f9cf
+GitCommit: f1a8498333ae3ab340b5b39fbac1d7e1dc0d628c
 Directory: 5.0/alpine
 
 Tags: 4.0.11, 4.0, 4, 4.0.11-stretch, 4.0-stretch, 4-stretch

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php5.6/apache
 
 Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php5.6/fpm
 
 Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php5.6/fpm-alpine
 
 Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.0/apache
 
 Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.0/fpm
 
 Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.0/fpm-alpine
 
 Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.1/apache
 
 Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.1/fpm
 
 Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.1/fpm-alpine
 
 Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.2/apache
 
 Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.2/fpm
 
 Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 443eb3028423485fdf3943250db5609f3f37afbe
+GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `ghost`: 2.6.2, more arches (thanks to https://github.com/nodejs/docker-node/pull/921)
- `joomla`: 3.9.1
- `matomo`: php-apcu to 5.1.14 (matomo-org/docker#125)
- `openjdk`: `7u181-2.6.14-2~deb8u1`
- `php`: fix arbitrary user permissions (docker-library/php#755)
- `postgres`: `dpkg-divert` config file for correctness (docker-library/postgres#529)
- `redis`: 5.0.2
- `wordpress`: add `--no-overwrite-dir` for arbitrary user (docker-library/wordpress#351)