### PR TITLE
Node security update

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,89 +3,89 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.13.0-jessie, 8.13-jessie, 8-jessie, carbon-jessie
+Tags: 8.14.0-jessie, 8.14-jessie, 8-jessie, carbon-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: 0ceefee0745a078709c60d92e4229f5eb6a3df42
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 8/jessie
 
-Tags: 8.13.0-alpine, 8.13-alpine, 8-alpine, carbon-alpine
+Tags: 8.14.0-alpine, 8.14-alpine, 8-alpine, carbon-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 77c2d0850a520de5e202757f54e5bc9b142f9adf
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 8/alpine
 
-Tags: 8.13.0-onbuild, 8.13-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.14.0-onbuild, 8.14-onbuild, 8-onbuild, carbon-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 0ceefee0745a078709c60d92e4229f5eb6a3df42
+GitCommit: 0aae692a71251b60c489c41b7b1f28daa05829e5
 Directory: 8/onbuild
 
-Tags: 8.13.0-slim, 8.13-slim, 8-slim, carbon-slim
+Tags: 8.14.0-slim, 8.14-slim, 8-slim, carbon-slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 0ceefee0745a078709c60d92e4229f5eb6a3df42
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 8/slim
 
-Tags: 8.13.0-stretch, 8.13-stretch, 8-stretch, carbon-stretch, 8.13.0, 8.13, 8, carbon
+Tags: 8.14.0-stretch, 8.14-stretch, 8-stretch, carbon-stretch, 8.14.0, 8.14, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 0ceefee0745a078709c60d92e4229f5eb6a3df42
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 8/stretch
 
-Tags: 6.14.4-jessie, 6.14-jessie, 6-jessie, boron-jessie
+Tags: 6.15.0-jessie, 6.15-jessie, 6-jessie, boron-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 6/jessie
 
-Tags: 6.14.4-alpine, 6.14-alpine, 6-alpine, boron-alpine
+Tags: 6.15.0-alpine, 6.15-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 77c2d0850a520de5e202757f54e5bc9b142f9adf
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 6/alpine
 
-Tags: 6.14.4-onbuild, 6.14-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.15.0-onbuild, 6.15-onbuild, 6-onbuild, boron-onbuild
 Architectures: arm32v7, amd64, i386
-GitCommit: 72dd945d29dee5afa73956ebc971bf3a472442f7
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 6/onbuild
 
-Tags: 6.14.4-slim, 6.14-slim, 6-slim, boron-slim
+Tags: 6.15.0-slim, 6.15-slim, 6-slim, boron-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 6/slim
 
-Tags: 6.14.4-stretch, 6.14-stretch, 6-stretch, boron-stretch, 6.14.4, 6.14, 6, boron
+Tags: 6.15.0-stretch, 6.15-stretch, 6-stretch, boron-stretch, 6.15.0, 6.15, 6, boron
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 6/stretch
 
-Tags: 11.2.0-alpine, 11.2-alpine, 11-alpine, current-alpine, alpine
+Tags: 11.3.0-alpine, 11.3-alpine, 11-alpine, current-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 77c2d0850a520de5e202757f54e5bc9b142f9adf
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 11/alpine
 
-Tags: 11.2.0-slim, 11.2-slim, 11-slim, current-slim, slim
+Tags: 11.3.0-slim, 11.3-slim, 11-slim, current-slim, slim
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 11/slim
 
-Tags: 11.2.0-stretch, 11.2-stretch, 11-stretch, current-stretch, stretch, 11.2.0, 11.2, 11, current, latest
+Tags: 11.3.0-stretch, 11.3-stretch, 11-stretch, current-stretch, stretch, 11.3.0, 11.3, 11, current, latest
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 11/stretch
 
-Tags: 10.13.0-jessie, 10.13-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.14.0-jessie, 10.14-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: arm32v7, amd64
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 10/jessie
 
-Tags: 10.13.0-alpine, 10.13-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.14.0-alpine, 10.14-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 77c2d0850a520de5e202757f54e5bc9b142f9adf
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 10/alpine
 
-Tags: 10.13.0-slim, 10.13-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.14.0-slim, 10.14-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: arm32v7, amd64
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 10/slim
 
-Tags: 10.13.0-stretch, 10.13-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.13.0, 10.13, 10, dubnium, lts
+Tags: 10.14.0-stretch, 10.14-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.14.0, 10.14, 10, dubnium, lts
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
+GitCommit: ed3e8825b01649d43188e1f606243396a0b995de
 Directory: 10/stretch
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
This is with https://github.com/nodejs/docker-node/pull/939, alternative to #5115