### PR TITLE
Add openjdk 11 based clojure images

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,32 +3,34 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 50e4f6aa534a88effa18239180ac390c91587289
+GitCommit: c450f6707b986cb7a59318bfdd1c18ae2292062e
 
-Tags: lein-2.8.1, lein, latest
-Directory: debian/lein
+Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
+Directory: target/openjdk-8/debian/lein
 
-Tags: lein-2.8.1-onbuild, lein-onbuild, onbuild
-Directory: debian/lein/onbuild
-
-Tags: lein-2.8.1-alpine, lein-alpine, alpine
+Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.8.1-alpine, lein-2.8.1-alpine, lein-alpine, alpine
 Architectures: amd64
-Directory: alpine/lein
+Directory: target/openjdk-8/alpine/lein
 
-Tags: lein-2.8.1-alpine-onbuild, lein-alpine-onbuild, alpine-onbuild
+Tags: openjdk-8-boot, openjdk-8-boot-2.8.1, boot-2.8.1, boot
+Directory: target/openjdk-8/debian/boot
+
+Tags: openjdk-8-boot-alpine, openjdk-8-boot-2.8.1-alpine, boot-2.8.1-alpine, boot-alpine
 Architectures: amd64
-Directory: alpine/lein/onbuild
+Directory: target/openjdk-8/alpine/boot
 
-Tags: boot-2.8.1, boot
-Directory: debian/boot
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.9.0.397, tools-deps-1.9.0.397, tools-deps
+Directory: target/openjdk-8/debian/tools-deps
 
-Tags: boot-2.8.1-alpine, boot-alpine
+Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.9.0.397-alpine, tools-deps-1.9.0.397-alpine, tools-deps-alpine
 Architectures: amd64
-Directory: alpine/boot
+Directory: target/openjdk-8/alpine/tools-deps
 
-Tags: tools-deps-1.9.0.397, tools-deps
-Directory: debian/tools-deps
+Tags: openjdk-11-lein, openjdk-11-lein-2.8.1
+Directory: target/openjdk-11/debian/lein
 
-Tags: tools-deps-1.9.0.397-alpine, tools-deps-alpine
-Architectures: amd64
-Directory: alpine/tools-deps
+Tags: openjdk-11-boot, openjdk-11-boot-2.8.1
+Directory: target/openjdk-11/debian/boot
+
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.9.0.397
+Directory: target/openjdk-11/debian/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 329b6aaafd9fc0f425b2080f14e27966ee685751
+GitCommit: e39cb83388009326bd098ad4503c3139df567c07
 
 Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
 Directory: target/openjdk-8/debian/lein

--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: c450f6707b986cb7a59318bfdd1c18ae2292062e
+GitCommit: 329b6aaafd9fc0f425b2080f14e27966ee685751
 
 Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
 Directory: target/openjdk-8/debian/lein


### PR DESCRIPTION
This also does away with the long-deprecated `onbuild` variants. We had to rewrite our build infrastructure to accommodate the new Java release cadence and allow for multiple major Java versions to coexist. It was much simpler to leave `onbuild` out since it would have just added yet another compounding variant to build for every combination of every other variant.