### PR TITLE
HASKELL: GHC 8.4.4 and 8.6.2

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,10 +3,10 @@ Maintainers: Darin Morrison <darinmorrison+git@gmail.com> (@freebroccolo),
              Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi)
 GitRepo: https://github.com/freebroccolo/docker-haskell
 
-Tags: 8.4.3, 8.4, 8, latest
-GitCommit: af83447feb6ebeabbc0cbad27adb3895e6262951
-Directory: 8.4
+Tags: 8.6.2, 8.6, 8, latest
+GitCommit: 5362898713c831feb18b57f106385cac2b5daa1a
+Directory: 8.6
 
-Tags: 8.2.2, 8.2
-GitCommit: af83447feb6ebeabbc0cbad27adb3895e6262951
-Directory: 8.2
+Tags: 8.4.4, 8.4
+GitCommit: 5362898713c831feb18b57f106385cac2b5daa1a
+Directory: 8.4


### PR DESCRIPTION
Note: existing tests will spit out extra warning output but still pass.  There is another PR to address this that I'll link here