### PR TITLE
Add haskell-stack test, update haskell-cabal test.

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -88,6 +88,7 @@ imageTests+=(
 	'
 	[haskell]='
 		haskell-cabal
+		haskell-stack
 		haskell-ghci
 		haskell-runhaskell
 	'

--- a/test/tests/haskell-cabal/container.sh
+++ b/test/tests/haskell-cabal/container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
-cabal update
+cabal new-update
+cabal new-install --lib hashable

--- a/test/tests/haskell-stack/container.sh
+++ b/test/tests/haskell-stack/container.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# stack mostly sends to stderr
+stack new myproject 2> /dev/null
+cd myproject
+stack config set resolver ghc-$(ghc --print-project-version) 2> /dev/null
+stack build 2> /dev/null

--- a/test/tests/haskell-stack/run.sh
+++ b/test/tests/haskell-stack/run.sh
@@ -1,0 +1,1 @@
+../run-bash-in-container.sh


### PR DESCRIPTION
Stack is a tool we've included in the haskell image since 7.10.3, so it only
makes sense to add a test for it. In addition, the updates to the haskell-cabal
test clean up the run.sh output and validate basic installation of a package.
Both the stack and cabal tests download (different!) upstream package indexes,
so they can take more than a few seconds each to complete.