### PR TITLE
Update to Flink 1.7.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,105 +1,155 @@
-# this file is generated via https://github.com/docker-flink/docker-flink/blob/79f446ff1f6b12be411638bd5839fc1a27397656/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-flink/docker-flink/blob/7086bb154b8b70a0b44b91f27165e09019c08247/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/docker-flink/docker-flink.git
 
-Tags: 1.5.5-hadoop24-scala_2.11, 1.5.5-hadoop24, 1.5-hadoop24
+Tags: 1.6.2-hadoop24-scala_2.11, 1.6.2-hadoop24, 1.6-hadoop24
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop24-scala_2.11-debian
-
-Tags: 1.5.5-hadoop26-scala_2.11, 1.5.5-hadoop26, 1.5-hadoop26
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop26-scala_2.11-debian
-
-Tags: 1.5.5-hadoop27-scala_2.11, 1.5.5-hadoop27, 1.5-hadoop27
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop27-scala_2.11-debian
-
-Tags: 1.5.5-hadoop28-scala_2.11, 1.5.5-hadoop28, 1.5-hadoop28
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop28-scala_2.11-debian
-
-Tags: 1.5.5-scala_2.11, 1.5-scala_2.11, 1.5.5, 1.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/scala_2.11-debian
-
-Tags: 1.5.5-hadoop24-scala_2.11-alpine, 1.5.5-hadoop24-alpine, 1.5-hadoop24-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop24-scala_2.11-alpine
-
-Tags: 1.5.5-hadoop26-scala_2.11-alpine, 1.5.5-hadoop26-alpine, 1.5-hadoop26-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop26-scala_2.11-alpine
-
-Tags: 1.5.5-hadoop27-scala_2.11-alpine, 1.5.5-hadoop27-alpine, 1.5-hadoop27-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop27-scala_2.11-alpine
-
-Tags: 1.5.5-hadoop28-scala_2.11-alpine, 1.5.5-hadoop28-alpine, 1.5-hadoop28-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/hadoop28-scala_2.11-alpine
-
-Tags: 1.5.5-scala_2.11-alpine, 1.5-scala_2.11-alpine, 1.5.5-alpine, 1.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
-Directory: 1.5/scala_2.11-alpine
-
-Tags: 1.6.2-hadoop24-scala_2.11, 1.6.2-hadoop24, 1.6-hadoop24, hadoop24
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop24-scala_2.11-debian
 
-Tags: 1.6.2-hadoop26-scala_2.11, 1.6.2-hadoop26, 1.6-hadoop26, hadoop26
+Tags: 1.6.2-hadoop26-scala_2.11, 1.6.2-hadoop26, 1.6-hadoop26
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop26-scala_2.11-debian
 
-Tags: 1.6.2-hadoop27-scala_2.11, 1.6.2-hadoop27, 1.6-hadoop27, hadoop27
+Tags: 1.6.2-hadoop27-scala_2.11, 1.6.2-hadoop27, 1.6-hadoop27
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop27-scala_2.11-debian
 
-Tags: 1.6.2-hadoop28-scala_2.11, 1.6.2-hadoop28, 1.6-hadoop28, hadoop28
+Tags: 1.6.2-hadoop28-scala_2.11, 1.6.2-hadoop28, 1.6-hadoop28
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop28-scala_2.11-debian
 
-Tags: 1.6.2-scala_2.11, 1.6-scala_2.11, scala_2.11, 1.6.2, 1.6, latest
+Tags: 1.6.2-scala_2.11, 1.6-scala_2.11, 1.6.2, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/scala_2.11-debian
 
-Tags: 1.6.2-hadoop24-scala_2.11-alpine, 1.6.2-hadoop24-alpine, 1.6-hadoop24-alpine, hadoop24-alpine
+Tags: 1.6.2-hadoop24-scala_2.11-alpine, 1.6.2-hadoop24-alpine, 1.6-hadoop24-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop24-scala_2.11-alpine
 
-Tags: 1.6.2-hadoop26-scala_2.11-alpine, 1.6.2-hadoop26-alpine, 1.6-hadoop26-alpine, hadoop26-alpine
+Tags: 1.6.2-hadoop26-scala_2.11-alpine, 1.6.2-hadoop26-alpine, 1.6-hadoop26-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop26-scala_2.11-alpine
 
-Tags: 1.6.2-hadoop27-scala_2.11-alpine, 1.6.2-hadoop27-alpine, 1.6-hadoop27-alpine, hadoop27-alpine
+Tags: 1.6.2-hadoop27-scala_2.11-alpine, 1.6.2-hadoop27-alpine, 1.6-hadoop27-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop27-scala_2.11-alpine
 
-Tags: 1.6.2-hadoop28-scala_2.11-alpine, 1.6.2-hadoop28-alpine, 1.6-hadoop28-alpine, hadoop28-alpine
+Tags: 1.6.2-hadoop28-scala_2.11-alpine, 1.6.2-hadoop28-alpine, 1.6-hadoop28-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/hadoop28-scala_2.11-alpine
 
-Tags: 1.6.2-scala_2.11-alpine, 1.6-scala_2.11-alpine, scala_2.11-alpine, 1.6.2-alpine, 1.6-alpine, alpine
+Tags: 1.6.2-scala_2.11-alpine, 1.6-scala_2.11-alpine, 1.6.2-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a8e4330c4cc20b25f549b8999c16144d540e87aa
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
 Directory: 1.6/scala_2.11-alpine
+
+Tags: 1.7.0-hadoop24-scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop24-scala_2.11-debian
+
+Tags: 1.7.0-hadoop24-scala_2.12, 1.7.0-hadoop24, 1.7-hadoop24, hadoop24
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop24-scala_2.12-debian
+
+Tags: 1.7.0-hadoop26-scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop26-scala_2.11-debian
+
+Tags: 1.7.0-hadoop26-scala_2.12, 1.7.0-hadoop26, 1.7-hadoop26, hadoop26
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop26-scala_2.12-debian
+
+Tags: 1.7.0-hadoop27-scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop27-scala_2.11-debian
+
+Tags: 1.7.0-hadoop27-scala_2.12, 1.7.0-hadoop27, 1.7-hadoop27, hadoop27
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop27-scala_2.12-debian
+
+Tags: 1.7.0-hadoop28-scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop28-scala_2.11-debian
+
+Tags: 1.7.0-hadoop28-scala_2.12, 1.7.0-hadoop28, 1.7-hadoop28, hadoop28
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop28-scala_2.12-debian
+
+Tags: 1.7.0-scala_2.11, 1.7-scala_2.11, scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/scala_2.11-debian
+
+Tags: 1.7.0-scala_2.12, 1.7-scala_2.12, scala_2.12, 1.7.0, 1.7, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/scala_2.12-debian
+
+Tags: 1.7.0-hadoop24-scala_2.11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop24-scala_2.11-alpine
+
+Tags: 1.7.0-hadoop24-scala_2.12-alpine, 1.7.0-hadoop24-alpine, 1.7-hadoop24-alpine, hadoop24-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop24-scala_2.12-alpine
+
+Tags: 1.7.0-hadoop26-scala_2.11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop26-scala_2.11-alpine
+
+Tags: 1.7.0-hadoop26-scala_2.12-alpine, 1.7.0-hadoop26-alpine, 1.7-hadoop26-alpine, hadoop26-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop26-scala_2.12-alpine
+
+Tags: 1.7.0-hadoop27-scala_2.11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop27-scala_2.11-alpine
+
+Tags: 1.7.0-hadoop27-scala_2.12-alpine, 1.7.0-hadoop27-alpine, 1.7-hadoop27-alpine, hadoop27-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop27-scala_2.12-alpine
+
+Tags: 1.7.0-hadoop28-scala_2.11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop28-scala_2.11-alpine
+
+Tags: 1.7.0-hadoop28-scala_2.12-alpine, 1.7.0-hadoop28-alpine, 1.7-hadoop28-alpine, hadoop28-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/hadoop28-scala_2.12-alpine
+
+Tags: 1.7.0-scala_2.11-alpine, 1.7-scala_2.11-alpine, scala_2.11-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/scala_2.11-alpine
+
+Tags: 1.7.0-scala_2.12-alpine, 1.7-scala_2.12-alpine, scala_2.12-alpine, 1.7.0-alpine, 1.7-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0a7ce6c7f2f7cc19110c61679984108ff41e3bb4
+Directory: 1.7/scala_2.12-alpine


### PR DESCRIPTION
Flink 1.7 once again has support for two scala versions, hence the increase in image count.