### PR TITLE
Update clojure git commit to latest SHA

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: e39cb83388009326bd098ad4503c3139df567c07
+GitCommit: 9ed339a714c220988375884eb6743c221b02beb5
 
 Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
 Directory: target/openjdk-8/debian/lein


### PR DESCRIPTION
...as requested in #5117 this adds the `--batch` arg to one of the gpg commands (it broke the other one, though) in the clojure image build.