### PR TITLE
Update node to 6.15.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -33,34 +33,34 @@ Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
 GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
 Directory: 8/stretch-slim
 
-Tags: 6.15.0-jessie, 6.15-jessie, 6-jessie, boron-jessie
+Tags: 6.15.1-jessie, 6.15-jessie, 6-jessie, boron-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: fd2bad889b28587d4722f69c4a51d025df2ae624
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/jessie
 
-Tags: 6.15.0-jessie-slim, 6.15-jessie-slim, 6-jessie-slim, boron-jessie-slim
+Tags: 6.15.1-jessie-slim, 6.15-jessie-slim, 6-jessie-slim, boron-jessie-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/jessie-slim
 
-Tags: 6.15.0-alpine, 6.15-alpine, 6-alpine, boron-alpine
+Tags: 6.15.1-alpine, 6.15-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: fd2bad889b28587d4722f69c4a51d025df2ae624
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/alpine
 
-Tags: 6.15.0-onbuild, 6.15-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.15.1-onbuild, 6.15-onbuild, 6-onbuild, boron-onbuild
 Architectures: arm32v7, amd64, i386
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/onbuild
 
-Tags: 6.15.0-stretch, 6.15-stretch, 6-stretch, boron-stretch, 6.15.0, 6.15, 6, boron
+Tags: 6.15.1-stretch, 6.15-stretch, 6-stretch, boron-stretch, 6.15.1, 6.15, 6, boron
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: fd2bad889b28587d4722f69c4a51d025df2ae624
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/stretch
 
-Tags: 6.15.0-stretch-slim, 6.15-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.15.0-slim, 6.15-slim, 6-slim, boron-slim
+Tags: 6.15.1-stretch-slim, 6.15-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.15.1-slim, 6.15-slim, 6-slim, boron-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/stretch-slim
 
 Tags: 11.3.0-alpine, 11.3-alpine, 11-alpine, current-alpine, alpine


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v6.15.1/

The security release last week apparently had a bug, so a hotfix has been released