### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -49,6 +49,21 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
 Directory: cosmic
 
+Tags: disco-curl, 19.04-curl
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
+Directory: disco/curl
+
+Tags: disco-scm, 19.04-scm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
+Directory: disco/scm
+
+Tags: disco, 19.04
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
+Directory: disco
+
 Tags: jessie-curl, oldstable-curl
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-21-jdk-oraclelinux7, 12-ea-21-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-21-jdk-oracle, 12-ea-21-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-21-jdk, 12-ea-21, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-22-jdk-oraclelinux7, 12-ea-22-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-22-jdk-oracle, 12-ea-22-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-22-jdk, 12-ea-22, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 0626946ad0c862bd1f4067cbd5f1d936dd2c95ce
+GitCommit: fb3108c4e046972368359c116635bea18dc8e918
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-20-jdk-alpine3.8, 12-ea-20-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-20-jdk-alpine, 12-ea-20-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-21-jdk-windowsservercore-ltsc2016, 12-ea-21-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-21-jdk-windowsservercore, 12-ea-21-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-22-jdk-windowsservercore-ltsc2016, 12-ea-22-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-22-jdk-windowsservercore, 12-ea-22-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0626946ad0c862bd1f4067cbd5f1d936dd2c95ce
+GitCommit: fb3108c4e046972368359c116635bea18dc8e918
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-21-jdk-windowsservercore-1709, 12-ea-21-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-21-jdk-windowsservercore, 12-ea-21-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-22-jdk-windowsservercore-1709, 12-ea-22-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-22-jdk-windowsservercore, 12-ea-22-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0626946ad0c862bd1f4067cbd5f1d936dd2c95ce
+GitCommit: fb3108c4e046972368359c116635bea18dc8e918
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-21-jdk-windowsservercore-1803, 12-ea-21-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-21-jdk-windowsservercore, 12-ea-21-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-22-jdk-windowsservercore-1803, 12-ea-22-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-22-jdk-windowsservercore, 12-ea-22-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0626946ad0c862bd1f4067cbd5f1d936dd2c95ce
+GitCommit: fb3108c4e046972368359c116635bea18dc8e918
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -42,12 +42,12 @@ Directory: 11/jdk/oracle
 
 Tags: 11.0.1-jdk-sid, 11.0.1-sid, 11.0-jdk-sid, 11.0-sid, 11-jdk-sid, 11-sid, jdk-sid, sid, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
+GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
 Directory: 11/jdk
 
 Tags: 11.0.1-jdk-slim-sid, 11.0.1-slim-sid, 11.0-jdk-slim-sid, 11.0-slim-sid, 11-jdk-slim-sid, 11-slim-sid, jdk-slim-sid, slim-sid, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
+GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
 Directory: 11/jdk/slim
 
 Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -73,12 +73,12 @@ Constraints: windowsservercore-1803
 
 Tags: 11.0.1-jre-sid, 11.0-jre-sid, 11-jre-sid, jre-sid, 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
+GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
 Directory: 11/jre
 
 Tags: 11.0.1-jre-slim-sid, 11.0-jre-slim-sid, 11-jre-slim-sid, jre-slim-sid, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 894a19d0401349d39ced7764190ea6263bb17ba0
+GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
 Directory: 11/jre/slim
 
 Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
 Directory: 3.4
 
 Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
-GitCommit: aab2a6f72bf5ff15da0bf1ac39bfe9b9e686119a
+GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
 Directory: 3.4/passenger
 
 Tags: 3.3.8, 3.3
@@ -19,5 +19,5 @@ GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
 Directory: 3.3
 
 Tags: 3.3.8-passenger, 3.3-passenger
-GitCommit: aab2a6f72bf5ff15da0bf1ac39bfe9b9e686119a
+GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
 Directory: 3.3/passenger


### PR DESCRIPTION
- `buildpack-deps`: add disco (docker-library/buildpack-deps#86)
- `openjdk`: 12-ea+22, `11.0.1+13-3`
- `redmine`: passenger 6.0.0