### PR TITLE
kong: override 1.0.0rc3 git commit

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -3,11 +3,11 @@ GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
 Tags: 1.0.0rc3-alpine, 1.0rc3-alpine, 1.0.0rc3, 1.0rc3
-GitCommit: 20bd026140c722c45532b4a6313f21b407f8afa5
+GitCommit: fa8fed4daa33b46c356c822b519529c07f39e104
 Directory: alpine
 
 Tags: 1.0.0rc3-centos, 1.0rc3-centos
-GitCommit: 20bd026140c722c45532b4a6313f21b407f8afa5
+GitCommit: fa8fed4daa33b46c356c822b519529c07f39e104
 Constraints: !aufs
 Directory: centos
 


### PR DESCRIPTION
Hello,

After detecting an error in how our dependencies were compiled in our latest release candidate (https://github.com/docker-library/official-images/pull/5097), we wish to override the commit to which our latest tags point to.