### PR TITLE
Update for latest CouchDB (2.3.0)

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,11 +3,11 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: f429c1ccf22fe8cf7717383462fbf2f56e6d0301
+GitCommit: ce1679b4c1312203df2af8936c367c7027d2e888
 
-Tags: latest, 2.2.0, 2.2, 2
+Tags: latest, 2.3.0, 2.3, 2
 Architectures: amd64
-Directory: 2.2.0
+Directory: 2.3.0
 
 # 1.x is no longer supported by the Apache CouchDB team.
 #


### PR DESCRIPTION
This is a security update, so we have dropped the 2.2.0 version.

Note that we are now installing from our `.deb` installer, which simplifies the Dockerfile, speeds image build, and is also saving us about 53MB of space.

We've got updated docs too, so I'll submit a PR for https://github.com/docker-library/docs/tree/master/couchdb in the morning.