### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,17 +4,32 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.0, 18.09, 18, stable, test, latest
+Tags: 18.09.1-beta2, 18.09-rc, rc, test
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 27e5adeb0597e445e3b9df951f03eaf89131184b
+Directory: 18.09-rc
+
+Tags: 18.09.1-beta2-dind, 18.09-rc-dind, rc-dind, test-dind
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 27e5adeb0597e445e3b9df951f03eaf89131184b
+Directory: 18.09-rc/dind
+
+Tags: 18.09.1-beta2-git, 18.09-rc-git, rc-git, test-git
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitCommit: 27e5adeb0597e445e3b9df951f03eaf89131184b
+Directory: 18.09-rc/git
+
+Tags: 18.09.0, 18.09, 18, stable, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09
 
-Tags: 18.09.0-dind, 18.09-dind, 18-dind, stable-dind, test-dind, dind
+Tags: 18.09.0-dind, 18.09-dind, 18-dind, stable-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/dind
 
-Tags: 18.09.0-git, 18.09-git, 18-git, stable-git, test-git, git
+Tags: 18.09.0-git, 18.09-git, 18-git, stable-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git

--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.3-apache, 8.6-apache, 8-apache, apache, 8.6.3, 8.6, 8, latest
+Tags: 8.6.4-apache, 8.6-apache, 8-apache, apache, 8.6.4, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: 2c1fc3d9ca678b682e68d599d046633a5deba858
 Directory: 8.6/apache
 
-Tags: 8.6.3-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.4-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: 2c1fc3d9ca678b682e68d599d046633a5deba858
 Directory: 8.6/fpm
 
-Tags: 8.6.3-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.4-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: 2c1fc3d9ca678b682e68d599d046633a5deba858
 Directory: 8.6/fpm-alpine
 
 Tags: 8.5.8-apache, 8.5-apache, 8.5.8, 8.5

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.5.1
-GitCommit: 649743f29f4f3e9b54959cced3e059c5c4aaa444
+Tags: 6.5.2
+GitCommit: 621b02788fba0220b7c47a21a24d360f99fd8555
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/gcc
+++ b/library/gcc
@@ -7,27 +7,27 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2017-10-10
 Tags: 5.5.0, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
+GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
 Directory: 5
 # Docker EOL: 2019-04-10
 
 # Last Modified: 2018-10-30
 Tags: 6.5.0, 6.5, 6
 Architectures: amd64, arm32v5, arm32v7
-GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
+GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
 Directory: 6
 # Docker EOL: 2020-04-30
 
 # Last Modified: 2018-01-25
 Tags: 7.3.0, 7.3, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
+GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
 Directory: 7
 # Docker EOL: 2019-07-25
 
 # Last Modified: 2018-07-26
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5fe30c993194e71c953a96499bffb07392408c10
+GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
 Directory: 8
 # Docker EOL: 2020-01-26

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.6.2, 2.6, 2, latest
+Tags: 2.7.1, 2.7, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bcd3f1c810dc3bed5be1306ef3f1c89659d9ceac
+GitCommit: 4d72092d379e04cdd08d80058e446146ced73c4f
 Directory: 2/debian
 
-Tags: 2.6.2-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.7.1-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bcd3f1c810dc3bed5be1306ef3f1c89659d9ceac
+GitCommit: 4d72092d379e04cdd08d80058e446146ced73c4f
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,45 +1,55 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/1fa9d01682376087032e856c0a8c319f97c2ebec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/4a2d233b1a42e255b8e4097d50d2241b97bd446e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.5.19, 1.5
+Tags: 1.9-dev9, 1.9-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.5
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.9-rc
 
-Tags: 1.5.19-alpine, 1.5-alpine
+Tags: 1.9-dev9-alpine, 1.9-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.5/alpine
-
-Tags: 1.6.14, 1.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.6
-
-Tags: 1.6.14-alpine, 1.6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.6/alpine
-
-Tags: 1.7.11, 1.7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.7
-
-Tags: 1.7.11-alpine, 1.7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5803ee6e7e1f542bb22dbf83761bbe908d8e66ab
-Directory: 1.7/alpine
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.9-rc/alpine
 
 Tags: 1.8.14, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9da24940385e6178f987737305ff499734437c90
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
 Directory: 1.8
 
 Tags: 1.8.14-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9da24940385e6178f987737305ff499734437c90
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
 Directory: 1.8/alpine
+
+Tags: 1.7.11, 1.7
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.7
+
+Tags: 1.7.11-alpine, 1.7-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.7/alpine
+
+Tags: 1.6.14, 1.6
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.6
+
+Tags: 1.6.14-alpine, 1.6-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.6/alpine
+
+Tags: 1.5.19, 1.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.5
+
+Tags: 1.5.19-alpine, 1.5-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+Directory: 1.5/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.5.1
-GitCommit: 09f59b3a0fe8771b12797be6158f99dec0be654e
+Tags: 6.5.2
+GitCommit: bc610048989693a2a668b65363e707d737c8536c
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.5.1
-GitCommit: 60f93194c822ef6eefa62b46448521b1b01d3ef3
+Tags: 6.5.2
+GitCommit: 24c05a06936c5021b1c39744c2fa0aaba1595ded
 Directory: 6
 
 Tags: 5.6.13, 5.6, 5

--- a/library/mongo
+++ b/library/mongo
@@ -99,31 +99,31 @@ GitCommit: b1c209cdd9b890cd62e85a2c7055fb8f00c7d248
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.5-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.5, 4.1, unstable
+Tags: 4.1.6-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.6, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
+GitCommit: f7d007d343fd6c97ec808ee28cd6dda898b26a0c
 Directory: 4.1
 
-Tags: 4.1.5-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
+Tags: 4.1.6-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
+GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.5-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
+Tags: 4.1.6-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
+GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.5-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.5, 4.1, unstable
+Tags: 4.1.6-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: d5e810eda79184ce146144a18105c3e5ab2130b7
+GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/openjdk
+++ b/library/openjdk
@@ -81,52 +81,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
 Directory: 11/jre/slim
 
-Tags: 10.0.2-jdk-oraclelinux7, 10.0.2-oraclelinux7, 10.0-jdk-oraclelinux7, 10.0-oraclelinux7, 10-jdk-oraclelinux7, 10-oraclelinux7, 10.0.2-jdk-oracle, 10.0.2-oracle, 10.0-jdk-oracle, 10.0-oracle, 10-jdk-oracle, 10-oracle
-Architectures: amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
-Directory: 10/jdk/oracle
-
-Tags: 10.0.2-jdk-sid, 10.0.2-sid, 10.0-jdk-sid, 10.0-sid, 10-jdk-sid, 10-sid, 10.0.2-jdk, 10.0.2, 10.0-jdk, 10.0, 10-jdk, 10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23e96e231951fc0edb5a1974280f6f460a44151f
-Directory: 10/jdk
-
-Tags: 10.0.2-jdk-slim-sid, 10.0.2-slim-sid, 10.0-jdk-slim-sid, 10.0-slim-sid, 10-jdk-slim-sid, 10-slim-sid, 10.0.2-jdk-slim, 10.0.2-slim, 10.0-jdk-slim, 10.0-slim, 10-jdk-slim, 10-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23e96e231951fc0edb5a1974280f6f460a44151f
-Directory: 10/jdk/slim
-
-Tags: 10.0.2-jdk-windowsservercore-ltsc2016, 10.0.2-windowsservercore-ltsc2016, 10.0-jdk-windowsservercore-ltsc2016, 10.0-windowsservercore-ltsc2016, 10-jdk-windowsservercore-ltsc2016, 10-windowsservercore-ltsc2016
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
-Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
-Directory: 10/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 10.0.2-jdk-windowsservercore-1709, 10.0.2-windowsservercore-1709, 10.0-jdk-windowsservercore-1709, 10.0-windowsservercore-1709, 10-jdk-windowsservercore-1709, 10-windowsservercore-1709
-SharedTags: 10.0.2-jdk-windowsservercore, 10.0.2-windowsservercore, 10.0-jdk-windowsservercore, 10.0-windowsservercore, 10-jdk-windowsservercore, 10-windowsservercore
-Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
-Directory: 10/jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
-Tags: 10.0.2-jdk-nanoserver-sac2016, 10.0.2-nanoserver-sac2016, 10.0-jdk-nanoserver-sac2016, 10.0-nanoserver-sac2016, 10-jdk-nanoserver-sac2016, 10-nanoserver-sac2016
-SharedTags: 10.0.2-jdk-nanoserver, 10.0.2-nanoserver, 10.0-jdk-nanoserver, 10.0-nanoserver, 10-jdk-nanoserver, 10-nanoserver
-Architectures: windows-amd64
-GitCommit: 7d6b0528da55c7b74feff4f565c9dbb8907b8c9a
-Directory: 10/jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
-Tags: 10.0.2-jre-sid, 10.0-jre-sid, 10-jre-sid, 10.0.2-jre, 10.0-jre, 10-jre
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23e96e231951fc0edb5a1974280f6f460a44151f
-Directory: 10/jre
-
-Tags: 10.0.2-jre-slim-sid, 10.0-jre-slim-sid, 10-jre-slim-sid, 10.0.2-jre-slim, 10.0-jre-slim, 10-jre-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23e96e231951fc0edb5a1974280f6f460a44151f
-Directory: 10/jre/slim
-
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595

--- a/library/postgres
+++ b/library/postgres
@@ -53,13 +53,3 @@ Tags: 9.4.20-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: d564da5142b2e5fa235707b05d8aa0fc76250418
 Directory: 9.4/alpine
-
-Tags: 9.3.25, 9.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
-Directory: 9.3
-
-Tags: 9.3.25-alpine, 9.3-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4955a99b600fa0badb1e707285617a23315421af
-Directory: 9.3/alpine

--- a/library/python
+++ b/library/python
@@ -184,17 +184,17 @@ Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016

--- a/library/tomcat
+++ b/library/tomcat
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/tomcat.git
 
 Tags: 7.0.92-jre7, 7.0-jre7, 7-jre7, 7.0.92, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
+GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
 Directory: 7/jre7
 
 Tags: 7.0.92-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.92-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
+GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
 Directory: 7/jre7-slim
 
 Tags: 7.0.92-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.92-alpine, 7.0-alpine, 7-alpine
@@ -21,12 +21,12 @@ Directory: 7/jre7-alpine
 
 Tags: 7.0.92-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
+GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
 Directory: 7/jre8
 
 Tags: 7.0.92-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 37baee2462247279efcf9e072f55d4ff3086a7a9
+GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
 Directory: 7/jre8-slim
 
 Tags: 7.0.92-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
@@ -36,12 +36,12 @@ Directory: 7/jre8-alpine
 
 Tags: 8.5.35-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.35, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
 Directory: 8.5/jre8
 
 Tags: 8.5.35-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.35-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
 Directory: 8.5/jre8-slim
 
 Tags: 8.5.35-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.35-alpine, 8.5-alpine, 8-alpine, alpine
@@ -49,34 +49,24 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.35-jre10, 8.5-jre10, 8-jre10, jre10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
-Directory: 8.5/jre10
-
-Tags: 8.5.35-jre10-slim, 8.5-jre10-slim, 8-jre10-slim, jre10-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
-Directory: 8.5/jre10-slim
-
 Tags: 8.5.35-jre11, 8.5-jre11, 8-jre11, jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
 Directory: 8.5/jre11
 
 Tags: 8.5.35-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
 Directory: 8.5/jre11-slim
 
 Tags: 9.0.13-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
 Directory: 9.0/jre8
 
 Tags: 9.0.13-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
 Directory: 9.0/jre8-slim
 
 Tags: 9.0.13-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
@@ -84,22 +74,12 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.13-jre10, 9.0-jre10, 9-jre10, 9.0.13, 9.0, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
-Directory: 9.0/jre10
-
-Tags: 9.0.13-jre10-slim, 9.0-jre10-slim, 9-jre10-slim, 9.0.13-slim, 9.0-slim, 9-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
-Directory: 9.0/jre10-slim
-
 Tags: 9.0.13-jre11, 9.0-jre11, 9-jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
 Directory: 9.0/jre11
 
 Tags: 9.0.13-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
 Directory: 9.0/jre11-slim

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 4.9.8-php5.6-apache, 4.9-php5.6-apache, 4-php5.6-apache, php5.6-apache, 4.9.8-php5.6, 4.9-php5.6, 4-php5.6, php5.6
+Tags: 5.0.0-php5.6-apache, 5.0-php5.6-apache, 5-php5.6-apache, php5.6-apache, 5.0.0-php5.6, 5.0-php5.6, 5-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php5.6/apache
 
-Tags: 4.9.8-php5.6-fpm, 4.9-php5.6-fpm, 4-php5.6-fpm, php5.6-fpm
+Tags: 5.0.0-php5.6-fpm, 5.0-php5.6-fpm, 5-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php5.6/fpm
 
-Tags: 4.9.8-php5.6-fpm-alpine, 4.9-php5.6-fpm-alpine, 4-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 5.0.0-php5.6-fpm-alpine, 5.0-php5.6-fpm-alpine, 5-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php5.6/fpm-alpine
 
-Tags: 4.9.8-php7.0-apache, 4.9-php7.0-apache, 4-php7.0-apache, php7.0-apache, 4.9.8-php7.0, 4.9-php7.0, 4-php7.0, php7.0
+Tags: 5.0.0-php7.0-apache, 5.0-php7.0-apache, 5-php7.0-apache, php7.0-apache, 5.0.0-php7.0, 5.0-php7.0, 5-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.0/apache
 
-Tags: 4.9.8-php7.0-fpm, 4.9-php7.0-fpm, 4-php7.0-fpm, php7.0-fpm
+Tags: 5.0.0-php7.0-fpm, 5.0-php7.0-fpm, 5-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.0/fpm
 
-Tags: 4.9.8-php7.0-fpm-alpine, 4.9-php7.0-fpm-alpine, 4-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 5.0.0-php7.0-fpm-alpine, 5.0-php7.0-fpm-alpine, 5-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.0/fpm-alpine
 
-Tags: 4.9.8-php7.1-apache, 4.9-php7.1-apache, 4-php7.1-apache, php7.1-apache, 4.9.8-php7.1, 4.9-php7.1, 4-php7.1, php7.1
+Tags: 5.0.0-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.0-php7.1, 5.0-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.1/apache
 
-Tags: 4.9.8-php7.1-fpm, 4.9-php7.1-fpm, 4-php7.1-fpm, php7.1-fpm
+Tags: 5.0.0-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.1/fpm
 
-Tags: 4.9.8-php7.1-fpm-alpine, 4.9-php7.1-fpm-alpine, 4-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 5.0.0-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.1/fpm-alpine
 
-Tags: 4.9.8-apache, 4.9-apache, 4-apache, apache, 4.9.8, 4.9, 4, latest, 4.9.8-php7.2-apache, 4.9-php7.2-apache, 4-php7.2-apache, php7.2-apache, 4.9.8-php7.2, 4.9-php7.2, 4-php7.2, php7.2
+Tags: 5.0.0-apache, 5.0-apache, 5-apache, apache, 5.0.0, 5.0, 5, latest, 5.0.0-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.0-php7.2, 5.0-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.2/apache
 
-Tags: 4.9.8-fpm, 4.9-fpm, 4-fpm, fpm, 4.9.8-php7.2-fpm, 4.9-php7.2-fpm, 4-php7.2-fpm, php7.2-fpm
+Tags: 5.0.0-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.0-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.2/fpm
 
-Tags: 4.9.8-fpm-alpine, 4.9-fpm-alpine, 4-fpm-alpine, fpm-alpine, 4.9.8-php7.2-fpm-alpine, 4.9-php7.2-fpm-alpine, 4-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.0.0-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.0-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 5bad0cb022513fc9bb3bbc72c62db2bac0f5e84a
+GitCommit: b3739870faafe1886544ddda7d2f2a88882eeb31
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
 - `docker` add `18.09.1-beta2`
 - `drupal` Update to 8.6.4
 - `elasticsearch` Update to 6.5.2
 - `gcc` https://github.com/docker-library/gcc/pull/53
 - `ghost` Update to 2.7.1
 - `haproxy` Add 1.9-dev
 - `kibana` Update to 6.5.2
 - `logstash` Update to 6.5.2
 - `mongo` Update to 4.1.6
 - `openjdk` drop openjdk 10 (https://github.com/docker-library/openjdk/pull/254)
 - `postgres` Remove end of life 9.3
 - `python` https://github.com/docker-library/python/pull/358
 - `tomcat` openssl bump to `1.1.0j-1~deb9u1` and drop jre 10 (https://github.com/docker-library/tomcat/pull/139)
 - `wordpress` Update to 5.0 :tada: :balloon: