### PR TITLE
Update node.js v11 from v11.3.0 to v11.4.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -63,19 +63,19 @@ Architectures: arm32v7, amd64, i386
 GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
 Directory: 6/stretch-slim
 
-Tags: 11.3.0-alpine, 11.3-alpine, 11-alpine, current-alpine, alpine
+Tags: 11.4.0-alpine, 11.4-alpine, 11-alpine, current-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: fd2bad889b28587d4722f69c4a51d025df2ae624
+GitCommit: 438f5dead5a7432dd72fe8946f4faf3942d89a21
 Directory: 11/alpine
 
-Tags: 11.3.0-stretch, 11.3-stretch, 11-stretch, current-stretch, stretch, 11.3.0, 11.3, 11, current, latest
+Tags: 11.4.0-stretch, 11.4-stretch, 11-stretch, current-stretch, stretch, 11.4.0, 11.4, 11, current, latest
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: fd2bad889b28587d4722f69c4a51d025df2ae624
+GitCommit: 438f5dead5a7432dd72fe8946f4faf3942d89a21
 Directory: 11/stretch
 
-Tags: 11.3.0-stretch-slim, 11.3-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.3.0-slim, 11.3-slim, 11-slim, current-slim, slim
+Tags: 11.4.0-stretch-slim, 11.4-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.4.0-slim, 11.4-slim, 11-slim, current-slim, slim
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 438f5dead5a7432dd72fe8946f4faf3942d89a21
 Directory: 11/stretch-slim
 
 Tags: 10.14.1-jessie, 10.14-jessie, 10-jessie, dubnium-jessie, lts-jessie


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/952
- https://github.com/nodejs/node/releases/tag/v11.4.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.4.0