### PR TITLE
Update node.js v10 from v10.14.1 to v10.14.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -78,29 +78,29 @@ Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
 GitCommit: 438f5dead5a7432dd72fe8946f4faf3942d89a21
 Directory: 11/stretch-slim
 
-Tags: 10.14.1-jessie, 10.14-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.14.2-jessie, 10.14-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: arm32v7, amd64
-GitCommit: e1f2520c7a5f29dc5896edc3816357c0267cb931
+GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
 Directory: 10/jessie
 
-Tags: 10.14.1-jessie-slim, 10.14-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
+Tags: 10.14.2-jessie-slim, 10.14-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
 Architectures: arm32v7, amd64
-GitCommit: e1f2520c7a5f29dc5896edc3816357c0267cb931
+GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
 Directory: 10/jessie-slim
 
-Tags: 10.14.1-alpine, 10.14-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.14.2-alpine, 10.14-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: e1f2520c7a5f29dc5896edc3816357c0267cb931
+GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
 Directory: 10/alpine
 
-Tags: 10.14.1-stretch, 10.14-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.14.1, 10.14, 10, dubnium, lts
+Tags: 10.14.2-stretch, 10.14-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.14.2, 10.14, 10, dubnium, lts
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: e1f2520c7a5f29dc5896edc3816357c0267cb931
+GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
 Directory: 10/stretch
 
-Tags: 10.14.1-stretch-slim, 10.14-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.14.1-slim, 10.14-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.14.2-stretch-slim, 10.14-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.14.2-slim, 10.14-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: arm32v7, amd64
-GitCommit: e1f2520c7a5f29dc5896edc3816357c0267cb931
+GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
 Directory: 10/stretch-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/955
- https://github.com/nodejs/node/releases/tag/v10.14.2
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.14.2