### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.5.2
-GitCommit: 621b02788fba0220b7c47a21a24d360f99fd8555
+Tags: 6.5.3
+GitCommit: ea4c976edb44a00de9ef45f1a4bff50d6aa31e4a
 Directory: 6
 
-Tags: 5.6.13, 5.6, 5
-GitCommit: a912899428b3c0854a463a30a3d7c5d52a088759
+Tags: 5.6.14, 5.6, 5
+GitCommit: 367769da361526411ffac12dae5fa19bb87c3f6c
 Directory: 5
 
-Tags: 5.6.13-alpine, 5.6-alpine, 5-alpine
-GitCommit: a912899428b3c0854a463a30a3d7c5d52a088759
+Tags: 5.6.14-alpine, 5.6-alpine, 5-alpine
+GitCommit: 367769da361526411ffac12dae5fa19bb87c3f6c
 Directory: 5/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9-dev9, 1.9-rc, rc
+Tags: 1.9-dev10, 1.9-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 19b86660de78597dd0cdd8f8f2a0d80f13fb10d4
 Directory: 1.9-rc
 
-Tags: 1.9-dev9-alpine, 1.9-rc-alpine, rc-alpine
+Tags: 1.9-dev10-alpine, 1.9-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 19b86660de78597dd0cdd8f8f2a0d80f13fb10d4
 Directory: 1.9-rc/alpine
 
 Tags: 1.8.14, 1.8, 1, latest

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.5.2
-GitCommit: bc610048989693a2a668b65363e707d737c8536c
+Tags: 6.5.3
+GitCommit: f08b40166a6d60129ac393bfd412c989e23393ac
 Directory: 6
 
-Tags: 5.6.13, 5.6, 5
-GitCommit: 52bb5b8b2f675befe52e370153dda288c83d09e9
+Tags: 5.6.14, 5.6, 5
+GitCommit: 0a3b4fcab39b5a59591645fddc933f1a1b06e1be
 Directory: 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.5.2
-GitCommit: 24c05a06936c5021b1c39744c2fa0aaba1595ded
+Tags: 6.5.3
+GitCommit: 60c7af40d88dd98ed726c610f9c986f0f18da74c
 Directory: 6
 
-Tags: 5.6.13, 5.6, 5
-GitCommit: babe058abf92da5091d976173639663f7fea0d59
+Tags: 5.6.14, 5.6, 5
+GitCommit: 5fbc733a0b2563a5f6e632f2d7fe1e65c4ee8cd5
 Directory: 5
 
-Tags: 5.6.13-alpine, 5.6-alpine, 5-alpine
-GitCommit: babe058abf92da5091d976173639663f7fea0d59
+Tags: 5.6.14-alpine, 5.6-alpine, 5-alpine
+GitCommit: 5fbc733a0b2563a5f6e632f2d7fe1e65c4ee8cd5
 Directory: 5/alpine

--- a/library/matomo
+++ b/library/matomo
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.7.0-apache, 3.7-apache, 3-apache, apache, 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
+GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
 Directory: apache
 
 Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
+GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
 Directory: fpm
 
 Tags: 3.7.0-fpm-alpine, 3.7-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bd45e666485f923769b238e3dee9c423488fad
+GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
 Directory: fpm-alpine

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: f1a8498333ae3ab340b5b39fbac1d7e1dc0d628c
 Directory: 5.0/alpine
 
-Tags: 4.0.11, 4.0, 4, 4.0.11-stretch, 4.0-stretch, 4-stretch
+Tags: 4.0.12, 4.0, 4, 4.0.12-stretch, 4.0-stretch, 4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5d019077b46494751482512c200c4df34463dc6
+GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
 Directory: 4.0
 
-Tags: 4.0.11-32bit, 4.0-32bit, 4-32bit, 4.0.11-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
+Tags: 4.0.12-32bit, 4.0-32bit, 4-32bit, 4.0.12-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
 Architectures: amd64
-GitCommit: a5d019077b46494751482512c200c4df34463dc6
+GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
 Directory: 4.0/32bit
 
-Tags: 4.0.11-alpine, 4.0-alpine, 4-alpine, 4.0.11-alpine3.8, 4.0-alpine3.8, 4-alpine3.8
+Tags: 4.0.12-alpine, 4.0-alpine, 4-alpine, 4.0.12-alpine3.8, 4.0-alpine3.8, 4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 53348c1c52c3d2e8666fbf748bc9e2297c35b452
+GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
 Directory: 4.0/alpine

--- a/library/redmine
+++ b/library/redmine
@@ -1,23 +1,32 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/10bdb805ef3e5a3edd4cd1a79369ae2bfdc6e3f9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/af8d60964bfeb8edf6faaa731591ddf1b0165ebd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 3.4.6, 3.4, 3, latest
+Tags: 4.0.0, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
+GitCommit: 5875d577cada0d1fb3cb8093f6b15b586b20f65e
+Directory: 4.0
+
+Tags: 4.0.0-passenger, 4.0-passenger, 4-passenger, passenger
+GitCommit: 5875d577cada0d1fb3cb8093f6b15b586b20f65e
+Directory: 4.0/passenger
+
+Tags: 3.4.7, 3.4, 3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8e9f5fc59b6fa899e07a0c2dfca0d46425e6c088
 Directory: 3.4
 
-Tags: 3.4.6-passenger, 3.4-passenger, 3-passenger, passenger
+Tags: 3.4.7-passenger, 3.4-passenger, 3-passenger
 GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
 Directory: 3.4/passenger
 
-Tags: 3.3.8, 3.3
+Tags: 3.3.9, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3aa206974b8f92c2953635e60c54a67435eca3de
+GitCommit: 8e9f5fc59b6fa899e07a0c2dfca0d46425e6c088
 Directory: 3.3
 
-Tags: 3.3.8-passenger, 3.3-passenger
+Tags: 3.3.9-passenger, 3.3-passenger
 GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
 Directory: 3.3/passenger

--- a/library/ruby
+++ b/library/ruby
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-preview3-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-preview3, 2.6-rc, rc
+Tags: 2.6.0-rc1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-rc1, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
+GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
 Directory: 2.6-rc/stretch
 
-Tags: 2.6.0-preview3-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-preview3-slim, 2.6-rc-slim, rc-slim
+Tags: 2.6.0-rc1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-rc1-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
+GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
 Directory: 2.6-rc/stretch/slim
 
-Tags: 2.6.0-preview3-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-preview3-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-rc1-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-rc1-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
+GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
 Directory: 2.6-rc/alpine3.8
 
-Tags: 2.6.0-preview3-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
+Tags: 2.6.0-rc1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7efc2b75c021c08bbe17207059b5fb3d21dd7355
+GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
+GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
+GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
+GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af33e632f173e90b4a7aba7644f2080b574e54f
+GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fbf07f3c82789488c6ea6080cf000a773c38765
+GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f3f2ecfc0e9d2957af9e14d5a314ca223fb008d2
+GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
 Directory: 2.3/alpine3.7

--- a/library/tomcat
+++ b/library/tomcat
@@ -59,27 +59,27 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
 Directory: 8.5/jre11-slim
 
-Tags: 9.0.13-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.14-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
+GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
 Directory: 9.0/jre8
 
-Tags: 9.0.13-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.14-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
+GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.13-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.14-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: a3690c7d71d468e51f0c01ded83f79c7686a2a35
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.13-jre11, 9.0-jre11, 9-jre11
+Tags: 9.0.14-jre11, 9.0-jre11, 9-jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
+GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
 Directory: 9.0/jre11
 
-Tags: 9.0.13-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
+Tags: 9.0.14-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7ecea4335598d1313f261269aeee81be0ff8ec7
+GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
 Directory: 9.0/jre11-slim


### PR DESCRIPTION
- `elasticsearch`: 5.6.14, 6.5.3
- `haproxy`: 1.9-dev10
- `kibana`: 5.6.14, 6.5.3
- `logstash`: 5.6.14, 6.5.3
- `matomo`: APCu 5.1.15
- `redis`: 4.0.12
- `redmine`: 4.0.0 (docker-library/redmine#147)
- `ruby`: 2.6.0-rc1, bundler 1.17.2
- `tomcat`: 9.0.14