### PR TITLE
Update clojure git commit & boot tags for boot 2.8.2, lein tags for lein 2.8.3, and tools-deps tags for 1.10.0.403

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 6f8c9e7d7a95fb907f3d8b26428134601706cb51
+GitCommit: c22fb30deed1864076d7ccd5a89117ef833905a7
 
 Tags: openjdk-8-lein, openjdk-8-lein-2.8.3, lein-2.8.3, lein, latest
 Directory: target/openjdk-8/debian/lein
@@ -19,10 +19,10 @@ Tags: openjdk-8-boot-alpine, openjdk-8-boot-2.8.2-alpine, boot-2.8.2-alpine, boo
 Architectures: amd64
 Directory: target/openjdk-8/alpine/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.9.0.397, tools-deps-1.9.0.397, tools-deps
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.0.403, tools-deps-1.10.0.403, tools-deps
 Directory: target/openjdk-8/debian/tools-deps
 
-Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.9.0.397-alpine, tools-deps-1.9.0.397-alpine, tools-deps-alpine
+Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.10.0.403-alpine, tools-deps-1.10.0.403-alpine, tools-deps-alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/tools-deps
 
@@ -32,5 +32,5 @@ Directory: target/openjdk-11/debian/lein
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.2
 Directory: target/openjdk-11/debian/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.9.0.397
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.0.403
 Directory: target/openjdk-11/debian/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -3,12 +3,12 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 88b905b20401c5aa66601fc4a5234f9dceb92c2f
+GitCommit: 6f8c9e7d7a95fb907f3d8b26428134601706cb51
 
-Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
+Tags: openjdk-8-lein, openjdk-8-lein-2.8.3, lein-2.8.3, lein, latest
 Directory: target/openjdk-8/debian/lein
 
-Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.8.1-alpine, lein-2.8.1-alpine, lein-alpine, alpine
+Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.8.3-alpine, lein-2.8.3-alpine, lein-alpine, alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/lein
 
@@ -26,7 +26,7 @@ Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.9.0.397-alpine, tools-
 Architectures: amd64
 Directory: target/openjdk-8/alpine/tools-deps
 
-Tags: openjdk-11-lein, openjdk-11-lein-2.8.1
+Tags: openjdk-11-lein, openjdk-11-lein-2.8.3
 Directory: target/openjdk-11/debian/lein
 
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.2

--- a/library/clojure
+++ b/library/clojure
@@ -3,7 +3,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 9ed339a714c220988375884eb6743c221b02beb5
+GitCommit: 88b905b20401c5aa66601fc4a5234f9dceb92c2f
 
 Tags: openjdk-8-lein, openjdk-8-lein-2.8.1, lein-2.8.1, lein, latest
 Directory: target/openjdk-8/debian/lein
@@ -12,10 +12,10 @@ Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.8.1-alpine, lein-2.8.1-alpine, lei
 Architectures: amd64
 Directory: target/openjdk-8/alpine/lein
 
-Tags: openjdk-8-boot, openjdk-8-boot-2.8.1, boot-2.8.1, boot
+Tags: openjdk-8-boot, openjdk-8-boot-2.8.2, boot-2.8.2, boot
 Directory: target/openjdk-8/debian/boot
 
-Tags: openjdk-8-boot-alpine, openjdk-8-boot-2.8.1-alpine, boot-2.8.1-alpine, boot-alpine
+Tags: openjdk-8-boot-alpine, openjdk-8-boot-2.8.2-alpine, boot-2.8.2-alpine, boot-alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/boot
 
@@ -29,7 +29,7 @@ Directory: target/openjdk-8/alpine/tools-deps
 Tags: openjdk-11-lein, openjdk-11-lein-2.8.1
 Directory: target/openjdk-11/debian/lein
 
-Tags: openjdk-11-boot, openjdk-11-boot-2.8.1
+Tags: openjdk-11-boot, openjdk-11-boot-2.8.2
 Directory: target/openjdk-11/debian/boot
 
 Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.9.0.397


### PR DESCRIPTION
New boot version release upstream