### PR TITLE
Update Solr to 7.6

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,107 +4,122 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.5.0, 7.5, 7, latest
+Tags: 7.6.0, 7.6, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: e82fc2ad32076ad64d9d5ab5aa837282a11ec62e
+Directory: 7.6
+
+Tags: 7.6.0-alpine, 7.6-alpine, 7-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: aaa5aaac26c462930753160499004db28163729a
+Directory: 7.6/alpine
+
+Tags: 7.6.0-slim, 7.6-slim, 7-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e82fc2ad32076ad64d9d5ab5aa837282a11ec62e
+Directory: 7.6/slim
+
+Tags: 7.5.0, 7.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.5
 
-Tags: 7.5.0-alpine, 7.5-alpine, 7-alpine, alpine
+Tags: 7.5.0-alpine, 7.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.5/alpine
 
-Tags: 7.5.0-slim, 7.5-slim, 7-slim, slim
+Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.5/slim
 
 Tags: 7.4.0, 7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.4
 
 Tags: 7.4.0-alpine, 7.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.4/alpine
 
 Tags: 7.4.0-slim, 7.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.4/slim
 
 Tags: 7.3.1, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.3
 
 Tags: 7.3.1-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.3/alpine
 
 Tags: 7.3.1-slim, 7.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.2
 
 Tags: 7.2.1-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.2/alpine
 
 Tags: 7.2.1-slim, 7.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 7.1/slim
 
 Tags: 6.6.5, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 6.6
 
 Tags: 6.6.5-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 6.6/alpine
 
 Tags: 6.6.5-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bc2dccc9c6453d73b4c4ee61475464703b8bb579
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9f398bdf013364581c3348c2cf5ed58b3bbebf8
+GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
 Directory: 5.5/slim


### PR DESCRIPTION
Add Solr 7.6. See [Release highlights](http://mail-archives.apache.org/mod_mbox/lucene-general/201812.mbox/%3CCABM%2Bu9%2B3KCNoH5Z1OSM2PpQ3NNLivUFxiZ7wuzr%2B1Qoour6%3DRw%40mail.gmail.com%3E) and full [Changes](http://lucene.apache.org/solr/7_6_0/changes/Changes.html). Fixes https://github.com/docker-library/official-images/issues/5194

Change base image from OpenJDK 10 to 11. Fixes https://github.com/docker-solr/docker-solr/issues/194