### PR TITLE
Update to v0.6.1-1 which is compiled with Go 1.10.7

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,10 +1,10 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: 6db20782a52c71a48e33a9f075ba632054c0112d
+GitCommit: ee9401173fbe4c672f3e3e71b0881d21f2112eca
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: server-0.6.1, server
+Tags: server-0.6.1-1, server
 Directory: notary-server
 
-Tags: signer-0.6.1, signer
+Tags: signer-0.6.1-1, signer
 Directory: notary-signer


### PR DESCRIPTION
This fixes TLS DoS condition in earlier Go releases.

This includes https://github.com/docker/notary-official-images/pull/14 which forces the new Go in Alpine 3.8, as we no longer use a `golang` official image base.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>