### PR TITLE
[security] Update haproxy to 1.8.15, 1.9-dev11

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9-dev10, 1.9-rc, rc
+Tags: 1.9-dev11, 1.9-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19b86660de78597dd0cdd8f8f2a0d80f13fb10d4
+GitCommit: 2683fad346bd01ae25e65176116e090eeb561133
 Directory: 1.9-rc
 
-Tags: 1.9-dev10-alpine, 1.9-rc-alpine, rc-alpine
+Tags: 1.9-dev11-alpine, 1.9-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 19b86660de78597dd0cdd8f8f2a0d80f13fb10d4
+GitCommit: 2683fad346bd01ae25e65176116e090eeb561133
 Directory: 1.9-rc/alpine
 
-Tags: 1.8.14, 1.8, 1, latest
+Tags: 1.8.15, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 85706f5fd4243468bbcfe7afb3ee852b6b35cdba
 Directory: 1.8
 
-Tags: 1.8.14-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.15-alpine, 1.8-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 85706f5fd4243468bbcfe7afb3ee852b6b35cdba
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7


### PR DESCRIPTION
These contain fixes for the following vulnerabilities

https://security-tracker.debian.org/tracker/CVE-2018-20102
https://security-tracker.debian.org/tracker/CVE-2018-20103