### PR TITLE
[Security] Add back-ported releases for Consul

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,13 +1,13 @@
-Maintainers: Preetha Appan <preetha@hashicorp.com> (@preetapan)
+Maintainers: Consul Team <consul@hashicorp.com>
 
-Tags: 1.3.0, latest
+Tags: 1.3.1
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 3e9120657c15e2f208e3cf16a698f1bb3bee3cdd
+GitCommit: 2da194710e10e02277cd6b4fb38fb1d1f3ec2fc7
 Directory: 0.X
 
-Tags: 1.4.0-rc1
+Tags: 1.4.0, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 3f040bac0f335116e264334d64c9f4fec524fe61
+GitCommit: a9fc2295556404f409d16de58be611b77079a870
 Directory: 0.X

--- a/library/consul
+++ b/library/consul
@@ -1,4 +1,4 @@
-Maintainers: Consul Team <consul@hashicorp.com>
+Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
 Tags: 1.3.1
 Architectures: amd64, arm32v6, arm64v8, i386


### PR DESCRIPTION
This PR adds several versions of Consul that we back-ported a security fix for. More details of that are available [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/consul-tool/kmGKTj3YxUg) and [here](https://www.hashicorp.com/blog/protecting-consul-from-rce-risk-in-specific-configurations). 

Additionally, it removes the 1.3.1 version per the request in https://github.com/docker-library/official-images/pull/5071/files#r234081669.

We expect to remove these versions in a future update to this file (our next scheduled release, 1.4.1) but would like them to be made available on Docker Hub. 1.4.0 remains the latest version.

Originally reported in https://github.com/hashicorp/consul/issues/5116.