### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.5.3
-GitCommit: ea4c976edb44a00de9ef45f1a4bff50d6aa31e4a
+Tags: 6.5.4
+GitCommit: deabc2adbaa9251213071e5b46c6742ab781dc84
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/golang
+++ b/library/golang
@@ -1,9 +1,48 @@
-# this file is generated via https://github.com/docker-library/golang/blob/e06b00cbe4974436ee00eaec215d7fbb123cbc24/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/0c8f21255b8c4b707901db4e5d77235b7a1b7159/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
+
+Tags: 1.12beta1-stretch, 1.12-rc-stretch, rc-stretch
+SharedTags: 1.12beta1, 1.12-rc, rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/stretch
+
+Tags: 1.12beta1-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8, 1.12beta1-alpine, 1.12-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/alpine3.8
+
+Tags: 1.12beta1-windowsservercore-ltsc2016, 1.12-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
+Architectures: windows-amd64
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 1.12beta1-windowsservercore-1709, 1.12-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
+Architectures: windows-amd64
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.12beta1-windowsservercore-1803, 1.12-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
+Architectures: windows-amd64
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 1.12beta1-nanoserver-sac2016, 1.12-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.12beta1-nanoserver, 1.12-rc-nanoserver, rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+Directory: 1.12-rc/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 1.11.4-stretch, 1.11-stretch, 1-stretch, stretch
 SharedTags: 1.11.4, 1.11, 1, latest

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/4a2d233b1a42e255b8e4097d50d2241b97bd446e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/7a79c7cdad7e2b1e81bd342b7bc0204027b8f326/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9-dev11, 1.9-rc, rc
+Tags: 1.9.0, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2683fad346bd01ae25e65176116e090eeb561133
-Directory: 1.9-rc
+GitCommit: 7a79c7cdad7e2b1e81bd342b7bc0204027b8f326
+Directory: 1.9
 
-Tags: 1.9-dev11-alpine, 1.9-rc-alpine, rc-alpine
+Tags: 1.9.0-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2683fad346bd01ae25e65176116e090eeb561133
-Directory: 1.9-rc/alpine
+GitCommit: 7a79c7cdad7e2b1e81bd342b7bc0204027b8f326
+Directory: 1.9/alpine
 
-Tags: 1.8.15, 1.8, 1, latest
+Tags: 1.8.15, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 85706f5fd4243468bbcfe7afb3ee852b6b35cdba
 Directory: 1.8
 
-Tags: 1.8.15-alpine, 1.8-alpine, 1-alpine, alpine
+Tags: 1.8.15-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 85706f5fd4243468bbcfe7afb3ee852b6b35cdba
 Directory: 1.8/alpine

--- a/library/julia
+++ b/library/julia
@@ -4,30 +4,30 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.0.2-stretch, 1.0-stretch, 1-stretch, stretch
-SharedTags: 1.0.2, 1.0, 1, latest
-Architectures: amd64, i386
-GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
+Tags: 1.0.3-stretch, 1.0-stretch, 1-stretch, stretch
+SharedTags: 1.0.3, 1.0, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/stretch
 
-Tags: 1.0.2-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.0.2, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.0.3, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 739386e833cc5e839a7bf8e42c4f2e3eed3eb11e
+GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.0.2-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.0.2, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.0.3, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 739386e833cc5e839a7bf8e42c4f2e3eed3eb11e
+GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.0.2-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.0.2, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.0.3, 1.0, 1, latest
 Architectures: windows-amd64
-GitCommit: 739386e833cc5e839a7bf8e42c4f2e3eed3eb11e
+GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.5.3
-GitCommit: f08b40166a6d60129ac393bfd412c989e23393ac
+Tags: 6.5.4
+GitCommit: e6b11543037b0c0ff88ea935ddddc0d3ec7d22cc
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.5.3
-GitCommit: 60c7af40d88dd98ed726c610f9c986f0f18da74c
+Tags: 6.5.4
+GitCommit: 80179ee0365f4be681948e3677e7c0adcd2183cd
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-23-jdk-oraclelinux7, 12-ea-23-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-23-jdk-oracle, 12-ea-23-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-23-jdk, 12-ea-23, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-24-jdk-oraclelinux7, 12-ea-24-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-24-jdk-oracle, 12-ea-24-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-24-jdk, 12-ea-24, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 5af847883c715d9dc76ace53ddbbf84a923e568a
+GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-20-jdk-alpine3.8, 12-ea-20-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-20-jdk-alpine, 12-ea-20-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-23-jdk-windowsservercore-ltsc2016, 12-ea-23-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-23-jdk-windowsservercore, 12-ea-23-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-24-jdk-windowsservercore-ltsc2016, 12-ea-24-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 5af847883c715d9dc76ace53ddbbf84a923e568a
+GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-23-jdk-windowsservercore-1709, 12-ea-23-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-23-jdk-windowsservercore, 12-ea-23-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-24-jdk-windowsservercore-1709, 12-ea-24-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 5af847883c715d9dc76ace53ddbbf84a923e568a
+GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-23-jdk-windowsservercore-1803, 12-ea-23-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-23-jdk-windowsservercore, 12-ea-23-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-24-jdk-windowsservercore-1803, 12-ea-24-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 5af847883c715d9dc76ace53ddbbf84a923e568a
+GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/ruby
+++ b/library/ruby
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-rc1-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-rc1, 2.6-rc, rc
+Tags: 2.6.0-rc2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-rc2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
+GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
 Directory: 2.6-rc/stretch
 
-Tags: 2.6.0-rc1-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-rc1-slim, 2.6-rc-slim, rc-slim
+Tags: 2.6.0-rc2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-rc2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
+GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
 Directory: 2.6-rc/stretch/slim
 
-Tags: 2.6.0-rc1-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-rc1-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-rc2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-rc2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
+GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
 Directory: 2.6-rc/alpine3.8
 
-Tags: 2.6.0-rc1-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
+Tags: 2.6.0-rc2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a42895d9fbb839e456f2f3624117761f86bcf43
+GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest

--- a/library/tomcat
+++ b/library/tomcat
@@ -34,29 +34,29 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
 Directory: 7/jre8-alpine
 
-Tags: 8.5.35-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.35, 8.5, 8, latest
+Tags: 8.5.37-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.37, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
+GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
 Directory: 8.5/jre8
 
-Tags: 8.5.35-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.35-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.37-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.37-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
+GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.35-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.35-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.37-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.37-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c0df3d5463944671fefe200bdadd95c69a616ab4
+GitCommit: d3d5932c4c852fa2861c68d6d1adaf0ce1b1a870
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.35-jre11, 8.5-jre11, 8-jre11, jre11
+Tags: 8.5.37-jre11, 8.5-jre11, 8-jre11, jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
+GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
 Directory: 8.5/jre11
 
-Tags: 8.5.35-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
+Tags: 8.5.37-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 113253d06d1cbd4b7d6ad7a505b02e3180c3f7ee
+GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
 Directory: 8.5/jre11-slim
 
 Tags: 9.0.14-jre8, 9.0-jre8, 9-jre8

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.0.1-php5.6-apache, 5.0-php5.6-apache, 5-php5.6-apache, php5.6-apache, 5.0.1-php5.6, 5.0-php5.6, 5-php5.6, php5.6
+Tags: 5.0.2-php5.6-apache, 5.0-php5.6-apache, 5-php5.6-apache, php5.6-apache, 5.0.2-php5.6, 5.0-php5.6, 5-php5.6, php5.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php5.6/apache
 
-Tags: 5.0.1-php5.6-fpm, 5.0-php5.6-fpm, 5-php5.6-fpm, php5.6-fpm
+Tags: 5.0.2-php5.6-fpm, 5.0-php5.6-fpm, 5-php5.6-fpm, php5.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php5.6/fpm
 
-Tags: 5.0.1-php5.6-fpm-alpine, 5.0-php5.6-fpm-alpine, 5-php5.6-fpm-alpine, php5.6-fpm-alpine
+Tags: 5.0.2-php5.6-fpm-alpine, 5.0-php5.6-fpm-alpine, 5-php5.6-fpm-alpine, php5.6-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php5.6/fpm-alpine
 
-Tags: 5.0.1-php7.0-apache, 5.0-php7.0-apache, 5-php7.0-apache, php7.0-apache, 5.0.1-php7.0, 5.0-php7.0, 5-php7.0, php7.0
+Tags: 5.0.2-php7.0-apache, 5.0-php7.0-apache, 5-php7.0-apache, php7.0-apache, 5.0.2-php7.0, 5.0-php7.0, 5-php7.0, php7.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.0/apache
 
-Tags: 5.0.1-php7.0-fpm, 5.0-php7.0-fpm, 5-php7.0-fpm, php7.0-fpm
+Tags: 5.0.2-php7.0-fpm, 5.0-php7.0-fpm, 5-php7.0-fpm, php7.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.0/fpm
 
-Tags: 5.0.1-php7.0-fpm-alpine, 5.0-php7.0-fpm-alpine, 5-php7.0-fpm-alpine, php7.0-fpm-alpine
+Tags: 5.0.2-php7.0-fpm-alpine, 5.0-php7.0-fpm-alpine, 5-php7.0-fpm-alpine, php7.0-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.0/fpm-alpine
 
-Tags: 5.0.1-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.1-php7.1, 5.0-php7.1, 5-php7.1, php7.1
+Tags: 5.0.2-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.2-php7.1, 5.0-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.1/apache
 
-Tags: 5.0.1-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
+Tags: 5.0.2-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.1/fpm
 
-Tags: 5.0.1-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 5.0.2-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.1/fpm-alpine
 
-Tags: 5.0.1-apache, 5.0-apache, 5-apache, apache, 5.0.1, 5.0, 5, latest, 5.0.1-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.1-php7.2, 5.0-php7.2, 5-php7.2, php7.2
+Tags: 5.0.2-apache, 5.0-apache, 5-apache, apache, 5.0.2, 5.0, 5, latest, 5.0.2-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.2-php7.2, 5.0-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.2/apache
 
-Tags: 5.0.1-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.1-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
+Tags: 5.0.2-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.2-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.2/fpm
 
-Tags: 5.0.1-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.1-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.0.2-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.2-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1c5c9ca909e1cd58714eb351922c80ceb2f30d9e
+GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `elasticsearch` bump to 6.5.4
- `golang` add 1.12beta1
- `haproxy` bump to 1.9.0; logging to stdout is now in a GA release!
- `julia` bump to 1.0.3
- `kibana` bump to 6.5.4
- `logstash` bump to 6.5.4
- `openjdk` bump to 12-ea-24
- `ruby` bump to 2.6.0-rc2
- `tomcat` bump to 8.5.37
- `wordpress` bump to 5.0.2

Elastic Diffs:

- https://github.com/elastic/elasticsearch-docker/compare/6.5.3...6.5.4
- https://github.com/elastic/logstash-docker/compare/6.5.3...6.5.4
- https://github.com/elastic/kibana-docker/compare/6.5.3...6.5.4