### PR TITLE
Update websphere-liberty beta to 2018.12.0.0

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: c1295e2e6ad436f143635013153cede9893c4475
+GitCommit: b042200103140fb529e94bb45a35f519057b5d42
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Updating to the newly released websphere-liberty beta version 2018.12.0.0.