### PR TITLE
Update r-base to R 3.5.2

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 3.5.1, latest
+Tags: 3.5.2, latest
 Architectures: amd64, arm64v8
-GitCommit: b9f9289ef27f07dc2f2b64d56d12646770b9b233
+GitCommit: a7ecee9111f3b5dde35555d338a0e30401f5c095
 Directory: r-base


### PR DESCRIPTION
Not sure why the old commits show up below.  I merged before making the two changes shown just now.