### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3b5d707612c934b2196d91f1ddda5faf7cf8521d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3faaa45afa794cc057376c13831f7ba3e627e545/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3b5d707612c934b2196d91f1ddda5faf7cf8521d
+GitCommit: 3faaa45afa794cc057376c13831f7ba3e627e545
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0b299265b6140985a88913133261b93d5a2c2c19
+amd64-GitCommit: 8784508d5587a5a6514bd393aa69c6a902145f83
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e3d0eb49bc2e66ef25202849d09e7d8baa120845
+arm32v5-GitCommit: af8ba791ac0e0e411dfc9880f175e680ba9f07d2
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: eb985e24967902bfdf6a5ec3fabaf49251e2d76d
+arm32v6-GitCommit: 9198623057c826944b37a471323a2aebaaac0eaf
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 238ae1cff3074d4358e8671056b43ac3f6f8e93f
+arm32v7-GitCommit: 26b67d7975ceb5ddb5c1968fccc96d8c97dd6897
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1a8a22485bd77156c946eaa1d534110d75c24514
+arm64v8-GitCommit: df30252f4970e30917592d521b68cc3b95e31caf
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 1be2d6ee59fe9b585f81ec965defe62608206950
+i386-GitCommit: 9bccd9e7379ecce1b97b22aa43a246e244694440
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 4aded97ae4afd237eb89bd7db14c4ca6a5f48570
+ppc64le-GitCommit: 3f81f9305520a02cce6ede99dab15830451ddeac
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 971c57858d77ed05c79773f7976ee997527829ce
+s390x-GitCommit: 9ba4bc65db5469fda8b6ac88d6ac81d200c70ece
 
 Tags: 1.29.3-uclibc, 1.29-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.7.1, 2.7, 2, latest
+Tags: 2.9.1, 2.9, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d72092d379e04cdd08d80058e446146ced73c4f
+GitCommit: e76d79d6b3071421a1b9aad47f6d341ae1403801
 Directory: 2/debian
 
-Tags: 2.7.1-alpine, 2.7-alpine, 2-alpine, alpine
+Tags: 2.9.1-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d72092d379e04cdd08d80058e446146ced73c4f
+GitCommit: e76d79d6b3071421a1b9aad47f6d341ae1403801
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1
@@ -23,13 +23,3 @@ Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 94e82489166b6d44f590306402492df09bbfbcbd
 Directory: 1/alpine
-
-Tags: 0.11.14, 0.11, 0
-Architectures: amd64, arm32v7, i386
-GitCommit: f1dde8050d6994a8df9564e50bffd4549c9c9305
-Directory: 0/debian
-
-Tags: 0.11.14-alpine, 0.11-alpine, 0-alpine
-Architectures: amd64
-GitCommit: e1880db3c56f85410ad3342cbd33e7f98f24bcac
-Directory: 0/alpine

--- a/library/joomla
+++ b/library/joomla
@@ -18,47 +18,47 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 392d635f5973e30501580deda634fb710e710e47
 Directory: php5.6/fpm-alpine
 
-Tags: 3.9.1-php7.0-apache, 3.9-php7.0-apache, 3-php7.0-apache, php7.0-apache, 3.9.1-php7.0, 3.9-php7.0, 3-php7.0, php7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
-Directory: php7.0/apache
-
-Tags: 3.9.1-php7.0-fpm, 3.9-php7.0-fpm, 3-php7.0-fpm, php7.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
-Directory: php7.0/fpm
-
-Tags: 3.9.1-php7.0-fpm-alpine, 3.9-php7.0-fpm-alpine, 3-php7.0-fpm-alpine, php7.0-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
-Directory: php7.0/fpm-alpine
-
 Tags: 3.9.1-apache, 3.9-apache, 3-apache, apache, 3.9.1, 3.9, 3, latest, 3.9.1-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.1-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.1/apache
 
 Tags: 3.9.1-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.1-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.1/fpm
 
 Tags: 3.9.1-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.1-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.1/fpm-alpine
 
 Tags: 3.9.1-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.1-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.2/apache
 
 Tags: 3.9.1-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.2/fpm
 
 Tags: 3.9.1-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 392d635f5973e30501580deda634fb710e710e47
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
 Directory: php7.2/fpm-alpine
+
+Tags: 3.9.1-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.1-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
+Directory: php7.3/apache
+
+Tags: 3.9.1-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
+Directory: php7.3/fpm
+
+Tags: 3.9.1-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: ce437363431d0a59d819b4af49a5aa1ffdf6e319
+Directory: php7.3/fpm-alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -14,9 +14,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 4d2df7be30fb608fd4ad743b74e7df80203a7dc0
 Directory: 10.3
 
-Tags: 10.2.19-bionic, 10.2-bionic, 10.2.19, 10.2
+Tags: 10.2.20-bionic, 10.2-bionic, 10.2.20, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
+GitCommit: 82c8067d6ef01c259eb1167619a09392989b4fd9
 Directory: 10.2
 
 Tags: 10.1.37-bionic, 10.1-bionic, 10.1.37, 10.1

--- a/library/mongo
+++ b/library/mongo
@@ -4,28 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.2.21-jessie, 3.2-jessie
-SharedTags: 3.2.21, 3.2
-# see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.2/main/
-# (i386, ppc64el, s390x are empty)
-Architectures: amd64
-GitCommit: 6932ac255d29759af9a74c6931faeb02de0fe53e
-Directory: 3.2
-
-Tags: 3.2.21-windowsservercore-ltsc2016, 3.2-windowsservercore-ltsc2016
-SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
-Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
-Directory: 3.2/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.2.21-windowsservercore-1709, 3.2-windowsservercore-1709
-SharedTags: 3.2.21-windowsservercore, 3.2-windowsservercore, 3.2.21, 3.2
-Architectures: windows-amd64
-GitCommit: 32e5645325ae5dff2ae6f934049cbd6b4635aec0
-Directory: 3.2/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 3.4.18-jessie, 3.4-jessie
 SharedTags: 3.4.18, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,12 +1,12 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/b334897770e2d249ac0d14d4425892dda675fd43/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/d828bb80bafcca1757b049c27bf3e503b1ddbbb8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 12-ea-24-jdk-oraclelinux7, 12-ea-24-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-24-jdk-oracle, 12-ea-24-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-24-jdk, 12-ea-24, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-25-jdk-oraclelinux7, 12-ea-25-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-25-jdk-oracle, 12-ea-25-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-25-jdk, 12-ea-25, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
+GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-20-jdk-alpine3.8, 12-ea-20-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-20-jdk-alpine, 12-ea-20-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -14,24 +14,24 @@ Architectures: amd64
 GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-24-jdk-windowsservercore-ltsc2016, 12-ea-24-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-25-jdk-windowsservercore-ltsc2016, 12-ea-25-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
+GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-24-jdk-windowsservercore-1709, 12-ea-24-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-25-jdk-windowsservercore-1709, 12-ea-25-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
+GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-24-jdk-windowsservercore-1803, 12-ea-24-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-24-jdk-windowsservercore, 12-ea-24-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-25-jdk-windowsservercore-1803, 12-ea-25-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 16316bc746915c10308aabde9fa8a09bdc83d1fc
+GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
@@ -40,14 +40,14 @@ Architectures: amd64
 GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/oracle
 
-Tags: 11.0.1-jdk-sid, 11.0.1-sid, 11.0-jdk-sid, 11.0-sid, 11-jdk-sid, 11-sid, jdk-sid, sid, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
+Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
+GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
 Directory: 11/jdk
 
-Tags: 11.0.1-jdk-slim-sid, 11.0.1-slim-sid, 11.0-jdk-slim-sid, 11.0-slim-sid, 11-jdk-slim-sid, 11-slim-sid, jdk-slim-sid, slim-sid, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
+Tags: 11.0.1-jdk-slim-stretch, 11.0.1-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, jdk-slim-stretch, slim-stretch, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
+GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
 Directory: 11/jdk/slim
 
 Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -71,24 +71,24 @@ GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.1-jre-sid, 11.0-jre-sid, 11-jre-sid, jre-sid, 11.0.1-jre, 11.0-jre, 11-jre, jre
+Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch, 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
+GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
 Directory: 11/jre
 
-Tags: 11.0.1-jre-slim-sid, 11.0-jre-slim-sid, 11-jre-slim-sid, jre-slim-sid, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
+Tags: 11.0.1-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, jre-slim-stretch, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78e731d8ba269c8d50c0f4ad9ee431c1c32f179a
+GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
 Directory: 11/jre/slim
 
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
+GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk
 
 Tags: 8u181-jdk-slim-stretch, 8u181-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u181-jdk-slim, 8u181-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
+GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk/slim
 
 Tags: 8u181-jdk-alpine3.8, 8u181-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u181-jdk-alpine, 8u181-alpine, 8-jdk-alpine, 8-alpine
@@ -126,12 +126,12 @@ Constraints: nanoserver-sac2016
 
 Tags: 8u181-jre-stretch, 8-jre-stretch, 8u181-jre, 8-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
+GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre
 
 Tags: 8u181-jre-slim-stretch, 8-jre-slim-stretch, 8u181-jre-slim, 8-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a33416016b60c045cf0ba99e82617ed6c130595
+GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre/slim
 
 Tags: 8u181-jre-alpine3.8, 8-jre-alpine3.8, 8u181-jre-alpine, 8-jre-alpine

--- a/library/python
+++ b/library/python
@@ -4,88 +4,88 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.7.1-stretch, 3.7-stretch, 3-stretch, stretch
-SharedTags: 3.7.1, 3.7, 3, latest
+Tags: 3.7.2-stretch, 3.7-stretch, 3-stretch, stretch
+SharedTags: 3.7.2, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/stretch
 
-Tags: 3.7.1-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.1-slim, 3.7-slim, 3-slim, slim
+Tags: 3.7.2-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.2-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/stretch/slim
 
-Tags: 3.7.1-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.1-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/alpine3.8
 
-Tags: 3.7.1-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
+Tags: 3.7.2-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/alpine3.7
 
-Tags: 3.7.1-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.1, 3.7, 3, latest
+Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.1-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
-SharedTags: 3.7.1-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.1, 3.7, 3, latest
+Tags: 3.7.2-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
+SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 4437475f468147e441561c3906806ef2cceea409
+GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.7-stretch, 3.6-stretch
-SharedTags: 3.6.7, 3.6
+Tags: 3.6.8-stretch, 3.6-stretch
+SharedTags: 3.6.8, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/stretch
 
-Tags: 3.6.7-slim-stretch, 3.6-slim-stretch, 3.6.7-slim, 3.6-slim
+Tags: 3.6.8-slim-stretch, 3.6-slim-stretch, 3.6.8-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/stretch/slim
 
-Tags: 3.6.7-jessie, 3.6-jessie
+Tags: 3.6.8-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/jessie
 
-Tags: 3.6.7-slim-jessie, 3.6-slim-jessie
+Tags: 3.6.8-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.7-alpine3.8, 3.6-alpine3.8, 3.6.7-alpine, 3.6-alpine
+Tags: 3.6.8-alpine3.8, 3.6-alpine3.8, 3.6.8-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/alpine3.8
 
-Tags: 3.6.7-alpine3.7, 3.6-alpine3.7
+Tags: 3.6.8-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/alpine3.7
 
-Tags: 3.6.7-alpine3.6, 3.6-alpine3.6
+Tags: 3.6.8-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/alpine3.6
 
-Tags: 3.6.7-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
-SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3.6.7, 3.6
+Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.7-windowsservercore-1709, 3.6-windowsservercore-1709
-SharedTags: 3.6.7-windowsservercore, 3.6-windowsservercore, 3.6.7, 3.6
+Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: bf1acb4f1caad419ff290d700044240b4e8cb0df
+GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-rc2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-rc2, 2.6-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
+GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
 Directory: 2.6-rc/stretch
 
 Tags: 2.6.0-rc2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-rc2-slim, 2.6-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
+GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
 Directory: 2.6-rc/stretch/slim
 
 Tags: 2.6.0-rc2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-rc2-alpine, 2.6-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
+GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
 Directory: 2.6-rc/alpine3.8
 
 Tags: 2.6.0-rc2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2b705cda315ff35733fa0d8c6edf19754cefb1d7
+GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
 Directory: 2.6-rc/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
+GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
+GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
+GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ae6b4aa2255ffb9ae9997efc104c4095c45f78e
+GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f56bde4498cb53ab4dec6d6a132e588487eb9b2
+GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a5dc0f54319ad958ea5217eef9d6477c753b7fed
+GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `busybox`: buildroot 2018.11.1 (docker-library/busybox#56)
- `ghost`: 2.9.1, remove 0.x (docker-library/ghost#167)
- `joomla`: https://github.com/joomla/docker-joomla/pull/71
- `mariadb`: 10.2.20
- `mongo`: remove 3.2 (EOL as of September 2018; see https://www.mongodb.com/support-policy)
- `openjdk`: `stretch`-based 11, cleaner `ca-certificates-java` workaround (docker-library/openjdk#259), 12-ea+25
- `python`: 3.6.8, 3.7.2
- `ruby`: rubygems 3.0.1