### PR TITLE
Update node.js v6, v8, v10 & v11

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,104 +3,104 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.14.1-jessie, 8.14-jessie, 8-jessie, carbon-jessie
+Tags: 8.15.0-jessie, 8.15-jessie, 8-jessie, carbon-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: 6d595cd0d4e0be708a48f0fee63dd1e29dff3b67
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/jessie
 
-Tags: 8.14.1-jessie-slim, 8.14-jessie-slim, 8-jessie-slim, carbon-jessie-slim
+Tags: 8.15.0-jessie-slim, 8.15-jessie-slim, 8-jessie-slim, carbon-jessie-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 6d595cd0d4e0be708a48f0fee63dd1e29dff3b67
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/jessie-slim
 
-Tags: 8.14.1-alpine, 8.14-alpine, 8-alpine, carbon-alpine
+Tags: 8.15.0-alpine, 8.15-alpine, 8-alpine, carbon-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 6d595cd0d4e0be708a48f0fee63dd1e29dff3b67
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/alpine
 
-Tags: 8.14.1-onbuild, 8.14-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.15.0-onbuild, 8.15-onbuild, 8-onbuild, carbon-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 6d595cd0d4e0be708a48f0fee63dd1e29dff3b67
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/onbuild
 
-Tags: 8.14.1-stretch, 8.14-stretch, 8-stretch, carbon-stretch, 8.14.1, 8.14, 8, carbon
+Tags: 8.15.0-stretch, 8.15-stretch, 8-stretch, carbon-stretch, 8.15.0, 8.15, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 6d595cd0d4e0be708a48f0fee63dd1e29dff3b67
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/stretch
 
-Tags: 8.14.1-stretch-slim, 8.14-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.14.1-slim, 8.14-slim, 8-slim, carbon-slim
+Tags: 8.15.0-stretch-slim, 8.15-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.15.0-slim, 8.15-slim, 8-slim, carbon-slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 594f25e585bfcebaa150e4650d3de5cbd51a1e55
+GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
 Directory: 8/stretch-slim
 
-Tags: 6.15.1-jessie, 6.15-jessie, 6-jessie, boron-jessie
+Tags: 6.16.0-jessie, 6.16-jessie, 6-jessie, boron-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/jessie
 
-Tags: 6.15.1-jessie-slim, 6.15-jessie-slim, 6-jessie-slim, boron-jessie-slim
+Tags: 6.16.0-jessie-slim, 6.16-jessie-slim, 6-jessie-slim, boron-jessie-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/jessie-slim
 
-Tags: 6.15.1-alpine, 6.15-alpine, 6-alpine, boron-alpine
+Tags: 6.16.0-alpine, 6.16-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/alpine
 
-Tags: 6.15.1-onbuild, 6.15-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.16.0-onbuild, 6.16-onbuild, 6-onbuild, boron-onbuild
 Architectures: arm32v7, amd64, i386
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/onbuild
 
-Tags: 6.15.1-stretch, 6.15-stretch, 6-stretch, boron-stretch, 6.15.1, 6.15, 6, boron
+Tags: 6.16.0-stretch, 6.16-stretch, 6-stretch, boron-stretch, 6.16.0, 6.16, 6, boron
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/stretch
 
-Tags: 6.15.1-stretch-slim, 6.15-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.15.1-slim, 6.15-slim, 6-slim, boron-slim
+Tags: 6.16.0-stretch-slim, 6.16-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.16.0-slim, 6.16-slim, 6-slim, boron-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 50ee09688e28b138b1454a74deaa710d558b6b58
+GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/stretch-slim
 
-Tags: 11.5.0-alpine, 11.5-alpine, 11-alpine, current-alpine, alpine
+Tags: 11.6.0-alpine, 11.6-alpine, 11-alpine, current-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 33feb454563058f4d543149956dee373c7b938e4
+GitCommit: e9d9c1ce0f4e87b11d7b0ecff529b715038782ae
 Directory: 11/alpine
 
-Tags: 11.5.0-stretch, 11.5-stretch, 11-stretch, current-stretch, stretch, 11.5.0, 11.5, 11, current, latest
+Tags: 11.6.0-stretch, 11.6-stretch, 11-stretch, current-stretch, stretch, 11.6.0, 11.6, 11, current, latest
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 33feb454563058f4d543149956dee373c7b938e4
+GitCommit: e9d9c1ce0f4e87b11d7b0ecff529b715038782ae
 Directory: 11/stretch
 
-Tags: 11.5.0-stretch-slim, 11.5-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.5.0-slim, 11.5-slim, 11-slim, current-slim, slim
+Tags: 11.6.0-stretch-slim, 11.6-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.6.0-slim, 11.6-slim, 11-slim, current-slim, slim
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 33feb454563058f4d543149956dee373c7b938e4
+GitCommit: e9d9c1ce0f4e87b11d7b0ecff529b715038782ae
 Directory: 11/stretch-slim
 
-Tags: 10.14.2-jessie, 10.14-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.15.0-jessie, 10.15-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: arm32v7, amd64
-GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
+GitCommit: f8c22aeb318ec3df876f8271b9b8a86005f0f53d
 Directory: 10/jessie
 
-Tags: 10.14.2-jessie-slim, 10.14-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
+Tags: 10.15.0-jessie-slim, 10.15-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
 Architectures: arm32v7, amd64
-GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
+GitCommit: f8c22aeb318ec3df876f8271b9b8a86005f0f53d
 Directory: 10/jessie-slim
 
-Tags: 10.14.2-alpine, 10.14-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.15.0-alpine, 10.15-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
+GitCommit: f8c22aeb318ec3df876f8271b9b8a86005f0f53d
 Directory: 10/alpine
 
-Tags: 10.14.2-stretch, 10.14-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.14.2, 10.14, 10, dubnium, lts
+Tags: 10.15.0-stretch, 10.15-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.15.0, 10.15, 10, dubnium, lts
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
+GitCommit: f8c22aeb318ec3df876f8271b9b8a86005f0f53d
 Directory: 10/stretch
 
-Tags: 10.14.2-stretch-slim, 10.14-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.14.2-slim, 10.14-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.15.0-stretch-slim, 10.15-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.15.0-slim, 10.15-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: arm32v7, amd64
-GitCommit: 3e539e6925a524bf4fda47ea33ed33d0d4fb0e20
+GitCommit: f8c22aeb318ec3df876f8271b9b8a86005f0f53d
 Directory: 10/stretch-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/964

- https://github.com/nodejs/node/releases/tag/v6.16.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#6.16.0

- https://github.com/nodejs/node/releases/tag/v8.15.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.15.0

- https://github.com/nodejs/node/releases/tag/v10.15.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.15.0

- https://github.com/nodejs/node/releases/tag/v11.6.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.6.0