### PR TITLE
Update docker image for Ruby 2.6 release

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/0b4ab84ebb15d80b591a5610200cf537fc4740ad/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/d4be0c416c61f1de327badb94e629aa993c2e2b4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-rc2-stretch, 2.6-rc-stretch, rc-stretch, 2.6.0-rc2, 2.6-rc, rc
+Tags: 2.6.0-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.0, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
-Directory: 2.6-rc/stretch
+GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+Directory: 2.6/stretch
 
-Tags: 2.6.0-rc2-slim-stretch, 2.6-rc-slim-stretch, rc-slim-stretch, 2.6.0-rc2-slim, 2.6-rc-slim, rc-slim
+Tags: 2.6.0-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.0-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
-Directory: 2.6-rc/stretch/slim
+GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+Directory: 2.6/stretch/slim
 
-Tags: 2.6.0-rc2-alpine3.8, 2.6-rc-alpine3.8, rc-alpine3.8, 2.6.0-rc2-alpine, 2.6-rc-alpine, rc-alpine
+Tags: 2.6.0-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8, 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
-Directory: 2.6-rc/alpine3.8
+GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+Directory: 2.6/alpine3.8
 
-Tags: 2.6.0-rc2-alpine3.7, 2.6-rc-alpine3.7, rc-alpine3.7
+Tags: 2.6.0-alpine3.7, 2.6-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f560c29e7d37e9b3e646c73bb829c56eb70d763
-Directory: 2.6-rc/alpine3.7
+GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+Directory: 2.6/alpine3.7
 
-Tags: 2.5.3-stretch, 2.5-stretch, 2-stretch, stretch, 2.5.3, 2.5, 2, latest
+Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/stretch
 
-Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2-slim-stretch, slim-stretch, 2.5.3-slim, 2.5-slim, 2-slim, slim
+Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2-alpine3.8, alpine3.8, 2.5.3-alpine, 2.5-alpine, 2-alpine, alpine
+Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/alpine3.8
 
-Tags: 2.5.3-alpine3.7, 2.5-alpine3.7, 2-alpine3.7, alpine3.7
+Tags: 2.5.3-alpine3.7, 2.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
 Directory: 2.5/alpine3.7


### PR DESCRIPTION
Ruby 2.6 has been released: https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

Official source for Docker image has been updated: https://github.com/docker-library/ruby/pull/253

I just ran the following to generate the updated bashbrew file (formatted for readability):

```
$ docker run \
    --rm -it \
    -w /ruby \
    --volume /clone/of/github.com/docker-library/ruby:/ruby \
    buildpack-deps \
    bash -c "
       curl -s https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-amd64 > /usr/local/bin/bashbrew;
       chmod +x /usr/local/bin/bashbrew;
       ./generate-stackbrew-library.sh
    " > /clone/of/github.com/docker-library/official-images/library/ruby
```