### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -42,12 +42,12 @@ Directory: 11/jdk/oracle
 
 Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
+GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jdk
 
 Tags: 11.0.1-jdk-slim-stretch, 11.0.1-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, jdk-slim-stretch, slim-stretch, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
+GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jdk/slim
 
 Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -73,12 +73,12 @@ Constraints: windowsservercore-1803
 
 Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch, 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
+GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jre
 
 Tags: 11.0.1-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, jre-slim-stretch, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63656af1180ca7727ff9e158fa1ee6d16997791c
+GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jre/slim
 
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.0, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
 Directory: 2.6/stretch
 
 Tags: 2.6.0-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.0-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.0-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8, 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
 Directory: 2.6/alpine3.8
 
 Tags: 2.6.0-alpine3.7, 2.6-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d4be0c416c61f1de327badb94e629aa993c2e2b4
+GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
 Directory: 2.6/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
+GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
+GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
+GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad99abb2b6d2df55d7b9b38440dacfe436fe0c3
+GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fec6089b541d8de9abc8646781785293f8e051d3
+GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1dd037551249b71b37117f2bdfeee0f18218d887
+GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `openjdk`: fix ca-certificates-java (docker-library/openjdk#263)
- `ruby`: bundler 1.17.3