### PR TITLE
Add Microsoft's weird new "mcr.microsoft.com/windows/xxx" images as explicitly permissible bases

### DIFF
--- a/naughty-from.sh
+++ b/naughty-from.sh
@@ -46,9 +46,9 @@ for img in $tags; do
 			| amd64=docker.elastic.co/elasticsearch/elasticsearch:* \
 			| amd64=docker.elastic.co/kibana/kibana:* \
 			| amd64=docker.elastic.co/logstash/logstash:* \
-			| windows-*=microsoft/nanoserver \
+			| windows-*=mcr.microsoft.com/windows/nanoserver:* \
+			| windows-*=mcr.microsoft.com/windows/servercore:* \
 			| windows-*=microsoft/nanoserver:* \
-			| windows-*=microsoft/windowsservercore \
 			| windows-*=microsoft/windowsservercore:* \
 			) continue ;;
 		esac


### PR DESCRIPTION
Still definitely think this is an odd move (as I've outlined in https://github.com/docker-library/golang/pull/257#issuecomment-449772799), but this is the only way we can get 1809+, so I guess we're moving forward with this.