### PR TITLE
Update docker-library images

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,48 +1,48 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3faaa45afa794cc057376c13831f7ba3e627e545/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/da2ff27fcc621a56b311b3dab5f8de7107f1f06f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3faaa45afa794cc057376c13831f7ba3e627e545
+GitCommit: da2ff27fcc621a56b311b3dab5f8de7107f1f06f
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8784508d5587a5a6514bd393aa69c6a902145f83
+amd64-GitCommit: b1495be7b9777efe53b3ead0325fa7d7984723f8
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: af8ba791ac0e0e411dfc9880f175e680ba9f07d2
+arm32v5-GitCommit: 7f961611dceaa448ae2309aa7ee29928543f9fd4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 9198623057c826944b37a471323a2aebaaac0eaf
+arm32v6-GitCommit: 81891ca3cdc7be9d9a8f1454210748d4226a42a8
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 26b67d7975ceb5ddb5c1968fccc96d8c97dd6897
+arm32v7-GitCommit: 8a24f8cfb79f861da3bc9702fde4c7f0b8fde9b7
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: df30252f4970e30917592d521b68cc3b95e31caf
+arm64v8-GitCommit: 2de1b6935114660701f88722bae68c4b54035c4b
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 9bccd9e7379ecce1b97b22aa43a246e244694440
+i386-GitCommit: 42b542a2737dde450b63e4bffd36ad41095a2e14
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 3f81f9305520a02cce6ede99dab15830451ddeac
+ppc64le-GitCommit: 1e4f5fef0512d7041e1362f9193a93032ea7769b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 9ba4bc65db5469fda8b6ac88d6ac81d200c70ece
+s390x-GitCommit: 7dc1fa9d56ec356dd341787c0de571b741283d1c
 
-Tags: 1.29.3-uclibc, 1.29-uclibc, 1-uclibc, uclibc
+Tags: 1.30.0-uclibc, 1.30-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: uclibc
 
-Tags: 1.29.3-glibc, 1.29-glibc, 1-glibc, glibc
+Tags: 1.30.0-glibc, 1.30-glibc, 1-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: glibc
 
-Tags: 1.29.3-musl, 1.29-musl, 1-musl, musl
+Tags: 1.30.0-musl, 1.30-musl, 1-musl, musl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: musl
 
-Tags: 1.29.3, 1.29, 1, latest
+Tags: 1.30.0, 1.30, 1, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 amd64-Directory: uclibc
 arm32v5-Directory: uclibc

--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/0c8f21255b8c4b707901db4e5d77235b7a1b7159/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/f80db24bd9f5640ba31e24501f4d7a9e60160978/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -19,28 +19,35 @@ Directory: 1.12-rc/alpine3.8
 Tags: 1.12beta1-windowsservercore-ltsc2016, 1.12-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.12-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.12beta1-windowsservercore-1709, 1.12-rc-windowsservercore-1709, rc-windowsservercore-1709
 SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.12-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 1.12beta1-windowsservercore-1803, 1.12-rc-windowsservercore-1803, rc-windowsservercore-1803
 SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.12-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 1.12beta1-windowsservercore-1809, 1.12-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.12beta1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta1, 1.12-rc, rc
+Architectures: windows-amd64
+GitCommit: f80db24bd9f5640ba31e24501f4d7a9e60160978
+Directory: 1.12-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 1.12beta1-nanoserver-sac2016, 1.12-rc-nanoserver-sac2016, rc-nanoserver-sac2016
 SharedTags: 1.12beta1-nanoserver, 1.12-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 0c8f21255b8c4b707901db4e5d77235b7a1b7159
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.12-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -63,28 +70,35 @@ Directory: 1.11/alpine3.7
 Tags: 1.11.4-windowsservercore-ltsc2016, 1.11-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.11.4-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.4, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 304174c7c604cbb7dd445ab58f479efe98f3bbf4
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.11/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.11.4-windowsservercore-1709, 1.11-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
 SharedTags: 1.11.4-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.4, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 304174c7c604cbb7dd445ab58f479efe98f3bbf4
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.11/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 1.11.4-windowsservercore-1803, 1.11-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
 SharedTags: 1.11.4-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.4, 1.11, 1, latest
 Architectures: windows-amd64
-GitCommit: 304174c7c604cbb7dd445ab58f479efe98f3bbf4
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.11/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 1.11.4-windowsservercore-1809, 1.11-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.11.4-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.4, 1.11, 1, latest
+Architectures: windows-amd64
+GitCommit: f80db24bd9f5640ba31e24501f4d7a9e60160978
+Directory: 1.11/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 1.11.4-nanoserver-sac2016, 1.11-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 1.11.4-nanoserver, 1.11-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 304174c7c604cbb7dd445ab58f479efe98f3bbf4
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.11/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -107,27 +121,34 @@ Directory: 1.10/alpine3.7
 Tags: 1.10.7-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016
 SharedTags: 1.10.7-windowsservercore, 1.10-windowsservercore, 1.10.7, 1.10
 Architectures: windows-amd64
-GitCommit: 592ba6d666abe8698b915749723498451060a919
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.10/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.10.7-windowsservercore-1709, 1.10-windowsservercore-1709
 SharedTags: 1.10.7-windowsservercore, 1.10-windowsservercore, 1.10.7, 1.10
 Architectures: windows-amd64
-GitCommit: 592ba6d666abe8698b915749723498451060a919
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.10/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 1.10.7-windowsservercore-1803, 1.10-windowsservercore-1803
 SharedTags: 1.10.7-windowsservercore, 1.10-windowsservercore, 1.10.7, 1.10
 Architectures: windows-amd64
-GitCommit: 592ba6d666abe8698b915749723498451060a919
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.10/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 1.10.7-windowsservercore-1809, 1.10-windowsservercore-1809
+SharedTags: 1.10.7-windowsservercore, 1.10-windowsservercore, 1.10.7, 1.10
+Architectures: windows-amd64
+GitCommit: f80db24bd9f5640ba31e24501f4d7a9e60160978
+Directory: 1.10/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 1.10.7-nanoserver-sac2016, 1.10-nanoserver-sac2016
 SharedTags: 1.10.7-nanoserver, 1.10-nanoserver
 Architectures: windows-amd64
-GitCommit: 592ba6d666abe8698b915749723498451060a919
+GitCommit: b77b1875cef30cd069506da1dc88977f981abeea
 Directory: 1.10/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016

--- a/library/hello-seattle
+++ b/library/hello-seattle
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 
 Tags: linux
 SharedTags: latest
@@ -26,20 +26,27 @@ s390x-Directory: s390x/hello-seattle
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-seattle/nanoserver-1803
 Constraints: nanoserver-1803
+
+Tags: nanoserver-1809
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
+windows-amd64-Directory: amd64/hello-seattle/nanoserver-1809
+Constraints: nanoserver-1809

--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 
 Tags: linux
 SharedTags: latest
@@ -26,20 +26,27 @@ s390x-Directory: s390x/hello-world
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-world/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hello-world/nanoserver-1803
 Constraints: nanoserver-1803
+
+Tags: nanoserver-1809
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
+windows-amd64-Directory: amd64/hello-world/nanoserver-1809
+Constraints: nanoserver-1809

--- a/library/hola-mundo
+++ b/library/hola-mundo
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/7c49831fd4a723d39fa33be77dc1fdee49b2ad85/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 7c49831fd4a723d39fa33be77dc1fdee49b2ad85
+GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 
 Tags: linux
 SharedTags: latest
@@ -26,20 +26,27 @@ s390x-Directory: s390x/hola-mundo
 Tags: nanoserver-sac2016
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: nanoserver-1709
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1709
 Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
 windows-amd64-Directory: amd64/hola-mundo/nanoserver-1803
 Constraints: nanoserver-1803
+
+Tags: nanoserver-1809
+SharedTags: nanoserver, latest
+Architectures: windows-amd64
+windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
+windows-amd64-Directory: amd64/hola-mundo/nanoserver-1809
+Constraints: nanoserver-1809

--- a/library/openjdk
+++ b/library/openjdk
@@ -9,31 +9,38 @@ Architectures: amd64
 GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-20-jdk-alpine3.8, 12-ea-20-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-20-jdk-alpine, 12-ea-20-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 266f01a904151eab55302df4a306a5042e77f58b
+GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
 Tags: 12-ea-25-jdk-windowsservercore-ltsc2016, 12-ea-25-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
 SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 12-ea-25-jdk-windowsservercore-1709, 12-ea-25-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
 SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 12-ea-25-jdk-windowsservercore-1803, 12-ea-25-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
 SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 12-ea-25-jdk-nanoserver-sac2016, 12-ea-25-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-25-jdk-nanoserver, 12-ea-25-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Architectures: windows-amd64
+GitCommit: 3057ebcdbe57f042e13274a0a87c79a81f8f2dfc
+Directory: 12/jdk/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 11.0.1-jdk-oraclelinux7, 11.0.1-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.1-jdk-oracle, 11.0.1-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
@@ -53,23 +60,30 @@ Directory: 11/jdk/slim
 Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.1-jdk-windowsservercore-1709, 11.0.1-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 11.0.1-jdk-windowsservercore-1803, 11.0.1-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
+
+Tags: 11.0.1-jdk-nanoserver-sac2016, 11.0.1-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 11.0.1-jdk-nanoserver, 11.0.1-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
+Architectures: windows-amd64
+GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+Directory: 11/jdk/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
 
 Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch, 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
+GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
 Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 11/alpine
 
 Tags: 10.6, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
+GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
 Directory: 10
 
 Tags: 10.6-alpine, 10-alpine
@@ -26,7 +26,7 @@ Directory: 10/alpine
 
 Tags: 9.6.11, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
+GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
 Directory: 9.6
 
 Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
@@ -36,7 +36,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.15, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
+GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
 Directory: 9.5
 
 Tags: 9.5.15-alpine, 9.5-alpine
@@ -46,7 +46,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.20, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040949af1595f49f2242f6d1f9c42fb042b3eaed
+GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
 Directory: 9.4
 
 Tags: 9.4.20-alpine, 9.4-alpine


### PR DESCRIPTION
- `busybox`: 1.30.0
- `golang`: Windows 2019 / 1809 support (docker-library/golang#257)
- `hello-seattle`: Windows 2019 / 1809 support (docker-library/hello-world#54)
- `hello-world`: Windows 2019 / 1809 support (docker-library/hello-world#54)
- `hola-mundo`: Windows 2019 / 1809 support (docker-library/hello-world#54)
- `openjdk`: 12-ea+25, Nano Server SAC2016 (docker-library/openjdk#260)
- `postgres`: bump `gosu` version (docker-library/postgres#541)