### PR TITLE
Specify version in websphere-liberty FROM instructions

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: b042200103140fb529e94bb45a35f519057b5d42
+GitCommit: 1f420974a387fddfe980659f8536473b398143c9
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Need to specify the version in the `FROM websphere-liberty:kernel` instructions to make sure we aren't basing on the wrong version of the product when building the images.  