### PR TITLE
Update Solr

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/d9f398bdf013364581c3348c2cf5ed58b3bbebf8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/3647e528b83949f2f3c3f9cb6fcb446510df97b7/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
@@ -6,120 +6,120 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 7.6.0, 7.6, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e82fc2ad32076ad64d9d5ab5aa837282a11ec62e
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.6
 
 Tags: 7.6.0-alpine, 7.6-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: aaa5aaac26c462930753160499004db28163729a
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.6/alpine
 
 Tags: 7.6.0-slim, 7.6-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e82fc2ad32076ad64d9d5ab5aa837282a11ec62e
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.5
 
 Tags: 7.5.0-alpine, 7.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.5/alpine
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.5/slim
 
 Tags: 7.4.0, 7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.4
 
 Tags: 7.4.0-alpine, 7.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.4/alpine
 
 Tags: 7.4.0-slim, 7.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.4/slim
 
 Tags: 7.3.1, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.3
 
 Tags: 7.3.1-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.3/alpine
 
 Tags: 7.3.1-slim, 7.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef954ee10a6483607daa32fc3c35a6ca462c0b3f
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.3/slim
 
 Tags: 7.2.1, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.2
 
 Tags: 7.2.1-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.2/alpine
 
 Tags: 7.2.1-slim, 7.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.2/slim
 
 Tags: 7.1.0, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.1
 
 Tags: 7.1.0-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.1/alpine
 
 Tags: 7.1.0-slim, 7.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 7.1/slim
 
 Tags: 6.6.5, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 6.6
 
 Tags: 6.6.5-alpine, 6.6-alpine, 6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 6.6/alpine
 
 Tags: 6.6.5-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9319e4b65c33c47dd5f901daec9d457571294396
+GitCommit: bbfaa1b560828203f0867eaa075bb8688785c652
 Directory: 5.5/slim


### PR DESCRIPTION
This update contains improvements to the docker-solr build process and a gosu version update; There is no new version of Solr, or changes to user scripts.

Changes:
- update gosu to the latest version
- update the travis build environment for the latest docker
- convert to multi-stage builds, see e.g. https://github.com/docker-solr/docker-solr/blob/master/7.6/Dockerfile . Review/feedback appreciated.