### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-1-jdk-oraclelinux7, 13-ea-1-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-1-jdk-oracle, 13-ea-1-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-1-jdk, 13-ea-1, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-2-jdk-oraclelinux7, 13-ea-2-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-2-jdk-oracle, 13-ea-2-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-2-jdk, 13-ea-2, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-1-jdk-alpine3.8, 13-ea-1-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-1-jdk-alpine, 13-ea-1-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -14,37 +14,37 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-1-jdk-windowsservercore-ltsc2016, 13-ea-1-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-1-jdk-windowsservercore, 13-ea-1-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-2-jdk-windowsservercore-ltsc2016, 13-ea-2-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-1-jdk-windowsservercore-1709, 13-ea-1-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-1-jdk-windowsservercore, 13-ea-1-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-2-jdk-windowsservercore-1709, 13-ea-2-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-1-jdk-windowsservercore-1803, 13-ea-1-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-1-jdk-windowsservercore, 13-ea-1-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-2-jdk-windowsservercore-1803, 13-ea-2-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-1-jdk-nanoserver-sac2016, 13-ea-1-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-1-jdk-nanoserver, 13-ea-1-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-2-jdk-nanoserver-sac2016, 13-ea-2-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-2-jdk-nanoserver, 13-ea-2-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-25-jdk-oraclelinux7, 12-ea-25-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-25-jdk-oracle, 12-ea-25-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-25-jdk, 12-ea-25, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-26-jdk-oraclelinux7, 12-ea-26-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-26-jdk-oracle, 12-ea-26-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-26-jdk, 12-ea-26, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 6f7c70eb527c39c3f315454b84fe0f776aa019fb
+GitCommit: 315ca52801a46e69af557460c7f0232a82582306
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -52,31 +52,31 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-25-jdk-windowsservercore-ltsc2016, 12-ea-25-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-26-jdk-windowsservercore-ltsc2016, 12-ea-26-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: 315ca52801a46e69af557460c7f0232a82582306
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-25-jdk-windowsservercore-1709, 12-ea-25-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-26-jdk-windowsservercore-1709, 12-ea-26-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: 315ca52801a46e69af557460c7f0232a82582306
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-25-jdk-windowsservercore-1803, 12-ea-25-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-25-jdk-windowsservercore, 12-ea-25-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-26-jdk-windowsservercore-1803, 12-ea-26-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: 315ca52801a46e69af557460c7f0232a82582306
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-25-jdk-nanoserver-sac2016, 12-ea-25-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-25-jdk-nanoserver, 12-ea-25-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-ea-26-jdk-nanoserver-sac2016, 12-ea-26-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-26-jdk-nanoserver, 12-ea-26-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: 3057ebcdbe57f042e13274a0a87c79a81f8f2dfc
+GitCommit: 315ca52801a46e69af557460c7f0232a82582306
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/a280ab8e8790052338ce59a1fee739df8f831f16/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/c32a9f63da6873d54d27029237bee845ab4ad05c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -128,58 +128,3 @@ Tags: 7.1.25-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.25-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4fa4c526cf52725f859d7067006e8d4b3c226a52
 Directory: 7.1/alpine3.8/zts
-
-Tags: 7.0.33-cli-stretch, 7.0-cli-stretch, 7.0.33-stretch, 7.0-stretch, 7.0.33-cli, 7.0-cli, 7.0.33, 7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/stretch/cli
-
-Tags: 7.0.33-apache-stretch, 7.0-apache-stretch, 7.0.33-apache, 7.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/stretch/apache
-
-Tags: 7.0.33-fpm-stretch, 7.0-fpm-stretch, 7.0.33-fpm, 7.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/stretch/fpm
-
-Tags: 7.0.33-zts-stretch, 7.0-zts-stretch, 7.0.33-zts, 7.0-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/stretch/zts
-
-Tags: 7.0.33-cli-jessie, 7.0-cli-jessie, 7.0.33-jessie, 7.0-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/jessie/cli
-
-Tags: 7.0.33-apache-jessie, 7.0-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/jessie/apache
-
-Tags: 7.0.33-fpm-jessie, 7.0-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/jessie/fpm
-
-Tags: 7.0.33-zts-jessie, 7.0-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/jessie/zts
-
-Tags: 7.0.33-cli-alpine3.7, 7.0-cli-alpine3.7, 7.0.33-alpine3.7, 7.0-alpine3.7, 7.0.33-cli-alpine, 7.0-cli-alpine, 7.0.33-alpine, 7.0-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/alpine3.7/cli
-
-Tags: 7.0.33-fpm-alpine3.7, 7.0-fpm-alpine3.7, 7.0.33-fpm-alpine, 7.0-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/alpine3.7/fpm
-
-Tags: 7.0.33-zts-alpine3.7, 7.0-zts-alpine3.7, 7.0.33-zts-alpine, 7.0-zts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b4319e8f767f1200c9013e08baf2c34b9c84e301
-Directory: 7.0/alpine3.7/zts

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.0-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.0, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.6/stretch
 
 Tags: 2.6.0-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.0-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.0-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8, 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.6/alpine3.8
 
 Tags: 2.6.0-alpine3.7, 2.6-alpine3.7, 2-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c52e456a323e12f76639993ae2bcf0429193cdd
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.6/alpine3.7
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.5/alpine3.8
 
 Tags: 2.5.3-alpine3.7, 2.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a8e858e5d031266333cf79593b8581d32dd1b73
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.5/alpine3.7
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/alpine3.8
 
 Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ba8328861cb53f2ad6fbaff788d5e2b904ab9c6d
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/alpine3.7
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e08dc45ad0386783e757d91347c6a61bc21744e
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/alpine3.7

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,36 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.0.2-php5.6-apache, 5.0-php5.6-apache, 5-php5.6-apache, php5.6-apache, 5.0.2-php5.6, 5.0-php5.6, 5-php5.6, php5.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php5.6/apache
-
-Tags: 5.0.2-php5.6-fpm, 5.0-php5.6-fpm, 5-php5.6-fpm, php5.6-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php5.6/fpm
-
-Tags: 5.0.2-php5.6-fpm-alpine, 5.0-php5.6-fpm-alpine, 5-php5.6-fpm-alpine, php5.6-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php5.6/fpm-alpine
-
-Tags: 5.0.2-php7.0-apache, 5.0-php7.0-apache, 5-php7.0-apache, php7.0-apache, 5.0.2-php7.0, 5.0-php7.0, 5-php7.0, php7.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php7.0/apache
-
-Tags: 5.0.2-php7.0-fpm, 5.0-php7.0-fpm, 5-php7.0-fpm, php7.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php7.0/fpm
-
-Tags: 5.0.2-php7.0-fpm-alpine, 5.0-php7.0-fpm-alpine, 5-php7.0-fpm-alpine, php7.0-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
-Directory: php7.0/fpm-alpine
-
 Tags: 5.0.2-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.2-php7.1, 5.0-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
@@ -65,16 +35,6 @@ GitCommit: f63c0db6593494e8fee0e542af9413e22c1da15b
 Directory: php7.2/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
-
-Tags: cli-2.1.0-php5.6, cli-2.1-php5.6, cli-2-php5.6, cli-php5.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
-Directory: php5.6/cli
-
-Tags: cli-2.1.0-php7.0, cli-2.1-php7.0, cli-2-php7.0, cli-php7.0
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
-Directory: php7.0/cli
 
 Tags: cli-2.1.0-php7.1, cli-2.1-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
- `openjdk`: 13-ea+2, 12-ea+26
- `php`: re-remove EOL 7.0 (docker-library/php#773)
- `ruby`: adjust RubyGems to be fixed at 3.0.1 or whatever comes with Ruby, whichever is later; also allow RubyGems/Ruby to control Bundler version (docker-library/ruby#255)
- `wordpress`: remove EOL PHP 5.6 and 7.0 variants (docker-library/wordpress#362)