### PR TITLE
[security] Update HAProxy to 1.9.1 and 1.8.17

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.0, 1.9, 1, latest
+Tags: 1.9.1, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a79c7cdad7e2b1e81bd342b7bc0204027b8f326
+GitCommit: 807430d78258a2bdb913f879ec8ea866d02ddcfd
 Directory: 1.9
 
-Tags: 1.9.0-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a79c7cdad7e2b1e81bd342b7bc0204027b8f326
+GitCommit: 807430d78258a2bdb913f879ec8ea866d02ddcfd
 Directory: 1.9/alpine
 
-Tags: 1.8.16, 1.8
+Tags: 1.8.17, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0fbc04187e47c770776a24f3ce40bc16795a6fcd
+GitCommit: aac7efb4d62177a1d60edc4b1b4e20cb2c833dec
 Directory: 1.8
 
-Tags: 1.8.16-alpine, 1.8-alpine
+Tags: 1.8.17-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0fbc04187e47c770776a24f3ce40bc16795a6fcd
+GitCommit: aac7efb4d62177a1d60edc4b1b4e20cb2c833dec
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7


### PR DESCRIPTION
https://www.mail-archive.com/haproxy@formilux.org/msg32299.html
https://www.mail-archive.com/haproxy@formilux.org/msg32303.html
https://www.mail-archive.com/haproxy@formilux.org/msg32304.html