### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -1,14 +1,14 @@
-# this file is generated via https://github.com/tianon/docker-bash/blob/bbffeabe24a9edabc79ef2e5f6418a70e09abafc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-bash/blob/35aa5f46fa4ed3019f571e0000d305aea685436c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 5.0-rc1, 5.0-rc, rc
+Tags: 5.0.0, 5.0, 5, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9dc1c12d0a8aa7ea4b51b166d0b64a78d44df9f0
-Directory: 5.0-rc
+GitCommit: 35aa5f46fa4ed3019f571e0000d305aea685436c
+Directory: 5.0
 
-Tags: 4.4.23, 4.4, 4, latest
+Tags: 4.4.23, 4.4, 4
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
 Directory: 4.4

--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,7 +16,7 @@ Directory: bionic/scm
 
 Tags: bionic, 18.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0db0cf15f1c507b17e7edc6dfbe301b8e357568f
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: bionic
 
 Tags: buster-curl, testing-curl
@@ -31,7 +31,7 @@ Directory: buster/scm
 
 Tags: buster, testing
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: buster
 
 Tags: cosmic-curl, 18.10-curl
@@ -46,7 +46,7 @@ Directory: cosmic/scm
 
 Tags: cosmic, 18.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: cosmic
 
 Tags: disco-curl, 19.04-curl
@@ -61,7 +61,7 @@ Directory: disco/scm
 
 Tags: disco, 19.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: disco
 
 Tags: jessie-curl, oldstable-curl
@@ -76,7 +76,7 @@ Directory: jessie/scm
 
 Tags: jessie, oldstable
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: jessie
 
 Tags: sid-curl, unstable-curl
@@ -91,7 +91,7 @@ Directory: sid/scm
 
 Tags: sid, unstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: sid
 
 Tags: stretch-curl, stable-curl, curl
@@ -106,7 +106,7 @@ Directory: stretch/scm
 
 Tags: stretch, stable, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: stretch
 
 Tags: trusty-curl, 14.04-curl
@@ -121,7 +121,7 @@ Directory: trusty/scm
 
 Tags: trusty, 14.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: trusty
 
 Tags: wheezy-curl, oldoldstable-curl
@@ -136,7 +136,7 @@ Directory: wheezy/scm
 
 Tags: wheezy, oldoldstable
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: wheezy
 
 Tags: xenial-curl, 16.04-curl
@@ -151,5 +151,5 @@ Directory: xenial/scm
 
 Tags: xenial, 16.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1
+GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
 Directory: xenial

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.9.1, 2.9, 2, latest
+Tags: 2.10.0, 2.10, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e76d79d6b3071421a1b9aad47f6d341ae1403801
+GitCommit: a020a8441b906f2c108740fe673b630906013f7a
 Directory: 2/debian
 
-Tags: 2.9.1-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.10.0-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e76d79d6b3071421a1b9aad47f6d341ae1403801
+GitCommit: a020a8441b906f2c108740fe673b630906013f7a
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/mariadb
+++ b/library/mariadb
@@ -9,9 +9,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 7a76abcb45a945614d803d29138680976ff1305c
 Directory: 10.4
 
-Tags: 10.3.11-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.11, 10.3, 10, latest
+Tags: 10.3.12-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.12, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4d2df7be30fb608fd4ad743b74e7df80203a7dc0
+GitCommit: db27681a5753e6f22eb73b5a9575d6b833ba1238
 Directory: 10.3
 
 Tags: 10.2.21-bionic, 10.2-bionic, 10.2.21, 10.2

--- a/library/pypy
+++ b/library/pypy
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
+GitCommit: 523034bb96ffeaeee83dffe880082252fb778f7d
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
+GitCommit: 523034bb96ffeaeee83dffe880082252fb778f7d
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie

--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 5875d577cada0d1fb3cb8093f6b15b586b20f65e
 Directory: 4.0
 
 Tags: 4.0.0-passenger, 4.0-passenger, 4-passenger, passenger
-GitCommit: 5875d577cada0d1fb3cb8093f6b15b586b20f65e
+GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 4.0/passenger
 
 Tags: 3.4.7, 3.4, 3
@@ -19,7 +19,7 @@ GitCommit: 8e9f5fc59b6fa899e07a0c2dfca0d46425e6c088
 Directory: 3.4
 
 Tags: 3.4.7-passenger, 3.4-passenger, 3-passenger
-GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
+GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 3.4/passenger
 
 Tags: 3.3.9, 3.3
@@ -28,5 +28,5 @@ GitCommit: 8e9f5fc59b6fa899e07a0c2dfca0d46425e6c088
 Directory: 3.3
 
 Tags: 3.3.9-passenger, 3.3-passenger
-GitCommit: d823080d113fd574adedaa94855e5e102e1b6390
+GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 3.3/passenger


### PR DESCRIPTION
- `bash`: 5.0 (GA)
- `buildpack-deps`: add `unzip` (docker-library/buildpack-deps#88)
- `ghost`: 2.10.0
- `mariadb`: 10.3.12
- `pypy`: (no change, just `update.sh` flakiness)
- `redmine`: passenger 6.0.1