### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.1-rc1, 18.09-rc, rc, test
+Tags: 18.09.1, 18.09, 18, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: f094d6bce78c1d9714bbaf9a059babb513322922
-Directory: 18.09-rc
-
-Tags: 18.09.1-rc1-dind, 18.09-rc-dind, rc-dind, test-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 27e5adeb0597e445e3b9df951f03eaf89131184b
-Directory: 18.09-rc/dind
-
-Tags: 18.09.1-rc1-git, 18.09-rc-git, rc-git, test-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 27e5adeb0597e445e3b9df951f03eaf89131184b
-Directory: 18.09-rc/git
-
-Tags: 18.09.0, 18.09, 18, stable, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
+GitCommit: d94b9832f55143f49e47d00de63589ed41f288e7
 Directory: 18.09
 
-Tags: 18.09.0-dind, 18.09-dind, 18-dind, stable-dind, dind
+Tags: 18.09.1-dind, 18.09-dind, 18-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/dind
 
-Tags: 18.09.0-git, 18.09-git, 18-git, stable-git, git
+Tags: 18.09.1-git, 18.09-git, 18-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.10.0, 2.10, 2, latest
+Tags: 2.10.1, 2.10, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a020a8441b906f2c108740fe673b630906013f7a
+GitCommit: f603121118d7060cde1451e55f5772317793c61e
 Directory: 2/debian
 
-Tags: 2.10.0-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.1-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a020a8441b906f2c108740fe673b630906013f7a
+GitCommit: f603121118d7060cde1451e55f5772317793c61e
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-2-jdk-oraclelinux7, 13-ea-2-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-2-jdk-oracle, 13-ea-2-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-2-jdk, 13-ea-2, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-3-jdk-oraclelinux7, 13-ea-3-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-3-jdk-oracle, 13-ea-3-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-3-jdk, 13-ea-3, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
+GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-1-jdk-alpine3.8, 13-ea-1-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-1-jdk-alpine, 13-ea-1-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -14,37 +14,37 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-2-jdk-windowsservercore-ltsc2016, 13-ea-2-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
+GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-2-jdk-windowsservercore-1709, 13-ea-2-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
+GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-2-jdk-windowsservercore-1803, 13-ea-2-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-2-jdk-windowsservercore, 13-ea-2-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
+GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-2-jdk-nanoserver-sac2016, 13-ea-2-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-2-jdk-nanoserver, 13-ea-2-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-3-jdk-nanoserver, 13-ea-3-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 48b2de7e228dd4435a957172e912a399dbb93732
+GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-26-jdk-oraclelinux7, 12-ea-26-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-26-jdk-oracle, 12-ea-26-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-26-jdk, 12-ea-26, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-27-jdk-oraclelinux7, 12-ea-27-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-27-jdk-oracle, 12-ea-27-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-27-jdk, 12-ea-27, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 315ca52801a46e69af557460c7f0232a82582306
+GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -52,31 +52,31 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-26-jdk-windowsservercore-ltsc2016, 12-ea-26-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 315ca52801a46e69af557460c7f0232a82582306
+GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-26-jdk-windowsservercore-1709, 12-ea-26-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 315ca52801a46e69af557460c7f0232a82582306
+GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-26-jdk-windowsservercore-1803, 12-ea-26-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-26-jdk-windowsservercore, 12-ea-26-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: 315ca52801a46e69af557460c7f0232a82582306
+GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-26-jdk-nanoserver-sac2016, 12-ea-26-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-26-jdk-nanoserver, 12-ea-26-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-27-jdk-nanoserver, 12-ea-27-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: 315ca52801a46e69af557460c7f0232a82582306
+GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -143,9 +143,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk/slim
 
-Tags: 8u181-jdk-alpine3.8, 8u181-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u181-jdk-alpine, 8u181-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u191-jdk-alpine3.8, 8u191-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u191-jdk-alpine, 8u191-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 47a6539cd18023dafb45db9013455136cc0bca07
+GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jdk/alpine
 
 Tags: 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
@@ -186,9 +186,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre/slim
 
-Tags: 8u181-jre-alpine3.8, 8-jre-alpine3.8, 8u181-jre-alpine, 8-jre-alpine
+Tags: 8u191-jre-alpine3.8, 8-jre-alpine3.8, 8u191-jre-alpine, 8-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 47a6539cd18023dafb45db9013455136cc0bca07
+GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jre/alpine
 
 Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7

--- a/library/php
+++ b/library/php
@@ -4,74 +4,74 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.0-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.0-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.0-cli, 7.3-cli, 7-cli, cli, 7.3.0, 7.3, 7, latest
+Tags: 7.3.1-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.1-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.1-cli, 7.3-cli, 7-cli, cli, 7.3.1, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a280ab8e8790052338ce59a1fee739df8f831f16
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/stretch/cli
 
-Tags: 7.3.0-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.0-apache, 7.3-apache, 7-apache, apache
+Tags: 7.3.1-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.1-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a280ab8e8790052338ce59a1fee739df8f831f16
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/stretch/apache
 
-Tags: 7.3.0-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.0-fpm, 7.3-fpm, 7-fpm, fpm
+Tags: 7.3.1-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.1-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 26ab6801ff1fafc04a972f63e5c963c7225614c1
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/stretch/fpm
 
-Tags: 7.3.0-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.0-zts, 7.3-zts, 7-zts, zts
+Tags: 7.3.1-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.1-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a280ab8e8790052338ce59a1fee739df8f831f16
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.0-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.0-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8, 7.3.0-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.0-alpine, 7.3-alpine, 7-alpine, alpine
+Tags: 7.3.1-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.1-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8, 7.3.1-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a280ab8e8790052338ce59a1fee739df8f831f16
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/alpine3.8/cli
 
-Tags: 7.3.0-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.3.0-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.3.1-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.3.1-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 26ab6801ff1fafc04a972f63e5c963c7225614c1
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/alpine3.8/fpm
 
-Tags: 7.3.0-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.3.0-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.3.1-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.3.1-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a280ab8e8790052338ce59a1fee739df8f831f16
+GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
 Directory: 7.3/alpine3.8/zts
 
-Tags: 7.2.13-cli-stretch, 7.2-cli-stretch, 7.2.13-stretch, 7.2-stretch, 7.2.13-cli, 7.2-cli, 7.2.13, 7.2
+Tags: 7.2.14-cli-stretch, 7.2-cli-stretch, 7.2.14-stretch, 7.2-stretch, 7.2.14-cli, 7.2-cli, 7.2.14, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.13-apache-stretch, 7.2-apache-stretch, 7.2.13-apache, 7.2-apache
+Tags: 7.2.14-apache-stretch, 7.2-apache-stretch, 7.2.14-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.13-fpm-stretch, 7.2-fpm-stretch, 7.2.13-fpm, 7.2-fpm
+Tags: 7.2.14-fpm-stretch, 7.2-fpm-stretch, 7.2.14-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.13-zts-stretch, 7.2-zts-stretch, 7.2.13-zts, 7.2-zts
+Tags: 7.2.14-zts-stretch, 7.2-zts-stretch, 7.2.14-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.13-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.13-alpine3.8, 7.2-alpine3.8, 7.2.13-cli-alpine, 7.2-cli-alpine, 7.2.13-alpine, 7.2-alpine
+Tags: 7.2.14-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.14-alpine3.8, 7.2-alpine3.8, 7.2.14-cli-alpine, 7.2-cli-alpine, 7.2.14-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.13-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7.2.13-fpm-alpine, 7.2-fpm-alpine
+Tags: 7.2.14-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7.2.14-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.13-zts-alpine3.8, 7.2-zts-alpine3.8, 7.2.13-zts-alpine, 7.2-zts-alpine
+Tags: 7.2.14-zts-alpine3.8, 7.2-zts-alpine3.8, 7.2.14-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c88c3d52f41a370f3a62e3ded62b7b223b4cb846
+GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.25-cli-stretch, 7.1-cli-stretch, 7.1.25-stretch, 7.1-stretch, 7.1.25-cli, 7.1-cli, 7.1.25, 7.1

--- a/library/postgres
+++ b/library/postgres
@@ -6,50 +6,50 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 112bf5ee8455f930354bc90f32d6a1c830525ed9
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 11/alpine
 
 Tags: 10.6, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 10
 
 Tags: 10.6-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7c287e7800dc08743da8d6372ab752e5438f662b
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 10/alpine
 
 Tags: 9.6.11, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.6
 
 Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb8d873277a533b2f1140a3f3624321a0c53f45d
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.6/alpine
 
 Tags: 9.5.15, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.5
 
 Tags: 9.5.15-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d48c7ca3c7b8c573a33b9f0598839aa7a06318ff
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.5/alpine
 
 Tags: 9.4.20, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8bfec9c70f06c5fb9815653732c5d976f6f3c36
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.4
 
 Tags: 9.4.20-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d564da5142b2e5fa235707b05d8aa0fc76250418
+GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
 Directory: 9.4/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -11,7 +11,7 @@ Directory: 2.6/stretch
 
 Tags: 2.6.0-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.0-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.0-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8, 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
@@ -31,7 +31,7 @@ Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2.5.3-alpine, 2.5-alpine
@@ -51,7 +51,7 @@ Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
@@ -61,7 +61,7 @@ Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
@@ -81,7 +81,7 @@ Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
@@ -91,7 +91,7 @@ Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine


### PR DESCRIPTION
- `docker`: 18.09.1
- `ghost`: 2.10.1
- `openjdk`: 13-ea+3, 12-ea+27, Alpine 8u191
- `php`: 7.2.14, 7.3.1
- `postgres`: `POSTGRES_PASSWORD` 100+ warning (docker-library/postgres#511)
- `ruby`: use `debian:xxx-slim` for `ruby:slim` variants (docker-library/ruby#257)