### PR TITLE
update oraclelinux for systemd

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 54ab6edcc7e8ec45613d34456093da338b537267
+amd64-GitCommit: b2b2ce9ff42452c7f5803b37df4810680e82155e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0b50b405c53879218587393cad77cf6bf2d44d9e
+arm64v8-GitCommit: 410244e35a9ca7d63398a0af75cf8a3f2f3ce026
 Constraints: !aufs
 
 Tags: 7.6, 7, latest


### PR DESCRIPTION
        [AMD64 7.6] 2019-01-14-87
        [ARM64v8 7.6] 2019-01-14-9

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>