### PR TITLE
[nats] Release v1.4.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,29 +2,29 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+GitCommit: 293f61293758877835f9aea650fac0077026cb02
 
-Tags: 1.3.0-linux, linux
-SharedTags: 1.3.0, latest
+Tags: 1.4.0-linux, linux
+SharedTags: 1.4.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+amd64-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 amd64-Directory: amd64
-arm32v6-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+arm32v6-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+arm32v7-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+arm64v8-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 arm64v8-Directory: arm64v8
 
-Tags: 1.3.0-nanoserver, nanoserver
-SharedTags: 1.3.0, latest
+Tags: 1.4.0-nanoserver, nanoserver
+SharedTags: 1.4.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+windows-amd64-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 1.3.0-windowsservercore, windowsservercore
+Tags: 1.4.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: fedce51f05d228353ca56e87062ad23a671387a0
+windows-amd64-GitCommit: 293f61293758877835f9aea650fac0077026cb02
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/gnatsd/releases/tag/v1.4.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>