### PR TITLE
Fedora Update 2019-01-16.

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -25,23 +25,24 @@ ppc64le-Directory: ppc64le/
 Tags: rawhide, 30
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/30
-GitCommit: b80c1380b58f3b9eaa972ecf4632c4f39929ce9a
+GitCommit: afccb1ee8eae5eb675f7e8a83bf17a8f38df6e4c
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 
 Tags: 28
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/28
-GitCommit: 5b1abab687c875971ba462626ea49dc58f53f8a1
+GitCommit: aa106da2be30656a7ccb32b96f6788031ce8656f
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
+arm32v7-Directory: armhfp/
 
 Tags: latest, 29
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/29
-GitCommit: 89ac1df688b600a81ed64ea789ccba6858bb9d6e
+GitCommit: 0b3c941b4e502e88e91773bcc44ae6d2e9e09f12
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/


### PR DESCRIPTION
This commits add sets a default CMD to /bin/bash

Signed-off-by: Clement Verna <cverna@tutanota.com>