### PR TITLE
Add fluentd images

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,25 +3,13 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Alpine images
-Tags: v1.3.3-1.0, v1.3-1
+Tags: v1.4.2-2.0, v1.4-2, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
-Directory: v1.3/alpine
-
-# Alpine onbuild images
-Tags: v1.3.3-onbuild-1.0, v1.3-onbuild-1
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
-Directory: v1.3/alpine-onbuild
+GitCommit: dabca3c327d08be6d43a8919316a57ca2228e603
+Directory: v1.4/alpine
 
 # Debian images
-Tags: v1.3.3-debian-1.0, v1.3-debian-1
+Tags: v1.4.2-debian-2.0, v1.4-debian-2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
-Directory: v1.3/debian
-
-# Debian onbuild images
-Tags: v1.3.3-debian-onbuild-1.0, v1.3-debian-onbuild-1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
-Directory: v1.3/debian-onbuild
+GitCommit: dabca3c327d08be6d43a8919316a57ca2228e603
+Directory: v1.4/debian

--- a/library/fluentd
+++ b/library/fluentd
@@ -1,0 +1,27 @@
+Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
+             Fluentd developers <fluentd@googlegroups.com> (@fluent/admins)
+GitRepo: https://github.com/fluent/fluentd-docker-image.git
+
+# Alpine images
+Tags: v1.3.3-1.0, v1.3-1
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
+Directory: v1.3/alpine
+
+# Alpine onbuild images
+Tags: v1.3.3-onbuild-1.0, v1.3-onbuild-1
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
+Directory: v1.3/alpine-onbuild
+
+# Debian images
+Tags: v1.3.3-debian-1.0, v1.3-debian-1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
+Directory: v1.3/debian
+
+# Debian onbuild images
+Tags: v1.3.3-debian-onbuild-1.0, v1.3-debian-onbuild-1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 82b73cc11a01626efb95f4f78fa0b67653602d61
+Directory: v1.3/debian-onbuild


### PR DESCRIPTION
New proposal to add fluentd image. This replaces old PR: https://github.com/docker-library/official-images/pull/3724

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
  - log collector
-	[x] is it reasonably popular, or does it solve a particular use case well?
  - logging part of CNCF
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long) https://github.com/docker-library/docs/pull/1403
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)

