### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,47 +4,47 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.5-apache, 8.6-apache, 8-apache, apache, 8.6.5, 8.6, 8, latest
+Tags: 8.6.7-apache, 8.6-apache, 8-apache, apache, 8.6.7, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 48f55a71e0286f2d65c5c7a594e6f10aa8ecf430
+GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
 Directory: 8.6/apache
 
-Tags: 8.6.5-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.7-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 48f55a71e0286f2d65c5c7a594e6f10aa8ecf430
+GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
 Directory: 8.6/fpm
 
-Tags: 8.6.5-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.7-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 48f55a71e0286f2d65c5c7a594e6f10aa8ecf430
+GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
 Directory: 8.6/fpm-alpine
 
-Tags: 8.5.8-apache, 8.5-apache, 8.5.8, 8.5
+Tags: 8.5.10-apache, 8.5-apache, 8.5.10, 8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
+GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
 Directory: 8.5/apache
 
-Tags: 8.5.8-fpm, 8.5-fpm
+Tags: 8.5.10-fpm, 8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
+GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
 Directory: 8.5/fpm
 
-Tags: 8.5.8-fpm-alpine, 8.5-fpm-alpine
+Tags: 8.5.10-fpm-alpine, 8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 8a9569a2d2e9ded138454b34ae043afd0bdb2660
+GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
 Directory: 8.5/fpm-alpine
 
-Tags: 7.61-apache, 7-apache, 7.61, 7
+Tags: 7.63-apache, 7-apache, 7.63, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
 Directory: 7/apache
 
-Tags: 7.61-fpm, 7-fpm
+Tags: 7.63-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
 Directory: 7/fpm
 
-Tags: 7.61-fpm-alpine, 7-fpm-alpine
+Tags: 7.63-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f6716f12feaa1e3b3a78d2748941342073f4b32
+GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
 Directory: 7/fpm-alpine

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.10.1, 2.10, 2, latest
+Tags: 2.11.1, 2.11, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c864fc0ced809605849854491b81d2743ab14d1d
+GitCommit: 6d461f871beece4b81395a73fff8544a76297d89
 Directory: 2/debian
 
-Tags: 2.10.1-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.11.1-alpine, 2.11-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c864fc0ced809605849854491b81d2743ab14d1d
+GitCommit: 6d461f871beece4b81395a73fff8544a76297d89
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1
@@ -21,5 +21,5 @@ Directory: 1/debian
 
 Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 350b3e6b5edbb719756a155aa5cf0bfce45a9641
+GitCommit: 316073c647646f5c65b42cafd37367cc6fc5ee02
 Directory: 1/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.1, 1.9, 1, latest
+Tags: 1.9.2, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 807430d78258a2bdb913f879ec8ea866d02ddcfd
+GitCommit: e0e721acc4e96764801493bc979f7cf53af608fa
 Directory: 1.9
 
-Tags: 1.9.1-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 807430d78258a2bdb913f879ec8ea866d02ddcfd
+GitCommit: e0e721acc4e96764801493bc979f7cf53af608fa
 Directory: 1.9/alpine
 
 Tags: 1.8.17, 1.8

--- a/library/joomla
+++ b/library/joomla
@@ -3,47 +3,47 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.9.1-apache, 3.9-apache, 3-apache, apache, 3.9.1, 3.9, 3, latest, 3.9.1-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.1-php7.1, 3.9-php7.1, 3-php7.1, php7.1
+Tags: 3.9.2-apache, 3.9-apache, 3-apache, apache, 3.9.2, 3.9, 3, latest, 3.9.2-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.2-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.1/apache
 
-Tags: 3.9.1-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.1-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.9.2-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.2-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.1/fpm
 
-Tags: 3.9.1-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.1-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.9.2-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.2-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.1/fpm-alpine
 
-Tags: 3.9.1-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.1-php7.2, 3.9-php7.2, 3-php7.2, php7.2
+Tags: 3.9.2-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.2-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.2/apache
 
-Tags: 3.9.1-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.2-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.2/fpm
 
-Tags: 3.9.1-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.2-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.2/fpm-alpine
 
-Tags: 3.9.1-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.1-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Tags: 3.9.2-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.2-php7.3, 3.9-php7.3, 3-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.3/apache
 
-Tags: 3.9.1-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Tags: 3.9.2-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.3/fpm
 
-Tags: 3.9.1-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 3.9.2-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c37b38198df22237daceba1585d5a0500a7229ab
+GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
 Directory: php7.3/fpm-alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -14,31 +14,31 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+Tags: 13-ea-3-jdk-windowsservercore-ltsc2016-ltsc2016, 13-ea-3-windowsservercore-ltsc2016-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016-ltsc2016, 13-ea-windowsservercore-ltsc2016-ltsc2016, 13-jdk-windowsservercore-ltsc2016-ltsc2016, 13-windowsservercore-ltsc2016-ltsc2016, 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+Tags: 13-ea-3-jdk-windowsservercore-1709-1709, 13-ea-3-windowsservercore-1709-1709, 13-ea-jdk-windowsservercore-1709-1709, 13-ea-windowsservercore-1709-1709, 13-jdk-windowsservercore-1709-1709, 13-windowsservercore-1709-1709, 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+Tags: 13-ea-3-jdk-windowsservercore-1803-1803, 13-ea-3-windowsservercore-1803-1803, 13-ea-jdk-windowsservercore-1803-1803, 13-ea-windowsservercore-1803-1803, 13-jdk-windowsservercore-1803-1803, 13-windowsservercore-1803-1803, 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+Tags: 13-ea-3-jdk-nanoserver-sac2016-sac2016, 13-ea-3-nanoserver-sac2016-sac2016, 13-ea-jdk-nanoserver-sac2016-sac2016, 13-ea-nanoserver-sac2016-sac2016, 13-jdk-nanoserver-sac2016-sac2016, 13-nanoserver-sac2016-sac2016, 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
 SharedTags: 13-ea-3-jdk-nanoserver, 13-ea-3-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -52,37 +52,37 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+Tags: 12-ea-27-jdk-windowsservercore-ltsc2016-ltsc2016, 12-ea-27-windowsservercore-ltsc2016-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016-ltsc2016, 12-ea-windowsservercore-ltsc2016-ltsc2016, 12-jdk-windowsservercore-ltsc2016-ltsc2016, 12-windowsservercore-ltsc2016-ltsc2016, 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+Tags: 12-ea-27-jdk-windowsservercore-1709-1709, 12-ea-27-windowsservercore-1709-1709, 12-ea-jdk-windowsservercore-1709-1709, 12-ea-windowsservercore-1709-1709, 12-jdk-windowsservercore-1709-1709, 12-windowsservercore-1709-1709, 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+Tags: 12-ea-27-jdk-windowsservercore-1803-1803, 12-ea-27-windowsservercore-1803-1803, 12-ea-jdk-windowsservercore-1803-1803, 12-ea-windowsservercore-1803-1803, 12-jdk-windowsservercore-1803-1803, 12-windowsservercore-1803-1803, 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+Tags: 12-ea-27-jdk-nanoserver-sac2016-sac2016, 12-ea-27-nanoserver-sac2016-sac2016, 12-ea-jdk-nanoserver-sac2016-sac2016, 12-ea-nanoserver-sac2016-sac2016, 12-jdk-nanoserver-sac2016-sac2016, 12-nanoserver-sac2016-sac2016, 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
 SharedTags: 12-ea-27-jdk-nanoserver, 12-ea-27-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.1-jdk-oraclelinux7, 11.0.1-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.1-jdk-oracle, 11.0.1-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
+Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
-GitCommit: 1ba292401cda0ed0b0c706c86b55d03dd5e27c5c
+GitCommit: bd732a9833011e418a553f0b603a66d9c4711391
 Directory: 11/jdk/oracle
 
 Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
@@ -95,31 +95,31 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jdk/slim
 
-Tags: 11.0.1-jdk-windowsservercore-ltsc2016, 11.0.1-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-ltsc2016-ltsc2016, 11.0.2-windowsservercore-ltsc2016-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016-ltsc2016, 11.0-windowsservercore-ltsc2016-ltsc2016, 11-jdk-windowsservercore-ltsc2016-ltsc2016, 11-windowsservercore-ltsc2016-ltsc2016, jdk-windowsservercore-ltsc2016-ltsc2016, windowsservercore-ltsc2016-ltsc2016, 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.1-jdk-windowsservercore-1709, 11.0.1-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-1709-1709, 11.0.2-windowsservercore-1709-1709, 11.0-jdk-windowsservercore-1709-1709, 11.0-windowsservercore-1709-1709, 11-jdk-windowsservercore-1709-1709, 11-windowsservercore-1709-1709, jdk-windowsservercore-1709-1709, windowsservercore-1709-1709, 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11.0.1-jdk-windowsservercore-1803, 11.0.1-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 11.0.1-jdk-windowsservercore, 11.0.1-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-1803-1803, 11.0.2-windowsservercore-1803-1803, 11.0-jdk-windowsservercore-1803-1803, 11.0-windowsservercore-1803-1803, 11-jdk-windowsservercore-1803-1803, 11-windowsservercore-1803-1803, jdk-windowsservercore-1803-1803, windowsservercore-1803-1803, 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.1-jdk-nanoserver-sac2016, 11.0.1-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 11.0.1-jdk-nanoserver, 11.0.1-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
+Tags: 11.0.2-jdk-nanoserver-sac2016-sac2016, 11.0.2-nanoserver-sac2016-sac2016, 11.0-jdk-nanoserver-sac2016-sac2016, 11.0-nanoserver-sac2016-sac2016, 11-jdk-nanoserver-sac2016-sac2016, 11-nanoserver-sac2016-sac2016, jdk-nanoserver-sac2016-sac2016, nanoserver-sac2016-sac2016, 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: d5214d1dd5be1fc53dae2dd35c852aaab6ace299
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -148,31 +148,31 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jdk/alpine
 
-Tags: 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+Tags: 8u191-jdk-windowsservercore-ltsc2016-ltsc2016, 8u191-windowsservercore-ltsc2016-ltsc2016, 8-jdk-windowsservercore-ltsc2016-ltsc2016, 8-windowsservercore-ltsc2016-ltsc2016, 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: fdf3bb8d168120655fe39e4098713e704db809df
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u191-jdk-windowsservercore-1709, 8u191-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
+Tags: 8u191-jdk-windowsservercore-1709-1709, 8u191-windowsservercore-1709-1709, 8-jdk-windowsservercore-1709-1709, 8-windowsservercore-1709-1709, 8u191-jdk-windowsservercore-1709, 8u191-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: fdf3bb8d168120655fe39e4098713e704db809df
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+Tags: 8u191-jdk-windowsservercore-1803-1803, 8u191-windowsservercore-1803-1803, 8-jdk-windowsservercore-1803-1803, 8-windowsservercore-1803-1803, 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 0cdf33bad33f7297e125b5ae8625299654eb34ae
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
+Tags: 8u191-jdk-nanoserver-sac2016-sac2016, 8u191-nanoserver-sac2016-sac2016, 8-jdk-nanoserver-sac2016-sac2016, 8-nanoserver-sac2016-sac2016, 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
 SharedTags: 8u191-jdk-nanoserver, 8u191-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: fdf3bb8d168120655fe39e4098713e704db809df
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/d828bb80bafcca1757b049c27bf3e503b1ddbbb8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/4964d6a8511d4797c56c3e0754937f2e9647b801/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -14,28 +14,35 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-3-jdk-windowsservercore-ltsc2016-ltsc2016, 13-ea-3-windowsservercore-ltsc2016-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016-ltsc2016, 13-ea-windowsservercore-ltsc2016-ltsc2016, 13-jdk-windowsservercore-ltsc2016-ltsc2016, 13-windowsservercore-ltsc2016-ltsc2016, 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+Tags: 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-3-jdk-windowsservercore-1709-1709, 13-ea-3-windowsservercore-1709-1709, 13-ea-jdk-windowsservercore-1709-1709, 13-ea-windowsservercore-1709-1709, 13-jdk-windowsservercore-1709-1709, 13-windowsservercore-1709-1709, 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+Tags: 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-3-jdk-windowsservercore-1803-1803, 13-ea-3-windowsservercore-1803-1803, 13-ea-jdk-windowsservercore-1803-1803, 13-ea-windowsservercore-1803-1803, 13-jdk-windowsservercore-1803-1803, 13-windowsservercore-1803-1803, 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+Tags: 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
 SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-3-jdk-nanoserver-sac2016-sac2016, 13-ea-3-nanoserver-sac2016-sac2016, 13-ea-jdk-nanoserver-sac2016-sac2016, 13-ea-nanoserver-sac2016-sac2016, 13-jdk-nanoserver-sac2016-sac2016, 13-nanoserver-sac2016-sac2016, 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+Tags: 13-ea-3-jdk-windowsservercore-1809, 13-ea-3-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Architectures: windows-amd64
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+Directory: 13/jdk/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
 SharedTags: 13-ea-3-jdk-nanoserver, 13-ea-3-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
@@ -52,28 +59,35 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-27-jdk-windowsservercore-ltsc2016-ltsc2016, 12-ea-27-windowsservercore-ltsc2016-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016-ltsc2016, 12-ea-windowsservercore-ltsc2016-ltsc2016, 12-jdk-windowsservercore-ltsc2016-ltsc2016, 12-windowsservercore-ltsc2016-ltsc2016, 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+Tags: 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-27-jdk-windowsservercore-1709-1709, 12-ea-27-windowsservercore-1709-1709, 12-ea-jdk-windowsservercore-1709-1709, 12-ea-windowsservercore-1709-1709, 12-jdk-windowsservercore-1709-1709, 12-windowsservercore-1709-1709, 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+Tags: 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-27-jdk-windowsservercore-1803-1803, 12-ea-27-windowsservercore-1803-1803, 12-ea-jdk-windowsservercore-1803-1803, 12-ea-windowsservercore-1803-1803, 12-jdk-windowsservercore-1803-1803, 12-windowsservercore-1803-1803, 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+Tags: 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
 SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-27-jdk-nanoserver-sac2016-sac2016, 12-ea-27-nanoserver-sac2016-sac2016, 12-ea-jdk-nanoserver-sac2016-sac2016, 12-ea-nanoserver-sac2016-sac2016, 12-jdk-nanoserver-sac2016-sac2016, 12-nanoserver-sac2016-sac2016, 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+Tags: 12-ea-27-jdk-windowsservercore-1809, 12-ea-27-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
+SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Architectures: windows-amd64
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+Directory: 12/jdk/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
 SharedTags: 12-ea-27-jdk-nanoserver, 12-ea-27-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
@@ -95,28 +109,35 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jdk/slim
 
-Tags: 11.0.2-jdk-windowsservercore-ltsc2016-ltsc2016, 11.0.2-windowsservercore-ltsc2016-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016-ltsc2016, 11.0-windowsservercore-ltsc2016-ltsc2016, 11-jdk-windowsservercore-ltsc2016-ltsc2016, 11-windowsservercore-ltsc2016-ltsc2016, jdk-windowsservercore-ltsc2016-ltsc2016, windowsservercore-ltsc2016-ltsc2016, 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.2-jdk-windowsservercore-1709-1709, 11.0.2-windowsservercore-1709-1709, 11.0-jdk-windowsservercore-1709-1709, 11.0-windowsservercore-1709-1709, 11-jdk-windowsservercore-1709-1709, 11-windowsservercore-1709-1709, jdk-windowsservercore-1709-1709, windowsservercore-1709-1709, 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11.0.2-jdk-windowsservercore-1803-1803, 11.0.2-windowsservercore-1803-1803, 11.0-jdk-windowsservercore-1803-1803, 11.0-windowsservercore-1803-1803, 11-jdk-windowsservercore-1803-1803, 11-windowsservercore-1803-1803, jdk-windowsservercore-1803-1803, windowsservercore-1803-1803, 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.2-jdk-nanoserver-sac2016-sac2016, 11.0.2-nanoserver-sac2016-sac2016, 11.0-jdk-nanoserver-sac2016-sac2016, 11.0-nanoserver-sac2016-sac2016, 11-jdk-nanoserver-sac2016-sac2016, 11-nanoserver-sac2016-sac2016, jdk-nanoserver-sac2016-sac2016, nanoserver-sac2016-sac2016, 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Architectures: windows-amd64
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+Directory: 11/jdk/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
@@ -148,28 +169,35 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jdk/alpine
 
-Tags: 8u191-jdk-windowsservercore-ltsc2016-ltsc2016, 8u191-windowsservercore-ltsc2016-ltsc2016, 8-jdk-windowsservercore-ltsc2016-ltsc2016, 8-windowsservercore-ltsc2016-ltsc2016, 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+Tags: 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u191-jdk-windowsservercore-1709-1709, 8u191-windowsservercore-1709-1709, 8-jdk-windowsservercore-1709-1709, 8-windowsservercore-1709-1709, 8u191-jdk-windowsservercore-1709, 8u191-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
+Tags: 8u191-jdk-windowsservercore-1709, 8u191-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 8u191-jdk-windowsservercore-1803-1803, 8u191-windowsservercore-1803-1803, 8-jdk-windowsservercore-1803-1803, 8-windowsservercore-1803-1803, 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+Tags: 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
 SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u191-jdk-nanoserver-sac2016-sac2016, 8u191-nanoserver-sac2016-sac2016, 8-jdk-nanoserver-sac2016-sac2016, 8-nanoserver-sac2016-sac2016, 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
+Tags: 8u191-jdk-windowsservercore-1809, 8u191-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Architectures: windows-amd64
+GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+Directory: 8/jdk/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
 SharedTags: 8u191-jdk-nanoserver, 8u191-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
 GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc

--- a/library/pypy
+++ b/library/pypy
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: 523034bb96ffeaeee83dffe880082252fb778f7d
+GitCommit: 9b24a15e48d364779806a2ceb8adf300969d4fff
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: 523034bb96ffeaeee83dffe880082252fb778f7d
+GitCommit: 9b24a15e48d364779806a2ceb8adf300969d4fff
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie


### PR DESCRIPTION
- `drupal`: 8.6.7, 8.5.10, 7.63
- `ghost`: 2.11.1
- `haproxy`: 1.9.2
- `joomla`: 3.9.2
- `openjdk`: 11.0.2, 12-ea+27, 13-ea+3, debian `8u181-b13-2~deb9u1`, Windows Server 1809 (docker-library/openjdk#269)
- `pypy`: weird `update.sh` flakiness again (no changes) -- we really need to look into that :sweat_smile: