### PR TITLE
Update Rocket.Chat version to 0.73.2

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 0.71.1, 0.71, 0, latest
-GitCommit: 45ab9367ba7ad36779ee0348e8489276e0a96323
+Tags: 0.73.2, 0.73, 0, latest
+GitCommit: 49c5b9b70d480384401c31777e0fbf0a179fc95b


### PR DESCRIPTION
Do you guys know what happened? the bot `docker-library-bot` have run successfully on our repo but nothing was updated here it seems.