### PR TITLE
kong: replace 1.0.1 with 1.0.2

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,25 +2,14 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 1.0.1-alpine, 1.0.1, 1.0, latest
-GitCommit: 65c096aa30ce26d5c6e245bb5ceef863d235345d
-GitFetch: refs/tags/1.0.1
+Tags: 1.0.2-alpine, 1.0.2, 1.0, latest
+GitCommit: c3448c49bfe775fec5182a1c6a21f7e44d1d8d4d
+GitFetch: refs/tags/1.0.2
 Directory: alpine
 
-Tags: 1.0.1-centos, 1.0-centos
-GitCommit: 65c096aa30ce26d5c6e245bb5ceef863d235345d
-GitFetch: refs/tags/1.0.1
-Constraints: !aufs
-Directory: centos
-
-Tags: 1.0.0-alpine, 1.0.0
-GitCommit: 504655faf24f095a7b2de2bae9756cf9499223ad
-GitFetch: refs/tags/1.0.0
-Directory: alpine
-
-Tags: 1.0.0-centos
-GitCommit: 504655faf24f095a7b2de2bae9756cf9499223ad
-GitFetch: refs/tags/1.0.0
+Tags: 1.0.2-centos, 1.0-centos
+GitCommit: c3448c49bfe775fec5182a1c6a21f7e44d1d8d4d
+GitFetch: refs/tags/1.0.2
 Constraints: !aufs
 Directory: centos
 


### PR DESCRIPTION
Kong 1.0.1 introduced a regression. 1.0.2 is a patch release and should
be used in lieu of 1.0.1.