### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: 5.0.0, 5.0, 5, latest
+Tags: 5.0.2, 5.0, 5, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 35aa5f46fa4ed3019f571e0000d305aea685436c
+GitCommit: c2624abd627508926752be982a17205f1e2c40a2
 Directory: 5.0
 
 Tags: 4.4.23, 4.4, 4

--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.37, 2.4, 2, latest
+Tags: 2.4.38, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a426e299988c48f4937dfb4a9a67ac479ca011e1
+GitCommit: 5a6a1d99f1d6e754ecfcdd7a13e12980b86d7b75
 Directory: 2.4
 
-Tags: 2.4.37-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.38-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a426e299988c48f4937dfb4a9a67ac479ca011e1
+GitCommit: 5a6a1d99f1d6e754ecfcdd7a13e12980b86d7b75
 Directory: 2.4/alpine

--- a/library/mongo
+++ b/library/mongo
@@ -26,25 +26,25 @@ GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.9-stretch, 3.6-stretch, 3-stretch
-SharedTags: 3.6.9, 3.6, 3
+Tags: 3.6.10-stretch, 3.6-stretch, 3-stretch
+SharedTags: 3.6.10, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: cac8a53d000f9e9f537438b976b719ad1b5bad3c
+GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
 Directory: 3.6
 
-Tags: 3.6.9-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.9-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.9, 3.6, 3
+Tags: 3.6.10-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.10-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.10, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 2674c80f0674f29484c4ccb4aff7d076227d5bc9
+GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.9-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
-SharedTags: 3.6.9-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.9, 3.6, 3
+Tags: 3.6.10-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.10-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.10, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 2674c80f0674f29484c4ccb4aff7d076227d5bc9
+GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
@@ -77,31 +77,31 @@ GitCommit: 6e4f9aebd519141a0f8dffbdb2a9502e668c3bd7
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.6-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.6, 4.1, unstable
+Tags: 4.1.7-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.7, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: cac8a53d000f9e9f537438b976b719ad1b5bad3c
+GitCommit: 48ed849349121d0127263e1722f140309e56637f
 Directory: 4.1
 
-Tags: 4.1.6-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
+Tags: 4.1.7-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
+GitCommit: 48ed849349121d0127263e1722f140309e56637f
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.6-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
+Tags: 4.1.7-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
+GitCommit: 48ed849349121d0127263e1722f140309e56637f
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.6-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.6-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.6, 4.1, unstable
+Tags: 4.1.7-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: b808c630a16f3ad1024a0eefeda57ab2cc83a35c
+GitCommit: 48ed849349121d0127263e1722f140309e56637f
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/mysql
+++ b/library/mysql
@@ -4,16 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.13, 8.0, 8, latest
-GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
+Tags: 8.0.14, 8.0, 8, latest
+GitCommit: 401385db80c61290d25c0a6c1c86bbf9d6552f4d
 Directory: 8.0
 
-Tags: 5.7.24, 5.7, 5
-GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
+Tags: 5.7.25, 5.7, 5
+GitCommit: bb7ea52db4e12d3fb526450d22382d5cd8cd41ca
 Directory: 5.7
 
-Tags: 5.6.42, 5.6
-GitCommit: 696fc899126ae00771b5d87bdadae836e704ae7d
+Tags: 5.6.43, 5.6
+GitCommit: c0454b9e0ede6050deb66e2aabbc213b11b3eefe
 Directory: 5.6
 
 Tags: 5.5.62, 5.5

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-3-jdk-oraclelinux7, 13-ea-3-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-3-jdk-oracle, 13-ea-3-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-3-jdk, 13-ea-3, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-4-jdk-oraclelinux7, 13-ea-4-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-4-jdk-oracle, 13-ea-4-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-4-jdk, 13-ea-4, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 66ec18c5985a36e4583bc05174fe3e7301109710
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-1-jdk-alpine3.8, 13-ea-1-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-1-jdk-alpine, 13-ea-1-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -14,44 +14,44 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-3-jdk-windowsservercore-ltsc2016, 13-ea-3-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-4-jdk-windowsservercore-ltsc2016, 13-ea-4-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-3-jdk-windowsservercore-1709, 13-ea-3-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-4-jdk-windowsservercore-1709, 13-ea-4-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-3-jdk-windowsservercore-1803, 13-ea-3-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-4-jdk-windowsservercore-1803, 13-ea-4-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-3-jdk-windowsservercore-1809, 13-ea-3-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-3-jdk-windowsservercore, 13-ea-3-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-4-jdk-windowsservercore-1809, 13-ea-4-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-3-jdk-nanoserver-sac2016, 13-ea-3-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-3-jdk-nanoserver, 13-ea-3-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-4-jdk-nanoserver-sac2016, 13-ea-4-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-4-jdk-nanoserver, 13-ea-4-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-27-jdk-oraclelinux7, 12-ea-27-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-27-jdk-oracle, 12-ea-27-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-27-jdk, 12-ea-27, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-28-jdk-oraclelinux7, 12-ea-28-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-28-jdk-oracle, 12-ea-28-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-28-jdk, 12-ea-28, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: c033737a139efaa2422d5e5c7073c4b341932b1a
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -59,44 +59,44 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-27-jdk-windowsservercore-ltsc2016, 12-ea-27-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-28-jdk-windowsservercore-ltsc2016, 12-ea-28-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-27-jdk-windowsservercore-1709, 12-ea-27-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-28-jdk-windowsservercore-1709, 12-ea-28-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-27-jdk-windowsservercore-1803, 12-ea-27-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-28-jdk-windowsservercore-1803, 12-ea-28-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-27-jdk-windowsservercore-1809, 12-ea-27-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
-SharedTags: 12-ea-27-jdk-windowsservercore, 12-ea-27-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-28-jdk-windowsservercore-1809, 12-ea-28-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
+SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-ea-27-jdk-nanoserver-sac2016, 12-ea-27-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-27-jdk-nanoserver, 12-ea-27-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-ea-28-jdk-nanoserver-sac2016, 12-ea-28-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-28-jdk-nanoserver, 12-ea-28-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
-GitCommit: bd732a9833011e418a553f0b603a66d9c4711391
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/oracle
 
 Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
@@ -112,35 +112,35 @@ Directory: 11/jdk/slim
 Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/redmine
+++ b/library/redmine
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.0.0, 4.0, 4, latest
+Tags: 4.0.1, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5875d577cada0d1fb3cb8093f6b15b586b20f65e
+GitCommit: ee79f40abbcafbcaaae3f8679079c68a919fe007
 Directory: 4.0
 
-Tags: 4.0.0-passenger, 4.0-passenger, 4-passenger, passenger
+Tags: 4.0.1-passenger, 4.0-passenger, 4-passenger, passenger
 GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 4.0/passenger
 
-Tags: 3.4.7, 3.4, 3
+Tags: 3.4.8, 3.4, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e9f5fc59b6fa899e07a0c2dfca0d46425e6c088
+GitCommit: a79b21ce022b4e6a050569e12b3d61f9271d30e8
 Directory: 3.4
 
-Tags: 3.4.7-passenger, 3.4-passenger, 3-passenger
+Tags: 3.4.8-passenger, 3.4-passenger, 3-passenger
 GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 3.4/passenger
 


### PR DESCRIPTION
- `bash`: 5.0.2
- `httpd`: 2.4.38
- `mongo`: 4.1.7, 3.6.10
- `mysql`: 8.0.14, 5.7.25, 5.6.43
- `openjdk`: odd new tarball URL for 11.0.2 (https://github.com/docker-library/openjdk/commit/2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885), 13-ea+4, 12-ea+28
- `redmine`: 3.4.8, 4.0.1