### PR TITLE
Updating repository structure

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,23 +1,21 @@
-Maintainers: Alasdair Nottingham <alasdair.nottingham@gmail.com> (@NottyCode)
+Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
+             Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: c9b9e76bdd31ea313b167c8142b334d3b62b1c69
-#GitRepo: https://github.com/naumanna/ci.docker-1.git
-#GitCommit: 90aead0a85e567548323cfb352b9030e7de675dc
-#GitFetch: refs/heads/18.0.0.4
+GitCommit: 7821b9c5f05d6ed9e2e86613383bc622ee028841
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: webProfile8, webProfile8-java8-ibm
-Directory: library/webProfile8/java8/ibmjava
+Directory: official/webProfile8/java8/ibmjava
 
 Tags: webProfile8-java8-ibmsfj
-Directory: library/webProfile8/java8/ibmsfj
+Directory: official/webProfile8/java8/ibmsfj
 Architectures: amd64
 
 Tags: javaee8, javaee8-java8-ibm, latest
-Directory: library/javaee8/java8/ibmjava
+Directory: official/javaee8/java8/ibmjava
 
 Tags: javaee8-java8-ibmsfj
-Directory: library/javaee8/java8/ibmsfj
+Directory: official/javaee8/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile1, microProfile1-java8-ibm
@@ -28,43 +26,43 @@ Directory: library/microProfile1/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile2, microProfile2-java8-ibm
-Directory: library/microProfile2/java8/ibmjava
+Directory: official/microProfile2/java8/ibmjava
 
 Tags: microProfile2-java8-ibmsfj
-Directory: library/microProfile2/java8/ibmsfj
+Directory: official/microProfile2/java8/ibmsfj
 Architectures: amd64
 
 Tags: springBoot2, springBoot2-java8-ibm
-Directory: library/springBoot2/java8/ibmjava
+Directory: official/springBoot2/java8/ibmjava
 
 Tags: springBoot2-java8-ibmsfj
-Directory: library/springBoot2/java8/ibmsfj
+Directory: official/springBoot2/java8/ibmsfj
 Architectures: amd64
 
 Tags: kernel, kernel-java8-ibm
-Directory: library/kernel/java8/ibmjava
+Directory: official/kernel/java8/ibmjava
 
 Tags: kernel-java8-ibmsfj
-Directory: library/kernel/java8/ibmsfj
+Directory: official/kernel/java8/ibmsfj
 Architectures: amd64
 
 Tags: webProfile7, webProfile7-java8-ibm
-Directory: library/webProfile7/java8/ibmjava
+Directory: official/webProfile7/java8/ibmjava
 
 Tags: webProfile7-java8-ibmsfj
-Directory: library/webProfile7/java8/ibmsfj
+Directory: official/webProfile7/java8/ibmsfj
 Architectures: amd64
 
 Tags: javaee7, javaee7-java8-ibm
-Directory: library/javaee7/java8/ibmjava
+Directory: official/javaee7/java8/ibmjava
 
 Tags: javaee7-java8-ibmsfj
-Directory: library/javaee7/java8/ibmsfj
+Directory: official/javaee7/java8/ibmsfj
 Architectures: amd64
 
 Tags: springBoot1, springBoot1-java8-ibm
-Directory: library/springBoot1/java8/ibmjava
+Directory: official/springBoot1/java8/ibmjava
 
 Tags: springBoot1-java8-ibmsfj
-Directory: library/springBoot1/java8/ibmsfj
+Directory: official/springBoot1/java8/ibmsfj
 Architectures: amd64

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -19,10 +19,10 @@ Directory: official/javaee8/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile1, microProfile1-java8-ibm
-Directory: library/microProfile1/java8/ibmjava
+Directory: official/microProfile1/java8/ibmjava
 
 Tags: microProfile1-java8-ibmsfj
-Directory: library/microProfile1/java8/ibmsfj
+Directory: official/microProfile1/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile2, microProfile2-java8-ibm


### PR DESCRIPTION
I have updated the Open Liberty repository structure via https://github.com/OpenLiberty/ci.docker/pull/48

This PR also picks up an update that cleans up the server warmup logs (https://github.com/OpenLiberty/ci.docker/pull/47)

Going forward, Andy and myself will maintain the Open Liberty image, so updated that section too.