### PR TITLE
[security] Update Debian for CVE-2019-3462

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,42 +7,42 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: f17cb6f96d9749d799e1778ef27aeb2283639413
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 223b1234e2bcd3248b7e8feb86b8aedd00e5487f
+amd64-GitCommit: 4b886062242c3cc15836c2a60a5b033c51298ff5
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: f77ebbf5dda5eaa06cc087e2a62fa85960fe275b
+arm32v5-GitCommit: dda7f403bf663a05d390fcc1689fc4a6f6f17333
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 16e6ad26988cc198bc7b8ade4ccefa864dd911d4
+arm32v7-GitCommit: b5eaa3c83a6cdd48d8190b601c01fc6737242aa0
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e49f92d76c6bd2b69cf966f7b60faa0755bfc8b5
+arm64v8-GitCommit: a460294713defbfb5aab700010c69e170a8b916e
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 5f2816666a18c9e072f786116eb5083c89f09fd7
+i386-GitCommit: ac451957d6dfee6e04f66526f204f59ecab78463
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: ef4e1d6db3e80610c362e32ba8e9e3bd5d5c3e01
+ppc64le-GitCommit: b9ac2b44172fabaf89cdd9038422b1dab9c15906
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 1bca36c8125b8dcbd4f240e7f5a8cffe8a42dabd
+s390x-GitCommit: 54c2f99cafe2a9432544183d0aa57dae6d5b7899
 
 # buster -- Debian x.y Testing distribution - Not Released
-Tags: buster, buster-20181226
+Tags: buster, buster-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster
 
-Tags: buster-slim, buster-20181226-slim
+Tags: buster-slim, buster-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster/slim
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20181226
+Tags: experimental, experimental-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: experimental
 
 # jessie -- Debian 8.11 Released 23 June 2018
-Tags: jessie, jessie-20181226, 8.11, 8
+Tags: jessie, jessie-20190122, 8.11, 8
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie
 
@@ -50,12 +50,12 @@ Tags: jessie-backports
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie/backports
 
-Tags: jessie-slim, jessie-20181226-slim, 8.11-slim, 8-slim
+Tags: jessie-slim, jessie-20190122-slim, 8.11-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie/slim
 
 # oldoldstable -- Debian 7.11 Released 04 June 2016
-Tags: oldoldstable, oldoldstable-20181226
+Tags: oldoldstable, oldoldstable-20190122
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable
 
@@ -63,12 +63,12 @@ Tags: oldoldstable-backports
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable/backports
 
-Tags: oldoldstable-slim, oldoldstable-20181226-slim
+Tags: oldoldstable-slim, oldoldstable-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable/slim
 
 # oldstable -- Debian 8.11 Released 23 June 2018
-Tags: oldstable, oldstable-20181226
+Tags: oldstable, oldstable-20190122
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable
 
@@ -76,26 +76,26 @@ Tags: oldstable-backports
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable/backports
 
-Tags: oldstable-slim, oldstable-20181226-slim
+Tags: oldstable-slim, oldstable-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable/slim
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20181226
+Tags: rc-buggy, rc-buggy-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20181226
+Tags: sid, sid-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid
 
-Tags: sid-slim, sid-20181226-slim
+Tags: sid-slim, sid-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid/slim
 
 # stable -- Debian 9.6 Released 10 November 2018
-Tags: stable, stable-20181226
+Tags: stable, stable-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable
 
@@ -103,12 +103,12 @@ Tags: stable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/backports
 
-Tags: stable-slim, stable-20181226-slim
+Tags: stable-slim, stable-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/slim
 
 # stretch -- Debian 9.6 Released 10 November 2018
-Tags: stretch, stretch-20181226, 9.6, 9, latest
+Tags: stretch, stretch-20190122, 9.6, 9, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch
 
@@ -116,30 +116,30 @@ Tags: stretch-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/backports
 
-Tags: stretch-slim, stretch-20181226-slim, 9.6-slim, 9-slim
+Tags: stretch-slim, stretch-20190122-slim, 9.6-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/slim
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20181226
+Tags: testing, testing-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing
 
-Tags: testing-slim, testing-20181226-slim
+Tags: testing-slim, testing-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing/slim
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20181226
+Tags: unstable, unstable-20190122
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable
 
-Tags: unstable-slim, unstable-20181226-slim
+Tags: unstable-slim, unstable-20190122-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable/slim
 
 # wheezy -- Debian 7.11 Released 04 June 2016
-Tags: wheezy, wheezy-20181226, 7.11, 7
+Tags: wheezy, wheezy-20190122, 7.11, 7
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy
 
@@ -147,6 +147,6 @@ Tags: wheezy-backports
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy/backports
 
-Tags: wheezy-slim, wheezy-20181226-slim, 7.11-slim, 7-slim
+Tags: wheezy-slim, wheezy-20190122-slim, 7.11-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy/slim


### PR DESCRIPTION
See https://security-tracker.debian.org/tracker/CVE-2019-3462.

This includes APT 1.4.9 in stretch/stable and APT 1.0.9.8.5 in jessie/oldstable.

As noted on the Debian security tracker, buster/testing and sid/unstable do not yet have a fix.

This also still includes wheezy/oldoldstable, but wheezy is officially EOL and thus does not contain a fix (to my knowledge).