### PR TITLE
[security] Update Ubuntu for CVE-2019-3462

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,44 +6,44 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 5d70c58c86bcbe1db7583d99e6988a7a7d048215
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 185c5e23efaa8c7c857683e6dcf4d886acda3cba
+amd64-GitCommit: b89c640e493edc0fb93cb2facd951f0ad6c4d00c
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: daab7acf93250ed29556df0127ca6ed9021a1688
+arm32v7-GitCommit: 4f423a8884da4a60c8f5892ef9d41bbea73203b3
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0e1c0eae48e7d8fc7492c684c636df8059f36099
+arm64v8-GitCommit: f6e4a8639130c096437cbe78ef9ae233377a8694
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 92373091a1e3940ff0625df67b28462a24a3593f
+i386-GitCommit: 7299dc6e6ed2496ee9d1b4741c4822927bfdabe3
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: c956413edba2dcbe4f82ec71826125e589834676
+ppc64le-GitCommit: 2af11719410720e0c63f81363b1268233508ba36
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: d001059f900bbad48b3cddf52ba8293360667f95
+s390x-GitCommit: b908bd675e1733fbf4d09e6cec1bf31cf1603993
 
-# 20181204 (bionic)
-Tags: 18.04, bionic-20181204, bionic, latest
+# 20190122 (bionic)
+Tags: 18.04, bionic-20190122, bionic, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20181219 (cosmic)
-Tags: 18.10, cosmic-20181219, cosmic, rolling
+# 20190122 (cosmic)
+Tags: 18.10, cosmic-20190122, cosmic, rolling
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: cosmic
 
-# 20181220 (disco)
-Tags: 19.04, disco-20181220, disco, devel
+# 20190118 (disco)
+Tags: 19.04, disco-20190118, disco, devel
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: disco
 
-# 20181217 (trusty)
-Tags: 14.04, trusty-20181217, trusty
+# 20190122 (trusty)
+Tags: 14.04, trusty-20190122, trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: trusty
 
-# 20181218 (xenial)
-Tags: 16.04, xenial-20181218, xenial
+# 20190122 (xenial)
+Tags: 16.04, xenial-20190122, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: xenial


### PR DESCRIPTION
See https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-3462.html.

As noted on the Ubuntu security tracker, disco/19.04 does not have a fix yet.

cc @mwhudson