### PR TITLE
Update Amazon Corretto to 8u202.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -3,6 +3,6 @@ Maintainers: Amazon Corretto Team (@corretto),
              iliana weller (@ilianaw)
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 
-Tags: 8, 8u192, 8-al2-full, latest
+Tags: 8, 8u202, 8-al2-full, latest
 GitFetch: refs/heads/8-al2-full
-GitCommit: ca83f84faf06f5ca115ac922926e37fb183a2126
+GitCommit: 00075d9caa52634b489867a1a8c5a146b1695d0a


### PR DESCRIPTION
This updates the Amazon Corretto image to use the 8u202 PSU patch baseline of OpenJDK.

Here's a quick link to the Dockerfile: [00075d9/Dockerfile](https://github.com/corretto/corretto-8-docker/blob/00075d9caa52634b489867a1a8c5a146b1695d0a/Dockerfile)