### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.11.1, 2.11, 2, latest
+Tags: 2.12.0, 2.12, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d461f871beece4b81395a73fff8544a76297d89
+GitCommit: 7bcba5c2626d5565bbd5d9c2f646788d56bfeff5
 Directory: 2/debian
 
-Tags: 2.11.1-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.12.0-alpine, 2.12-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d461f871beece4b81395a73fff8544a76297d89
+GitCommit: 7bcba5c2626d5565bbd5d9c2f646788d56bfeff5
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/julia
+++ b/library/julia
@@ -1,57 +1,59 @@
-# this file is generated via https://github.com/docker-library/julia/blob/19c41722f3d366865377bd2679b026a0ab1192cb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/5d127e73c6cdba4787e74968c4d3234b70b00b5f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.0.3-stretch, 1.0-stretch, 1-stretch, stretch
-SharedTags: 1.0.3, 1.0, 1, latest
+Tags: 1.1.0-stretch, 1.1-stretch, 1-stretch, stretch
+SharedTags: 1.1.0, 1.1, 1, latest
+Architectures: amd64, i386
+GitCommit: cccb8b5148d509a74cb12b64de44ad7b20328f23
+Directory: 1.1/stretch
+
+Tags: 1.1.0-windowsservercore-ltsc2016, 1.1-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.1.0, 1.1, 1, latest
+Architectures: windows-amd64
+GitCommit: cccb8b5148d509a74cb12b64de44ad7b20328f23
+Directory: 1.1/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 1.1.0-windowsservercore-1709, 1.1-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.1.0, 1.1, 1, latest
+Architectures: windows-amd64
+GitCommit: cccb8b5148d509a74cb12b64de44ad7b20328f23
+Directory: 1.1/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.1.0-windowsservercore-1803, 1.1-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.1.0, 1.1, 1, latest
+Architectures: windows-amd64
+GitCommit: cccb8b5148d509a74cb12b64de44ad7b20328f23
+Directory: 1.1/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 1.0.3-stretch, 1.0-stretch
+SharedTags: 1.0.3, 1.0
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/stretch
 
-Tags: 1.0.3-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.0.3, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-ltsc2016, 1.0-windowsservercore-ltsc2016
+SharedTags: 1.0.3, 1.0
 Architectures: windows-amd64
 GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.0.3-windowsservercore-1709, 1.0-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.0.3, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-1709, 1.0-windowsservercore-1709
+SharedTags: 1.0.3, 1.0
 Architectures: windows-amd64
 GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.0.3-windowsservercore-1803, 1.0-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.0.3, 1.0, 1, latest
+Tags: 1.0.3-windowsservercore-1803, 1.0-windowsservercore-1803
+SharedTags: 1.0.3, 1.0
 Architectures: windows-amd64
 GitCommit: 60c9e91e86668dfd86f19034ebee211dfe3dd423
 Directory: 1.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
-
-Tags: 0.7.0-stretch, 0.7-stretch, 0-stretch
-SharedTags: 0.7.0, 0.7, 0
-Architectures: amd64, i386
-GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
-Directory: 0/stretch
-
-Tags: 0.7.0-jessie, 0.7-jessie, 0-jessie
-Architectures: amd64, i386
-GitCommit: 467c652ab40064be58ba83ed4448f139592c7525
-Directory: 0/jessie
-
-Tags: 0.7.0-windowsservercore-ltsc2016, 0.7-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016
-SharedTags: 0.7.0, 0.7, 0
-Architectures: windows-amd64
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
-Directory: 0/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 0.7.0-windowsservercore-1709, 0.7-windowsservercore-1709, 0-windowsservercore-1709
-SharedTags: 0.7.0, 0.7, 0
-Architectures: windows-amd64
-GitCommit: 9e8bb3426385de28cfac6576baef9bf580fe0e33
-Directory: 0/windows/windowsservercore-1709
-Constraints: windowsservercore-1709

--- a/library/mongo
+++ b/library/mongo
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.4.18-jessie, 3.4-jessie
-SharedTags: 3.4.18, 3.4
+Tags: 3.4.19-jessie, 3.4-jessie
+SharedTags: 3.4.19, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: cac8a53d000f9e9f537438b976b719ad1b5bad3c
+GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
 Directory: 3.4
 
-Tags: 3.4.18-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
-SharedTags: 3.4.18-windowsservercore, 3.4-windowsservercore, 3.4.18, 3.4
+Tags: 3.4.19-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: 3.4.19-windowsservercore, 3.4-windowsservercore, 3.4.19, 3.4
 Architectures: windows-amd64
-GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
+GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.18-windowsservercore-1709, 3.4-windowsservercore-1709
-SharedTags: 3.4.18-windowsservercore, 3.4-windowsservercore, 3.4.18, 3.4
+Tags: 3.4.19-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: 3.4.19-windowsservercore, 3.4-windowsservercore, 3.4.19, 3.4
 Architectures: windows-amd64
-GitCommit: df76a27fa96398f234a2287d327687e37d3c8d98
+GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,12 +1,13 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/4964d6a8511d4797c56c3e0754937f2e9647b801/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/dc54a4e3928e9ba558074af63efd216c01ef1a92/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-4-jdk-oraclelinux7, 13-ea-4-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-4-jdk-oracle, 13-ea-4-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle, 13-ea-4-jdk, 13-ea-4, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-5-jdk-oraclelinux7, 13-ea-5-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-5-jdk-oracle, 13-ea-5-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-1-jdk-alpine3.8, 13-ea-1-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-1-jdk-alpine, 13-ea-1-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -14,44 +15,45 @@ Architectures: amd64
 GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-4-jdk-windowsservercore-ltsc2016, 13-ea-4-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-5-jdk-windowsservercore-ltsc2016, 13-ea-5-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-4-jdk-windowsservercore-1709, 13-ea-4-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-5-jdk-windowsservercore-1709, 13-ea-5-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-4-jdk-windowsservercore-1803, 13-ea-4-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-5-jdk-windowsservercore-1803, 13-ea-5-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-4-jdk-windowsservercore-1809, 13-ea-4-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-4-jdk-windowsservercore, 13-ea-4-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore
+Tags: 13-ea-5-jdk-windowsservercore-1809, 13-ea-5-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-4-jdk-nanoserver-sac2016, 13-ea-4-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-4-jdk-nanoserver, 13-ea-4-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-5-jdk-nanoserver-sac2016, 13-ea-5-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-5-jdk-nanoserver, 13-ea-5-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 765ef28d1bb2c8d1aef7d072dadea5db41d8ced3
+GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-28-jdk-oraclelinux7, 12-ea-28-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-28-jdk-oracle, 12-ea-28-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle, 12-ea-28-jdk, 12-ea-28, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-29-jdk-oraclelinux7, 12-ea-29-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-29-jdk-oracle, 12-ea-29-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+SharedTags: 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/oracle
 
 Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
@@ -59,38 +61,38 @@ Architectures: amd64
 GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-28-jdk-windowsservercore-ltsc2016, 12-ea-28-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-29-jdk-windowsservercore-ltsc2016, 12-ea-29-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-28-jdk-windowsservercore-1709, 12-ea-28-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-29-jdk-windowsservercore-1709, 12-ea-29-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-28-jdk-windowsservercore-1803, 12-ea-28-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-29-jdk-windowsservercore-1803, 12-ea-29-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-28-jdk-windowsservercore-1809, 12-ea-28-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
-SharedTags: 12-ea-28-jdk-windowsservercore, 12-ea-28-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore
+Tags: 12-ea-29-jdk-windowsservercore-1809, 12-ea-29-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
+SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-ea-28-jdk-nanoserver-sac2016, 12-ea-28-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-28-jdk-nanoserver, 12-ea-28-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-ea-29-jdk-nanoserver-sac2016, 12-ea-29-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-29-jdk-nanoserver, 12-ea-29-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: d283315254bbaadabfe76ef0ebfda770debabfdb
+GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -99,7 +101,8 @@ Architectures: amd64
 GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/oracle
 
-Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch, 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
+Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch
+SharedTags: 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jdk
@@ -144,7 +147,8 @@ GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch, 11.0.1-jre, 11.0-jre, 11-jre, jre
+Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch
+SharedTags: 11.0.1-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jre
@@ -154,7 +158,8 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
 Directory: 11/jre/slim
 
-Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch, 8u181-jdk, 8u181, 8-jdk, 8
+Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch
+SharedTags: 8u181-jdk, 8u181, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk
@@ -169,42 +174,43 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jdk/alpine
 
-Tags: 8u191-jdk-windowsservercore-ltsc2016, 8u191-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Tags: 8u201-jdk-windowsservercore-ltsc2016, 8u201-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u191-jdk-windowsservercore-1709, 8u191-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
-SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Tags: 8u201-jdk-windowsservercore-1709, 8u201-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
+SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 8u191-jdk-windowsservercore-1803, 8u191-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
-SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Tags: 8u201-jdk-windowsservercore-1803, 8u201-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u191-jdk-windowsservercore-1809, 8u191-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u191-jdk-windowsservercore, 8u191-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+Tags: 8u201-jdk-windowsservercore-1809, 8u201-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u191-jdk-nanoserver-sac2016, 8u191-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
-SharedTags: 8u191-jdk-nanoserver, 8u191-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u201-jdk-nanoserver-sac2016, 8u201-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
+SharedTags: 8u201-jdk-nanoserver, 8u201-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: a2a90dd274e1a56937699d2d8f81ebaf4e3173dc
+GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u181-jre-stretch, 8-jre-stretch, 8u181-jre, 8-jre
+Tags: 8u181-jre-stretch, 8-jre-stretch
+SharedTags: 8u181-jre, 8-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre
@@ -219,7 +225,8 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
 Directory: 8/jre/alpine
 
-Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie, 7u181-jdk, 7u181, 7-jdk, 7
+Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie
+SharedTags: 7u181-jdk, 7u181, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk
@@ -234,7 +241,8 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
 Directory: 7/jdk/alpine
 
-Tags: 7u181-jre-jessie, 7-jre-jessie, 7u181-jre, 7-jre
+Tags: 7u181-jre-jessie, 7-jre-jessie
+SharedTags: 7u181-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre

--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: 9b24a15e48d364779806a2ceb8adf300969d4fff
+GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: 9b24a15e48d364779806a2ceb8adf300969d4fff
+GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
+GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
 Directory: 3
 
 Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim, 3-6.0.0-slim-jessie, 3-6.0-slim-jessie, 3-6-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: e63e6ad8c3a28f5ff6c3019a493093da15248d20
+GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -7,206 +7,206 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.2-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.2, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/stretch
 
 Tags: 3.7.2-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.2-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.2-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/alpine3.7
 
 Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.2-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: ab8b829cfefdb460ebc17e570332f0479039e918
+GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.8-stretch, 3.6-stretch
 SharedTags: 3.6.8, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/stretch
 
 Tags: 3.6.8-slim-stretch, 3.6-slim-stretch, 3.6.8-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.8-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/jessie
 
 Tags: 3.6.8-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.8-alpine3.8, 3.6-alpine3.8, 3.6.8-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.8-alpine3.7, 3.6-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/alpine3.7
 
 Tags: 3.6.8-alpine3.6, 3.6-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/alpine3.6
 
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 721671c28aad96ad2c1970e83c2af71ceff15f1b
+GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/stretch
 
 Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/jessie
 
 Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/alpine3.8
 
 Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/alpine3.7
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/stretch
 
 Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/jessie
 
 Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/alpine3.8
 
 Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/alpine3.7
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 39c500cc8aefcb67a76d518d789441ef85fc771f
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/alpine3.7
 
 Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: abcc6175b7a36558f3f805b318a8dd68ce1d18ce
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: ac49e0bb09aafe4100fe5662636c24fce7206008
+GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 4.0.1, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ee79f40abbcafbcaaae3f8679079c68a919fe007
+GitCommit: 541a213ae394f0d097ca322c316f779767b77982
 Directory: 4.0
 
 Tags: 4.0.1-passenger, 4.0-passenger, 4-passenger, passenger


### PR DESCRIPTION
- `ghost`: 2.12.0
- `julia`: 1.1 (deprecated 0.7)
- `mongo`: 3.4.19
- `openjdk`: 13-ea+5, 12-ea+29, windows ojdkbuild 1.8.0.201-1, use `SharedTags:` for 12+ (docker-library/openjdk#273)
- `pypy`: pip 19.0.1
- `python`: pip 19.0.1
- `redmine`: Ruby 2.6 (docker-library/redmine#152)