### PR TITLE
Security upgrade to Matomo 3.8.0

### DIFF
--- a/library/matomo
+++ b/library/matomo
@@ -2,17 +2,17 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.8.0-apache, 3.8-apache, 3-apache, apache, 3.8.0, 3.8, 3, latest
+Tags: 3.8.1-apache, 3.8-apache, 3-apache, apache, 3.8.1, 3.8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
+GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
 Directory: apache
 
-Tags: 3.8.0-fpm, 3.8-fpm, 3-fpm, fpm
+Tags: 3.8.1-fpm, 3.8-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
+GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
 Directory: fpm
 
-Tags: 3.8.0-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.8.1-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
+GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
 Directory: fpm-alpine

--- a/library/matomo
+++ b/library/matomo
@@ -2,17 +2,17 @@
 Maintainers: Pierre Ozoux <pierre@piwik.org> (@pierreozoux)
 GitRepo: https://github.com/matomo-org/docker.git
 
-Tags: 3.7.0-apache, 3.7-apache, 3-apache, apache, 3.7.0, 3.7, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
+Tags: 3.8.0-apache, 3.8-apache, 3-apache, apache, 3.8.0, 3.8, 3, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
 Directory: apache
 
-Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
+Tags: 3.8.0-fpm, 3.8-fpm, 3-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
 Directory: fpm
 
-Tags: 3.7.0-fpm-alpine, 3.7-fpm-alpine, 3-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b2fed55bdead8254694c8e63f7b1eb5e89c022e
+Tags: 3.8.0-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 9a8a264487faab73e332e1ea9d950155c5799693
 Directory: fpm-alpine


### PR DESCRIPTION
This was not included in #5344, so I'm pushing this here.
https://matomo.org/changelog/matomo-3-8-0/