### PR TITLE
Updated GN version to 3.6.0

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,13 +1,13 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/4e77623ad6a2cfb94c3c57e3558815e44936adae/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/40ed4dce1cba141b69baffd2eac833e7f59d12aa/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: 3.4.4, 3.4, latest
-GitCommit: 2d357e39f107bf2527b9b4b396084a759c245b72
-Directory: 3.4.4
+Tags: 3.6.0, 3.6, latest
+GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
+Directory: 3.6.0
 
-Tags: 3.4.4-postgres, 3.4-postgres, postgres
-GitCommit: 4e77623ad6a2cfb94c3c57e3558815e44936adae
-Directory: 3.4.4/postgres
+Tags: 3.6.0-postgres, 3.6-postgres, postgres
+GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
+Directory: 3.6.0/postgres


### PR DESCRIPTION
Updated official GN version to its latest release (3.6.0), to catch up with the [latest changes on the image code](https://github.com/geonetwork/docker-geonetwork).

