### PR TITLE
Upgrade CrateDB to 3.2.2

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -5,7 +5,11 @@ Maintainers: Christian Bader <christian.bader@crate.io> (@christianbader),
              Mika Naylor <mika@crate.io> (@autophagy)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 3.1.5, 3.1, latest
+Tags: 3.2.2, 3.2, latest
+Architectures: amd64, arm64v8
+GitCommit: 8fcf838b360080011282c8b27c2d97b5edc15855
+
+Tags: 3.1.5, 3.1
 Architectures: amd64, arm64v8
 GitCommit: 07eeb2c9e0a1ea18eb147bdd324a6f2993933e64
 


### PR DESCRIPTION
The switch from alpine to centos involved in this upgrade was prompted by the lack of official JDK 11 support in Alpine, which we are upgrading to - we felt like moving to centos (similar to Elasticsearch) was the appropriate step to take here.

We've done this in the jump from 3.1 to 3.2, so that this upgrade does not happen between hotfix versions.