### PR TITLE
Update RabbitMQ to 3.7.10 and 3.7.11-rc.2

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/736a3b3e4da08555f07d9dd9c21ddf8f16a4b97f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/5bfde9806e24cfd84437197d5d171caef2adcae3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.8, 3.7, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
-Directory: 3.7/debian
+Tags: 3.7.11-rc.2, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8a623bb9420b8bfb1cbad2467abb48db26e7ddbc
+Directory: 3.7-rc/ubuntu
 
-Tags: 3.7.8-management, 3.7-management, 3-management, management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
-Directory: 3.7/debian/management
+Tags: 3.7.11-rc.2-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
 
-Tags: 3.7.8-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.11-rc.2-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
+GitCommit: 8a623bb9420b8bfb1cbad2467abb48db26e7ddbc
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.11-rc.2-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
+Tags: 3.7.10, 3.7, 3, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a51c5ad7333baae15f609e9fcbac1400d02b96a6
+Directory: 3.7/ubuntu
+
+Tags: 3.7.10-management, 3.7-management, 3-management, management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7/ubuntu/management
+
+Tags: 3.7.10-alpine, 3.7-alpine, 3-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: a51c5ad7333baae15f609e9fcbac1400d02b96a6
 Directory: 3.7/alpine
 
-Tags: 3.7.8-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.10-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management
-
-Tags: 3.6.16, 3.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
-Directory: 3.6/debian
-
-Tags: 3.6.16-management, 3.6-management
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
-Directory: 3.6/debian/management
-
-Tags: 3.6.16-alpine, 3.6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a8fd1c6ee027baafb7144c24ad3c995ba5e0d24
-Directory: 3.6/alpine
-
-Tags: 3.6.16-management-alpine, 3.6-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b9eda3e4665c24db70a9a290fddf33bc5c567b10
-Directory: 3.6/alpine/management


### PR DESCRIPTION
See https://github.com/docker-library/rabbitmq/pull/297 :+1: :tada:

cc @gerhard @michaelklishin (this is the second half of the image update which gets it to https://hub.docker.com/_/rabbitmq -- see https://github.com/docker-library/official-images for more details on the process/program/flow)