### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.12.0, 2.12, 2, latest
+Tags: 2.13.1, 2.13, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7bcba5c2626d5565bbd5d9c2f646788d56bfeff5
+GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
 Directory: 2/debian
 
-Tags: 2.12.0-alpine, 2.12-alpine, 2-alpine, alpine
+Tags: 2.13.1-alpine, 2.13-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7bcba5c2626d5565bbd5d9c2f646788d56bfeff5
+GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 350b3e6b5edbb719756a155aa5cf0bfce45a9641
+GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
 Directory: 1/debian
 
 Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 316073c647646f5c65b42cafd37367cc6fc5ee02
+GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
 Directory: 1/alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.2, 1.9, 1, latest
+Tags: 1.9.3, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0e721acc4e96764801493bc979f7cf53af608fa
+GitCommit: d075532302bb77a73697bb08f367dee1e8f7bde8
 Directory: 1.9
 
-Tags: 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.3-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e0e721acc4e96764801493bc979f7cf53af608fa
+GitCommit: d075532302bb77a73697bb08f367dee1e8f7bde8
 Directory: 1.9/alpine
 
 Tags: 1.8.17, 1.8

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.4.1-bionic, 10.4-bionic, 10.4.1, 10.4
+Tags: 10.4.2-bionic, 10.4-bionic, 10.4.2, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7a76abcb45a945614d803d29138680976ff1305c
+GitCommit: 4fd10c511f4fdf39f9e57ba72e1612084ea2b717
 Directory: 10.4
 
 Tags: 10.3.12-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.12, 10.3, 10, latest

--- a/library/openjdk
+++ b/library/openjdk
@@ -10,9 +10,9 @@ Architectures: amd64
 GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-1-jdk-alpine3.8, 13-ea-1-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-1-jdk-alpine, 13-ea-1-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-5-jdk-alpine3.8, 13-ea-5-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-5-jdk-alpine, 13-ea-5-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: db97c023c9f036d5e4df5fd9d1e5d21bdbabccce
+GitCommit: ac57930ee4cb62a9106dff2244e0b38220a5164b
 Directory: 13/jdk/alpine
 
 Tags: 13-ea-5-jdk-windowsservercore-ltsc2016, 13-ea-5-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
@@ -56,9 +56,9 @@ Architectures: amd64
 GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-25-jdk-alpine3.8, 12-ea-25-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-25-jdk-alpine, 12-ea-25-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-29-jdk-alpine3.8, 12-ea-29-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-29-jdk-alpine, 12-ea-29-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 25c0a52bf0c70eafc6341bdb621580f4f282e1a1
+GitCommit: 89c5b6e626b9b8e27c1d4fd021ff8fd2a786ac26
 Directory: 12/jdk/alpine
 
 Tags: 12-ea-29-jdk-windowsservercore-ltsc2016, 12-ea-29-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016

--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.1, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: 42f9ab3bab65fdbabbf35130c68a9869b6e82ee7
 Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine


### PR DESCRIPTION
- `ghost`: 2.13.1
- `haproxy`: 1.9.3
- `mariadb`: 10.4.2
- `openjdk`: 13-ea+5, 12-ea+29
- `postgres`: debian `11.1-3.pgdg90+1`