### PR TITLE
Update websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 1f420974a387fddfe980659f8536473b398143c9
+GitCommit: 9b344d1c76f43bf4e41f4386c924f9c210a1ebbd
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
- We have added new configuration XML snippets which are available for customers when they're building their derived image, such as to add support for Hazelcast
- Small fix in the kernel (for user's 1001 home)