### PR TITLE
add enterprise releases from 1.2.0-ent to 1.4.2-ent

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -5,3 +5,63 @@ Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 9bd2aa7ecf2414b8712e055f2374699148e8941c
 Directory: 0.X
+
+Tags: 1.2.0-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: ecefe0ba6acff8554147e65f312a29417e3b1573
+Directory: 0.X
+
+Tags: 1.2.1-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: bfb697071b6c69b00806d356aa6a95012b48a2b7
+Directory: 0.X
+
+Tags: 1.2.2-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 314b52444c8fdee0ebf7b8eb68eafb31a2663612
+Directory: 0.X
+
+Tags: 1.2.3-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: e0856c5de903799a2e1000bd7d7d29d372375f5f
+Directory: 0.X
+
+Tags: 1.2.4-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: efb7018ca2495b51a5232b515aff63c0712a7752
+Directory: 0.X
+
+Tags: 1.3.0-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 403452f60a2be5504ffeea85cba81db14c48d173
+Directory: 0.X
+
+Tags: 1.3.1-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 9898da06ec8e902cc147c04b0269378b7b39f4ff
+Directory: 0.X
+
+Tags: 1.4.0-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 3f66537b25421d181a20994ae4062241e75d3f97
+Directory: 0.X
+
+Tags: 1.4.1-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 31ddd0cbe701ba55625ac5f70461fb528030f710
+Directory: 0.X
+
+Tags: 1.4.2-ent
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 4372eef3cc7ac357d5742f9e179ba30b5edf7896
+Directory: 0.X


### PR DESCRIPTION
We are releasing Consul enterprise binaries and would like to package them as Docker containers for enterprise users. For the majority of users, they should be using the OSS release and therefore after these containers are built, we will be removing them from this list and remove them from the `Supported` list for clarity. 