### PR TITLE
Update docker image for Ruby 2.6.1 release

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,105 +1,105 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/d4be0c416c61f1de327badb94e629aa993c2e2b4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/6301325faf42a96b1fd1be5650e451cae31e0728/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.0-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.0, 2.6, 2, latest
+Tags: 2.6.1-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.1, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.6/stretch
 
-Tags: 2.6.0-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.0-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.0-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8, 2.6.0-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.6/alpine3.8
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.6/alpine3.9
 
-Tags: 2.6.0-alpine3.7, 2.6-alpine3.7, 2-alpine3.7, alpine3.7
+Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.6/alpine3.7
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.6/alpine3.8
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.3-alpine3.8, 2.5-alpine3.8, 2.5.3-alpine, 2.5-alpine
+Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.5/alpine3.8
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.5/alpine3.9
 
-Tags: 2.5.3-alpine3.7, 2.5-alpine3.7
+Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.5/alpine3.7
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.5-alpine3.8, 2.4-alpine3.8, 2.4.5-alpine, 2.4-alpine
+Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.4/alpine3.8
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.4/alpine3.9
 
-Tags: 2.4.5-alpine3.7, 2.4-alpine3.7
+Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
-Directory: 2.4/alpine3.7
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
Hi,

thought I could lend a hand here and provide a PR for the [recently updated ruby image](https://github.com/docker-library/ruby/commit/3e2c9f3f3c34820dd38212f68c1d5f0300264711).
What I did:

```
docker run \
    --rm -it \
    -w /ruby \
    --volume $PWD/ruby:/ruby \
    buildpack-deps \
    bash -c "
       curl -s https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-amd64 > /usr/local/bin/bashbrew;
       chmod +x /usr/local/bin/bashbrew;
       ./generate-stackbrew-library.sh
    " > official-images/library/ruby
```

Found in #5234.

Hope that's the right way to do it :)

Best, Klaus