### PR TITLE
Add WebSphere Liberty 19.0.0.1 images

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,37 +2,64 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 9b344d1c76f43bf4e41f4386c924f9c210a1ebbd
+GitCommit: 0d54e20ffde7faf94353bcd3127364f95ef22e32
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
 Directory: beta
 
-Tags: 18.0.0.4-javaee8, javaee8, latest
+Tags: 19.0.0.1-javaee8, javaee8, latest
+Directory: ga/19.0.0.1/javaee8
+
+Tags: 19.0.0.1-webProfile8, webProfile8
+Directory: ga/19.0.0.1/webProfile8
+
+Tags: 19.0.0.1-microProfile1, microProfile1
+Directory: ga/19.0.0.1/microProfile1
+
+Tags: 19.0.0.1-microProfile2, microProfile2
+Directory: ga/19.0.0.1/microProfile2
+
+Tags: 19.0.0.1-springBoot2, springBoot2
+Directory: ga/19.0.0.1/springBoot2
+
+Tags: 19.0.0.1-kernel, kernel
+Directory: ga/19.0.0.1/kernel
+
+Tags: 19.0.0.1-springBoot1, springBoot1
+Directory: ga/19.0.0.1/springBoot1
+
+Tags: 19.0.0.1-webProfile7, webProfile7
+Directory: ga/19.0.0.1/webProfile7
+
+Tags: 19.0.0.1-javaee7, javaee7
+Directory: ga/19.0.0.1/javaee7
+
+Tags: 18.0.0.4-javaee8
 Directory: ga/18.0.0.4/javaee8
 
-Tags: 18.0.0.4-webProfile8, webProfile8
+Tags: 18.0.0.4-webProfile8
 Directory: ga/18.0.0.4/webProfile8
 
-Tags: 18.0.0.4-microProfile1, microProfile1
+Tags: 18.0.0.4-microProfile1
 Directory: ga/18.0.0.4/microProfile1
 
-Tags: 18.0.0.4-microProfile2, microProfile2
+Tags: 18.0.0.4-microProfile2
 Directory: ga/18.0.0.4/microProfile2
 
-Tags: 18.0.0.4-springBoot2, springBoot2
+Tags: 18.0.0.4-springBoot2
 Directory: ga/18.0.0.4/springBoot2
 
-Tags: 18.0.0.4-kernel, kernel
+Tags: 18.0.0.4-kernel
 Directory: ga/18.0.0.4/kernel
 
-Tags: 18.0.0.4-springBoot1, springBoot1
+Tags: 18.0.0.4-springBoot1
 Directory: ga/18.0.0.4/springBoot1
 
-Tags: 18.0.0.4-webProfile7, webProfile7
+Tags: 18.0.0.4-webProfile7
 Directory: ga/18.0.0.4/webProfile7
 
-Tags: 18.0.0.4-javaee7, javaee7
+Tags: 18.0.0.4-javaee7
 Directory: ga/18.0.0.4/javaee7
 
 Tags: 18.0.0.3-javaee8


### PR DESCRIPTION
Add WebSphere Liberty 19.0.0.1 images.

We are keeping the 18.0.0.4 and 18.0.0.3 images to keep them current with base changes to give customers time to move up, but from now on we will eliminate the oldest version when adding a new one because we only want to keep N-2 versions.