### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/f80db24bd9f5640ba31e24501f4d7a9e60160978/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/c58a1077faf66bd47ea9c0f3680b252572f26bb3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -11,7 +11,12 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
 Directory: 1.12-rc/stretch
 
-Tags: 1.12beta2-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8, 1.12beta2-alpine, 1.12-rc-alpine, rc-alpine
+Tags: 1.12beta2-alpine3.9, 1.12-rc-alpine3.9, rc-alpine3.9, 1.12beta2-alpine, 1.12-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
+Directory: 1.12-rc/alpine3.9
+
+Tags: 1.12beta2-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
 Directory: 1.12-rc/alpine3.8
@@ -57,15 +62,15 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/stretch
 
-Tags: 1.11.5-alpine3.8, 1.11-alpine3.8, 1-alpine3.8, alpine3.8, 1.11.5-alpine, 1.11-alpine, 1-alpine, alpine
+Tags: 1.11.5-alpine3.9, 1.11-alpine3.9, 1-alpine3.9, alpine3.9, 1.11.5-alpine, 1.11-alpine, 1-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
+Directory: 1.11/alpine3.9
+
+Tags: 1.11.5-alpine3.8, 1.11-alpine3.8, 1-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/alpine3.8
-
-Tags: 1.11.5-alpine3.7, 1.11-alpine3.7, 1-alpine3.7, alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.11/alpine3.7
 
 Tags: 1.11.5-windowsservercore-ltsc2016, 1.11-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.5, 1.11, 1, latest
@@ -108,15 +113,15 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.10/stretch
 
-Tags: 1.10.8-alpine3.8, 1.10-alpine3.8, 1.10.8-alpine, 1.10-alpine
+Tags: 1.10.8-alpine3.9, 1.10-alpine3.9, 1.10.8-alpine, 1.10-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
+Directory: 1.10/alpine3.9
+
+Tags: 1.10.8-alpine3.8, 1.10-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.10/alpine3.8
-
-Tags: 1.10.8-alpine3.7, 1.10-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/alpine3.7
 
 Tags: 1.10.8-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016
 SharedTags: 1.10.8-windowsservercore, 1.10-windowsservercore, 1.10.8, 1.10

--- a/library/haproxy
+++ b/library/haproxy
@@ -11,7 +11,7 @@ Directory: 1.9
 
 Tags: 1.9.3-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d075532302bb77a73697bb08f367dee1e8f7bde8
+GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
 Directory: 1.9/alpine
 
 Tags: 1.8.17, 1.8
@@ -21,7 +21,7 @@ Directory: 1.8
 
 Tags: 1.8.17-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: aac7efb4d62177a1d60edc4b1b4e20cb2c833dec
+GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7
@@ -31,7 +31,7 @@ Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
 Directory: 1.7/alpine
 
 Tags: 1.6.14, 1.6

--- a/library/httpd
+++ b/library/httpd
@@ -11,5 +11,5 @@ Directory: 2.4
 
 Tags: 2.4.38-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a6a1d99f1d6e754ecfcdd7a13e12980b86d7b75
+GitCommit: 90fef23add315b93438c2ef5a089fd58bf00153e
 Directory: 2.4/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -24,12 +24,12 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
 Directory: 10.1
 
-Tags: 10.0.37-xenial, 10.0-xenial, 10.0.37, 10.0
+Tags: 10.0.38-xenial, 10.0-xenial, 10.0.38, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
+GitCommit: 8901e548307c933a3d661ac608d1151c8ad04180
 Directory: 10.0
 
-Tags: 5.5.62-trusty, 5.5-trusty, 5-trusty, 5.5.62, 5.5, 5
+Tags: 5.5.63-trusty, 5.5-trusty, 5-trusty, 5.5.63, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
+GitCommit: 59fb80752413b40c2b3831a28cc6ae376a2b0b6e
 Directory: 5.5

--- a/library/memcached
+++ b/library/memcached
@@ -11,5 +11,5 @@ Directory: debian
 
 Tags: 1.5.12-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c7bc33a596845a439051bbe32357b4b0e6e9dddc
+GitCommit: 24ecf1cbeb76244031036eed161bb8bd00c99085
 Directory: alpine

--- a/library/mysql
+++ b/library/mysql
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.14, 8.0, 8, latest
-GitCommit: 401385db80c61290d25c0a6c1c86bbf9d6552f4d
+Tags: 8.0.15, 8.0, 8, latest
+GitCommit: a7a737f1eb44db467c85c8229df9d886dd63460e
 Directory: 8.0
 
 Tags: 5.7.25, 5.7, 5

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,104 +1,104 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/dc54a4e3928e9ba558074af63efd216c01ef1a92/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/37dbf0917c384321c6c0faa5db00586c4448325f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-5-jdk-oraclelinux7, 13-ea-5-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-5-jdk-oracle, 13-ea-5-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-6-jdk-oraclelinux7, 13-ea-6-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-6-jdk-oracle, 13-ea-6-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-5-jdk-alpine3.8, 13-ea-5-alpine3.8, 13-ea-jdk-alpine3.8, 13-ea-alpine3.8, 13-jdk-alpine3.8, 13-alpine3.8, 13-ea-5-jdk-alpine, 13-ea-5-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-5-jdk-alpine3.9, 13-ea-5-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-5-jdk-alpine, 13-ea-5-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: ac57930ee4cb62a9106dff2244e0b38220a5164b
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-5-jdk-windowsservercore-ltsc2016, 13-ea-5-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-6-jdk-windowsservercore-ltsc2016, 13-ea-6-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-5-jdk-windowsservercore-1709, 13-ea-5-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-6-jdk-windowsservercore-1709, 13-ea-6-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-5-jdk-windowsservercore-1803, 13-ea-5-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-6-jdk-windowsservercore-1803, 13-ea-6-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-5-jdk-windowsservercore-1809, 13-ea-5-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-5-jdk-windowsservercore, 13-ea-5-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-5-jdk, 13-ea-5, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-6-jdk-windowsservercore-1809, 13-ea-6-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-5-jdk-nanoserver-sac2016, 13-ea-5-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-5-jdk-nanoserver, 13-ea-5-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-6-jdk-nanoserver-sac2016, 13-ea-6-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-6-jdk-nanoserver, 13-ea-6-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 922344e3283ef2c87cb17cc04ded9cef5e13a1e5
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-29-jdk-oraclelinux7, 12-ea-29-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-29-jdk-oracle, 12-ea-29-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
-SharedTags: 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-30-jdk-oraclelinux7, 12-ea-30-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-30-jdk-oracle, 12-ea-30-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
+SharedTags: 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-29-jdk-alpine3.8, 12-ea-29-alpine3.8, 12-ea-jdk-alpine3.8, 12-ea-alpine3.8, 12-jdk-alpine3.8, 12-alpine3.8, 12-ea-29-jdk-alpine, 12-ea-29-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
+Tags: 12-ea-29-jdk-alpine3.9, 12-ea-29-alpine3.9, 12-ea-jdk-alpine3.9, 12-ea-alpine3.9, 12-jdk-alpine3.9, 12-alpine3.9, 12-ea-29-jdk-alpine, 12-ea-29-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
 Architectures: amd64
-GitCommit: 89c5b6e626b9b8e27c1d4fd021ff8fd2a786ac26
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 12/jdk/alpine
 
-Tags: 12-ea-29-jdk-windowsservercore-ltsc2016, 12-ea-29-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-30-jdk-windowsservercore-ltsc2016, 12-ea-30-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-29-jdk-windowsservercore-1709, 12-ea-29-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-30-jdk-windowsservercore-1709, 12-ea-30-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-29-jdk-windowsservercore-1803, 12-ea-29-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-30-jdk-windowsservercore-1803, 12-ea-30-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-29-jdk-windowsservercore-1809, 12-ea-29-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
-SharedTags: 12-ea-29-jdk-windowsservercore, 12-ea-29-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-29-jdk, 12-ea-29, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-ea-30-jdk-windowsservercore-1809, 12-ea-30-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
+SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-ea-29-jdk-nanoserver-sac2016, 12-ea-29-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-29-jdk-nanoserver, 12-ea-29-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-ea-30-jdk-nanoserver-sac2016, 12-ea-30-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-ea-30-jdk-nanoserver, 12-ea-30-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: 67b5d6546da46331b5414c84408b4bacdf14b673
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
 Architectures: amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/oracle
 
 Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch
@@ -115,35 +115,35 @@ Directory: 11/jdk/slim
 Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
 SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 2ac692bcec79f6ffe1c26b3bfc79eb9b1beae885
+GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -169,9 +169,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk/slim
 
-Tags: 8u191-jdk-alpine3.8, 8u191-alpine3.8, 8-jdk-alpine3.8, 8-alpine3.8, 8u191-jdk-alpine, 8u191-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u191-jdk-alpine3.9, 8u191-alpine3.9, 8-jdk-alpine3.9, 8-alpine3.9, 8u191-jdk-alpine, 8u191-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 8/jdk/alpine
 
 Tags: 8u201-jdk-windowsservercore-ltsc2016, 8u201-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
@@ -220,9 +220,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre/slim
 
-Tags: 8u191-jre-alpine3.8, 8-jre-alpine3.8, 8u191-jre-alpine, 8-jre-alpine
+Tags: 8u191-jre-alpine3.9, 8-jre-alpine3.9, 8u191-jre-alpine, 8-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 38cb0eb077acf2a429f32a879903cd305733d561
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 8/jre/alpine
 
 Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie
@@ -236,9 +236,9 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk/slim
 
-Tags: 7u181-jdk-alpine3.8, 7u181-alpine3.8, 7-jdk-alpine3.8, 7-alpine3.8, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u181-jdk-alpine3.9, 7u181-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 7/jdk/alpine
 
 Tags: 7u181-jre-jessie, 7-jre-jessie
@@ -252,7 +252,7 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre/slim
 
-Tags: 7u181-jre-alpine3.8, 7-jre-alpine3.8, 7u181-jre-alpine, 7-jre-alpine
+Tags: 7u181-jre-alpine3.9, 7-jre-alpine3.9, 7u181-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1778c73b834d04d5b5c61baee4cce8c127031f9c
+GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 7/jre/alpine

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/783878384a8f3953ed571e5a34ba0fe546726c85/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/e9320fdb752edb2fb5d1be8412172f5c78255a45/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,180 +6,125 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.3.1-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.1-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.1-cli, 7.3-cli, 7-cli, cli, 7.3.1, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.1-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.1-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.1-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.1-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.1-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.1-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/stretch/zts
 
 Tags: 7.3.1-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.1-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8, 7.3.1-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/alpine3.8/cli
 
 Tags: 7.3.1-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.3.1-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/alpine3.8/fpm
 
 Tags: 7.3.1-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.3.1-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 1eb2c0ab518d874ab8c114c514e16aa09394de14
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/alpine3.8/zts
 
 Tags: 7.2.14-cli-stretch, 7.2-cli-stretch, 7.2.14-stretch, 7.2-stretch, 7.2.14-cli, 7.2-cli, 7.2.14, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.14-apache-stretch, 7.2-apache-stretch, 7.2.14-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.14-fpm-stretch, 7.2-fpm-stretch, 7.2.14-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.14-zts-stretch, 7.2-zts-stretch, 7.2.14-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.14-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.14-alpine3.8, 7.2-alpine3.8, 7.2.14-cli-alpine, 7.2-cli-alpine, 7.2.14-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/alpine3.8/cli
 
 Tags: 7.2.14-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7.2.14-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/alpine3.8/fpm
 
 Tags: 7.2.14-zts-alpine3.8, 7.2-zts-alpine3.8, 7.2.14-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: c44aab7001ea12c8bec96664533df503bbf0af19
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.26-cli-stretch, 7.1-cli-stretch, 7.1.26-stretch, 7.1-stretch, 7.1.26-cli, 7.1-cli, 7.1.26, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.26-apache-stretch, 7.1-apache-stretch, 7.1.26-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.26-fpm-stretch, 7.1-fpm-stretch, 7.1.26-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.26-zts-stretch, 7.1-zts-stretch, 7.1.26-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.26-cli-jessie, 7.1-cli-jessie, 7.1.26-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.26-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.26-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.26-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.26-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.26-alpine3.8, 7.1-alpine3.8, 7.1.26-cli-alpine, 7.1-cli-alpine, 7.1.26-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/alpine3.8/cli
 
 Tags: 7.1.26-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.26-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/alpine3.8/fpm
 
 Tags: 7.1.26-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.26-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f189799b756321f6ea311b61335db69650b268d
+GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/alpine3.8/zts
-
-Tags: 5.6.40-cli-stretch, 5.6-cli-stretch, 5-cli-stretch, 5.6.40-stretch, 5.6-stretch, 5-stretch, 5.6.40-cli, 5.6-cli, 5-cli, 5.6.40, 5.6, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/stretch/cli
-
-Tags: 5.6.40-apache-stretch, 5.6-apache-stretch, 5-apache-stretch, 5.6.40-apache, 5.6-apache, 5-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/stretch/apache
-
-Tags: 5.6.40-fpm-stretch, 5.6-fpm-stretch, 5-fpm-stretch, 5.6.40-fpm, 5.6-fpm, 5-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/stretch/fpm
-
-Tags: 5.6.40-zts-stretch, 5.6-zts-stretch, 5-zts-stretch, 5.6.40-zts, 5.6-zts, 5-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/stretch/zts
-
-Tags: 5.6.40-cli-jessie, 5.6-cli-jessie, 5-cli-jessie, 5.6.40-jessie, 5.6-jessie, 5-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/jessie/cli
-
-Tags: 5.6.40-apache-jessie, 5.6-apache-jessie, 5-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/jessie/apache
-
-Tags: 5.6.40-fpm-jessie, 5.6-fpm-jessie, 5-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/jessie/fpm
-
-Tags: 5.6.40-zts-jessie, 5.6-zts-jessie, 5-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/jessie/zts
-
-Tags: 5.6.40-cli-alpine3.8, 5.6-cli-alpine3.8, 5-cli-alpine3.8, 5.6.40-alpine3.8, 5.6-alpine3.8, 5-alpine3.8, 5.6.40-cli-alpine, 5.6-cli-alpine, 5-cli-alpine, 5.6.40-alpine, 5.6-alpine, 5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/alpine3.8/cli
-
-Tags: 5.6.40-fpm-alpine3.8, 5.6-fpm-alpine3.8, 5-fpm-alpine3.8, 5.6.40-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/alpine3.8/fpm
-
-Tags: 5.6.40-zts-alpine3.8, 5.6-zts-alpine3.8, 5-zts-alpine3.8, 5.6.40-zts-alpine, 5.6-zts-alpine, 5-zts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 783878384a8f3953ed571e5a34ba0fe546726c85
-Directory: 5.6/alpine3.8/zts

--- a/library/postgres
+++ b/library/postgres
@@ -11,7 +11,7 @@ Directory: 11
 
 Tags: 11.1-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
 Directory: 11/alpine
 
 Tags: 10.6, 10
@@ -21,7 +21,7 @@ Directory: 10
 
 Tags: 10.6-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
 Directory: 10/alpine
 
 Tags: 9.6.11, 9.6, 9
@@ -31,7 +31,7 @@ Directory: 9.6
 
 Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
 Directory: 9.6/alpine
 
 Tags: 9.5.15, 9.5
@@ -41,7 +41,7 @@ Directory: 9.5
 
 Tags: 9.5.15-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
 Directory: 9.5/alpine
 
 Tags: 9.4.20, 9.4
@@ -51,5 +51,5 @@ Directory: 9.4
 
 Tags: 9.4.20-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
 Directory: 9.4/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.7.11-rc.2, 3.7-rc
+Tags: 3.8.0-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a623bb9420b8bfb1cbad2467abb48db26e7ddbc
-Directory: 3.7-rc/ubuntu
+GitCommit: 26cf98f1a793a1db5b549604f8485e39b8e5dffe
+Directory: 3.8-rc/ubuntu
 
-Tags: 3.7.11-rc.2-management, 3.7-rc-management
+Tags: 3.8.0-beta.2-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.7.11-rc.2-alpine, 3.7-rc-alpine
+Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a623bb9420b8bfb1cbad2467abb48db26e7ddbc
-Directory: 3.7-rc/alpine
+GitCommit: 26cf98f1a793a1db5b549604f8485e39b8e5dffe
+Directory: 3.8-rc/alpine
 
-Tags: 3.7.11-rc.2-management-alpine, 3.7-rc-management-alpine
+Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.10, 3.7, 3, latest
+Tags: 3.7.11, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a51c5ad7333baae15f609e9fcbac1400d02b96a6
+GitCommit: 4320a3fdbf9f189ee29dc03abf3df82180459f12
 Directory: 3.7/ubuntu
 
-Tags: 3.7.10-management, 3.7-management, 3-management, management
+Tags: 3.7.11-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.10-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.11-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a51c5ad7333baae15f609e9fcbac1400d02b96a6
+GitCommit: 4320a3fdbf9f189ee29dc03abf3df82180459f12
 Directory: 3.7/alpine
 
-Tags: 3.7.10-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.11-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/redis
+++ b/library/redis
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redis/blob/dc6dc737baa434528ce31948b22b4c6ccc78793a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/f226612406cc2ab1b89694488af27bbcb35d7c65/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -16,7 +16,7 @@ Directory: 5.0/32bit
 
 Tags: 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.3-alpine3.9, 5.0-alpine3.9, 5-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2435f1f1f9192ea79cadb4e078504fe696658064
+GitCommit: 60db7082c81f5d457046f199244c5d651f04b3fa
 Directory: 5.0/alpine
 
 Tags: 4.0.12, 4.0, 4, 4.0.12-stretch, 4.0-stretch, 4-stretch
@@ -31,5 +31,5 @@ Directory: 4.0/32bit
 
 Tags: 4.0.12-alpine, 4.0-alpine, 4-alpine, 4.0.12-alpine3.9, 4.0-alpine3.9, 4-alpine3.9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2435f1f1f9192ea79cadb4e078504fe696658064
+GitCommit: 60db7082c81f5d457046f199244c5d651f04b3fa
 Directory: 4.0/alpine

--- a/library/redis
+++ b/library/redis
@@ -14,9 +14,9 @@ Architectures: amd64
 GitCommit: 7be79f51e29a009fefdc218c8479d340b8c4a5e1
 Directory: 5.0/32bit
 
-Tags: 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.3-alpine3.8, 5.0-alpine3.8, 5-alpine3.8, alpine3.8
+Tags: 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.3-alpine3.9, 5.0-alpine3.9, 5-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7be79f51e29a009fefdc218c8479d340b8c4a5e1
+GitCommit: 2435f1f1f9192ea79cadb4e078504fe696658064
 Directory: 5.0/alpine
 
 Tags: 4.0.12, 4.0, 4, 4.0.12-stretch, 4.0-stretch, 4-stretch
@@ -29,7 +29,7 @@ Architectures: amd64
 GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
 Directory: 4.0/32bit
 
-Tags: 4.0.12-alpine, 4.0-alpine, 4-alpine, 4.0.12-alpine3.8, 4.0-alpine3.8, 4-alpine3.8
+Tags: 4.0.12-alpine, 4.0-alpine, 4-alpine, 4.0.12-alpine3.9, 4.0-alpine3.9, 4-alpine3.9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
+GitCommit: 2435f1f1f9192ea79cadb4e078504fe696658064
 Directory: 4.0/alpine

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/6301325faf42a96b1fd1be5650e451cae31e0728/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.1-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.1, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 3e2c9f3f3c34820dd38212f68c1d5f0300264711
 Directory: 2.6/stretch
 
 Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 3e2c9f3f3c34820dd38212f68c1d5f0300264711
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.6/alpine3.9
 
 Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.6/alpine3.8
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.5/alpine3.9
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.4/alpine3.9
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6301325faf42a96b1fd1be5650e451cae31e0728
+GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
 Directory: 2.3/alpine3.7

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.0.3-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.3-php7.1, 5.0-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.1/apache
 
 Tags: 5.0.3-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.1/fpm
 
 Tags: 5.0.3-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.1/fpm-alpine
 
 Tags: 5.0.3-apache, 5.0-apache, 5-apache, apache, 5.0.3, 5.0, 5, latest, 5.0.3-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.3-php7.2, 5.0-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.2/apache
 
 Tags: 5.0.3-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.3-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.2/fpm
 
 Tags: 5.0.3-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.3-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.2/fpm-alpine
 
 Tags: 5.0.3-php7.3-apache, 5.0-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.0.3-php7.3, 5.0-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.3/apache
 
 Tags: 5.0.3-php7.3-fpm, 5.0-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.3/fpm
 
 Tags: 5.0.3-php7.3-fpm-alpine, 5.0-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: d775299ddae6dafa232166f44b7c03d23ddf7bb6
+GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `golang`: Alpine 3.9 (docker-library/golang#262)
- `haproxy`: Alpine 3.9 (docker-library/haproxy#82)
- `httpd`: Alpine 3.9 (docker-library/httpd#124)
- `mariadb`: 10.0.38, 5.5.63
- `memcached`: Alpine 3.9 (docker-library/memcached#45)
- `mysql`: 8.0.15
- `openjdk`: 13-ea+6, 12-ea+30, Alpine 3.9 (docker-library/openjdk#276)
- `php`: axe 5.6 (EOL), consistent `/var/www/html` permissions (docker-library/php#787)
- `postgres`: Alpine 3.9 (docker-library/postgres#550)
- `rabbitmq`: 3.7.11, 3.8.0-beta.2
- `redis`: Alpine 3.9 (docker-library/redis#183)
- `ruby`: Alpine 3.9 (docker-library/ruby#262)
- `wordpress`: `chown` of `.` in very certain narrow cases (docker-library/wordpress#371)