### PR TITLE
Update Ubuntu, especially for CVE-2019-3462 in Disco

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,35 +6,35 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 5d70c58c86bcbe1db7583d99e6988a7a7d048215
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b89c640e493edc0fb93cb2facd951f0ad6c4d00c
+amd64-GitCommit: 1cc295b1507b68a66942b2ff5c2dbf395850208a
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 4f423a8884da4a60c8f5892ef9d41bbea73203b3
+arm32v7-GitCommit: fb09e36905d621051ae2cc265320fac1d2b9d6aa
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f6e4a8639130c096437cbe78ef9ae233377a8694
+arm64v8-GitCommit: fcfae77d288fef99a1b1a2043dca951840880e45
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 7299dc6e6ed2496ee9d1b4741c4822927bfdabe3
+i386-GitCommit: 797afc4f9bbd6a169ebc8dc7a85caffb1c7c847e
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 2af11719410720e0c63f81363b1268233508ba36
+ppc64le-GitCommit: a495dd9296e6d3c7777c7d720df5c29fe15259f3
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b908bd675e1733fbf4d09e6cec1bf31cf1603993
+s390x-GitCommit: 5fb41457894726fcf6ac043ba1aa09803ca69598
 
-# 20190122 (bionic)
-Tags: 18.04, bionic-20190122, bionic, latest
+# 20190204 (bionic)
+Tags: 18.04, bionic-20190204, bionic, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20190122 (cosmic)
-Tags: 18.10, cosmic-20190122, cosmic, rolling
+# 20190131 (cosmic)
+Tags: 18.10, cosmic-20190131, cosmic, rolling
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: cosmic
 
-# 20190118 (disco)
-Tags: 19.04, disco-20190118, disco, devel
+# 20190204 (disco)
+Tags: 19.04, disco-20190204, disco, devel
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: disco
 


### PR DESCRIPTION
Final bit of https://github.com/docker-library/official-images/pull/5330; see also https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-3462.html.

cc @mwhudson