### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -1,49 +1,49 @@
-# this file is generated via https://github.com/tianon/docker-bash/blob/35aa5f46fa4ed3019f571e0000d305aea685436c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-bash/blob/96e8d89c9f89a0d22f04af7584c64b7e2a74087b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 5.0.2, 5.0, 5, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c2624abd627508926752be982a17205f1e2c40a2
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 5.0
 
 Tags: 4.4.23, 4.4, 4
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bee3aa767f9ecbe455c92c8b98bdbf4ab0a5db0
+GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.0

--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/89ef755062d82d098069a216e8924b6b13e815a0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/63ab35e6d743301bbe4a43025ff4d0f52a372774/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/busybox
+++ b/library/busybox
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/da2ff27fcc621a56b311b3dab5f8de7107f1f06f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/d213e7f485c98fb1593439e296103bf9c3e422d4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: da2ff27fcc621a56b311b3dab5f8de7107f1f06f
+GitCommit: d213e7f485c98fb1593439e296103bf9c3e422d4
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: b1495be7b9777efe53b3ead0325fa7d7984723f8

--- a/library/drupal
+++ b/library/drupal
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/a97122faee2234e22f990e8c942b357e806511e1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/d1ceae22e9d4c19d8b22179a664a99ffefe30d2a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/0a7f7464baaa3a24cdd35e1173d84ab94e32a14d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/b310e74341c7e0f908ebef8919aee4f550b6f59f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/ghost
+++ b/library/ghost
@@ -1,17 +1,17 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/3557ab61ea77fef9e6894ff5eff85c340ab5707e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/b153b80c4e9ce17834f6b90e50c25a48a0c515e5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.13.1, 2.13, 2, latest
+Tags: 2.13.2, 2.13, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
+GitCommit: d878b8869995d360959fcfdef1617c046263ee12
 Directory: 2/debian
 
-Tags: 2.13.1-alpine, 2.13-alpine, 2-alpine, alpine
+Tags: 2.13.2-alpine, 2.13-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
+GitCommit: d878b8869995d360959fcfdef1617c046263ee12
 Directory: 2/alpine
 
 Tags: 1.25.6, 1.25, 1

--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/7a79c7cdad7e2b1e81bd342b7bc0204027b8f326/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/1e9525fb1db023943e1e37a0f26d9e2b77b74020/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/httpd
+++ b/library/httpd
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/httpd/blob/f359a8e12bc91144822ade51afc883a3a293935b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/httpd/blob/b3146c0dc0d3831077a28df82348c5afed4d9ea7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/irssi
+++ b/library/irssi
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/jessfraz/irssi/blob/29e5068c23e0f12f3db8d99f3a7dcff5329ecad0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/jessfraz/irssi/blob/2bdee8662a663da5d53553023df12e2b43d74fc2/generate-stackbrew-library.sh
 
 Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)

--- a/library/julia
+++ b/library/julia
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/julia/blob/5d127e73c6cdba4787e74968c4d3234b70b00b5f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/ce675aacea50716cc41bf795f6ac53fc74e55209/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/memcached
+++ b/library/memcached
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/memcached/blob/0642c9f9a9ef8087e6fa7fe848ee7fe5cc9a13ca/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/memcached/blob/d479d257a7249542b31afd799f22d5b39faa2781/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/mongo
+++ b/library/mongo
@@ -48,32 +48,32 @@ GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.5-xenial, 4.0-xenial, 4-xenial, xenial
-SharedTags: 4.0.5, 4.0, 4, latest
+Tags: 4.0.6-xenial, 4.0-xenial, 4-xenial, xenial
+SharedTags: 4.0.6, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 6e4f9aebd519141a0f8dffbdb2a9502e668c3bd7
+GitCommit: 0a423591d7243256819edc97cef579206d01f6c7
 Directory: 4.0
 
-Tags: 4.0.5-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.5, 4.0, 4, latest
+Tags: 4.0.6-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.0.6-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.6, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 6e4f9aebd519141a0f8dffbdb2a9502e668c3bd7
+GitCommit: 0a423591d7243256819edc97cef579206d01f6c7
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.5-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
-SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.5, 4.0, 4, latest
+Tags: 4.0.6-windowsservercore-1709, 4.0-windowsservercore-1709, 4-windowsservercore-1709, windowsservercore-1709
+SharedTags: 4.0.6-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.6, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 6e4f9aebd519141a0f8dffbdb2a9502e668c3bd7
+GitCommit: 0a423591d7243256819edc97cef579206d01f6c7
 Directory: 4.0/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.0.5-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.5, 4.0, 4, latest
+Tags: 4.0.6-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.0.6-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.6, 4.0, 4, latest
 Architectures: windows-amd64
-GitCommit: 6e4f9aebd519141a0f8dffbdb2a9502e668c3bd7
+GitCommit: 0a423591d7243256819edc97cef579206d01f6c7
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/37dbf0917c384321c6c0faa5db00586c4448325f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/53d2c23fafa844a8ba3a049df69f00b058e7574f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -101,15 +101,15 @@ Architectures: amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/oracle
 
-Tags: 11.0.1-jdk-stretch, 11.0.1-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch
-SharedTags: 11.0.1-jdk, 11.0.1, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
+Tags: 11.0.2-jdk-stretch, 11.0.2-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch
+SharedTags: 11.0.2-jdk, 11.0.2, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
+GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jdk
 
-Tags: 11.0.1-jdk-slim-stretch, 11.0.1-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, jdk-slim-stretch, slim-stretch, 11.0.1-jdk-slim, 11.0.1-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
+Tags: 11.0.2-jdk-slim-stretch, 11.0.2-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, jdk-slim-stretch, slim-stretch, 11.0.2-jdk-slim, 11.0.2-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
+GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jdk/slim
 
 Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -147,15 +147,15 @@ GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.1-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch
-SharedTags: 11.0.1-jre, 11.0-jre, 11-jre, jre
+Tags: 11.0.2-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch
+SharedTags: 11.0.2-jre, 11.0-jre, 11-jre, jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
+GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jre
 
-Tags: 11.0.1-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, jre-slim-stretch, 11.0.1-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
+Tags: 11.0.2-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, jre-slim-stretch, 11.0.2-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 258870647c5a4281c4cc81d0d17b6fd95bcf4141
+GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jre/slim
 
 Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch

--- a/library/php
+++ b/library/php
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/e9320fdb752edb2fb5d1be8412172f5c78255a45/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/5f2b9c2d6036b3ea16a71c562903e27fed939662/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,19 +24,34 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.1-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.1-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8, 7.3.1-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
+Tags: 7.3.1-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.1-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.1-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.3/alpine3.9/cli
+
+Tags: 7.3.1-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.1-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.3/alpine3.9/fpm
+
+Tags: 7.3.1-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.1-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.3/alpine3.9/zts
+
+Tags: 7.3.1-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.1-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.3/alpine3.8/cli
 
-Tags: 7.3.1-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8, 7.3.1-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.3.1-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.3/alpine3.8/fpm
 
-Tags: 7.3.1-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8, 7.3.1-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.3.1-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.3/alpine3.8/zts
 
 Tags: 7.2.14-cli-stretch, 7.2-cli-stretch, 7.2.14-stretch, 7.2-stretch, 7.2.14-cli, 7.2-cli, 7.2.14, 7.2
@@ -59,19 +74,34 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.14-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.14-alpine3.8, 7.2-alpine3.8, 7.2.14-cli-alpine, 7.2-cli-alpine, 7.2.14-alpine, 7.2-alpine
+Tags: 7.2.14-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.14-alpine3.9, 7.2-alpine3.9, 7.2.14-cli-alpine, 7.2-cli-alpine, 7.2.14-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.2/alpine3.9/cli
+
+Tags: 7.2.14-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.14-fpm-alpine, 7.2-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.2/alpine3.9/fpm
+
+Tags: 7.2.14-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.14-zts-alpine, 7.2-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.2/alpine3.9/zts
+
+Tags: 7.2.14-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.14-alpine3.8, 7.2-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.14-fpm-alpine3.8, 7.2-fpm-alpine3.8, 7.2.14-fpm-alpine, 7.2-fpm-alpine
+Tags: 7.2.14-fpm-alpine3.8, 7.2-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.14-zts-alpine3.8, 7.2-zts-alpine3.8, 7.2.14-zts-alpine, 7.2-zts-alpine
+Tags: 7.2.14-zts-alpine3.8, 7.2-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.26-cli-stretch, 7.1-cli-stretch, 7.1.26-stretch, 7.1-stretch, 7.1.26-cli, 7.1-cli, 7.1.26, 7.1
@@ -114,17 +144,32 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.26-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.26-alpine3.8, 7.1-alpine3.8, 7.1.26-cli-alpine, 7.1-cli-alpine, 7.1.26-alpine, 7.1-alpine
+Tags: 7.1.26-cli-alpine3.9, 7.1-cli-alpine3.9, 7.1.26-alpine3.9, 7.1-alpine3.9, 7.1.26-cli-alpine, 7.1-cli-alpine, 7.1.26-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.1/alpine3.9/cli
+
+Tags: 7.1.26-fpm-alpine3.9, 7.1-fpm-alpine3.9, 7.1.26-fpm-alpine, 7.1-fpm-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.1/alpine3.9/fpm
+
+Tags: 7.1.26-zts-alpine3.9, 7.1-zts-alpine3.9, 7.1.26-zts-alpine, 7.1-zts-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+Directory: 7.1/alpine3.9/zts
+
+Tags: 7.1.26-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.26-alpine3.8, 7.1-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.1/alpine3.8/cli
 
-Tags: 7.1.26-fpm-alpine3.8, 7.1-fpm-alpine3.8, 7.1.26-fpm-alpine, 7.1-fpm-alpine
+Tags: 7.1.26-fpm-alpine3.8, 7.1-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.1/alpine3.8/fpm
 
-Tags: 7.1.26-zts-alpine3.8, 7.1-zts-alpine3.8, 7.1.26-zts-alpine, 7.1-zts-alpine
+Tags: 7.1.26-zts-alpine3.8, 7.1-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
 Directory: 7.1/alpine3.8/zts

--- a/library/postgres
+++ b/library/postgres
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/7f3fd17214f5ff59feaec6126cf562710b545c73/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/fa41e210db87b7aa932351e68a075253078828b1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/49cb32fb9c5e401178ba352d5b9e95396a74412b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/9e930c58c833e4a245c3cf90e0d03b32e8a64e2e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -15,15 +15,15 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
 Directory: 3.7/stretch/slim
 
-Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.2-alpine3.9, 3.7-alpine3.9, 3-alpine3.9, alpine3.9, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
-Directory: 3.7/alpine3.8
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.7/alpine3.9
 
-Tags: 3.7.2-alpine3.7, 3.7-alpine3.7, 3-alpine3.7, alpine3.7
+Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
-Directory: 3.7/alpine3.7
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.7/alpine3.8
 
 Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
@@ -60,20 +60,15 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
 Directory: 3.6/jessie/slim
 
-Tags: 3.6.8-alpine3.8, 3.6-alpine3.8, 3.6.8-alpine, 3.6-alpine
+Tags: 3.6.8-alpine3.9, 3.6-alpine3.9, 3.6.8-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.6/alpine3.9
+
+Tags: 3.6.8-alpine3.8, 3.6-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
 Directory: 3.6/alpine3.8
-
-Tags: 3.6.8-alpine3.7, 3.6-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
-Directory: 3.6/alpine3.7
-
-Tags: 3.6.8-alpine3.6, 3.6-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
-Directory: 3.6/alpine3.6
 
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
@@ -110,15 +105,15 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
 Directory: 3.5/jessie/slim
 
-Tags: 3.5.6-alpine3.8, 3.5-alpine3.8, 3.5.6-alpine, 3.5-alpine
+Tags: 3.5.6-alpine3.9, 3.5-alpine3.9, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
-Directory: 3.5/alpine3.8
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.5/alpine3.9
 
-Tags: 3.5.6-alpine3.7, 3.5-alpine3.7
+Tags: 3.5.6-alpine3.8, 3.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
-Directory: 3.5/alpine3.7
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.5/alpine3.8
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
@@ -146,15 +141,15 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
 Directory: 3.4/wheezy
 
-Tags: 3.4.9-alpine3.8, 3.4-alpine3.8, 3.4.9-alpine, 3.4-alpine
+Tags: 3.4.9-alpine3.9, 3.4-alpine3.9, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
-Directory: 3.4/alpine3.8
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.4/alpine3.9
 
-Tags: 3.4.9-alpine3.7, 3.4-alpine3.7
+Tags: 3.4.9-alpine3.8, 3.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
-Directory: 3.4/alpine3.7
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 3.4/alpine3.8
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
@@ -182,20 +177,15 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
 Directory: 2.7/wheezy
 
-Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8, 2.7.15-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.15-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+Directory: 2.7/alpine3.9
+
+Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 662514b58264cff440912d93648ecf202a43f31c
 Directory: 2.7/alpine3.8
-
-Tags: 2.7.15-alpine3.7, 2.7-alpine3.7, 2-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
-Directory: 2.7/alpine3.7
-
-Tags: 2.7.15-alpine3.6, 2.7-alpine3.6, 2-alpine3.6
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
-Directory: 2.7/alpine3.6
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2

--- a/library/redmine
+++ b/library/redmine
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/af8d60964bfeb8edf6faaa731591ddf1b0165ebd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/863c825f35760f6ad7ed6a7f83cb97e2c103f6d3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/35cf993e41e8554876d61d5a438834086a5ae2ee/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/tomcat
+++ b/library/tomcat
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/tomcat/blob/185917c653a1a7504e5cc82c0a8ceb6a8a171bc8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/tomcat/blob/513ef1dadaaca7b6700dfef62990380954a0af80/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)

--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/96a8124c468049e097beec9aa4008bda26671d7e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/ebef32eda0f1c4bb5eb3041a24c461d8b12e322c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)


### PR DESCRIPTION
- `bash`: Alpine 3.9
- `buildpack-deps`: *no image changes*
- `busybox`: *no image changes*
- `drupal`: *no image changes*
- `gcc`: *no image changes*
- `ghost`: 2.13.2
- `haproxy`: *no image changes*
- `httpd`: *no image changes*
- `irssi`: *no image changes*
- `julia`: *no image changes*
- `memcached`: *no image changes*
- `mongo`: 4.0.6
- `openjdk`: 11.0.2 (Debian)
- `php`: Alpine 3.9 (docker-library/php#786)
- `postgres`: *no image changes*
- `python`: Alpine 3.9 (docker-library/python#375)
- `redmine`: *no image changes*
- `ruby`: *no image changes*
- `tomcat`: *no image changes*
- `wordpress`: *no image changes*