### PR TITLE
Update to Jetty 9.4.14, add JRE 11

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -2,32 +2,37 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.4.12, 9.4, 9, 9.4.12-jre8, 9.4-jre8, 9-jre8, latest, jre8
+Tags: 9.4.14-jre11, 9.4-jre11, 9-jre11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 9.4-jre11
+GitCommit: f82248fc064042f4cd76423a91ab8be8f008da36
+
+Tags: 9.4.14, 9.4, 9, 9.4.14-jre8, 9.4-jre8, 9-jre8, latest, jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 9.4-jre8
-GitCommit: 29d5dacf52294fbc46fab5ad5e234bb31db9354b
+GitCommit: 4dce0dae363410fb631ccf14c13383074d67efb9
 
 Tags: 9.4.12-alpine, 9.4-alpine, 9-alpine, 9.4.12-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: 9.4-jre8/alpine
-GitCommit: 29d5dacf52294fbc46fab5ad5e234bb31db9354b
+GitCommit: 8b52914e1aa73caa1807870039b8436e53fba1bf
 
 Tags: 9.3.24, 9.3, 9.3.24-jre8, 9.3-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 9.3-jre8
-GitCommit: 8f839f5c0c24d90f7f6c6de707096e70b50b49be
+GitCommit: 8b52914e1aa73caa1807870039b8436e53fba1bf
 
 Tags: 9.3.24-alpine, 9.3-alpine, 9.3.24-jre8-alpine, 9.3-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 Directory: 9.3-jre8/alpine
-GitCommit: 8f839f5c0c24d90f7f6c6de707096e70b50b49be
+GitCommit: 8b52914e1aa73caa1807870039b8436e53fba1bf
 
 Tags: 9.2.26, 9.2, 9.2.26-jre8, 9.2-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 9.2-jre8
-GitCommit: 25b573d129be2a0e5384e3fdf746e6e64aa1be1d
+GitCommit: d8d81a817fc1d60111f2ff65eb5afbb7873e976c
 
 Tags: 9.2.26-jre7, 9.2-jre7, 9-jre7, jre7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 9.2-jre7
-GitCommit: 25b573d129be2a0e5384e3fdf746e6e64aa1be1d
+GitCommit: d8d81a817fc1d60111f2ff65eb5afbb7873e976c


### PR DESCRIPTION
* Also includes GPG "Happy Eyes" build stability improvements

Related Pull Requests: https://github.com/appropriate/docker-jetty/pull/99, https://github.com/appropriate/docker-jetty/pull/101