### PR TITLE
Update Thrift to 0.12

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -6,4 +6,6 @@
 0.10.0: git://github.com/ahawkins/docker-thrift@e1f81dfe3e8fac5588e12d2b880166d1743dbecd 0.10
 0.11: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
 0.11.0: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
-latest: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
+0.12: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
+0.12.0: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
+latest: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12

--- a/library/thrift
+++ b/library/thrift
@@ -6,6 +6,6 @@
 0.10.0: git://github.com/ahawkins/docker-thrift@e1f81dfe3e8fac5588e12d2b880166d1743dbecd 0.10
 0.11: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
 0.11.0: git://github.com/ahawkins/docker-thrift@00e197d889426695446baec4e034b5ddbb15bcb3 0.11
-0.12: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
-0.12.0: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
-latest: git://github.com/ahawkins-docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
+0.12: git://github.com/ahawkins/docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
+0.12.0: git://github.com/ahawkins/docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12
+latest: git://github.com/ahawkins/docker-thrift@d7e73876549d205898b1922bcbf69e74ef11c288 0.12


### PR DESCRIPTION
Reference: https://github.com/ahawkins/docker-thrift/pull/16