### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.7-apache, 8.6-apache, 8-apache, apache, 8.6.7, 8.6, 8, latest
+Tags: 8.6.8-apache, 8.6-apache, 8-apache, apache, 8.6.8, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
+GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
 Directory: 8.6/apache
 
-Tags: 8.6.7-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.8-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
+GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
 Directory: 8.6/fpm
 
-Tags: 8.6.7-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.8-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 67961f89447baff5c2a029dc3b3ea2645eab1a29
+GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
 Directory: 8.6/fpm-alpine
 
 Tags: 8.5.10-apache, 8.5-apache, 8.5.10, 8.5
@@ -34,17 +34,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
 Directory: 8.5/fpm-alpine
 
-Tags: 7.63-apache, 7-apache, 7.63, 7
+Tags: 7.64-apache, 7-apache, 7.64, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
+GitCommit: 4ee004ea6b20dee3daae3b462b0dbdcab0b6dcb1
 Directory: 7/apache
 
-Tags: 7.63-fpm, 7-fpm
+Tags: 7.64-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
+GitCommit: 4ee004ea6b20dee3daae3b462b0dbdcab0b6dcb1
 Directory: 7/fpm
 
-Tags: 7.63-fpm-alpine, 7-fpm-alpine
+Tags: 7.64-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: becaa12ccee3c51886a54c75a04666a99f037f2e
+GitCommit: 4ee004ea6b20dee3daae3b462b0dbdcab0b6dcb1
 Directory: 7/fpm-alpine

--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.3, 1.9, 1, latest
+Tags: 1.9.4, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d075532302bb77a73697bb08f367dee1e8f7bde8
+GitCommit: 51e62eeb27fc5eb31152687e4b003867e2aa2ab5
 Directory: 1.9
 
-Tags: 1.9.3-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.4-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
+GitCommit: 51e62eeb27fc5eb31152687e4b003867e2aa2ab5
 Directory: 1.9/alpine
 
-Tags: 1.8.17, 1.8
+Tags: 1.8.18, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aac7efb4d62177a1d60edc4b1b4e20cb2c833dec
+GitCommit: e740da55b605458a9bfae3c71ef5e1e50837bff9
 Directory: 1.8
 
-Tags: 1.8.17-alpine, 1.8-alpine
+Tags: 1.8.18-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
+GitCommit: e740da55b605458a9bfae3c71ef5e1e50837bff9
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.5.4
-GitCommit: e6b11543037b0c0ff88ea935ddddc0d3ec7d22cc
+Tags: 6.6.0
+GitCommit: 7b1d6e90f134740291a149e0cf10ca2e93dde188
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.5.4
-GitCommit: 80179ee0365f4be681948e3677e7c0adcd2183cd
+Tags: 6.6.0
+GitCommit: 50802fe3b6bf1e369ca54b71d36406ba6a9723ab
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/mariadb
+++ b/library/mariadb
@@ -19,9 +19,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 9dcf0846746ae9c0006bee41a2c78996a35a9557
 Directory: 10.2
 
-Tags: 10.1.37-bionic, 10.1-bionic, 10.1.37, 10.1
+Tags: 10.1.38-bionic, 10.1-bionic, 10.1.38, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eac38f7d1478b2570203bf8c1ca68bea74637d9c
+GitCommit: c57380ba7837bb05b4f2a709394e5d6378e9ea79
 Directory: 10.1
 
 Tags: 10.0.38-xenial, 10.0-xenial, 10.0.38, 10.0

--- a/library/openjdk
+++ b/library/openjdk
@@ -236,9 +236,9 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk/slim
 
-Tags: 7u181-jdk-alpine3.9, 7u181-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u181-jdk-alpine, 7u181-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u201-jdk-alpine3.9, 7u201-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u201-jdk-alpine, 7u201-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
+GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
 Directory: 7/jdk/alpine
 
 Tags: 7u181-jre-jessie, 7-jre-jessie
@@ -252,7 +252,7 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre/slim
 
-Tags: 7u181-jre-alpine3.9, 7-jre-alpine3.9, 7u181-jre-alpine, 7-jre-alpine
+Tags: 7u201-jre-alpine3.9, 7-jre-alpine3.9, 7u201-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
+GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
 Directory: 7/jre/alpine

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/5bfde9806e24cfd84437197d5d171caef2adcae3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/0576eabd93cf3ea348b7abec1e73056af1e47f88/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 26cf98f1a793a1db5b549604f8485e39b8e5dffe
+GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.2-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 26cf98f1a793a1db5b549604f8485e39b8e5dffe
+GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.11, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4320a3fdbf9f189ee29dc03abf3df82180459f12
+GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
 Directory: 3.7/ubuntu
 
 Tags: 3.7.11-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.11-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4320a3fdbf9f189ee29dc03abf3df82180459f12
+GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
 Directory: 3.7/alpine
 
 Tags: 3.7.11-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
- `drupal`: 8.6.8, 7.64
- `haproxy`: 1.9.4, 1.8.18
- `kibana`: 6.6.0
- `logstash`: 6.6.0
- `mariadb`: 10.1.38
- `openjdk`: 7u201 (Alpine)
- `rabbitmq`: fixed `i386` building (docker-library/rabbitmq#310)