### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -5,26 +5,26 @@ Maintainers: Amazon Linux Team <amazon-linux@amazon.com> (@aws),
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
 GitCommit: f5382475bb163a79163c2ce9c6d314d6b44f3146
 
-Tags: 2.0.20190115, 2, latest
+Tags: 2.0.20190207, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 04063a7fea41cb62cadfea8f411d3f03c2bb0f58
+amd64-GitCommit: dbfdd38a233a962adbb8db4f496e3c481a40091c
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a8bac488dabeba389e25cb2fb8e29cb981d3d7da
+arm64v8-GitCommit: cbb0d3f7cdcb258c6c94323300d9484f61ebba00
 
-Tags: 2.0.20190115-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20190207-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: fd78a97651383e54a16d522f9940c9864dc9cd16
+amd64-GitCommit: 567e271cd0e635bd4bcd07f04d950fbf5d749c62
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 91b1bb1c8d2ea9dd7928277f25c9f590d678c6df
+arm64v8-GitCommit: 90707047ec8de322e6a81d351c9d7679f6adb06e
 
-Tags: 2018.03.0.20190118, 2018.03, 1
+Tags: 2018.03.0.20190207, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: e3dff64bfe5cb08c4670fa948b4f891c1e65301b
+amd64-GitCommit: 20561821147e92b3a3af74eb6d6019a5d5eb2494
 
-Tags: 2018.03.0.20190118-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20190207-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: ca11c2eee4f215d7c5367f9ece138ac1b417b1a2
+amd64-GitCommit: 374f23aae55d3462cd51dbf72a9ee3fcbddca30b


### PR DESCRIPTION
Indirectly fixes https://github.com/corretto/corretto-8-docker/issues/21.