### PR TITLE
[nats-streaming-server] Release v0.12.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 
-Tags: 0.11.2-linux, linux
-SharedTags: 0.11.2, latest
+Tags: 0.12.0-linux, linux
+SharedTags: 0.12.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+amd64-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 amd64-Directory: amd64
-arm32v6-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+arm32v6-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+arm32v7-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+arm64v8-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 arm64v8-Directory: arm64v8
 
-Tags: 0.11.2-nanoserver, nanoserver
-SharedTags: 0.11.2, latest
+Tags: 0.12.0-nanoserver, nanoserver
+SharedTags: 0.12.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+windows-amd64-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.11.2-windowsservercore, windowsservercore
+Tags: 0.12.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 465ef4c302c17cf248755ad2c739ce26c720d221
+windows-amd64-GitCommit: 1696f7aeb6857c4b96a8f22fae2868864cb41634
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.12.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>