### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.8-apache, 8.6-apache, 8-apache, apache, 8.6.8, 8.6, 8, latest
+Tags: 8.6.9-apache, 8.6-apache, 8-apache, apache, 8.6.9, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
+GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
 Directory: 8.6/apache
 
-Tags: 8.6.8-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.9-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
+GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
 Directory: 8.6/fpm
 
-Tags: 8.6.8-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.9-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90c7b19862ffe5026207a7a1192f0fc534a10f4b
+GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
 Directory: 8.6/fpm-alpine
 
 Tags: 8.5.10-apache, 8.5-apache, 8.5.10, 8.5

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.5.4
-GitCommit: deabc2adbaa9251213071e5b46c6742ab781dc84
+Tags: 6.6.0
+GitCommit: 99c825a40d4214e9605cc8566e0dcac7468552fb
 Directory: 6
 
 Tags: 5.6.14, 5.6, 5

--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.13.2, 2.13, 2, latest
+Tags: 2.14.0, 2.14, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d878b8869995d360959fcfdef1617c046263ee12
+GitCommit: f519ad6fe6b40af8d95bde401c90eb3f2e56b807
 Directory: 2/debian
 
-Tags: 2.13.2-alpine, 2.13-alpine, 2-alpine, alpine
+Tags: 2.14.0-alpine, 2.14-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d878b8869995d360959fcfdef1617c046263ee12
+GitCommit: f519ad6fe6b40af8d95bde401c90eb3f2e56b807
 Directory: 2/alpine
 
-Tags: 1.25.6, 1.25, 1
+Tags: 1.25.7, 1.25, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
+GitCommit: c4b0064aa0ef96e7fea06bbbd41ab82722a7f80c
 Directory: 1/debian
 
-Tags: 1.25.6-alpine, 1.25-alpine, 1-alpine
+Tags: 1.25.7-alpine, 1.25-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ebeeac6fccfe38dc1cfa41b2ce9f310e75f1529a
+GitCommit: c4b0064aa0ef96e7fea06bbbd41ab82722a7f80c
 Directory: 1/alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-6-jdk-oraclelinux7, 13-ea-6-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-6-jdk-oracle, 13-ea-6-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-7-jdk-oraclelinux7, 13-ea-7-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-7-jdk-oracle, 13-ea-7-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-5-jdk-alpine3.9, 13-ea-5-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-5-jdk-alpine, 13-ea-5-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,38 +15,38 @@ Architectures: amd64
 GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-6-jdk-windowsservercore-ltsc2016, 13-ea-6-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-7-jdk-windowsservercore-ltsc2016, 13-ea-7-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-6-jdk-windowsservercore-1709, 13-ea-6-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-7-jdk-windowsservercore-1709, 13-ea-7-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-6-jdk-windowsservercore-1803, 13-ea-6-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-7-jdk-windowsservercore-1803, 13-ea-7-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-6-jdk-windowsservercore-1809, 13-ea-6-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-6-jdk-windowsservercore, 13-ea-6-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-6-jdk, 13-ea-6, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-7-jdk-windowsservercore-1809, 13-ea-7-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-6-jdk-nanoserver-sac2016, 13-ea-6-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-6-jdk-nanoserver, 13-ea-6-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-7-jdk-nanoserver-sac2016, 13-ea-7-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-7-jdk-nanoserver, 13-ea-7-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/php
+++ b/library/php
@@ -4,104 +4,104 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.1-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.1-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.1-cli, 7.3-cli, 7-cli, cli, 7.3.1, 7.3, 7, latest
+Tags: 7.3.2-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.2-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.2-cli, 7.3-cli, 7-cli, cli, 7.3.2, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/stretch/cli
 
-Tags: 7.3.1-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.1-apache, 7.3-apache, 7-apache, apache
+Tags: 7.3.2-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.2-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/stretch/apache
 
-Tags: 7.3.1-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.1-fpm, 7.3-fpm, 7-fpm, fpm
+Tags: 7.3.2-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.2-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/stretch/fpm
 
-Tags: 7.3.1-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.1-zts, 7.3-zts, 7-zts, zts
+Tags: 7.3.2-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.2-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.1-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.1-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.1-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.1-alpine, 7.3-alpine, 7-alpine, alpine
+Tags: 7.3.2-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.2-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.2-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.2-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.9/cli
 
-Tags: 7.3.1-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.1-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Tags: 7.3.2-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.2-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.9/fpm
 
-Tags: 7.3.1-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.1-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
+Tags: 7.3.2-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.2-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.9/zts
 
-Tags: 7.3.1-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.1-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
+Tags: 7.3.2-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.2-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.8/cli
 
-Tags: 7.3.1-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
+Tags: 7.3.2-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.8/fpm
 
-Tags: 7.3.1-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
+Tags: 7.3.2-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
 Directory: 7.3/alpine3.8/zts
 
-Tags: 7.2.14-cli-stretch, 7.2-cli-stretch, 7.2.14-stretch, 7.2-stretch, 7.2.14-cli, 7.2-cli, 7.2.14, 7.2
+Tags: 7.2.15-cli-stretch, 7.2-cli-stretch, 7.2.15-stretch, 7.2-stretch, 7.2.15-cli, 7.2-cli, 7.2.15, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.14-apache-stretch, 7.2-apache-stretch, 7.2.14-apache, 7.2-apache
+Tags: 7.2.15-apache-stretch, 7.2-apache-stretch, 7.2.15-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.14-fpm-stretch, 7.2-fpm-stretch, 7.2.14-fpm, 7.2-fpm
+Tags: 7.2.15-fpm-stretch, 7.2-fpm-stretch, 7.2.15-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.14-zts-stretch, 7.2-zts-stretch, 7.2.14-zts, 7.2-zts
+Tags: 7.2.15-zts-stretch, 7.2-zts-stretch, 7.2.15-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.14-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.14-alpine3.9, 7.2-alpine3.9, 7.2.14-cli-alpine, 7.2-cli-alpine, 7.2.14-alpine, 7.2-alpine
+Tags: 7.2.15-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.15-alpine3.9, 7.2-alpine3.9, 7.2.15-cli-alpine, 7.2-cli-alpine, 7.2.15-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.9/cli
 
-Tags: 7.2.14-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.14-fpm-alpine, 7.2-fpm-alpine
+Tags: 7.2.15-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.15-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.9/fpm
 
-Tags: 7.2.14-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.14-zts-alpine, 7.2-zts-alpine
+Tags: 7.2.15-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.15-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.9/zts
 
-Tags: 7.2.14-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.14-alpine3.8, 7.2-alpine3.8
+Tags: 7.2.15-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.15-alpine3.8, 7.2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.14-fpm-alpine3.8, 7.2-fpm-alpine3.8
+Tags: 7.2.15-fpm-alpine3.8, 7.2-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.14-zts-alpine3.8, 7.2-zts-alpine3.8
+Tags: 7.2.15-zts-alpine3.8, 7.2-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.26-cli-stretch, 7.1-cli-stretch, 7.1.26-stretch, 7.1-stretch, 7.1.26-cli, 7.1-cli, 7.1.26, 7.1

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
+GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.2-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
+GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.11, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
+GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
 Directory: 3.7/ubuntu
 
 Tags: 3.7.11-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.11-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c3af691fc3dfcaa608ecbe2d8017a41c7616be64
+GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
 Directory: 3.7/alpine
 
 Tags: 3.7.11-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -34,52 +34,52 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
 Directory: 7/jre8-alpine
 
-Tags: 8.5.37-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.37, 8.5, 8, latest
+Tags: 8.5.38-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.38, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
+GitCommit: e72a07eecdd750daf5690f786fddb4e40fa2c244
 Directory: 8.5/jre8
 
-Tags: 8.5.37-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.37-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.38-jre8-slim, 8.5-jre8-slim, 8-jre8-slim, jre8-slim, 8.5.38-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
+GitCommit: e72a07eecdd750daf5690f786fddb4e40fa2c244
 Directory: 8.5/jre8-slim
 
-Tags: 8.5.37-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.37-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.38-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.38-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d3d5932c4c852fa2861c68d6d1adaf0ce1b1a870
+GitCommit: 0c424e7244945e69d564fbc27f644ec20f58e193
 Directory: 8.5/jre8-alpine
 
-Tags: 8.5.37-jre11, 8.5-jre11, 8-jre11, jre11
+Tags: 8.5.38-jre11, 8.5-jre11, 8-jre11, jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
+GitCommit: e72a07eecdd750daf5690f786fddb4e40fa2c244
 Directory: 8.5/jre11
 
-Tags: 8.5.37-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
+Tags: 8.5.38-jre11-slim, 8.5-jre11-slim, 8-jre11-slim, jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b7edb6276a275185ddeb3db989573bf35aca2b5
+GitCommit: e72a07eecdd750daf5690f786fddb4e40fa2c244
 Directory: 8.5/jre11-slim
 
-Tags: 9.0.14-jre8, 9.0-jre8, 9-jre8
+Tags: 9.0.16-jre8, 9.0-jre8, 9-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
+GitCommit: ec2d88f0a3b34292c1693e90bdf786e2545a157e
 Directory: 9.0/jre8
 
-Tags: 9.0.14-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
+Tags: 9.0.16-jre8-slim, 9.0-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
+GitCommit: ec2d88f0a3b34292c1693e90bdf786e2545a157e
 Directory: 9.0/jre8-slim
 
-Tags: 9.0.14-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
+Tags: 9.0.16-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a3690c7d71d468e51f0c01ded83f79c7686a2a35
+GitCommit: f5fc6e54e0ce5cd54254074a0fe152a541ef29c5
 Directory: 9.0/jre8-alpine
 
-Tags: 9.0.14-jre11, 9.0-jre11, 9-jre11
+Tags: 9.0.16-jre11, 9.0-jre11, 9-jre11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
+GitCommit: ec2d88f0a3b34292c1693e90bdf786e2545a157e
 Directory: 9.0/jre11
 
-Tags: 9.0.14-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
+Tags: 9.0.16-jre11-slim, 9.0-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f58a6b4236cfe10672c9505aab5024100c9e084d
+GitCommit: ec2d88f0a3b34292c1693e90bdf786e2545a157e
 Directory: 9.0/jre11-slim


### PR DESCRIPTION
- `drupal`: 8.6.9
- `elasticsearch`: 6.6.0
- `ghost`: 2.14.0, 1.25.7
- `openjdk`: 13-ea+7
- `php`: 7.2.15, 7.3.2
- `rabbitmq`: fix `procps` (Alpine instead; docker-library/rabbitmq#311)
- `tomcat`: 8.5.38, 9.0.16