### PR TITLE
Update lein to 2.9.0 in clojure

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,12 +3,12 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 91f3d11eaf065104ec5d3f2a75a27650ebda2878
+GitCommit: 4893ce621b61ba0a1c0b844b2ec7e62274df88e1
 
-Tags: openjdk-8-lein, openjdk-8-lein-2.8.3, lein-2.8.3, lein, latest
+Tags: openjdk-8-lein, openjdk-8-lein-2.9.0, lein-2.9.0, lein, latest
 Directory: target/openjdk-8/debian/lein
 
-Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.8.3-alpine, lein-2.8.3-alpine, lein-alpine, alpine
+Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.9.0-alpine, lein-2.9.0-alpine, lein-alpine, alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/lein
 
@@ -26,7 +26,7 @@ Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.10.0.411-alpine, tools
 Architectures: amd64
 Directory: target/openjdk-8/alpine/tools-deps
 
-Tags: openjdk-11-lein, openjdk-11-lein-2.8.3
+Tags: openjdk-11-lein, openjdk-11-lein-2.9.0
 Directory: target/openjdk-11/debian/lein
 
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.2


### PR DESCRIPTION
[New version of leiningen was just released](https://github.com/technomancy/leiningen/releases/tag/2.9.0).