### PR TITLE
Update docker-library images

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,54 +5,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.12beta2-stretch, 1.12-rc-stretch, rc-stretch
-SharedTags: 1.12beta2, 1.12-rc, rc
+Tags: 1.12rc1-stretch, 1.12-rc-stretch, rc-stretch
+SharedTags: 1.12rc1, 1.12-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/stretch
 
-Tags: 1.12beta2-alpine3.9, 1.12-rc-alpine3.9, rc-alpine3.9, 1.12beta2-alpine, 1.12-rc-alpine, rc-alpine
+Tags: 1.12rc1-alpine3.9, 1.12-rc-alpine3.9, rc-alpine3.9, 1.12rc1-alpine, 1.12-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/alpine3.9
 
-Tags: 1.12beta2-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8
+Tags: 1.12rc1-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/alpine3.8
 
-Tags: 1.12beta2-windowsservercore-ltsc2016, 1.12-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.12beta2-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta2, 1.12-rc, rc
+Tags: 1.12rc1-windowsservercore-ltsc2016, 1.12-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12beta2-windowsservercore-1709, 1.12-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.12beta2-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta2, 1.12-rc, rc
+Tags: 1.12rc1-windowsservercore-1709, 1.12-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.12beta2-windowsservercore-1803, 1.12-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.12beta2-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta2, 1.12-rc, rc
+Tags: 1.12rc1-windowsservercore-1803, 1.12-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12beta2-windowsservercore-1809, 1.12-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.12beta2-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12beta2, 1.12-rc, rc
+Tags: 1.12rc1-windowsservercore-1809, 1.12-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
 Architectures: windows-amd64
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12beta2-nanoserver-sac2016, 1.12-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.12beta2-nanoserver, 1.12-rc-nanoserver, rc-nanoserver
+Tags: 1.12rc1-nanoserver-sac2016, 1.12-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.12rc1-nanoserver, 1.12-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: ad773d11d0bdf21d1f4bc4adf7ea580e71f49d10
+GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
 Directory: 1.12-rc/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 51e62eeb27fc5eb31152687e4b003867e2aa2ab5
 Directory: 1.9/alpine
 
-Tags: 1.8.18, 1.8
+Tags: 1.8.19, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e740da55b605458a9bfae3c71ef5e1e50837bff9
+GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
 Directory: 1.8
 
-Tags: 1.8.18-alpine, 1.8-alpine
+Tags: 1.8.19-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e740da55b605458a9bfae3c71ef5e1e50837bff9
+GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7

--- a/library/httpd
+++ b/library/httpd
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.38, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a6a1d99f1d6e754ecfcdd7a13e12980b86d7b75
+GitCommit: f6cb814440756f97821895731765d306528a3429
 Directory: 2.4
 
 Tags: 2.4.38-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90fef23add315b93438c2ef5a089fd58bf00153e
+GitCommit: f6cb814440756f97821895731765d306528a3429
 Directory: 2.4/alpine

--- a/library/mariadb
+++ b/library/mariadb
@@ -14,9 +14,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: db27681a5753e6f22eb73b5a9575d6b833ba1238
 Directory: 10.3
 
-Tags: 10.2.21-bionic, 10.2-bionic, 10.2.21, 10.2
+Tags: 10.2.22-bionic, 10.2-bionic, 10.2.22, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9dcf0846746ae9c0006bee41a2c78996a35a9557
+GitCommit: dbfc5061a3f863c7cf0908b1c4c70f837c1cf992
 Directory: 10.2
 
 Tags: 10.1.38-bionic, 10.1-bionic, 10.1.38, 10.1

--- a/library/matomo
+++ b/library/matomo
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.8.1-apache, 3.8-apache, 3-apache, apache, 3.8.1, 3.8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
+GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
 Directory: apache
 
 Tags: 3.8.1-fpm, 3.8-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
+GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
 Directory: fpm
 
 Tags: 3.8.1-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 965f0e8de2f06f6a771fe8c5827222233c0ffbec
+GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
 Directory: fpm-alpine

--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
+GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
 Directory: 2
 
 Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
+GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
 Directory: 2/slim
 
 Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
+GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
 Directory: 3
 
 Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim, 3-6.0.0-slim-jessie, 3-6.0-slim-jessie, 3-6-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, arm32v5, i386
-GitCommit: ced7c041cd98198ae06b6522f5a10884384374aa
+GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
 Directory: 3/slim

--- a/library/python
+++ b/library/python
@@ -7,196 +7,196 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.7.2-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.2, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/stretch
 
 Tags: 3.7.2-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.2-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.2-alpine3.9, 3.7-alpine3.9, 3-alpine3.9, alpine3.9, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/alpine3.9
 
 Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.2-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 344fd4f05b1e81dd97f8334e30035c0359dfde7f
+GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.8-stretch, 3.6-stretch
 SharedTags: 3.6.8, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/stretch
 
 Tags: 3.6.8-slim-stretch, 3.6-slim-stretch, 3.6.8-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.8-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/jessie
 
 Tags: 3.6.8-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.8-alpine3.9, 3.6-alpine3.9, 3.6.8-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/alpine3.9
 
 Tags: 3.6.8-alpine3.8, 3.6-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: dd36c08c1f94083476a8579b8bf20c4cd46c6400
+GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/stretch
 
 Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/jessie
 
 Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 72cda33211d4718c347a381625cf0ea59e20040c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.9, 3.5-alpine3.9, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/alpine3.9
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
 Directory: 3.5/alpine3.8
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/stretch
 
 Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/jessie
 
 Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 408f7b8130a44463119acfd66d28430f8b4a1f06
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.9, 3.4-alpine3.9, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/alpine3.9
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
 Directory: 3.4/alpine3.8
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/alpine3.9
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 662514b58264cff440912d93648ecf202a43f31c
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 24860503e8c7d1fba51e352bfdd25474d56a7ab7
+GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,6 +24,26 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
+Tags: 3.7.12-rc.2, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 735d96f0b6b3381ee5d7c058abbe83c70ce970de
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.12-rc.2-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.12-rc.2-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 735d96f0b6b3381ee5d7c058abbe83c70ce970de
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.12-rc.2-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.11, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051


### PR DESCRIPTION
- `golang`: 1.12rc1
- `haproxy`: 1.8.19
- `httpd`: `extra/httpd-ssl.conf` logging (docker-library/httpd#126)
- `mariadb`: 10.2.22
- `matomo`: APCu 5.1.17
- `pypy`: PIP 19.0.2
- `python`: PIP 19.0.2
- `rabbitmq`: 3.7.12-rc.2