### PR TITLE
Add OpenJDK +  HotSpot images from AdoptOpenJDK.

### DIFF
--- a/library/adoptopenjdk-hotspot
+++ b/library/adoptopenjdk-hotspot
@@ -4,7 +4,7 @@ Maintainers: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 Tags: latest, 8, 8-jdk, jdk, 8u202-b08-jdk
-Architectures: amd64, ppc64le, s390x
+Architectures: amd64, aarch64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
@@ -16,7 +16,7 @@ Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8-slim, slim, 8-jdk-slim, 8u202-b08-jdk-slim
-Architectures: amd64, ppc64le, s390x
+Architectures: amd64, aarch64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
@@ -28,7 +28,7 @@ Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.slim
 
 Tags: 11, 11-jdk, 11.0.2.7-jdk
-Architectures: amd64, ppc64le, s390x
+Architectures: amd64, aarch64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
@@ -40,7 +40,7 @@ Directory: 11/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11-slim, 11-jdk-slim, 11.0.2.7-jdk-slim
-Architectures: amd64, ppc64le, s390x
+Architectures: amd64, aarch64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim

--- a/library/adoptopenjdk-hotspot
+++ b/library/adoptopenjdk-hotspot
@@ -1,0 +1,52 @@
+# AdoptOpenJDK official images for OpenJDK with HotSpot
+
+Maintainers: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
+
+Tags: latest, 8, 8-jdk, jdk, 8u202-b08-jdk
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: 8-jdk-alpine, jdk-alpine, 8u202-b08-jdk-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: 8-slim, slim, 8-jdk-slim, 8u202-b08-jdk-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/ubuntu
+File: Dockerfile.hotspot.releases.slim
+
+Tags: 8-slim-alpine, slim-alpine, 8-jdk-slim-alpine, 8u202-b08-jdk-slim-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/alpine
+File: Dockerfile.hotspot.releases.slim
+
+Tags: 11, 11-jdk, 11.0.2.7-jdk
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: 11-jdk-alpine, 11.0.2.7-jdk-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: 11-slim, 11-jdk-slim, 11.0.2.7-jdk-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/ubuntu
+File: Dockerfile.hotspot.releases.slim
+
+Tags: 11-slim-alpine, 11-jdk-slim-alpine, 11.0.2.7-jdk-slim-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/alpine
+File: Dockerfile.hotspot.releases.slim

--- a/library/adoptopenjdk-hotspot
+++ b/library/adoptopenjdk-hotspot
@@ -4,7 +4,7 @@ Maintainers: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 Tags: latest, 8, 8-jdk, jdk, 8u202-b08-jdk
-Architectures: amd64, aarch64, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
@@ -16,7 +16,7 @@ Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8-slim, slim, 8-jdk-slim, 8u202-b08-jdk-slim
-Architectures: amd64, aarch64, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
@@ -28,7 +28,7 @@ Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.slim
 
 Tags: 11, 11-jdk, 11.0.2.7-jdk
-Architectures: amd64, aarch64, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
@@ -40,7 +40,7 @@ Directory: 11/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11-slim, 11-jdk-slim, 11.0.2.7-jdk-slim
-Architectures: amd64, aarch64, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim


### PR DESCRIPTION
-	[ ] associated with or contacted upstream?
        - Yes, this is from the [AdoptOpenJDK](https://adoptopenjdk.net/) community, and I'm the maintainer for the current AdoptOpenJDK docker images.
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
        - Language Runtime
-	[ ] is it reasonably popular, or does it solve a particular use case well?
        - The current [OpenJDK docker images from AdoptOpenJDK](https://hub.docker.com/u/adoptopenjdk) have over 260k pulls across releases.
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
         - docs [PR](https://github.com/docker-library/docs/pull/1427).
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
         - The dockerfiles and scripts have been derived from the [ibmjava](https://hub.docker.com/_/ibmjava/) official images.
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)