### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -3,28 +3,28 @@ Maintainers: Amazon Linux Team <amazon-linux@amazon.com> (@aws),
              Praveen K Paladugu (@praveen-pk),
              Eric Warehime (@Eric-Warehime)
 GitRepo: https://github.com/aws/amazon-linux-docker-images.git
-GitCommit: f5382475bb163a79163c2ce9c6d314d6b44f3146
+GitCommit: b5cacd0dbffde5edd59890a42a3109872f59bb9c
 
-Tags: 2.0.20190207, 2, latest
+Tags: 2.0.20190212, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: dbfdd38a233a962adbb8db4f496e3c481a40091c
+amd64-GitCommit: 2005a6a2839e438f4f728900ac021f0dd27ad60f
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: cbb0d3f7cdcb258c6c94323300d9484f61ebba00
+arm64v8-GitCommit: 4d5459b704ac292217c034466e1347f9d3d1555a
 
-Tags: 2.0.20190207-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20190212-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 567e271cd0e635bd4bcd07f04d950fbf5d749c62
+amd64-GitCommit: 3afa3b0ade59ef31a72c2331329eecb82a7a8ba2
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 90707047ec8de322e6a81d351c9d7679f6adb06e
+arm64v8-GitCommit: f227e5949b48cc512f158750452861e7ce1526ca
 
-Tags: 2018.03.0.20190207, 2018.03, 1
+Tags: 2018.03.0.20190212, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 20561821147e92b3a3af74eb6d6019a5d5eb2494
+amd64-GitCommit: 6ba97eac5a6222140a5b70ae1083da0f1e3f2f18
 
-Tags: 2018.03.0.20190207-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20190212-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 374f23aae55d3462cd51dbf72a9ee3fcbddca30b
+amd64-GitCommit: d53016cae3efb56598428cad7b7699598f29d297


### PR DESCRIPTION
Our [git generation script](https://github.com/aws/amazon-linux-docker-images/blob/master/update-script/update.sh) is finally live now and we are one step closer to replacing me with a robot. :robot: 

AL2 is an update to amazon-linux-extras, AL1 fixes [ALAS-2019-1151](https://alas.aws.amazon.com/ALAS-2019-1151.html).