### PR TITLE
Update docker-library images

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.20, 2.1
+Tags: 2.1.21, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
+GitCommit: c71c19d1fe8796c15217fd1b8024bb44aa011593
 Directory: 2.1
 
-Tags: 2.2.13, 2.2, 2
+Tags: 2.2.14, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
+GitCommit: 386357f2c90e5a53ad26f610cdc0eb001a67e9f0
 Directory: 2.2
 
-Tags: 3.0.17, 3.0
+Tags: 3.0.18, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
+GitCommit: 7d1d7789603d94ec1c8e71d15ef57dacd5cb4dd0
 Directory: 3.0
 
-Tags: 3.11.3, 3.11, 3, latest
+Tags: 3.11.4, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 5c58a3353bb4d533f78bf809f1e55ea0b67b4ba5
+GitCommit: 064fb4e2682bf9c1909e4cb27225fa74862c9086
 Directory: 3.11

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.14.0, 2.14, 2, latest
+Tags: 2.14.2, 2.14, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f519ad6fe6b40af8d95bde401c90eb3f2e56b807
+GitCommit: 26325b209a75466681128e17a49747ceec7b0d68
 Directory: 2/debian
 
-Tags: 2.14.0-alpine, 2.14-alpine, 2-alpine, alpine
+Tags: 2.14.2-alpine, 2.14-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f519ad6fe6b40af8d95bde401c90eb3f2e56b807
+GitCommit: 26325b209a75466681128e17a49747ceec7b0d68
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1

--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.1.2, 1.1, 1, latest
+Tags: 1.2.0, 1.2, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a94cec8b8e5771117577522dbed7d9376852abc5
+GitCommit: ec5a36f9e17511c0b9768719db0aeeef1715fe42
 Directory: debian
 
-Tags: 1.1.2-alpine, 1.1-alpine, 1-alpine, alpine
+Tags: 1.2.0-alpine, 1.2-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a94cec8b8e5771117577522dbed7d9376852abc5
+GitCommit: ec5a36f9e17511c0b9768719db0aeeef1715fe42
 Directory: alpine

--- a/library/joomla
+++ b/library/joomla
@@ -3,47 +3,47 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.9.2-apache, 3.9-apache, 3-apache, apache, 3.9.2, 3.9, 3, latest, 3.9.2-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.2-php7.1, 3.9-php7.1, 3-php7.1, php7.1
+Tags: 3.9.3-apache, 3.9-apache, 3-apache, apache, 3.9.3, 3.9, 3, latest, 3.9.3-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.3-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.1/apache
 
-Tags: 3.9.2-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.2-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.9.3-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.3-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.1/fpm
 
-Tags: 3.9.2-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.2-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.9.3-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.3-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.1/fpm-alpine
 
-Tags: 3.9.2-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.2-php7.2, 3.9-php7.2, 3-php7.2, php7.2
+Tags: 3.9.3-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.3-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.2/apache
 
-Tags: 3.9.2-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.3-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.2/fpm
 
-Tags: 3.9.2-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.3-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.2/fpm-alpine
 
-Tags: 3.9.2-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.2-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Tags: 3.9.3-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.3-php7.3, 3.9-php7.3, 3-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.3/apache
 
-Tags: 3.9.2-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Tags: 3.9.3-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.3/fpm
 
-Tags: 3.9.2-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 3.9.3-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 92369d62db27163003c25ceeec0ba7417981d529
+GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.3/fpm-alpine

--- a/library/mongo
+++ b/library/mongo
@@ -77,31 +77,31 @@ GitCommit: 0a423591d7243256819edc97cef579206d01f6c7
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.7-xenial, 4.1-xenial, unstable-xenial
-SharedTags: 4.1.7, 4.1, unstable
+Tags: 4.1.8-xenial, 4.1-xenial, unstable-xenial
+SharedTags: 4.1.8, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.1/multiverse/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64, arm64v8
-GitCommit: 48ed849349121d0127263e1722f140309e56637f
+GitCommit: 3a7ef0fcac41b94f34d3c92fff4dd19c6f2063bb
 Directory: 4.1
 
-Tags: 4.1.7-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
+Tags: 4.1.8-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
+SharedTags: 4.1.8-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.8, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 48ed849349121d0127263e1722f140309e56637f
+GitCommit: f1775b5e7710b94d08726c7aeaba528ddab52fae
 Directory: 4.1/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.7-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
-SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
+Tags: 4.1.8-windowsservercore-1709, 4.1-windowsservercore-1709, unstable-windowsservercore-1709
+SharedTags: 4.1.8-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.8, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 48ed849349121d0127263e1722f140309e56637f
+GitCommit: f1775b5e7710b94d08726c7aeaba528ddab52fae
 Directory: 4.1/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 4.1.7-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.7-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.7, 4.1, unstable
+Tags: 4.1.8-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
+SharedTags: 4.1.8-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.8, 4.1, unstable
 Architectures: windows-amd64
-GitCommit: 48ed849349121d0127263e1722f140309e56637f
+GitCommit: f1775b5e7710b94d08726c7aeaba528ddab52fae
 Directory: 4.1/windows/windowsservercore-1803
 Constraints: windowsservercore-1803

--- a/library/pypy
+++ b/library/pypy
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/6639ae9a138cc307b44b695aa42adee696af7123/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2-6.0.0, 2-6.0, 2-6, 2, 2-6.0.0-jessie, 2-6.0-jessie, 2-6-jessie, 2-jessie
-Architectures: amd64, arm32v5, i386
-GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
-Directory: 2
+Tags: 2.7-7.0.0, 2.7-7.0, 2.7-7, 2.7, 2-7.0.0, 2-7.0, 2-7, 2, 2.7-7.0.0-jessie, 2.7-7.0-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.0.0-jessie, 2-7.0-jessie, 2-7-jessie, 2-jessie
+Architectures: amd64, i386
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 2.7
 
-Tags: 2-6.0.0-slim, 2-6.0-slim, 2-6-slim, 2-slim, 2-6.0.0-slim-jessie, 2-6.0-slim-jessie, 2-6-slim-jessie, 2-slim-jessie
-Architectures: amd64, arm32v5, i386
-GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
-Directory: 2/slim
+Tags: 2.7-7.0.0-slim, 2.7-7.0-slim, 2.7-7-slim, 2.7-slim, 2-7.0.0-slim, 2-7.0-slim, 2-7-slim, 2-slim, 2.7-7.0.0-slim-jessie, 2.7-7.0-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.0.0-slim-jessie, 2-7.0-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
+Architectures: amd64, i386
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 2.7/slim
 
-Tags: 3-6.0.0, 3-6.0, 3-6, 3, latest, 3-6.0.0-jessie, 3-6.0-jessie, 3-6-jessie, 3-jessie, jessie
-Architectures: amd64, arm32v5, i386
-GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
-Directory: 3
+Tags: 3.5-7.0.0, 3.5-7.0, 3.5-7, 3.5, 3-7.0.0, 3-7.0, 3-7, 3, latest, 3.5-7.0.0-jessie, 3.5-7.0-jessie, 3.5-7-jessie, 3.5-jessie, 3-7.0.0-jessie, 3-7.0-jessie, 3-7-jessie, 3-jessie, jessie
+Architectures: amd64, i386
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 3.5
 
-Tags: 3-6.0.0-slim, 3-6.0-slim, 3-6-slim, 3-slim, slim, 3-6.0.0-slim-jessie, 3-6.0-slim-jessie, 3-6-slim-jessie, 3-slim-jessie, slim-jessie
-Architectures: amd64, arm32v5, i386
-GitCommit: 222aaa969173610fae9850305b1f4946724cc5ff
-Directory: 3/slim
+Tags: 3.5-7.0.0-slim, 3.5-7.0-slim, 3.5-7-slim, 3.5-slim, 3-7.0.0-slim, 3-7.0-slim, 3-7-slim, 3-slim, slim, 3.5-7.0.0-slim-jessie, 3.5-7.0-slim-jessie, 3.5-7-slim-jessie, 3.5-slim-jessie, 3-7.0.0-slim-jessie, 3-7.0-slim-jessie, 3-7-slim-jessie, 3-slim-jessie, slim-jessie
+Architectures: amd64, i386
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 3.5/slim
+
+Tags: 3.6-7.0.0, 3.6-7.0, 3.6-7, 3.6, 3.6-7.0.0-jessie, 3.6-7.0-jessie, 3.6-7-jessie, 3.6-jessie
+Architectures: amd64
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 3.6
+
+Tags: 3.6-7.0.0-slim, 3.6-7.0-slim, 3.6-7-slim, 3.6-slim, 3.6-7.0.0-slim-jessie, 3.6-7.0-slim-jessie, 3.6-7-slim-jessie, 3.6-slim-jessie
+Architectures: amd64
+GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+Directory: 3.6/slim


### PR DESCRIPTION
- `cassandra`: 3.11.4, 3.0.18, 2.2.14, 2.1.21
- `ghost`: 2.14.2
- `irssi`: 1.2.0
- `joomla`: 3.9.3, APCu 5.1.17
- `mongo`: 4.1.8
- `pypy`: 7.0.0 (docker-library/pypy#30)