### PR TITLE
Add logic to tests for ignoring images that have zero tests

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -11,6 +11,8 @@ globalTests+=(
 # for "explicit" images, only run tests that are explicitly specified for that image/variant
 explicitTests+=(
 	[:onbuild]=1
+	[:nanoserver]=1
+	[:windowsservercore]=1
 )
 imageTests[:onbuild]+='
 	override-cmd


### PR DESCRIPTION
Even if the image does not exist, like windows images.

Yay, no more test failures for windows images.

```console
$ ./test/run.sh golang:1.12rc1-windowsservercore-1803
testing golang:1.12rc1-windowsservercore-1803
	image has no tests...skipping
$ echo $?
0
```