### PR TITLE
Update docker-library images

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,95 +4,90 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-7-jdk-oraclelinux7, 13-ea-7-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-7-jdk-oracle, 13-ea-7-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-8-jdk-oraclelinux7, 13-ea-8-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-8-jdk-oracle, 13-ea-8-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-5-jdk-alpine3.9, 13-ea-5-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-5-jdk-alpine, 13-ea-5-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-7-jdk-alpine3.9, 13-ea-7-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-7-jdk-alpine, 13-ea-7-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
+GitCommit: fc1b362bdd68ab37654e47cc1276bf3fc212d132
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-7-jdk-windowsservercore-ltsc2016, 13-ea-7-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-8-jdk-windowsservercore-ltsc2016, 13-ea-8-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-7-jdk-windowsservercore-1709, 13-ea-7-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-8-jdk-windowsservercore-1709, 13-ea-8-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-7-jdk-windowsservercore-1803, 13-ea-7-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-8-jdk-windowsservercore-1803, 13-ea-8-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-7-jdk-windowsservercore-1809, 13-ea-7-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-7-jdk-windowsservercore, 13-ea-7-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-7-jdk, 13-ea-7, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-8-jdk-windowsservercore-1809, 13-ea-8-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-7-jdk-nanoserver-sac2016, 13-ea-7-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-7-jdk-nanoserver, 13-ea-7-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-8-jdk-nanoserver-sac2016, 13-ea-8-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-8-jdk-nanoserver, 13-ea-8-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: eb8786f1fa772d2e8867b9cf7fedcffd0e94966b
+GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-ea-30-jdk-oraclelinux7, 12-ea-30-oraclelinux7, 12-ea-jdk-oraclelinux7, 12-ea-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, 12-ea-30-jdk-oracle, 12-ea-30-oracle, 12-ea-jdk-oracle, 12-ea-oracle, 12-jdk-oracle, 12-oracle
-SharedTags: 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, 12-jdk-oracle, 12-oracle
+SharedTags: 12-jdk, 12
 Architectures: amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/oracle
 
-Tags: 12-ea-29-jdk-alpine3.9, 12-ea-29-alpine3.9, 12-ea-jdk-alpine3.9, 12-ea-alpine3.9, 12-jdk-alpine3.9, 12-alpine3.9, 12-ea-29-jdk-alpine, 12-ea-29-alpine, 12-ea-jdk-alpine, 12-ea-alpine, 12-jdk-alpine, 12-alpine
-Architectures: amd64
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
-Directory: 12/jdk/alpine
-
-Tags: 12-ea-30-jdk-windowsservercore-ltsc2016, 12-ea-30-windowsservercore-ltsc2016, 12-ea-jdk-windowsservercore-ltsc2016, 12-ea-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-ea-30-jdk-windowsservercore-1709, 12-ea-30-windowsservercore-1709, 12-ea-jdk-windowsservercore-1709, 12-ea-windowsservercore-1709, 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-ea-30-jdk-windowsservercore-1803, 12-ea-30-windowsservercore-1803, 12-ea-jdk-windowsservercore-1803, 12-ea-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-ea-30-jdk-windowsservercore-1809, 12-ea-30-windowsservercore-1809, 12-ea-jdk-windowsservercore-1809, 12-ea-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
-SharedTags: 12-ea-30-jdk-windowsservercore, 12-ea-30-windowsservercore, 12-ea-jdk-windowsservercore, 12-ea-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, 12-ea-30-jdk, 12-ea-30, 12-ea-jdk, 12-ea, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-ea-30-jdk-nanoserver-sac2016, 12-ea-30-nanoserver-sac2016, 12-ea-jdk-nanoserver-sac2016, 12-ea-nanoserver-sac2016, 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-ea-30-jdk-nanoserver, 12-ea-30-nanoserver, 12-ea-jdk-nanoserver, 12-ea-nanoserver, 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
+SharedTags: 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
+GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/postgres
+++ b/library/postgres
@@ -4,52 +4,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 11.1, 11, latest
+Tags: 11.2, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 42f9ab3bab65fdbabbf35130c68a9869b6e82ee7
+GitCommit: 7e80419825e4bab4e749bc61334570ffc261ea5e
 Directory: 11
 
-Tags: 11.1-alpine, 11-alpine, alpine
+Tags: 11.2-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
+GitCommit: 6c3b27f1433ad81675afb386a182098dc867e3e8
 Directory: 11/alpine
 
-Tags: 10.6, 10
+Tags: 10.7, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: ef04f3055bab11b10d3d5c41a659acfacf2c850b
 Directory: 10
 
-Tags: 10.6-alpine, 10-alpine
+Tags: 10.7-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
+GitCommit: cc305ee1c59d93ac1808108edda6556b879374a4
 Directory: 10/alpine
 
-Tags: 9.6.11, 9.6, 9
+Tags: 9.6.12, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: a9610d18de51c189c9d4b0197c408e2e3bfb7917
 Directory: 9.6
 
-Tags: 9.6.11-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.12-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
+GitCommit: 122fb0bdcc8058166d7535d30724278efbe41e86
 Directory: 9.6/alpine
 
-Tags: 9.5.15, 9.5
+Tags: 9.5.16, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: 58793919b63a1e0b2a9797b857bf435276e28436
 Directory: 9.5
 
-Tags: 9.5.15-alpine, 9.5-alpine
+Tags: 9.5.16-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
+GitCommit: c6da877bba4184e5e112032f52e36bcabccc6ce8
 Directory: 9.5/alpine
 
-Tags: 9.4.20, 9.4
+Tags: 9.4.21, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45b855af13f6a753fa77bb830c482af6a69d50da
+GitCommit: 23d28bb5957e74cfa1167262fffaddab1bdea4d6
 Directory: 9.4
 
-Tags: 9.4.20-alpine, 9.4-alpine
+Tags: 9.4.21-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cfac232e3cccb8f3b499b7a286ccdf6eafbde808
+GitCommit: fd5c083fcfb276b9cc2299057a8c6c8431bc3b0a
 Directory: 9.4/alpine


### PR DESCRIPTION
- `openjdk`: 12 RC! (and Alpine removal; docker-library/openjdk#281), 13-ea+8
- `postgres`: 11.2, 10.7, 9.6.12, 9.5.16, 9.4.21