### PR TITLE
Update docker-library images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.6.0
-GitCommit: 99c825a40d4214e9605cc8566e0dcac7468552fb
+Tags: 6.6.1
+GitCommit: b6f135ff5d0a61b899993a8aa3e725f1b0b3058a
 Directory: 6
 
-Tags: 5.6.14, 5.6, 5
-GitCommit: 367769da361526411ffac12dae5fa19bb87c3f6c
+Tags: 5.6.15, 5.6, 5
+GitCommit: 6854914f0b890840c75b6db9eeaefbc26177df9c
 Directory: 5
 
-Tags: 5.6.14-alpine, 5.6-alpine, 5-alpine
-GitCommit: 367769da361526411ffac12dae5fa19bb87c3f6c
+Tags: 5.6.15-alpine, 5.6-alpine, 5-alpine
+GitCommit: 6854914f0b890840c75b6db9eeaefbc26177df9c
 Directory: 5/alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.6.0
-GitCommit: 7b1d6e90f134740291a149e0cf10ca2e93dde188
+Tags: 6.6.1
+GitCommit: ad6a8d3f912d148e4ceb6eae5eb28eacfc9d9e45
 Directory: 6
 
-Tags: 5.6.14, 5.6, 5
-GitCommit: 0a3b4fcab39b5a59591645fddc933f1a1b06e1be
+Tags: 5.6.15, 5.6, 5
+GitCommit: 6390aacfcb9454bf6e3bcd2a78fed7fe78f1bda2
 Directory: 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.6.0
-GitCommit: 50802fe3b6bf1e369ca54b71d36406ba6a9723ab
+Tags: 6.6.1
+GitCommit: ebda4ecb21993ffdfe397f0fee3e9fedfd069c56
 Directory: 6
 
-Tags: 5.6.14, 5.6, 5
-GitCommit: 5fbc733a0b2563a5f6e632f2d7fe1e65c4ee8cd5
+Tags: 5.6.15, 5.6, 5
+GitCommit: d5c3923dd5bf35a3a59fcd7287ea0b4b88aaa99a
 Directory: 5
 
-Tags: 5.6.14-alpine, 5.6-alpine, 5-alpine
-GitCommit: 5fbc733a0b2563a5f6e632f2d7fe1e65c4ee8cd5
+Tags: 5.6.15-alpine, 5.6-alpine, 5-alpine
+GitCommit: d5c3923dd5bf35a3a59fcd7287ea0b4b88aaa99a
 Directory: 5/alpine

--- a/library/php
+++ b/library/php
@@ -6,170 +6,170 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.3.2-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.2-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.2-cli, 7.3-cli, 7-cli, cli, 7.3.2, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.2-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.2-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.2-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.2-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.2-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.2-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/stretch/zts
 
 Tags: 7.3.2-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.2-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.2-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.2-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.9/cli
 
 Tags: 7.3.2-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.2-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.9/fpm
 
 Tags: 7.3.2-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.2-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.9/zts
 
 Tags: 7.3.2-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.2-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.8/cli
 
 Tags: 7.3.2-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.8/fpm
 
 Tags: 7.3.2-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3c64c61733a19863c5283f3f336add33dd298eeb
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.3/alpine3.8/zts
 
 Tags: 7.2.15-cli-stretch, 7.2-cli-stretch, 7.2.15-stretch, 7.2-stretch, 7.2.15-cli, 7.2-cli, 7.2.15, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.15-apache-stretch, 7.2-apache-stretch, 7.2.15-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.15-fpm-stretch, 7.2-fpm-stretch, 7.2.15-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.15-zts-stretch, 7.2-zts-stretch, 7.2.15-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.15-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.15-alpine3.9, 7.2-alpine3.9, 7.2.15-cli-alpine, 7.2-cli-alpine, 7.2.15-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.9/cli
 
 Tags: 7.2.15-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.15-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.9/fpm
 
 Tags: 7.2.15-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.15-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.9/zts
 
 Tags: 7.2.15-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.15-alpine3.8, 7.2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.8/cli
 
 Tags: 7.2.15-fpm-alpine3.8, 7.2-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.8/fpm
 
 Tags: 7.2.15-zts-alpine3.8, 7.2-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 52c62d3afbb0c94f3727aba946de619c6c3bf6e0
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.26-cli-stretch, 7.1-cli-stretch, 7.1.26-stretch, 7.1-stretch, 7.1.26-cli, 7.1-cli, 7.1.26, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.26-apache-stretch, 7.1-apache-stretch, 7.1.26-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.26-fpm-stretch, 7.1-fpm-stretch, 7.1.26-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.26-zts-stretch, 7.1-zts-stretch, 7.1.26-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/stretch/zts
 
 Tags: 7.1.26-cli-jessie, 7.1-cli-jessie, 7.1.26-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/jessie/cli
 
 Tags: 7.1.26-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/jessie/apache
 
 Tags: 7.1.26-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/jessie/fpm
 
 Tags: 7.1.26-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ea377551f7527c4e5602bea716c4ba0011dbaee9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/jessie/zts
 
 Tags: 7.1.26-cli-alpine3.9, 7.1-cli-alpine3.9, 7.1.26-alpine3.9, 7.1-alpine3.9, 7.1.26-cli-alpine, 7.1-cli-alpine, 7.1.26-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.9/cli
 
 Tags: 7.1.26-fpm-alpine3.9, 7.1-fpm-alpine3.9, 7.1.26-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.9/fpm
 
 Tags: 7.1.26-zts-alpine3.9, 7.1-zts-alpine3.9, 7.1.26-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.9/zts
 
 Tags: 7.1.26-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.26-alpine3.8, 7.1-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.8/cli
 
 Tags: 7.1.26-fpm-alpine3.8, 7.1-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.8/fpm
 
 Tags: 7.1.26-zts-alpine3.8, 7.1-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90beb19f3889260f6f622012218e33bd643f08a9
+GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
 Directory: 7.1/alpine3.8/zts

--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/9e930c58c833e4a245c3cf90e0d03b32e8a64e2e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/9fd50c0bc8466f976087cca423382f573fb9e7a2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -28,16 +28,30 @@ Directory: 3.7/alpine3.8
 Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.2-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 3.7.2-windowsservercore-1803, 3.7-windowsservercore-1803, 3-windowsservercore-1803, windowsservercore-1803
+SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 3.7/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 3.7.2-windowsservercore-1809, 3.7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 3.7/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 3.6.8-stretch, 3.6-stretch
 SharedTags: 3.6.8, 3.6
@@ -73,16 +87,30 @@ Directory: 3.6/alpine3.8
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 3.6.8-windowsservercore-1803, 3.6-windowsservercore-1803
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 3.6/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 3.6.8-windowsservercore-1809, 3.6-windowsservercore-1809
+SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 3.6/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
@@ -190,13 +218,27 @@ Directory: 2.7/alpine3.8
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
+
+Tags: 2.7.15-windowsservercore-1803, 2.7-windowsservercore-1803, 2-windowsservercore-1803
+SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 2.7/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 2.7.15-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
+SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Architectures: windows-amd64
+GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+Directory: 2.7/windows/windowsservercore-1809
+Constraints: windowsservercore-1809

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
+GitCommit: 495af25addbcaa7627c75037854cc1f7123e2aa1
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.2-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
+GitCommit: 495af25addbcaa7627c75037854cc1f7123e2aa1
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
@@ -24,62 +24,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.9
+Tags: 3.7.12, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 820e85707b885356d3697fa89cfb2538b2e6c53d
-Directory: 3.7.9/ubuntu
-
-Tags: 3.7.9-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 820e85707b885356d3697fa89cfb2538b2e6c53d
-Directory: 3.7.9/ubuntu/management
-
-Tags: 3.7.9-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 820e85707b885356d3697fa89cfb2538b2e6c53d
-Directory: 3.7.9/alpine
-
-Tags: 3.7.9-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 820e85707b885356d3697fa89cfb2538b2e6c53d
-Directory: 3.7.9/alpine/management
-
-Tags: 3.7.12-rc.2, 3.7-rc
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 735d96f0b6b3381ee5d7c058abbe83c70ce970de
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.12-rc.2-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.12-rc.2-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 735d96f0b6b3381ee5d7c058abbe83c70ce970de
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.12-rc.2-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.11, 3.7, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
+GitCommit: c7d3e07b750c802e31c9db9eb775587f15178dad
 Directory: 3.7/ubuntu
 
-Tags: 3.7.11-management, 3.7-management, 3-management, management
+Tags: 3.7.12-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.11-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.12-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a2fb2ac48e6f8cad601be05c3faf4e7d68d43051
+GitCommit: c7d3e07b750c802e31c9db9eb775587f15178dad
 Directory: 3.7/alpine
 
-Tags: 3.7.11-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.12-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/redis
+++ b/library/redis
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 60db7082c81f5d457046f199244c5d651f04b3fa
 Directory: 5.0/alpine
 
-Tags: 4.0.12, 4.0, 4, 4.0.12-stretch, 4.0-stretch, 4-stretch
+Tags: 4.0.13, 4.0, 4, 4.0.13-stretch, 4.0-stretch, 4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
+GitCommit: 8e1acc18156603cc3643bf22ced6069cf8be1622
 Directory: 4.0
 
-Tags: 4.0.12-32bit, 4.0-32bit, 4-32bit, 4.0.12-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
+Tags: 4.0.13-32bit, 4.0-32bit, 4-32bit, 4.0.13-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
 Architectures: amd64
-GitCommit: e964e2975dabf8169edcbf89a72d4163191de02e
+GitCommit: 8e1acc18156603cc3643bf22ced6069cf8be1622
 Directory: 4.0/32bit
 
-Tags: 4.0.12-alpine, 4.0-alpine, 4-alpine, 4.0.12-alpine3.9, 4.0-alpine3.9, 4-alpine3.9
+Tags: 4.0.13-alpine, 4.0-alpine, 4-alpine, 4.0.13-alpine3.9, 4.0-alpine3.9, 4-alpine3.9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 60db7082c81f5d457046f199244c5d651f04b3fa
+GitCommit: 8e1acc18156603cc3643bf22ced6069cf8be1622
 Directory: 4.0/alpine


### PR DESCRIPTION
- `elasticsearch`: 6.6.1, 5.6.15
- `kibana`: 6.6.1, 5.6.15
- `logstash`: 6.6.1, 5.6.15
- `php`: remove `*.a` files (docker-library/php#796)
- `python`: Windows Server 1803, 1809 (docker-library/python#379)
- `rabbitmq`: 3.7.12, 3.8.0-beta.2, Erlang/OTP 21.2.6
- `redis`: 4.0.13