### PR TITLE
[ros] remove images for EOL ROS Ardent

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -156,23 +156,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: ardent
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: ardent-ros-core, ardent-ros-core-xenial
-Architectures: amd64, arm64v8
-GitCommit: 4f09cf3ebe9300879f9a27eca2c60632ff980431
-Directory: ros/ardent/ubuntu/xenial/ros-core
-
-Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
-Architectures: amd64, arm64v8
-GitCommit: 4f09cf3ebe9300879f9a27eca2c60632ff980431
-Directory: ros/ardent/ubuntu/xenial/ros-base
-
-
-################################################################################
 # Release: bouncy
 
 ########################################


### PR DESCRIPTION
@ruffsl as discussed in https://github.com/osrf/docker_images/pull/227#pullrequestreview-205630609