### PR TITLE
Update docker-library images

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git
 
-Tags: 18.06.2-ce, 18.06.2, 18.06, edge
+Tags: 18.06.3-ce, 18.06.3, 18.06, edge
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: c2943e9a0803eea85526f63510a0a8c1e38630d5
+GitCommit: 08e48bcb07e3edeff5399676924c42d18f894df6
 Directory: 18.06
 
-Tags: 18.06.2-ce-dind, 18.06.2-dind, 18.06-dind, edge-dind
+Tags: 18.06.3-ce-dind, 18.06.3-dind, 18.06-dind, edge-dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 65fab2cd767c10f22ee66afa919eda80dbdc8872
 Directory: 18.06/dind
 
-Tags: 18.06.2-ce-git, 18.06.2-git, 18.06-git, edge-git
+Tags: 18.06.3-ce-git, 18.06.3-git, 18.06-git, edge-git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
 Directory: 18.06/git

--- a/library/drupal
+++ b/library/drupal
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.9-apache, 8.6-apache, 8-apache, apache, 8.6.9, 8.6, 8, latest
+Tags: 8.6.10-apache, 8.6-apache, 8-apache, apache, 8.6.10, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
+GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
 Directory: 8.6/apache
 
-Tags: 8.6.9-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.10-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
+GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
 Directory: 8.6/fpm
 
-Tags: 8.6.9-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.10-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 3f1e9a36417c14f4e2dc803463ce99d6d22653a6
+GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
 Directory: 8.6/fpm-alpine
 
-Tags: 8.5.10-apache, 8.5-apache, 8.5.10, 8.5
+Tags: 8.5.11-apache, 8.5-apache, 8.5.11, 8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
+GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
 Directory: 8.5/apache
 
-Tags: 8.5.10-fpm, 8.5-fpm
+Tags: 8.5.11-fpm, 8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
+GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
 Directory: 8.5/fpm
 
-Tags: 8.5.10-fpm-alpine, 8.5-fpm-alpine
+Tags: 8.5.11-fpm-alpine, 8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b7220e37ef3f417b39a8b50de772013124105d83
+GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
 Directory: 8.5/fpm-alpine
 
 Tags: 7.64-apache, 7-apache, 7.64, 7

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.14.3, 2.14, 2, latest
+Tags: 2.15.0, 2.15, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 447df5eee5ef94897ee17e36bb571402dce0d193
+GitCommit: 5b33b634568ba8e0ebf02256d32f5e426931a071
 Directory: 2/debian
 
-Tags: 2.14.3-alpine, 2.14-alpine, 2-alpine, alpine
+Tags: 2.15.0-alpine, 2.15-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 447df5eee5ef94897ee17e36bb571402dce0d193
+GitCommit: 5b33b634568ba8e0ebf02256d32f5e426931a071
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1

--- a/library/mariadb
+++ b/library/mariadb
@@ -9,9 +9,9 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 4fd10c511f4fdf39f9e57ba72e1612084ea2b717
 Directory: 10.4
 
-Tags: 10.3.12-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.12, 10.3, 10, latest
+Tags: 10.3.13-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.13, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: db27681a5753e6f22eb73b5a9575d6b833ba1238
+GitCommit: 8e2027a09843ddae816c716e03a1397a4bcd8cb1
 Directory: 10.3
 
 Tags: 10.2.22-bionic, 10.2-bionic, 10.2.22, 10.2

--- a/library/pypy
+++ b/library/pypy
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2.7-7.0.0, 2.7-7.0, 2.7-7, 2.7, 2-7.0.0, 2-7.0, 2-7, 2, 2.7-7.0.0-jessie, 2.7-7.0-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.0.0-jessie, 2-7.0-jessie, 2-7-jessie, 2-jessie
 Architectures: amd64, i386
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 2.7
 
 Tags: 2.7-7.0.0-slim, 2.7-7.0-slim, 2.7-7-slim, 2.7-slim, 2-7.0.0-slim, 2-7.0-slim, 2-7-slim, 2-slim, 2.7-7.0.0-slim-jessie, 2.7-7.0-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.0.0-slim-jessie, 2-7.0-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
 Architectures: amd64, i386
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 2.7/slim
 
 Tags: 3.5-7.0.0, 3.5-7.0, 3.5-7, 3.5, 3-7.0.0, 3-7.0, 3-7, 3, latest, 3.5-7.0.0-jessie, 3.5-7.0-jessie, 3.5-7-jessie, 3.5-jessie, 3-7.0.0-jessie, 3-7.0-jessie, 3-7-jessie, 3-jessie, jessie
 Architectures: amd64, i386
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 3.5
 
 Tags: 3.5-7.0.0-slim, 3.5-7.0-slim, 3.5-7-slim, 3.5-slim, 3-7.0.0-slim, 3-7.0-slim, 3-7-slim, 3-slim, slim, 3.5-7.0.0-slim-jessie, 3.5-7.0-slim-jessie, 3.5-7-slim-jessie, 3.5-slim-jessie, 3-7.0.0-slim-jessie, 3-7.0-slim-jessie, 3-7-slim-jessie, 3-slim-jessie, slim-jessie
 Architectures: amd64, i386
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 3.5/slim
 
 Tags: 3.6-7.0.0, 3.6-7.0, 3.6-7, 3.6, 3.6-7.0.0-jessie, 3.6-7.0-jessie, 3.6-7-jessie, 3.6-jessie
 Architectures: amd64
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 3.6
 
 Tags: 3.6-7.0.0-slim, 3.6-7.0-slim, 3.6-7-slim, 3.6-slim, 3.6-7.0.0-slim-jessie, 3.6-7.0-slim-jessie, 3.6-7-slim-jessie, 3.6-slim-jessie
 Architectures: amd64
-GitCommit: ca73fc5b08ad6ff2d6fb69dce2942a0ea51766d3
+GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
 Directory: 3.6/slim

--- a/library/python
+++ b/library/python
@@ -4,241 +4,285 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
+Tags: 3.8.0a1-stretch, 3.8-rc-stretch, rc-stretch
+SharedTags: 3.8.0a1, 3.8-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/stretch
+
+Tags: 3.8.0a1-slim-stretch, 3.8-rc-slim-stretch, rc-slim-stretch, 3.8.0a1-slim, 3.8-rc-slim, rc-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/stretch/slim
+
+Tags: 3.8.0a1-alpine3.9, 3.8-rc-alpine3.9, rc-alpine3.9, 3.8.0a1-alpine, 3.8-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/alpine3.9
+
+Tags: 3.8.0a1-windowsservercore-ltsc2016, 3.8-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.8.0a1-windowsservercore, 3.8-rc-windowsservercore, rc-windowsservercore, 3.8.0a1, 3.8-rc, rc
+Architectures: windows-amd64
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 3.8.0a1-windowsservercore-1709, 3.8-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 3.8.0a1-windowsservercore, 3.8-rc-windowsservercore, rc-windowsservercore, 3.8.0a1, 3.8-rc, rc
+Architectures: windows-amd64
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 3.8.0a1-windowsservercore-1803, 3.8-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 3.8.0a1-windowsservercore, 3.8-rc-windowsservercore, rc-windowsservercore, 3.8.0a1, 3.8-rc, rc
+Architectures: windows-amd64
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 3.8.0a1-windowsservercore-1809, 3.8-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 3.8.0a1-windowsservercore, 3.8-rc-windowsservercore, rc-windowsservercore, 3.8.0a1, 3.8-rc, rc
+Architectures: windows-amd64
+GitCommit: 6c42dbe19061cb1abcda541dc0c7a4d0aef5aacf
+Directory: 3.8-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
 Tags: 3.7.2-stretch, 3.7-stretch, 3-stretch, stretch
 SharedTags: 3.7.2, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/stretch
 
 Tags: 3.7.2-slim-stretch, 3.7-slim-stretch, 3-slim-stretch, slim-stretch, 3.7.2-slim, 3.7-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.2-alpine3.9, 3.7-alpine3.9, 3-alpine3.9, alpine3.9, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/alpine3.9
 
 Tags: 3.7.2-alpine3.8, 3.7-alpine3.8, 3-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3189e185470f8abd8957c78973cda6b2413ca0fe
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/alpine3.8
 
 Tags: 3.7.2-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.2-windowsservercore-1709, 3.7-windowsservercore-1709, 3-windowsservercore-1709, windowsservercore-1709
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.7.2-windowsservercore-1803, 3.7-windowsservercore-1803, 3-windowsservercore-1803, windowsservercore-1803
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 3.7.2-windowsservercore-1809, 3.7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.7.2-windowsservercore, 3.7-windowsservercore, 3-windowsservercore, windowsservercore, 3.7.2, 3.7, 3, latest
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.6.8-stretch, 3.6-stretch
 SharedTags: 3.6.8, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/stretch
 
 Tags: 3.6.8-slim-stretch, 3.6-slim-stretch, 3.6.8-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.8-jessie, 3.6-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/jessie
 
 Tags: 3.6.8-slim-jessie, 3.6-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.8-alpine3.9, 3.6-alpine3.9, 3.6.8-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/alpine3.9
 
 Tags: 3.6.8-alpine3.8, 3.6-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 65a048b4c3e198d418c9a5293446169e22336258
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/alpine3.8
 
 Tags: 3.6.8-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.6.8-windowsservercore-1709, 3.6-windowsservercore-1709
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 3.6.8-windowsservercore-1803, 3.6-windowsservercore-1803
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 3.6.8-windowsservercore-1809, 3.6-windowsservercore-1809
 SharedTags: 3.6.8-windowsservercore, 3.6-windowsservercore, 3.6.8, 3.6
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.5.6-stretch, 3.5-stretch
 SharedTags: 3.5.6, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/stretch
 
 Tags: 3.5.6-slim-stretch, 3.5-slim-stretch, 3.5.6-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.6-jessie, 3.5-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/jessie
 
 Tags: 3.5.6-slim-jessie, 3.5-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.9, 3.5-alpine3.9, 3.5.6-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/alpine3.9
 
 Tags: 3.5.6-alpine3.8, 3.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 27ed0c128794a6478cf0bf36d43586487fbf5c1e
+GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/alpine3.8
 
 Tags: 3.4.9-stretch, 3.4-stretch
 SharedTags: 3.4.9, 3.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/stretch
 
 Tags: 3.4.9-slim-stretch, 3.4-slim-stretch, 3.4.9-slim, 3.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/stretch/slim
 
 Tags: 3.4.9-jessie, 3.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/jessie
 
 Tags: 3.4.9-slim-jessie, 3.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/jessie/slim
 
 Tags: 3.4.9-wheezy, 3.4-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.9, 3.4-alpine3.9, 3.4.9-alpine, 3.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/alpine3.9
 
 Tags: 3.4.9-alpine3.8, 3.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e86b089fc7c39d4c6ec5bcca1e1f11a40673893f
+GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/alpine3.8
 
 Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
 SharedTags: 2.7.15, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/stretch
 
 Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/stretch/slim
 
 Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/jessie
 
 Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/jessie/slim
 
 Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/wheezy
 
 Tags: 2.7.15-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.15-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/alpine3.9
 
 Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 275aea55602ac3aa7beb9e346d713c0732e11195
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/alpine3.8
 
 Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 2.7.15-windowsservercore-1803, 2.7-windowsservercore-1803, 2-windowsservercore-1803
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 2.7.15-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
 SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
 Architectures: windows-amd64
-GitCommit: 28511e31de4c395af981084a1033e9aff79190de
+GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
 Directory: 2.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809

--- a/library/tomcat
+++ b/library/tomcat
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 7.0.92-jre7, 7.0-jre7, 7-jre7, 7.0.92, 7.0, 7
+Tags: 7.0.93-jre7, 7.0-jre7, 7-jre7, 7.0.93, 7.0, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
+GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre7
 
-Tags: 7.0.92-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.92-slim, 7.0-slim, 7-slim
+Tags: 7.0.93-jre7-slim, 7.0-jre7-slim, 7-jre7-slim, 7.0.93-slim, 7.0-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
+GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre7-slim
 
-Tags: 7.0.92-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.92-alpine, 7.0-alpine, 7-alpine
+Tags: 7.0.93-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.93-alpine, 7.0-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
+GitCommit: 6a91f7af8b2449372ad234ed5303160e9be54c18
 Directory: 7/jre7-alpine
 
-Tags: 7.0.92-jre8, 7.0-jre8, 7-jre8
+Tags: 7.0.93-jre8, 7.0-jre8, 7-jre8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
+GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre8
 
-Tags: 7.0.92-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
+Tags: 7.0.93-jre8-slim, 7.0-jre8-slim, 7-jre8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffde17a33a1930496bb43c75bc7a826c977d3807
+GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre8-slim
 
-Tags: 7.0.92-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
+Tags: 7.0.93-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1722fc14b4eb66f746a2067739f32d4111f408de
+GitCommit: 6a91f7af8b2449372ad234ed5303160e9be54c18
 Directory: 7/jre8-alpine
 
 Tags: 8.5.38-jre8, 8.5-jre8, 8-jre8, jre8, 8.5.38, 8.5, 8, latest

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.0.3-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.3-php7.1, 5.0-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.1/apache
 
 Tags: 5.0.3-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.1/fpm
 
 Tags: 5.0.3-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.1/fpm-alpine
 
 Tags: 5.0.3-apache, 5.0-apache, 5-apache, apache, 5.0.3, 5.0, 5, latest, 5.0.3-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.3-php7.2, 5.0-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.2/apache
 
 Tags: 5.0.3-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.3-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.2/fpm
 
 Tags: 5.0.3-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.3-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.2/fpm-alpine
 
 Tags: 5.0.3-php7.3-apache, 5.0-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.0.3-php7.3, 5.0-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.3/apache
 
 Tags: 5.0.3-php7.3-fpm, 5.0-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.3/fpm
 
 Tags: 5.0.3-php7.3-fpm-alpine, 5.0-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 4e108fd7f80ca167ea0f38531e2ae26b3f19783e
+GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `docker`: 18.06.3
- `drupal`: 8.6.10, 8.5.11
- `ghost`: 2.15.0
- `mariadb`: 10.3.13
- `pypy`: pip 19.0.3
- `python`: 3.8.0a1, pip 19.0.3
- `tomcat`: 7.0.93
- `wordpress`: remove outdated `TODO` comment