### PR TITLE
Update docker-library images

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: e2740e64805f58dae4eb3a7958ded1fa19e6c349
 Directory: 7
 # Docker EOL: 2020-06-06
 
-# Last Modified: 2018-07-26
-Tags: 8.2.0, 8.2, 8, latest
+# Last Modified: 2019-02-22
+Tags: 8.3.0, 8.3, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
+GitCommit: 28213c0ec6bfadb6c8f7c45b7f67bf8e53b0655f
 Directory: 8
-# Docker EOL: 2020-01-26
+# Docker EOL: 2020-08-22

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-8-jdk-oraclelinux7, 13-ea-8-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-8-jdk-oracle, 13-ea-8-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-9-jdk-oraclelinux7, 13-ea-9-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-9-jdk-oracle, 13-ea-9-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-7-jdk-alpine3.9, 13-ea-7-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-7-jdk-alpine, 13-ea-7-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,79 +15,79 @@ Architectures: amd64
 GitCommit: fc1b362bdd68ab37654e47cc1276bf3fc212d132
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-8-jdk-windowsservercore-ltsc2016, 13-ea-8-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-9-jdk-windowsservercore-ltsc2016, 13-ea-9-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-8-jdk-windowsservercore-1709, 13-ea-8-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-9-jdk-windowsservercore-1709, 13-ea-9-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-8-jdk-windowsservercore-1803, 13-ea-8-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-9-jdk-windowsservercore-1803, 13-ea-9-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-8-jdk-windowsservercore-1809, 13-ea-8-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-8-jdk-windowsservercore, 13-ea-8-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-8-jdk, 13-ea-8, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-9-jdk-windowsservercore-1809, 13-ea-9-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-8-jdk-nanoserver-sac2016, 13-ea-8-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-8-jdk-nanoserver, 13-ea-8-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-9-jdk-nanoserver-sac2016, 13-ea-9-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-9-jdk-nanoserver, 13-ea-9-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: b22cd578c9eafb0cf9f2a64352aa79d17b6eb644
+GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
 Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, 12-jdk-oracle, 12-oracle
 SharedTags: 12-jdk, 12
 Architectures: amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/oracle
 
 Tags: 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
 SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
 SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
 Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
 SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
 SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
 Architectures: windows-amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
 SharedTags: 12-jdk-nanoserver, 12-nanoserver
 Architectures: windows-amd64
-GitCommit: da1f3a4a52a54cbfad0b2f900f6d4a73406fcb67
+GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,6 +24,26 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
+Tags: 3.7.13-beta.1, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c9712e6f8d95ec11872c876cea2c20e8eacb52ed
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.13-beta.1-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.13-beta.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: c9712e6f8d95ec11872c876cea2c20e8eacb52ed
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.13-beta.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.12, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c7d3e07b750c802e31c9db9eb775587f15178dad

--- a/library/redmine
+++ b/library/redmine
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.0.1, 4.0, 4, latest
+Tags: 4.0.2, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 541a213ae394f0d097ca322c316f779767b77982
+GitCommit: cea16044e97567c28802fc8cc06f6cd036c49a5c
 Directory: 4.0
 
-Tags: 4.0.1-passenger, 4.0-passenger, 4-passenger, passenger
+Tags: 4.0.2-passenger, 4.0-passenger, 4-passenger, passenger
 GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 4.0/passenger
 
-Tags: 3.4.8, 3.4, 3
+Tags: 3.4.9, 3.4, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a79b21ce022b4e6a050569e12b3d61f9271d30e8
+GitCommit: efc1e701fa422088588c8fc4e6dfbbed0162c84b
 Directory: 3.4
 
-Tags: 3.4.8-passenger, 3.4-passenger, 3-passenger
+Tags: 3.4.9-passenger, 3.4-passenger, 3-passenger
 GitCommit: dbc5d7e5e339569a09e1d060cc76ff247df3be0d
 Directory: 3.4/passenger
 

--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.0.3-php7.1-apache, 5.0-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.0.3-php7.1, 5.0-php7.1, 5-php7.1, php7.1
+Tags: 5.1.0-php7.1-apache, 5.1-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.1.0-php7.1, 5.1-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.1/apache
 
-Tags: 5.0.3-php7.1-fpm, 5.0-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
+Tags: 5.1.0-php7.1-fpm, 5.1-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.1/fpm
 
-Tags: 5.0.3-php7.1-fpm-alpine, 5.0-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 5.1.0-php7.1-fpm-alpine, 5.1-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.1/fpm-alpine
 
-Tags: 5.0.3-apache, 5.0-apache, 5-apache, apache, 5.0.3, 5.0, 5, latest, 5.0.3-php7.2-apache, 5.0-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.0.3-php7.2, 5.0-php7.2, 5-php7.2, php7.2
+Tags: 5.1.0-apache, 5.1-apache, 5-apache, apache, 5.1.0, 5.1, 5, latest, 5.1.0-php7.2-apache, 5.1-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.1.0-php7.2, 5.1-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.2/apache
 
-Tags: 5.0.3-fpm, 5.0-fpm, 5-fpm, fpm, 5.0.3-php7.2-fpm, 5.0-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
+Tags: 5.1.0-fpm, 5.1-fpm, 5-fpm, fpm, 5.1.0-php7.2-fpm, 5.1-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.2/fpm
 
-Tags: 5.0.3-fpm-alpine, 5.0-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.0.3-php7.2-fpm-alpine, 5.0-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.1.0-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.1.0-php7.2-fpm-alpine, 5.1-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.2/fpm-alpine
 
-Tags: 5.0.3-php7.3-apache, 5.0-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.0.3-php7.3, 5.0-php7.3, 5-php7.3, php7.3
+Tags: 5.1.0-php7.3-apache, 5.1-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.1.0-php7.3, 5.1-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.3/apache
 
-Tags: 5.0.3-php7.3-fpm, 5.0-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.1.0-php7.3-fpm, 5.1-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.3/fpm
 
-Tags: 5.0.3-php7.3-fpm-alpine, 5.0-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.1.0-php7.3-fpm-alpine, 5.1-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: cb3f7fc1c85762269e79773ef26a055add94c2ca
+GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
- `gcc`: 8.3.0
- `openjdk`: 13-ea+9, 12 RC (build 33)
- `rabbitmq`: 3.7.13-beta.1
- `redmine`: 3.4.9, 4.0.2
- `wordpress`: 5.1