### PR TITLE
Updating permissions for server cache

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -61,30 +61,3 @@ Directory: ga/18.0.0.4/webProfile7
 
 Tags: 18.0.0.4-javaee7
 Directory: ga/18.0.0.4/javaee7
-
-Tags: 18.0.0.3-javaee8
-Directory: ga/18.0.0.3/javaee8
-
-Tags: 18.0.0.3-webProfile8
-Directory: ga/18.0.0.3/webProfile8
-
-Tags: 18.0.0.3-microProfile1
-Directory: ga/18.0.0.3/microProfile1
-
-Tags: 18.0.0.3-microProfile2
-Directory: ga/18.0.0.3/microProfile2
-
-Tags: 18.0.0.3-springBoot2
-Directory: ga/18.0.0.3/springBoot2
-
-Tags: 18.0.0.3-kernel
-Directory: ga/18.0.0.3/kernel
-
-Tags: 18.0.0.3-springBoot1
-Directory: ga/18.0.0.3/springBoot1
-
-Tags: 18.0.0.3-webProfile7
-Directory: ga/18.0.0.3/webProfile7
-
-Tags: 18.0.0.3-javaee7
-Directory: ga/18.0.0.3/javaee7

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 0d54e20ffde7faf94353bcd3127364f95ef22e32
+GitCommit: 14635141855a960d8df14ba5a3fbe4241b107b1a
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
We found out that the Liberty start/stop warmup has made it not possible to run as a different user than our default `1001` user.   See PR https://github.com/WASdev/ci.docker/pull/225 for more details.

This fix ensures we can run as any user and still get the performance benefits of the server warmup.