### PR TITLE
Update Go to 1.12 (GA)

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,159 +1,103 @@
-# this file is generated via https://github.com/docker-library/golang/blob/c58a1077faf66bd47ea9c0f3680b252572f26bb3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/89448956000721eec288d8aeff4c52138a9dbd87/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.12rc1-stretch, 1.12-rc-stretch, rc-stretch
-SharedTags: 1.12rc1, 1.12-rc, rc
+Tags: 1.12.0-stretch, 1.12-stretch, 1-stretch, stretch
+SharedTags: 1.12.0, 1.12, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/stretch
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/stretch
 
-Tags: 1.12rc1-alpine3.9, 1.12-rc-alpine3.9, rc-alpine3.9, 1.12rc1-alpine, 1.12-rc-alpine, rc-alpine
+Tags: 1.12.0-alpine3.9, 1.12-alpine3.9, 1-alpine3.9, alpine3.9, 1.12.0-alpine, 1.12-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/alpine3.9
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/alpine3.9
 
-Tags: 1.12rc1-alpine3.8, 1.12-rc-alpine3.8, rc-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/alpine3.8
-
-Tags: 1.12rc1-windowsservercore-ltsc2016, 1.12-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
+Tags: 1.12.0-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.12.0-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.0, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/windows/windowsservercore-ltsc2016
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12rc1-windowsservercore-1709, 1.12-rc-windowsservercore-1709, rc-windowsservercore-1709
-SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
+Tags: 1.12.0-windowsservercore-1709, 1.12-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.12.0-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.0, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/windows/windowsservercore-1709
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.12rc1-windowsservercore-1803, 1.12-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
+Tags: 1.12.0-windowsservercore-1803, 1.12-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.12.0-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.0, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/windows/windowsservercore-1803
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12rc1-windowsservercore-1809, 1.12-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.12rc1-windowsservercore, 1.12-rc-windowsservercore, rc-windowsservercore, 1.12rc1, 1.12-rc, rc
+Tags: 1.12.0-windowsservercore-1809, 1.12-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.12.0-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.0, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/windows/windowsservercore-1809
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12rc1-nanoserver-sac2016, 1.12-rc-nanoserver-sac2016, rc-nanoserver-sac2016
-SharedTags: 1.12rc1-nanoserver, 1.12-rc-nanoserver, rc-nanoserver
+Tags: 1.12.0-nanoserver-sac2016, 1.12-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.12.0-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: d9eeb1f6fa4d19f63dc1e845c01442738f22320f
-Directory: 1.12-rc/windows/nanoserver-sac2016
+GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
+Directory: 1.12/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 1.11.5-stretch, 1.11-stretch, 1-stretch, stretch
-SharedTags: 1.11.5, 1.11, 1, latest
+Tags: 1.11.5-stretch, 1.11-stretch
+SharedTags: 1.11.5, 1.11
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/stretch
 
-Tags: 1.11.5-alpine3.9, 1.11-alpine3.9, 1-alpine3.9, alpine3.9, 1.11.5-alpine, 1.11-alpine, 1-alpine, alpine
+Tags: 1.11.5-alpine3.9, 1.11-alpine3.9, 1.11.5-alpine, 1.11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
 Directory: 1.11/alpine3.9
 
-Tags: 1.11.5-alpine3.8, 1.11-alpine3.8, 1-alpine3.8, alpine3.8
+Tags: 1.11.5-alpine3.8, 1.11-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/alpine3.8
 
-Tags: 1.11.5-windowsservercore-ltsc2016, 1.11-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.5, 1.11, 1, latest
+Tags: 1.11.5-windowsservercore-ltsc2016, 1.11-windowsservercore-ltsc2016
+SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1.11.5, 1.11
 Architectures: windows-amd64
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.11.5-windowsservercore-1709, 1.11-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
-SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.5, 1.11, 1, latest
+Tags: 1.11.5-windowsservercore-1709, 1.11-windowsservercore-1709
+SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1.11.5, 1.11
 Architectures: windows-amd64
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 1.11.5-windowsservercore-1803, 1.11-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.5, 1.11, 1, latest
+Tags: 1.11.5-windowsservercore-1803, 1.11-windowsservercore-1803
+SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1.11.5, 1.11
 Architectures: windows-amd64
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.11.5-windowsservercore-1809, 1.11-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1-windowsservercore, windowsservercore, 1.11.5, 1.11, 1, latest
+Tags: 1.11.5-windowsservercore-1809, 1.11-windowsservercore-1809
+SharedTags: 1.11.5-windowsservercore, 1.11-windowsservercore, 1.11.5, 1.11
 Architectures: windows-amd64
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.11.5-nanoserver-sac2016, 1.11-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.11.5-nanoserver, 1.11-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.11.5-nanoserver-sac2016, 1.11-nanoserver-sac2016
+SharedTags: 1.11.5-nanoserver, 1.11-nanoserver
 Architectures: windows-amd64
 GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
-Tags: 1.10.8-stretch, 1.10-stretch
-SharedTags: 1.10.8, 1.10
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/stretch
-
-Tags: 1.10.8-alpine3.9, 1.10-alpine3.9, 1.10.8-alpine, 1.10-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
-Directory: 1.10/alpine3.9
-
-Tags: 1.10.8-alpine3.8, 1.10-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/alpine3.8
-
-Tags: 1.10.8-windowsservercore-ltsc2016, 1.10-windowsservercore-ltsc2016
-SharedTags: 1.10.8-windowsservercore, 1.10-windowsservercore, 1.10.8, 1.10
-Architectures: windows-amd64
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 1.10.8-windowsservercore-1709, 1.10-windowsservercore-1709
-SharedTags: 1.10.8-windowsservercore, 1.10-windowsservercore, 1.10.8, 1.10
-Architectures: windows-amd64
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
-Tags: 1.10.8-windowsservercore-1803, 1.10-windowsservercore-1803
-SharedTags: 1.10.8-windowsservercore, 1.10-windowsservercore, 1.10.8, 1.10
-Architectures: windows-amd64
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
-Tags: 1.10.8-windowsservercore-1809, 1.10-windowsservercore-1809
-SharedTags: 1.10.8-windowsservercore, 1.10-windowsservercore, 1.10.8, 1.10
-Architectures: windows-amd64
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 1.10.8-nanoserver-sac2016, 1.10-nanoserver-sac2016
-SharedTags: 1.10.8-nanoserver, 1.10-nanoserver
-Architectures: windows-amd64
-GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
-Directory: 1.10/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016


### PR DESCRIPTION
https://github.com/docker-library/golang/pull/264