### PR TITLE
Remove "opensuse:tumbleweed" from supported tags

### DIFF
--- a/library/opensuse
+++ b/library/opensuse
@@ -17,14 +17,3 @@ GitCommit: 0611a04c49ad2d19cf4765455549e028f8a8015d
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
-
-# This is the multiarch section specific for openSUSE-Tumbleweed
-Tags: tumbleweed
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitFetch: refs/heads/openSUSE-Tumbleweed
-GitCommit: 2b8e47140b2a964ac827d17d4b5edd52ee22997d
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-


### PR DESCRIPTION
Refs https://github.com/docker-library/official-images/issues/5371

cc @Vogtinator

This doesn't remove the tag, but does stop us from "rebuilding" / re-pushing the artifacts *and* removes it from the "Supported tags and respective `Dockerfile` links" list (which is my main motivation here, so that list matches what the deprecation notice above it claims). This would also allow us to remove the tag now, if you're satisfied with where the image description is.

Once `leap` is also no longer supported (~June 30?), we can look to remove the `library/opensuse` file altogether and delete the actual tag contents from Docker Hub.

Make sense?