### PR TITLE
Upgrade CrateDB to 3.2.4

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -5,9 +5,9 @@ Maintainers: Christian Bader <christian.bader@crate.io> (@christianbader),
              Mika Naylor <mika@crate.io> (@autophagy)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 3.2.3, 3.2, latest
+Tags: 3.2.4, 3.2, latest
 Architectures: amd64, arm64v8
-GitCommit: c39ccfb1bc739e206b9a6bdf491d15a6cb0d87b7
+GitCommit: 38eafb02dce2ef85b6ae3b5fc57490498e12e31a
 
 Tags: 3.1.6, 3.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
One of the things included in this upgrade is the removal of the docker healthcheck. The healthcheck was checking whether or not the app was configured correctly, which is not something Docker should be concerned with. The purpose of the healthcheck is to check whether the application itself is running, not whether it is configured correctly.

This is evidenced by the fact other databases, such as Elasticsearch, PostgreSQL and MySQL do not include healthchecks in their docker containers. If the CrateDB process stops, the docker container stops with it. The healthcheck was redundant.