### PR TITLE
Update clojure lein & tools-deps variants to latest

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -3,12 +3,12 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Kirill Chernyshov <delaguardo@gmail.com> (@DeLaGuardo)
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 4893ce621b61ba0a1c0b844b2ec7e62274df88e1
+GitCommit: f99253341ba6df568482b65e4ac5d62c963713a3
 
-Tags: openjdk-8-lein, openjdk-8-lein-2.9.0, lein-2.9.0, lein, latest
+Tags: openjdk-8-lein, openjdk-8-lein-2.9.1, lein-2.9.1, lein, latest
 Directory: target/openjdk-8/debian/lein
 
-Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.9.0-alpine, lein-2.9.0-alpine, lein-alpine, alpine
+Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.9.1-alpine, lein-2.9.1-alpine, lein-alpine, alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/lein
 
@@ -19,18 +19,18 @@ Tags: openjdk-8-boot-alpine, openjdk-8-boot-2.8.2-alpine, boot-2.8.2-alpine, boo
 Architectures: amd64
 Directory: target/openjdk-8/alpine/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.0.411, tools-deps-1.10.0.411, tools-deps
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.0.414, tools-deps-1.10.0.414, tools-deps
 Directory: target/openjdk-8/debian/tools-deps
 
-Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.10.0.411-alpine, tools-deps-1.10.0.411-alpine, tools-deps-alpine
+Tags: openjdk-8-tools-deps-alpine, openjdk-8-tools-deps-1.10.0.414-alpine, tools-deps-1.10.0.414-alpine, tools-deps-alpine
 Architectures: amd64
 Directory: target/openjdk-8/alpine/tools-deps
 
-Tags: openjdk-11-lein, openjdk-11-lein-2.9.0
+Tags: openjdk-11-lein, openjdk-11-lein-2.9.1
 Directory: target/openjdk-11/debian/lein
 
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.2
 Directory: target/openjdk-11/debian/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.0.411
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.0.414
 Directory: target/openjdk-11/debian/tools-deps


### PR DESCRIPTION
Leiningen has released version 2.9.1 and tools-deps has released version 1.10.0.414.