### PR TITLE
Fix image aliases for tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -130,11 +130,17 @@ for dockerImage in "$@"; do
 		testRepo="${testRepo##*/}"
 	fi
 	
-	if [ -n "${testAlias[$repo:$variant]}" ]; then
-		testRepo="${testAlias[$repo:$variant]}"
-	elif [ -n "${testAlias[$repo]}" ]; then
-		testRepo="${testAlias[$repo]}"
-	fi
+	for possibleAlias in \
+		"${testAlias[$repo:$variant]}" \
+		"${testAlias[$repo]}" \
+		"${testAlias[$testRepo:$variant]}" \
+		"${testAlias[$testRepo]}" \
+	; do
+		if [ -n "$possibleAlias" ]; then
+			testRepo="$possibleAlias"
+			break
+		fi
+	done
 	
 	explicitVariant=
 	if [ \


### PR DESCRIPTION
When we do test builds, we tag them as "update.sh/xxx:yyy", but the code here that made "mariadb" an alias of "mysql" for the purpose of running tests didn't apply that alias properly.

(This is the root cause of https://github.com/docker-library/official-images/pull/5476#issuecomment-467682616)