### PR TITLE
[security] Update Node.js to 11.10.1, 10.15.2, 8.15.1, 6.17.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,104 +3,104 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.15.0-jessie, 8.15-jessie, 8-jessie, carbon-jessie
+Tags: 8.15.1-jessie, 8.15-jessie, 8-jessie, carbon-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/jessie
 
-Tags: 8.15.0-jessie-slim, 8.15-jessie-slim, 8-jessie-slim, carbon-jessie-slim
+Tags: 8.15.1-jessie-slim, 8.15-jessie-slim, 8-jessie-slim, carbon-jessie-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/jessie-slim
 
-Tags: 8.15.0-alpine, 8.15-alpine, 8-alpine, carbon-alpine
+Tags: 8.15.1-alpine, 8.15-alpine, 8-alpine, carbon-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/alpine
 
-Tags: 8.15.0-onbuild, 8.15-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.15.1-onbuild, 8.15-onbuild, 8-onbuild, carbon-onbuild
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/onbuild
 
-Tags: 8.15.0-stretch, 8.15-stretch, 8-stretch, carbon-stretch, 8.15.0, 8.15, 8, carbon
+Tags: 8.15.1-stretch, 8.15-stretch, 8-stretch, carbon-stretch, 8.15.1, 8.15, 8, carbon
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/stretch
 
-Tags: 8.15.0-stretch-slim, 8.15-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.15.0-slim, 8.15-slim, 8-slim, carbon-slim
+Tags: 8.15.1-stretch-slim, 8.15-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.15.1-slim, 8.15-slim, 8-slim, carbon-slim
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 86b9618674b01fc5549f83696a90d5bc21f38af0
+GitCommit: de76fb48b532d6be012098dc3538bd15329a27d0
 Directory: 8/stretch-slim
 
-Tags: 6.16.0-jessie, 6.16-jessie, 6-jessie, boron-jessie
+Tags: 6.17.0-jessie, 6.17-jessie, 6-jessie, boron-jessie
 Architectures: arm32v7, amd64, i386
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/jessie
 
-Tags: 6.16.0-jessie-slim, 6.16-jessie-slim, 6-jessie-slim, boron-jessie-slim
+Tags: 6.17.0-jessie-slim, 6.17-jessie-slim, 6-jessie-slim, boron-jessie-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/jessie-slim
 
-Tags: 6.16.0-alpine, 6.16-alpine, 6-alpine, boron-alpine
+Tags: 6.17.0-alpine, 6.17-alpine, 6-alpine, boron-alpine
 Architectures: amd64
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/alpine
 
-Tags: 6.16.0-onbuild, 6.16-onbuild, 6-onbuild, boron-onbuild
+Tags: 6.17.0-onbuild, 6.17-onbuild, 6-onbuild, boron-onbuild
 Architectures: arm32v7, amd64, i386
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/onbuild
 
-Tags: 6.16.0-stretch, 6.16-stretch, 6-stretch, boron-stretch, 6.16.0, 6.16, 6, boron
+Tags: 6.17.0-stretch, 6.17-stretch, 6-stretch, boron-stretch, 6.17.0, 6.17, 6, boron
 Architectures: arm32v7, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/stretch
 
-Tags: 6.16.0-stretch-slim, 6.16-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.16.0-slim, 6.16-slim, 6-slim, boron-slim
+Tags: 6.17.0-stretch-slim, 6.17-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.17.0-slim, 6.17-slim, 6-slim, boron-slim
 Architectures: arm32v7, amd64, i386
-GitCommit: daa131d713cf42ae181292471766879f750b5230
+GitCommit: 6833ee622c5a1d4c054ffaf96115f2a20714f5f3
 Directory: 6/stretch-slim
 
-Tags: 11.10.0-alpine, 11.10-alpine, 11-alpine, current-alpine, alpine
+Tags: 11.10.1-alpine, 11.10-alpine, 11-alpine, current-alpine, alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 7b643da4aeb3d77f1c26c9f6fadd32b04f8d7bc9
+GitCommit: 926bddb46b98edf3e1cf75d128afc7cb3b06fb54
 Directory: 11/alpine
 
-Tags: 11.10.0-stretch, 11.10-stretch, 11-stretch, current-stretch, stretch, 11.10.0, 11.10, 11, current, latest
+Tags: 11.10.1-stretch, 11.10-stretch, 11-stretch, current-stretch, stretch, 11.10.1, 11.10, 11, current, latest
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 7b643da4aeb3d77f1c26c9f6fadd32b04f8d7bc9
+GitCommit: 926bddb46b98edf3e1cf75d128afc7cb3b06fb54
 Directory: 11/stretch
 
-Tags: 11.10.0-stretch-slim, 11.10-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.10.0-slim, 11.10-slim, 11-slim, current-slim, slim
+Tags: 11.10.1-stretch-slim, 11.10-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.10.1-slim, 11.10-slim, 11-slim, current-slim, slim
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 7b643da4aeb3d77f1c26c9f6fadd32b04f8d7bc9
+GitCommit: 926bddb46b98edf3e1cf75d128afc7cb3b06fb54
 Directory: 11/stretch-slim
 
-Tags: 10.15.1-jessie, 10.15-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.15.2-jessie, 10.15-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: arm32v7, amd64
-GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
+GitCommit: 1d01380b9fa115e26df9430f7c6c591a1643f798
 Directory: 10/jessie
 
-Tags: 10.15.1-jessie-slim, 10.15-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
+Tags: 10.15.2-jessie-slim, 10.15-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
 Architectures: arm32v7, amd64
-GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
+GitCommit: 1d01380b9fa115e26df9430f7c6c591a1643f798
 Directory: 10/jessie-slim
 
-Tags: 10.15.1-alpine, 10.15-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.15.2-alpine, 10.15-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: arm32v6, arm64v8, amd64, i386, ppc64le, s390x
-GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
+GitCommit: 1d01380b9fa115e26df9430f7c6c591a1643f798
 Directory: 10/alpine
 
-Tags: 10.15.1-stretch, 10.15-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.15.1, 10.15, 10, dubnium, lts
+Tags: 10.15.2-stretch, 10.15-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.15.2, 10.15, 10, dubnium, lts
 Architectures: arm32v7, arm64v8, amd64, ppc64le, s390x
-GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
+GitCommit: 1d01380b9fa115e26df9430f7c6c591a1643f798
 Directory: 10/stretch
 
-Tags: 10.15.1-stretch-slim, 10.15-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.15.1-slim, 10.15-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.15.2-stretch-slim, 10.15-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.15.2-slim, 10.15-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: arm32v7, amd64
-GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
+GitCommit: 1d01380b9fa115e26df9430f7c6c591a1643f798
 Directory: 10/stretch-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
https://github.com/nodejs/docker-node/pull/1003 / https://github.com/nodejs/docker-node/pull/996