### PR TITLE
Add Solr 7.7.1, remove older versions

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,24 +4,24 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.7.0, 7.7, 7, latest
+Tags: 7.7.1, 7.7, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ee37360cff7faa9e5ce285857df3949f2691c07a
+GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
 Directory: 7.7
 
-Tags: 7.7.0-alpine, 7.7-alpine, 7-alpine, alpine
+Tags: 7.7.1-alpine, 7.7-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ee37360cff7faa9e5ce285857df3949f2691c07a
+GitCommit: 6b9921de4e848a3188445c1f0311d33fec0024a0
 Directory: 7.7/alpine
 
-Tags: 7.7.0-slim, 7.7-slim, 7-slim, slim
+Tags: 7.7.1-slim, 7.7-slim, 7-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ee37360cff7faa9e5ce285857df3949f2691c07a
+GitCommit: 6b9921de4e848a3188445c1f0311d33fec0024a0
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
 Directory: 7.6
 
 Tags: 7.6.0-alpine, 7.6-alpine
@@ -36,7 +36,7 @@ Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
 Directory: 7.5
 
 Tags: 7.5.0-alpine, 7.5-alpine
@@ -49,69 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
 Directory: 7.5/slim
 
-Tags: 7.4.0, 7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.4
-
-Tags: 7.4.0-alpine, 7.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.4/alpine
-
-Tags: 7.4.0-slim, 7.4-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.4/slim
-
-Tags: 7.3.1, 7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.3
-
-Tags: 7.3.1-alpine, 7.3-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.3/alpine
-
-Tags: 7.3.1-slim, 7.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.3/slim
-
-Tags: 7.2.1, 7.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.2
-
-Tags: 7.2.1-alpine, 7.2-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.2/alpine
-
-Tags: 7.2.1-slim, 7.2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.2/slim
-
-Tags: 7.1.0, 7.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.1
-
-Tags: 7.1.0-alpine, 7.1-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.1/alpine
-
-Tags: 7.1.0-slim, 7.1-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
-Directory: 7.1/slim
-
 Tags: 6.6.5, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
 Directory: 6.6
 
 Tags: 6.6.5-alpine, 6.6-alpine, 6-alpine
@@ -126,7 +66,7 @@ Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201902.mbox/%3CCAHPRk5GiRpSkr0YNc%2Bed2FemDm%2B%3D6TRHjsh4Xkg%3DVLTh7vGq_Q%40mail.gmail.com%3E
Changes: https://lucene.apache.org/solr/7_7_1/changes/Changes.html

This release includes an important bug fix for SOLR-13248: if you're using 7.5-7.7.0 and are creating new collections in SolrCloud, you'll want to upgrade to 7.7.1

On the docker-solr side, we're dropping older minor versions in the 7 line, and updating the Dockerfiles due to upstream changes.