### PR TITLE
Update websphere-liberty to 19.0.0.2

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -61,3 +61,30 @@ Directory: ga/18.0.0.4/webProfile7
 
 Tags: 18.0.0.4-javaee7
 Directory: ga/18.0.0.4/javaee7
+
+Tags: 18.0.0.3-kernel
+Directory: ga/18.0.0.3/kernel
+
+Tags: 18.0.0.3-javaee8
+Directory: ga/18.0.0.3/javaee8
+
+Tags: 18.0.0.3-webProfile8
+Directory: ga/18.0.0.3/webProfile8
+
+Tags: 18.0.0.3-microProfile1
+Directory: ga/18.0.0.3/microProfile1
+
+Tags: 18.0.0.3-microProfile2
+Directory: ga/18.0.0.3/microProfile2
+
+Tags: 18.0.0.3-springBoot2
+Directory: ga/18.0.0.3/springBoot2
+
+Tags: 18.0.0.3-springBoot1
+Directory: ga/18.0.0.3/springBoot1
+
+Tags: 18.0.0.3-webProfile7
+Directory: ga/18.0.0.3/webProfile7
+
+Tags: 18.0.0.3-javaee7
+Directory: ga/18.0.0.3/javaee7

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,38 +2,41 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 14635141855a960d8df14ba5a3fbe4241b107b1a
+GitCommit: 54970cbcd26a09ca3ed1819629a4fef1beef4af2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
 Directory: beta
 
-Tags: 19.0.0.1-javaee8, javaee8, latest
-Directory: ga/19.0.0.1/javaee8
+Tags: 19.0.0.2-kernel, kernel
+Directory: ga/19.0.0.2/kernel
 
-Tags: 19.0.0.1-webProfile8, webProfile8
-Directory: ga/19.0.0.1/webProfile8
+Tags: 19.0.0.2-javaee8, javaee8, latest
+Directory: ga/19.0.0.2/javaee8
 
-Tags: 19.0.0.1-microProfile1, microProfile1
-Directory: ga/19.0.0.1/microProfile1
+Tags: 19.0.0.2-webProfile8, webProfile8
+Directory: ga/19.0.0.2/webProfile8
 
-Tags: 19.0.0.1-microProfile2, microProfile2
-Directory: ga/19.0.0.1/microProfile2
+Tags: 19.0.0.2-microProfile1, microProfile1
+Directory: ga/19.0.0.2/microProfile1
 
-Tags: 19.0.0.1-springBoot2, springBoot2
-Directory: ga/19.0.0.1/springBoot2
+Tags: 19.0.0.2-microProfile2, microProfile2
+Directory: ga/19.0.0.2/microProfile2
 
-Tags: 19.0.0.1-kernel, kernel
-Directory: ga/19.0.0.1/kernel
+Tags: 19.0.0.2-springBoot2, springBoot2
+Directory: ga/19.0.0.2/springBoot2
 
-Tags: 19.0.0.1-springBoot1, springBoot1
-Directory: ga/19.0.0.1/springBoot1
+Tags: 19.0.0.2-springBoot1, springBoot1
+Directory: ga/19.0.0.2/springBoot1
 
-Tags: 19.0.0.1-webProfile7, webProfile7
-Directory: ga/19.0.0.1/webProfile7
+Tags: 19.0.0.2-webProfile7, webProfile7
+Directory: ga/19.0.0.2/webProfile7
 
-Tags: 19.0.0.1-javaee7, javaee7
-Directory: ga/19.0.0.1/javaee7
+Tags: 19.0.0.2-javaee7, javaee7
+Directory: ga/19.0.0.2/javaee7
+
+Tags: 18.0.0.4-kernel
+Directory: ga/18.0.0.4/kernel
 
 Tags: 18.0.0.4-javaee8
 Directory: ga/18.0.0.4/javaee8
@@ -49,9 +52,6 @@ Directory: ga/18.0.0.4/microProfile2
 
 Tags: 18.0.0.4-springBoot2
 Directory: ga/18.0.0.4/springBoot2
-
-Tags: 18.0.0.4-kernel
-Directory: ga/18.0.0.4/kernel
 
 Tags: 18.0.0.4-springBoot1
 Directory: ga/18.0.0.4/springBoot1


### PR DESCRIPTION
Updating websphere-liberty to the newly released 19.0.0.2, and beta to 2019.2.0.0.