### PR TITLE
Update docker-library images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,7 +16,7 @@ Directory: bionic/scm
 
 Tags: bionic, 18.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: bionic
 
 Tags: buster-curl, testing-curl
@@ -31,7 +31,7 @@ Directory: buster/scm
 
 Tags: buster, testing
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: buster
 
 Tags: cosmic-curl, 18.10-curl
@@ -46,7 +46,7 @@ Directory: cosmic/scm
 
 Tags: cosmic, 18.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: cosmic
 
 Tags: disco-curl, 19.04-curl
@@ -61,7 +61,7 @@ Directory: disco/scm
 
 Tags: disco, 19.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: disco
 
 Tags: jessie-curl, oldstable-curl
@@ -76,7 +76,7 @@ Directory: jessie/scm
 
 Tags: jessie, oldstable
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: jessie
 
 Tags: sid-curl, unstable-curl
@@ -91,7 +91,7 @@ Directory: sid/scm
 
 Tags: sid, unstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: sid
 
 Tags: stretch-curl, stable-curl, curl
@@ -106,7 +106,7 @@ Directory: stretch/scm
 
 Tags: stretch, stable, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: stretch
 
 Tags: trusty-curl, 14.04-curl
@@ -121,7 +121,7 @@ Directory: trusty/scm
 
 Tags: trusty, 14.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: trusty
 
 Tags: wheezy-curl, oldoldstable-curl
@@ -136,7 +136,7 @@ Directory: wheezy/scm
 
 Tags: wheezy, oldoldstable
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: wheezy
 
 Tags: xenial-curl, 16.04-curl
@@ -151,5 +151,5 @@ Directory: xenial/scm
 
 Tags: xenial, 16.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fd6bc9602ab42ec1f11dd5680e528d2266f3325
+GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: xenial

--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.3-rc1, 18.09-rc, rc, test
+Tags: 18.09.3, 18.09, 18, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 0ea1769704a07017fd9a876590de2feb434d33e2
-Directory: 18.09-rc
-
-Tags: 18.09.3-rc1-dind, 18.09-rc-dind, rc-dind, test-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 42a505379852819393f6a904eef3b1943070bf56
-Directory: 18.09-rc/dind
-
-Tags: 18.09.3-rc1-git, 18.09-rc-git, rc-git, test-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 42a505379852819393f6a904eef3b1943070bf56
-Directory: 18.09-rc/git
-
-Tags: 18.09.2, 18.09, 18, stable, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 0ea1769704a07017fd9a876590de2feb434d33e2
+GitCommit: 7411f18388ff3cc475f8b866cd2561f6b7822541
 Directory: 18.09
 
-Tags: 18.09.2-dind, 18.09-dind, 18-dind, stable-dind, dind
+Tags: 18.09.3-dind, 18.09-dind, 18-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 65fab2cd767c10f22ee66afa919eda80dbdc8872
 Directory: 18.09/dind
 
-Tags: 18.09.2-git, 18.09-git, 18-git, stable-git, git
+Tags: 18.09.3-git, 18.09-git, 18-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.16.1, 2.16, 2, latest
+Tags: 2.16.2, 2.16, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: adc3ba8acecc4a9c7cd88a452ce7ddc46151ad1e
+GitCommit: 375352f9ef19aa856d93b5008b44f959ce97b5ab
 Directory: 2/debian
 
-Tags: 2.16.1-alpine, 2.16-alpine, 2-alpine, alpine
+Tags: 2.16.2-alpine, 2.16-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: adc3ba8acecc4a9c7cd88a452ce7ddc46151ad1e
+GitCommit: 375352f9ef19aa856d93b5008b44f959ce97b5ab
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1

--- a/library/mariadb
+++ b/library/mariadb
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.4.3-bionic, 10.4-bionic, 10.4.3, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9d64941afc37e118beb796f2ae16f64e8e630d6d
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 10.4
 
 Tags: 10.3.13-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.13, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8e2027a09843ddae816c716e03a1397a4bcd8cb1
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 10.3
 
 Tags: 10.2.22-bionic, 10.2-bionic, 10.2.22, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: dbfc5061a3f863c7cf0908b1c4c70f837c1cf992
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 10.2
 
 Tags: 10.1.38-bionic, 10.1-bionic, 10.1.38, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c57380ba7837bb05b4f2a709394e5d6378e9ea79
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 10.1
 
 Tags: 10.0.38-xenial, 10.0-xenial, 10.0.38, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 8901e548307c933a3d661ac608d1151c8ad04180
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 10.0
 
 Tags: 5.5.63-trusty, 5.5-trusty, 5-trusty, 5.5.63, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 59fb80752413b40c2b3831a28cc6ae376a2b0b6e
+GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
 Directory: 5.5

--- a/library/mariadb
+++ b/library/mariadb
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.4.2-bionic, 10.4-bionic, 10.4.2, 10.4
+Tags: 10.4.3-bionic, 10.4-bionic, 10.4.3, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4fd10c511f4fdf39f9e57ba72e1612084ea2b717
+GitCommit: 9d64941afc37e118beb796f2ae16f64e8e630d6d
 Directory: 10.4
 
 Tags: 10.3.13-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.13, 10.3, 10, latest

--- a/library/mongo
+++ b/library/mongo
@@ -26,25 +26,25 @@ GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 3.6.10-stretch, 3.6-stretch, 3-stretch
-SharedTags: 3.6.10, 3.6, 3
+Tags: 3.6.11-stretch, 3.6-stretch, 3-stretch
+SharedTags: 3.6.11, 3.6, 3
 # see http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/3.6/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
+GitCommit: 7276b14c1e9b5f83b37f5f452e6a9f293aea2d8b
 Directory: 3.6
 
-Tags: 3.6.10-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.10-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.10, 3.6, 3
+Tags: 3.6.11-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.11-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.11, 3.6, 3
 Architectures: windows-amd64
-GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
+GitCommit: 7276b14c1e9b5f83b37f5f452e6a9f293aea2d8b
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.6.10-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
-SharedTags: 3.6.10-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.10, 3.6, 3
+Tags: 3.6.11-windowsservercore-1709, 3.6-windowsservercore-1709, 3-windowsservercore-1709
+SharedTags: 3.6.11-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.11, 3.6, 3
 Architectures: windows-amd64
-GitCommit: e3d632f0b8c5b979f06ec933eca2a08293161530
+GitCommit: 7276b14c1e9b5f83b37f5f452e6a9f293aea2d8b
 Directory: 3.6/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-9-jdk-oraclelinux7, 13-ea-9-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-9-jdk-oracle, 13-ea-9-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-10-jdk-oraclelinux7, 13-ea-10-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-10-jdk-oracle, 13-ea-10-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-9-jdk-alpine3.9, 13-ea-9-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-9-jdk-alpine, 13-ea-9-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,38 +15,38 @@ Architectures: amd64
 GitCommit: 032278c8c0f77b2d5ba6c63a6cfb2b9ea54aa75d
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-9-jdk-windowsservercore-ltsc2016, 13-ea-9-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-10-jdk-windowsservercore-ltsc2016, 13-ea-10-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-9-jdk-windowsservercore-1709, 13-ea-9-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-10-jdk-windowsservercore-1709, 13-ea-10-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-9-jdk-windowsservercore-1803, 13-ea-9-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-10-jdk-windowsservercore-1803, 13-ea-10-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-9-jdk-windowsservercore-1809, 13-ea-9-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-9-jdk-windowsservercore, 13-ea-9-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-9-jdk, 13-ea-9, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-10-jdk-windowsservercore-1809, 13-ea-10-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-9-jdk-nanoserver-sac2016, 13-ea-9-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-9-jdk-nanoserver, 13-ea-9-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-10-jdk-nanoserver-sac2016, 13-ea-10-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-10-jdk-nanoserver, 13-ea-10-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 8d76d63dbc207b5715e7d7698214ee3fcff830f8
+GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4dd2d4af82e86bfaa63236818d08c18d5e594466
+GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.2-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4dd2d4af82e86bfaa63236818d08c18d5e594466
+GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
@@ -24,29 +24,29 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.13-beta.1, 3.7-rc
+Tags: 3.7.13-rc.2, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f37d5ef612c106d1b1cc7d9891afdc170dc64116
+GitCommit: f6ff7c3746a345dfb28100b9c22f79fca2e84ed7
 Directory: 3.7-rc/ubuntu
 
-Tags: 3.7.13-beta.1-management, 3.7-rc-management
+Tags: 3.7.13-rc.2-management, 3.7-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7-rc/ubuntu/management
 
-Tags: 3.7.13-beta.1-alpine, 3.7-rc-alpine
+Tags: 3.7.13-rc.2-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f37d5ef612c106d1b1cc7d9891afdc170dc64116
+GitCommit: f6ff7c3746a345dfb28100b9c22f79fca2e84ed7
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.13-beta.1-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.13-rc.2-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management
 
 Tags: 3.7.12, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b40c4eedf6edac07d6eaf1b2687d9b6d61d931a9
+GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
 Directory: 3.7/ubuntu
 
 Tags: 3.7.12-management, 3.7-management, 3-management, management
@@ -56,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.12-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b40c4eedf6edac07d6eaf1b2687d9b6d61d931a9
+GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
 Directory: 3.7/alpine
 
 Tags: 3.7.12-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine

--- a/library/ruby
+++ b/library/ruby
@@ -11,17 +11,17 @@ Directory: 2.6/stretch
 
 Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e2c9f3f3c34820dd38212f68c1d5f0300264711
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.6/alpine3.9
 
 Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.6/alpine3.8
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
@@ -31,17 +31,17 @@ Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.5/alpine3.9
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
@@ -51,7 +51,7 @@ Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
@@ -61,17 +61,17 @@ Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.4/alpine3.9
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
@@ -81,7 +81,7 @@ Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
@@ -91,15 +91,15 @@ Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: da4b249e4ad5e521ba8c3d8b17119e9ac5af8df0
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f29d8d2181f8450ee1a5f08f82c21f66ebfde2cb
+GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `buildpack-deps`: `libgmp-dev` (docker-library/buildpack-deps#92)
- `docker`: 18.09.3
- `ghost`: 2.16.2
- `mariadb`: 10.4.3
- `mongo`: 3.6.11
- `openjdk`: 13-ea+10
- `rabbitmq`: 3.7.13-rc.2, `RABBITMQ_VM_MEMORY_HIGH_WATERMARK=0` valid (docker-library/rabbitmq#322)
- `ruby`: `libgmp` (docker-library/ruby#266)