### PR TITLE
Update docker-library images

### DIFF
--- a/library/python
+++ b/library/python
@@ -223,66 +223,66 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/alpine3.8
 
-Tags: 2.7.15-stretch, 2.7-stretch, 2-stretch
-SharedTags: 2.7.15, 2.7, 2
+Tags: 2.7.16-stretch, 2.7-stretch, 2-stretch
+SharedTags: 2.7.16, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/stretch
 
-Tags: 2.7.15-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.15-slim, 2.7-slim, 2-slim
+Tags: 2.7.16-slim-stretch, 2.7-slim-stretch, 2-slim-stretch, 2.7.16-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/stretch/slim
 
-Tags: 2.7.15-jessie, 2.7-jessie, 2-jessie
+Tags: 2.7.16-jessie, 2.7-jessie, 2-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/jessie
 
-Tags: 2.7.15-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
+Tags: 2.7.16-slim-jessie, 2.7-slim-jessie, 2-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/jessie/slim
 
-Tags: 2.7.15-wheezy, 2.7-wheezy, 2-wheezy
+Tags: 2.7.16-wheezy, 2.7-wheezy, 2-wheezy
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/wheezy
 
-Tags: 2.7.15-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.15-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.16-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.16-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/alpine3.9
 
-Tags: 2.7.15-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
+Tags: 2.7.16-alpine3.8, 2.7-alpine3.8, 2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/alpine3.8
 
-Tags: 2.7.15-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
-SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Tags: 2.7.16-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
+SharedTags: 2.7.16-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.16, 2.7, 2
 Architectures: windows-amd64
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 2.7.15-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
-SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Tags: 2.7.16-windowsservercore-1709, 2.7-windowsservercore-1709, 2-windowsservercore-1709
+SharedTags: 2.7.16-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.16, 2.7, 2
 Architectures: windows-amd64
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 2.7.15-windowsservercore-1803, 2.7-windowsservercore-1803, 2-windowsservercore-1803
-SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Tags: 2.7.16-windowsservercore-1803, 2.7-windowsservercore-1803, 2-windowsservercore-1803
+SharedTags: 2.7.16-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.16, 2.7, 2
 Architectures: windows-amd64
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 2.7.15-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
-SharedTags: 2.7.15-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.15, 2.7, 2
+Tags: 2.7.16-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
+SharedTags: 2.7.16-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.16, 2.7, 2
 Architectures: windows-amd64
-GitCommit: f444edd8a36e828ddf9d72aa3d3282725db0e48b
+GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809

--- a/library/ruby
+++ b/library/ruby
@@ -11,17 +11,17 @@ Directory: 2.6/stretch
 
 Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.6/alpine3.9
 
 Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.6/alpine3.8
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
@@ -31,17 +31,17 @@ Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.5/alpine3.9
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
@@ -51,7 +51,7 @@ Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
@@ -61,17 +61,17 @@ Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.4/alpine3.9
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
@@ -81,7 +81,7 @@ Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
@@ -91,15 +91,15 @@ Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: eae22dc2dfe30b48f1633912396110539e1b8d49
+GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `python`: 2.7.16
- `ruby`: add `gmp` persistently (https://github.com/docker-library/ruby/pull/269)