### PR TITLE
Add Amazon Corretto 11 image

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -1,8 +1,13 @@
 Maintainers: Amazon Corretto Team (@corretto),
              Eric Edens (@ericedens),
              iliana weller (@ilianaw)
-GitRepo: https://github.com/corretto/corretto-8-docker.git
 
 Tags: 8, 8u202, 8-al2-full, latest
+GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
 GitCommit: 00075d9caa52634b489867a1a8c5a146b1695d0a
+
+Tags: 11, 11.0.2, 11-al2-full
+GitRepo: https://github.com/corretto/corretto-11-docker.git
+GitFetch: refs/heads/11-al2-full
+GitCommit: 3ccbeb54d8258c12314b57382762ae0c5cd10871


### PR DESCRIPTION
This is the [release candidate](https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-corretto-11-is-now-available-as-a-release-candidate/) for Amazon Corretto 11, and is at the update level of 11.0.2. It installs the RPMs that are availabe on our [downloads page](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html), using an out-of-band public GPG key to verify the download.

Here's the [Dockerfile](https://github.com/corretto/corretto-11-docker/blob/master/Dockerfile).