### PR TITLE
Update docker-library images

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.16.2, 2.16, 2, latest
+Tags: 2.16.4, 2.16, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 375352f9ef19aa856d93b5008b44f959ce97b5ab
+GitCommit: f740a8ac3d105798cf5c86aa8073d37305927034
 Directory: 2/debian
 
-Tags: 2.16.2-alpine, 2.16-alpine, 2-alpine, alpine
+Tags: 2.16.4-alpine, 2.16-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 375352f9ef19aa856d93b5008b44f959ce97b5ab
+GitCommit: f740a8ac3d105798cf5c86aa8073d37305927034
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/8832650f4b1a00dab55d8a66cf282cdc3b142af3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mariadb/blob/b5689dcb9e0f411ed05070a9ce96ad1768f48825/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.4.3-bionic, 10.4-bionic, 10.4.3, 10.4
+Tags: 10.4.3-bionic, 10.4-bionic, rc-bionic, 10.4.3, 10.4, rc
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.4
 
 Tags: 10.3.13-bionic, 10.3-bionic, 10-bionic, bionic, 10.3.13, 10.3, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.3
 
 Tags: 10.2.22-bionic, 10.2-bionic, 10.2.22, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.2
 
 Tags: 10.1.38-bionic, 10.1-bionic, 10.1.38, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.1
 
 Tags: 10.0.38-xenial, 10.0-xenial, 10.0.38, 10.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.0
 
 Tags: 5.5.63-trusty, 5.5-trusty, 5-trusty, 5.5.63, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 43ab06b91a7a83b697f402fd86d91322341007ee
+GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 5.5

--- a/library/php
+++ b/library/php
@@ -4,172 +4,172 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.3.2-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.2-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.2-cli, 7.3-cli, 7-cli, cli, 7.3.2, 7.3, 7, latest
+Tags: 7.3.3-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.3-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.3-cli, 7.3-cli, 7-cli, cli, 7.3.3, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/stretch/cli
 
-Tags: 7.3.2-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.2-apache, 7.3-apache, 7-apache, apache
+Tags: 7.3.3-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.3-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/stretch/apache
 
-Tags: 7.3.2-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.2-fpm, 7.3-fpm, 7-fpm, fpm
+Tags: 7.3.3-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.3-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/stretch/fpm
 
-Tags: 7.3.2-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.2-zts, 7.3-zts, 7-zts, zts
+Tags: 7.3.3-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.3-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.2-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.2-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.2-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.2-alpine, 7.3-alpine, 7-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.3.3-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.3-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.3-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.3-alpine, 7.3-alpine, 7-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.9/cli
 
-Tags: 7.3.2-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.2-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.3.3-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.3-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.9/fpm
 
-Tags: 7.3.2-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.2-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.3.3-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.3-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.9/zts
 
-Tags: 7.3.2-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.2-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
+Tags: 7.3.3-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.3-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.8/cli
 
-Tags: 7.3.2-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
+Tags: 7.3.3-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.8/fpm
 
-Tags: 7.3.2-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
+Tags: 7.3.3-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: bb16de8a711d1ba1dc76adf4665b3b1c06a06922
 Directory: 7.3/alpine3.8/zts
 
-Tags: 7.2.15-cli-stretch, 7.2-cli-stretch, 7.2.15-stretch, 7.2-stretch, 7.2.15-cli, 7.2-cli, 7.2.15, 7.2
+Tags: 7.2.16-cli-stretch, 7.2-cli-stretch, 7.2.16-stretch, 7.2-stretch, 7.2.16-cli, 7.2-cli, 7.2.16, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/stretch/cli
 
-Tags: 7.2.15-apache-stretch, 7.2-apache-stretch, 7.2.15-apache, 7.2-apache
+Tags: 7.2.16-apache-stretch, 7.2-apache-stretch, 7.2.16-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/stretch/apache
 
-Tags: 7.2.15-fpm-stretch, 7.2-fpm-stretch, 7.2.15-fpm, 7.2-fpm
+Tags: 7.2.16-fpm-stretch, 7.2-fpm-stretch, 7.2.16-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/stretch/fpm
 
-Tags: 7.2.15-zts-stretch, 7.2-zts-stretch, 7.2.15-zts, 7.2-zts
+Tags: 7.2.16-zts-stretch, 7.2-zts-stretch, 7.2.16-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/stretch/zts
 
-Tags: 7.2.15-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.15-alpine3.9, 7.2-alpine3.9, 7.2.15-cli-alpine, 7.2-cli-alpine, 7.2.15-alpine, 7.2-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.2.16-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.16-alpine3.9, 7.2-alpine3.9, 7.2.16-cli-alpine, 7.2-cli-alpine, 7.2.16-alpine, 7.2-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.9/cli
 
-Tags: 7.2.15-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.15-fpm-alpine, 7.2-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.2.16-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.16-fpm-alpine, 7.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.9/fpm
 
-Tags: 7.2.15-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.15-zts-alpine, 7.2-zts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.2.16-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.16-zts-alpine, 7.2-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.9/zts
 
-Tags: 7.2.15-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.15-alpine3.8, 7.2-alpine3.8
+Tags: 7.2.16-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.16-alpine3.8, 7.2-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.8/cli
 
-Tags: 7.2.15-fpm-alpine3.8, 7.2-fpm-alpine3.8
+Tags: 7.2.16-fpm-alpine3.8, 7.2-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.8/fpm
 
-Tags: 7.2.15-zts-alpine3.8, 7.2-zts-alpine3.8
+Tags: 7.2.16-zts-alpine3.8, 7.2-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: 873725e57ec2fc5f2642dc0023676597bcc4bea9
 Directory: 7.2/alpine3.8/zts
 
-Tags: 7.1.26-cli-stretch, 7.1-cli-stretch, 7.1.26-stretch, 7.1-stretch, 7.1.26-cli, 7.1-cli, 7.1.26, 7.1
+Tags: 7.1.27-cli-stretch, 7.1-cli-stretch, 7.1.27-stretch, 7.1-stretch, 7.1.27-cli, 7.1-cli, 7.1.27, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/stretch/cli
 
-Tags: 7.1.26-apache-stretch, 7.1-apache-stretch, 7.1.26-apache, 7.1-apache
+Tags: 7.1.27-apache-stretch, 7.1-apache-stretch, 7.1.27-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/stretch/apache
 
-Tags: 7.1.26-fpm-stretch, 7.1-fpm-stretch, 7.1.26-fpm, 7.1-fpm
+Tags: 7.1.27-fpm-stretch, 7.1-fpm-stretch, 7.1.27-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/stretch/fpm
 
-Tags: 7.1.26-zts-stretch, 7.1-zts-stretch, 7.1.26-zts, 7.1-zts
+Tags: 7.1.27-zts-stretch, 7.1-zts-stretch, 7.1.27-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/stretch/zts
 
-Tags: 7.1.26-cli-jessie, 7.1-cli-jessie, 7.1.26-jessie, 7.1-jessie
+Tags: 7.1.27-cli-jessie, 7.1-cli-jessie, 7.1.27-jessie, 7.1-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/jessie/cli
 
-Tags: 7.1.26-apache-jessie, 7.1-apache-jessie
+Tags: 7.1.27-apache-jessie, 7.1-apache-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/jessie/apache
 
-Tags: 7.1.26-fpm-jessie, 7.1-fpm-jessie
+Tags: 7.1.27-fpm-jessie, 7.1-fpm-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/jessie/fpm
 
-Tags: 7.1.26-zts-jessie, 7.1-zts-jessie
+Tags: 7.1.27-zts-jessie, 7.1-zts-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/jessie/zts
 
-Tags: 7.1.26-cli-alpine3.9, 7.1-cli-alpine3.9, 7.1.26-alpine3.9, 7.1-alpine3.9, 7.1.26-cli-alpine, 7.1-cli-alpine, 7.1.26-alpine, 7.1-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.1.27-cli-alpine3.9, 7.1-cli-alpine3.9, 7.1.27-alpine3.9, 7.1-alpine3.9, 7.1.27-cli-alpine, 7.1-cli-alpine, 7.1.27-alpine, 7.1-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.9/cli
 
-Tags: 7.1.26-fpm-alpine3.9, 7.1-fpm-alpine3.9, 7.1.26-fpm-alpine, 7.1-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.1.27-fpm-alpine3.9, 7.1-fpm-alpine3.9, 7.1.27-fpm-alpine, 7.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.9/fpm
 
-Tags: 7.1.26-zts-alpine3.9, 7.1-zts-alpine3.9, 7.1.26-zts-alpine, 7.1-zts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+Tags: 7.1.27-zts-alpine3.9, 7.1-zts-alpine3.9, 7.1.27-zts-alpine, 7.1-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.9/zts
 
-Tags: 7.1.26-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.26-alpine3.8, 7.1-alpine3.8
+Tags: 7.1.27-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.27-alpine3.8, 7.1-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.8/cli
 
-Tags: 7.1.26-fpm-alpine3.8, 7.1-fpm-alpine3.8
+Tags: 7.1.27-fpm-alpine3.8, 7.1-fpm-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.8/fpm
 
-Tags: 7.1.26-zts-alpine3.8, 7.1-zts-alpine3.8
+Tags: 7.1.27-zts-alpine3.8, 7.1-zts-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 640a30e8ff27b1ad7523a212522472fda84d56ff
+GitCommit: a5cc6ff7d8f14330e55f8df673c69e2f35adf957
 Directory: 7.1/alpine3.8/zts

--- a/library/ruby
+++ b/library/ruby
@@ -6,100 +6,100 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.6.1-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.1, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e2c9f3f3c34820dd38212f68c1d5f0300264711
+GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
 Directory: 2.6/stretch
 
 Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
 Directory: 2.6/alpine3.9
 
 Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
 Directory: 2.6/alpine3.8
 
 Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.5/stretch
 
 Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.5/alpine3.9
 
 Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/stretch
 
 Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.5-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/jessie
 
 Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/jessie/slim
 
 Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/alpine3.9
 
 Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/stretch
 
 Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/stretch/slim
 
 Tags: 2.3.8-jessie, 2.3-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 84db4691c080384c8fbce44c722d46cedd6a384b
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/jessie
 
 Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/jessie/slim
 
 Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/alpine3.8
 
 Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 73adf677cdb4b79ff4c98fb19aca11802e0d0ec9
+GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
 Directory: 2.3/alpine3.7


### PR DESCRIPTION
- `ghost`: 2.16.4
- `mariadb`: add `rc` alias (docker-library/mariadb#230)
- `php`: 7.3.3, 7.2.16, 7.1.27
- `ruby`: update RubyGems to 3.0.3 (https://github.com/docker-library/ruby/pull/271) [security]