### PR TITLE
Update docker-library images

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -4,46 +4,46 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
 Tags: 5.0.2, 5.0, 5, latest
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 5.0
 
 Tags: 4.4.23, 4.4, 4
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.4
 
 Tags: 4.3.48, 4.3
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.3
 
 Tags: 4.2.53, 4.2
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.2
 
 Tags: 4.1.17, 4.1
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.1
 
 Tags: 4.0.44, 4.0
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.2
 
 Tags: 3.1.23, 3.1
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.1
 
 Tags: 3.0.22, 3.0
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 38a2a9828a6916afcb05663fd5db950afaf4c17d
 Directory: 3.0

--- a/library/drupal
+++ b/library/drupal
@@ -15,7 +15,7 @@ GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
 Directory: 8.6/fpm
 
 Tags: 8.6.10-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
 Directory: 8.6/fpm-alpine
 
@@ -30,7 +30,7 @@ GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
 Directory: 8.5/fpm
 
 Tags: 8.5.11-fpm-alpine, 8.5-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
 Directory: 8.5/fpm-alpine
 
@@ -45,6 +45,6 @@ GitCommit: 4ee004ea6b20dee3daae3b462b0dbdcab0b6dcb1
 Directory: 7/fpm
 
 Tags: 7.64-fpm-alpine, 7-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4ee004ea6b20dee3daae3b462b0dbdcab0b6dcb1
 Directory: 7/fpm-alpine

--- a/library/golang
+++ b/library/golang
@@ -12,7 +12,7 @@ GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
 Directory: 1.12/stretch
 
 Tags: 1.12.0-alpine3.9, 1.12-alpine3.9, 1-alpine3.9, alpine3.9, 1.12.0-alpine, 1.12-alpine, 1-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ff7c350f627c6724e9bffa19f519545a5997a924
 Directory: 1.12/alpine3.9
 
@@ -58,7 +58,7 @@ GitCommit: 2e795f515357c575359f0720acaf7f5490f8bcf5
 Directory: 1.11/stretch
 
 Tags: 1.11.5-alpine3.9, 1.11-alpine3.9, 1.11.5-alpine, 1.11-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7967b894abc1ff563e2d854afd9beabd37def26c
 Directory: 1.11/alpine3.9
 

--- a/library/haproxy
+++ b/library/haproxy
@@ -10,7 +10,7 @@ GitCommit: 51e62eeb27fc5eb31152687e4b003867e2aa2ab5
 Directory: 1.9
 
 Tags: 1.9.4-alpine, 1.9-alpine, 1-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 51e62eeb27fc5eb31152687e4b003867e2aa2ab5
 Directory: 1.9/alpine
 
@@ -20,7 +20,7 @@ GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
 Directory: 1.8
 
 Tags: 1.8.19-alpine, 1.8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
 Directory: 1.8/alpine
 
@@ -30,7 +30,7 @@ GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
 Directory: 1.7/alpine
 

--- a/library/httpd
+++ b/library/httpd
@@ -10,6 +10,6 @@ GitCommit: f6cb814440756f97821895731765d306528a3429
 Directory: 2.4
 
 Tags: 2.4.38-alpine, 2.4-alpine, 2-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f6cb814440756f97821895731765d306528a3429
 Directory: 2.4/alpine

--- a/library/joomla
+++ b/library/joomla
@@ -14,7 +14,7 @@ GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.1/fpm
 
 Tags: 3.9.3-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.3-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.1/fpm-alpine
 
@@ -29,7 +29,7 @@ GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.2/fpm
 
 Tags: 3.9.3-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.2/fpm-alpine
 
@@ -44,6 +44,6 @@ GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.3/fpm
 
 Tags: 3.9.3-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
 Directory: php7.3/fpm-alpine

--- a/library/matomo
+++ b/library/matomo
@@ -13,6 +13,6 @@ GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
 Directory: fpm
 
 Tags: 3.8.1-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
 Directory: fpm-alpine

--- a/library/memcached
+++ b/library/memcached
@@ -10,6 +10,6 @@ GitCommit: c7bc33a596845a439051bbe32357b4b0e6e9dddc
 Directory: debian
 
 Tags: 1.5.12-alpine, 1.5-alpine, 1-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 24ecf1cbeb76244031036eed161bb8bd00c99085
 Directory: alpine

--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-10-jdk-oraclelinux7, 13-ea-10-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-10-jdk-oracle, 13-ea-10-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-11-jdk-oraclelinux7, 13-ea-11-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-11-jdk-oracle, 13-ea-11-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-9-jdk-alpine3.9, 13-ea-9-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-9-jdk-alpine, 13-ea-9-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,38 +15,38 @@ Architectures: amd64
 GitCommit: 032278c8c0f77b2d5ba6c63a6cfb2b9ea54aa75d
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-10-jdk-windowsservercore-ltsc2016, 13-ea-10-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-11-jdk-windowsservercore-ltsc2016, 13-ea-11-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-10-jdk-windowsservercore-1709, 13-ea-10-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-11-jdk-windowsservercore-1709, 13-ea-11-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-10-jdk-windowsservercore-1803, 13-ea-10-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-11-jdk-windowsservercore-1803, 13-ea-11-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-10-jdk-windowsservercore-1809, 13-ea-10-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-10-jdk-windowsservercore, 13-ea-10-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-10-jdk, 13-ea-10, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-11-jdk-windowsservercore-1809, 13-ea-11-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-10-jdk-nanoserver-sac2016, 13-ea-10-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-10-jdk-nanoserver, 13-ea-10-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-11-jdk-nanoserver-sac2016, 13-ea-11-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-11-jdk-nanoserver, 13-ea-11-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 823c4ba26ee436c8a8abf7c0703b98b01960cca2
+GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -165,7 +165,7 @@ GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jdk/slim
 
 Tags: 8u191-jdk-alpine3.9, 8u191-alpine3.9, 8-jdk-alpine3.9, 8-alpine3.9, 8u191-jdk-alpine, 8u191-alpine, 8-jdk-alpine, 8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 8/jdk/alpine
 
@@ -216,7 +216,7 @@ GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
 Directory: 8/jre/slim
 
 Tags: 8u191-jre-alpine3.9, 8-jre-alpine3.9, 8u191-jre-alpine, 8-jre-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
 Directory: 8/jre/alpine
 
@@ -232,7 +232,7 @@ GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jdk/slim
 
 Tags: 7u201-jdk-alpine3.9, 7u201-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u201-jdk-alpine, 7u201-alpine, 7-jdk-alpine, 7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
 Directory: 7/jdk/alpine
 
@@ -248,6 +248,6 @@ GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
 Directory: 7/jre/slim
 
 Tags: 7u201-jre-alpine3.9, 7-jre-alpine3.9, 7u201-jre-alpine, 7-jre-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
 Directory: 7/jre/alpine

--- a/library/postgres
+++ b/library/postgres
@@ -10,7 +10,7 @@ GitCommit: 7e80419825e4bab4e749bc61334570ffc261ea5e
 Directory: 11
 
 Tags: 11.2-alpine, 11-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6c3b27f1433ad81675afb386a182098dc867e3e8
 Directory: 11/alpine
 
@@ -20,7 +20,7 @@ GitCommit: ef04f3055bab11b10d3d5c41a659acfacf2c850b
 Directory: 10
 
 Tags: 10.7-alpine, 10-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cc305ee1c59d93ac1808108edda6556b879374a4
 Directory: 10/alpine
 
@@ -30,7 +30,7 @@ GitCommit: a9610d18de51c189c9d4b0197c408e2e3bfb7917
 Directory: 9.6
 
 Tags: 9.6.12-alpine, 9.6-alpine, 9-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 122fb0bdcc8058166d7535d30724278efbe41e86
 Directory: 9.6/alpine
 
@@ -40,7 +40,7 @@ GitCommit: 58793919b63a1e0b2a9797b857bf435276e28436
 Directory: 9.5
 
 Tags: 9.5.16-alpine, 9.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c6da877bba4184e5e112032f52e36bcabccc6ce8
 Directory: 9.5/alpine
 
@@ -50,6 +50,6 @@ GitCommit: 23d28bb5957e74cfa1167262fffaddab1bdea4d6
 Directory: 9.4
 
 Tags: 9.4.21-alpine, 9.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fd5c083fcfb276b9cc2299057a8c6c8431bc3b0a
 Directory: 9.4/alpine

--- a/library/python
+++ b/library/python
@@ -16,7 +16,7 @@ GitCommit: fc2b02ab98f1d24e149758b05273d5f712a8946e
 Directory: 3.8-rc/stretch/slim
 
 Tags: 3.8.0a2-alpine3.9, 3.8-rc-alpine3.9, rc-alpine3.9, 3.8.0a2-alpine, 3.8-rc-alpine, rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fc2b02ab98f1d24e149758b05273d5f712a8946e
 Directory: 3.8-rc/alpine3.9
 
@@ -60,7 +60,7 @@ GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.2-alpine3.9, 3.7-alpine3.9, 3-alpine3.9, alpine3.9, 3.7.2-alpine, 3.7-alpine, 3-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9bb5d46dbcf16250a2d292ddc1e0b7a792aa275f
 Directory: 3.7/alpine3.9
 
@@ -119,7 +119,7 @@ GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/jessie/slim
 
 Tags: 3.6.8-alpine3.9, 3.6-alpine3.9, 3.6.8-alpine, 3.6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b9cb77020447a1ac30f5f1e17f31e534826db7bb
 Directory: 3.6/alpine3.9
 
@@ -178,7 +178,7 @@ GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/jessie/slim
 
 Tags: 3.5.6-alpine3.9, 3.5-alpine3.9, 3.5.6-alpine, 3.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af2cf72d9c6c304d041c88db3e79242fd8c9ce60
 Directory: 3.5/alpine3.9
 
@@ -214,7 +214,7 @@ GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/wheezy
 
 Tags: 3.4.9-alpine3.9, 3.4-alpine3.9, 3.4.9-alpine, 3.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ae9270e7cab01ce5cde6efe89694d04dd9ef9f65
 Directory: 3.4/alpine3.9
 
@@ -250,7 +250,7 @@ GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/wheezy
 
 Tags: 2.7.16-alpine3.9, 2.7-alpine3.9, 2-alpine3.9, 2.7.16-alpine, 2.7-alpine, 2-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 636e02777ea417851942e6e826fe5a6b4dee6f74
 Directory: 2.7/alpine3.9
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,62 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.0-beta.2, 3.8-rc
+Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
+GitCommit: 653e7496aa1196e2b55587440d86ad8c9a323008
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.0-beta.2-management, 3.8-rc-management
+Tags: 3.8.0-beta.3-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.0-beta.2-alpine, 3.8-rc-alpine
+Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
+GitCommit: 653e7496aa1196e2b55587440d86ad8c9a323008
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.0-beta.2-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.13-rc.2, 3.7-rc
+Tags: 3.7.13, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6ff7c3746a345dfb28100b9c22f79fca2e84ed7
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.13-rc.2-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.13-rc.2-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f6ff7c3746a345dfb28100b9c22f79fca2e84ed7
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.13-rc.2-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.12, 3.7, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
+GitCommit: 45cba1ede73342a01dbeacc348f8f077be4b1079
 Directory: 3.7/ubuntu
 
-Tags: 3.7.12-management, 3.7-management, 3-management, management
+Tags: 3.7.13-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.12-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.13-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7f1cedb9e4ca45eeaf1e4454aab4ae92c18f0d8
+GitCommit: 45cba1ede73342a01dbeacc348f8f077be4b1079
 Directory: 3.7/alpine
 
-Tags: 3.7.12-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.13-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management

--- a/library/redis
+++ b/library/redis
@@ -15,7 +15,7 @@ GitCommit: 7be79f51e29a009fefdc218c8479d340b8c4a5e1
 Directory: 5.0/32bit
 
 Tags: 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.3-alpine3.9, 5.0-alpine3.9, 5-alpine3.9, alpine3.9
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 60db7082c81f5d457046f199244c5d651f04b3fa
 Directory: 5.0/alpine
 
@@ -30,6 +30,6 @@ GitCommit: 8e1acc18156603cc3643bf22ced6069cf8be1622
 Directory: 4.0/32bit
 
 Tags: 4.0.13-alpine, 4.0-alpine, 4-alpine, 4.0.13-alpine3.9, 4.0-alpine3.9, 4-alpine3.9
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8e1acc18156603cc3643bf22ced6069cf8be1622
 Directory: 4.0/alpine

--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.1.0-php7.1-apache, 5.1-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.1.0-php7.1, 5.1-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.1/apache
 
 Tags: 5.1.0-php7.1-fpm, 5.1-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.1/fpm
 
 Tags: 5.1.0-php7.1-fpm-alpine, 5.1-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.1/fpm-alpine
 
 Tags: 5.1.0-apache, 5.1-apache, 5-apache, apache, 5.1.0, 5.1, 5, latest, 5.1.0-php7.2-apache, 5.1-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.1.0-php7.2, 5.1-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.2/apache
 
 Tags: 5.1.0-fpm, 5.1-fpm, 5-fpm, fpm, 5.1.0-php7.2-fpm, 5.1-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.2/fpm
 
 Tags: 5.1.0-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.1.0-php7.2-fpm-alpine, 5.1-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.2/fpm-alpine
 
 Tags: 5.1.0-php7.3-apache, 5.1-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.1.0-php7.3, 5.1-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.3/apache
 
 Tags: 5.1.0-php7.3-fpm, 5.1-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.3/fpm
 
 Tags: 5.1.0-php7.3-fpm-alpine, 5.1-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: b8bfd453a65ce574982d328103aaa2850997cede
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 870e663c9a455a7e5116ce319fda5fceef4f54a0
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-2.1.0-php7.1, cli-2.1-php7.1, cli-2-php7.1, cli-php7.1
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
 Directory: php7.1/cli
 
 Tags: cli-2.1.0, cli-2.1, cli-2, cli, cli-2.1.0-php7.2, cli-2.1-php7.2, cli-2-php7.2, cli-php7.2
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
 Directory: php7.2/cli
 
 Tags: cli-2.1.0-php7.3, cli-2.1-php7.3, cli-2-php7.3, cli-php7.3
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f36a09ba86bc6f53326a36975f79bcf35bed7f9b
 Directory: php7.3/cli


### PR DESCRIPTION
- `bash`: Alpine `arm32v7`
- `drupal`: Alpine `arm32v7`
- `golang`: Alpine `arm32v7`
- `haproxy`: Alpine `arm32v7`
- `httpd`: Alpine `arm32v7`
- `joomla`: Alpine `arm32v7`
- `matomo`: Alpine `arm32v7`
- `memcached`: Alpine `arm32v7`
- `openjdk`: 13-ea-11, Alpine `arm32v7` (8u191, 7u201)
- `postgres`: Alpine `arm32v7`
- `python`: Alpine `arm32v7`
- `rabbitmq`: 3.8.0-beta.3, 3.7.13, Alpine `arm32v7`
- `redis`: Alpine `arm32v7`
- `wordpress`: non-fatal database connection test (docker-library/wordpress#386), Alpine `arm32v7`