### PR TITLE
Bump for CouchDB - 2.3.1

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,9 +3,13 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: ce1679b4c1312203df2af8936c367c7027d2e888
+GitCommit: 3bcc626d30623789b4750d076f059bcd010c2a04
 
-Tags: latest, 2.3.0, 2.3, 2
+Tags: latest, 2.3.1, 2.3, 2
+Architectures: amd64
+Directory: 2.3.1
+
+Tags: 2.3.0
 Architectures: amd64
 Directory: 2.3.0
 


### PR DESCRIPTION
New release, new commit.

Minor change to our Dockerfile to disable IPv6 to fix gpg2 signature retrieval. Otherwise, it's identical to 2.3.0.