### PR TITLE
Update YOURLS GitCommit sha

### DIFF
--- a/library/yourls
+++ b/library/yourls
@@ -6,15 +6,15 @@ GitRepo: https://github.com/YOURLS/docker-yourls.git
 
 Tags: 1.7.3-apache, 1.7-apache, 1-apache, apache, 1.7.3, 1.7, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 71832c631cd4cb174070d54d3136aa2e413edee8
+GitCommit: f7ed6e15964d9e9025267598541e5e93e7924f8f
 Directory: apache
 
 Tags: 1.7.3-fpm, 1.7-fpm, 1-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 71832c631cd4cb174070d54d3136aa2e413edee8
+GitCommit: f7ed6e15964d9e9025267598541e5e93e7924f8f
 Directory: fpm
 
 Tags: 1.7.3-fpm-alpine, 1.7-fpm-alpine, 1-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: 71832c631cd4cb174070d54d3136aa2e413edee8
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: f7ed6e15964d9e9025267598541e5e93e7924f8f
 Directory: fpm-alpine


### PR DESCRIPTION
Another little fix for the YOURLS image.

Refs:
* https://github.com/YOURLS/docker-yourls/pull/23
* https://github.com/YOURLS/docker-yourls/pull/24

Also, parent fpm-alpine image seems to add `arm32v7` compatibility.