### PR TITLE
Update docker image for Ruby 2.6.2 release

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,44 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.6.1-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.1, 2.6, 2, latest
+Tags: 2.6.2-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.2, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
+GitCommit: 995719add69339b78bd8cde46183b4902b761add
 Directory: 2.6/stretch
 
-Tags: 2.6.1-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.1-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.2-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.2-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
+GitCommit: 995719add69339b78bd8cde46183b4902b761add
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.1-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.1-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.2-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.2-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
+GitCommit: 995719add69339b78bd8cde46183b4902b761add
 Directory: 2.6/alpine3.9
 
-Tags: 2.6.1-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
+Tags: 2.6.2-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 96fc06fb331a20ba823ecc11563a99d1eb94203f
+GitCommit: 995719add69339b78bd8cde46183b4902b761add
 Directory: 2.6/alpine3.8
 
-Tags: 2.5.3-stretch, 2.5-stretch, 2.5.3, 2.5
+Tags: 2.5.4-stretch, 2.5-stretch, 2.5.4, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
 Directory: 2.5/stretch
 
-Tags: 2.5.3-slim-stretch, 2.5-slim-stretch, 2.5.3-slim, 2.5-slim
+Tags: 2.5.4-slim-stretch, 2.5-slim-stretch, 2.5.4-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.3-alpine3.9, 2.5-alpine3.9, 2.5.3-alpine, 2.5-alpine
+Tags: 2.5.4-alpine3.9, 2.5-alpine3.9, 2.5.4-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
 Directory: 2.5/alpine3.9
 
-Tags: 2.5.3-alpine3.8, 2.5-alpine3.8
+Tags: 2.5.4-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4


### PR DESCRIPTION
Adding new ruby version [2.6.2](https://github.com/docker-library/ruby/commit/995719add69339b78bd8cde46183b4902b761add).
What I did:

```
docker run \
    --rm -it \
    -w /ruby \
    --volume $PWD/ruby:/ruby \
    buildpack-deps \
    bash -c "
       curl -s https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-amd64 > /usr/local/bin/bashbrew;
       chmod +x /usr/local/bin/bashbrew;
       ./generate-stackbrew-library.sh
    " > official-images/library/ruby
```