### PR TITLE
Update docker-library images

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.6.10-apache, 8.6-apache, 8-apache, apache, 8.6.10, 8.6, 8, latest
+Tags: 8.6.11-apache, 8.6-apache, 8-apache, apache, 8.6.11, 8.6, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
+GitCommit: aa90b9ad4c37a205c0641efddecccc038235ea28
 Directory: 8.6/apache
 
-Tags: 8.6.10-fpm, 8.6-fpm, 8-fpm, fpm
+Tags: 8.6.11-fpm, 8.6-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
+GitCommit: aa90b9ad4c37a205c0641efddecccc038235ea28
 Directory: 8.6/fpm
 
-Tags: 8.6.10-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.6.11-fpm-alpine, 8.6-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: d459c51e430f321c0d06cab276db5c61a075eac3
+GitCommit: aa90b9ad4c37a205c0641efddecccc038235ea28
 Directory: 8.6/fpm-alpine
 
-Tags: 8.5.11-apache, 8.5-apache, 8.5.11, 8.5
+Tags: 8.5.12-apache, 8.5-apache, 8.5.12, 8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
+GitCommit: b969c632c937902f891c1c9476a32c76dc07f2e4
 Directory: 8.5/apache
 
-Tags: 8.5.11-fpm, 8.5-fpm
+Tags: 8.5.12-fpm, 8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
+GitCommit: b969c632c937902f891c1c9476a32c76dc07f2e4
 Directory: 8.5/fpm
 
-Tags: 8.5.11-fpm-alpine, 8.5-fpm-alpine
+Tags: 8.5.12-fpm-alpine, 8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 608625a98410261dafab17ad5c3dbb4e12e3cceb
+GitCommit: b969c632c937902f891c1c9476a32c76dc07f2e4
 Directory: 8.5/fpm-alpine
 
 Tags: 7.64-apache, 7-apache, 7.64, 7

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.6.1
-GitCommit: b6f135ff5d0a61b899993a8aa3e725f1b0b3058a
+Tags: 6.6.2
+GitCommit: 2b7cab01397ff37510c8970827fa4c399c87d23a
 Directory: 6
 
 Tags: 5.6.15, 5.6, 5

--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.16.4, 2.16, 2, latest
+Tags: 2.18.1, 2.18, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f740a8ac3d105798cf5c86aa8073d37305927034
+GitCommit: 76e2d36690015a97a4498899ed08c925633eb4c8
 Directory: 2/debian
 
-Tags: 2.16.4-alpine, 2.16-alpine, 2-alpine, alpine
+Tags: 2.18.1-alpine, 2.18-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f740a8ac3d105798cf5c86aa8073d37305927034
+GitCommit: 76e2d36690015a97a4498899ed08c925633eb4c8
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1

--- a/library/joomla
+++ b/library/joomla
@@ -3,47 +3,47 @@
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
 GitRepo: https://github.com/joomla/docker-joomla.git
 
-Tags: 3.9.3-apache, 3.9-apache, 3-apache, apache, 3.9.3, 3.9, 3, latest, 3.9.3-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.3-php7.1, 3.9-php7.1, 3-php7.1, php7.1
+Tags: 3.9.4-apache, 3.9-apache, 3-apache, apache, 3.9.4, 3.9, 3, latest, 3.9.4-php7.1-apache, 3.9-php7.1-apache, 3-php7.1-apache, php7.1-apache, 3.9.4-php7.1, 3.9-php7.1, 3-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.1/apache
 
-Tags: 3.9.3-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.3-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
+Tags: 3.9.4-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.4-php7.1-fpm, 3.9-php7.1-fpm, 3-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.1/fpm
 
-Tags: 3.9.3-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.3-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 3.9.4-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.4-php7.1-fpm-alpine, 3.9-php7.1-fpm-alpine, 3-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.1/fpm-alpine
 
-Tags: 3.9.3-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.3-php7.2, 3.9-php7.2, 3-php7.2, php7.2
+Tags: 3.9.4-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.4-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.2/apache
 
-Tags: 3.9.3-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.4-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.2/fpm
 
-Tags: 3.9.3-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.4-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.2/fpm-alpine
 
-Tags: 3.9.3-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.3-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Tags: 3.9.4-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.4-php7.3, 3.9-php7.3, 3-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.3/apache
 
-Tags: 3.9.3-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Tags: 3.9.4-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.3/fpm
 
-Tags: 3.9.3-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 3.9.4-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 771702b8073e6037bf28aa5a486fca182b86c439
+GitCommit: 13d38e1c494304fdacd016c59bb5ea0de35ab1c8
 Directory: php7.3/fpm-alpine

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.6.1
-GitCommit: ad6a8d3f912d148e4ceb6eae5eb28eacfc9d9e45
+Tags: 6.6.2
+GitCommit: bc26b5669948efedd267a9c60e1dc34ee8fbb5f0
 Directory: 6
 
 Tags: 5.6.15, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.6.1
-GitCommit: ebda4ecb21993ffdfe397f0fee3e9fedfd069c56
+Tags: 6.6.2
+GitCommit: bea296dda8e4f95a3863e3aa0d2d1eecb78babc4
 Directory: 6
 
 Tags: 5.6.15, 5.6, 5

--- a/library/matomo
+++ b/library/matomo
@@ -4,15 +4,15 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.8.1-apache, 3.8-apache, 3-apache, apache, 3.8.1, 3.8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
+GitCommit: e2bb14b2d91fd64be4edd9ce2feb91b172c84511
 Directory: apache
 
 Tags: 3.8.1-fpm, 3.8-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
+GitCommit: e2bb14b2d91fd64be4edd9ce2feb91b172c84511
 Directory: fpm
 
 Tags: 3.8.1-fpm-alpine, 3.8-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 31c9f0a2f86a70152ca0219029b16170130cb26b
+GitCommit: e2bb14b2d91fd64be4edd9ce2feb91b172c84511
 Directory: fpm-alpine

--- a/library/mongo
+++ b/library/mongo
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.4.19-jessie, 3.4-jessie
-SharedTags: 3.4.19, 3.4
+Tags: 3.4.20-jessie, 3.4-jessie
+SharedTags: 3.4.20, 3.4
 # see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/3.4/main/
 # (i386, ppc64el, s390x are empty)
 Architectures: amd64
-GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
+GitCommit: 135be00ece480b72826d871f5725214c35a1a9ab
 Directory: 3.4
 
-Tags: 3.4.19-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
-SharedTags: 3.4.19-windowsservercore, 3.4-windowsservercore, 3.4.19, 3.4
+Tags: 3.4.20-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
+SharedTags: 3.4.20-windowsservercore, 3.4-windowsservercore, 3.4.20, 3.4
 Architectures: windows-amd64
-GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
+GitCommit: 135be00ece480b72826d871f5725214c35a1a9ab
 Directory: 3.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.19-windowsservercore-1709, 3.4-windowsservercore-1709
-SharedTags: 3.4.19-windowsservercore, 3.4-windowsservercore, 3.4.19, 3.4
+Tags: 3.4.20-windowsservercore-1709, 3.4-windowsservercore-1709
+SharedTags: 3.4.20-windowsservercore, 3.4-windowsservercore, 3.4.20, 3.4
 Architectures: windows-amd64
-GitCommit: 5ab118c15c474192dc6ab058e5cb370b73ced636
+GitCommit: 135be00ece480b72826d871f5725214c35a1a9ab
 Directory: 3.4/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 

--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 653e7496aa1196e2b55587440d86ad8c9a323008
+GitCommit: 5fe8361fc2b14587c44f7b6c573e442cf2cbdcd4
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 653e7496aa1196e2b55587440d86ad8c9a323008
+GitCommit: 5fe8361fc2b14587c44f7b6c573e442cf2cbdcd4
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.13, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45cba1ede73342a01dbeacc348f8f077be4b1079
+GitCommit: fe180abbbcdec93323805133205fc345e67784b9
 Directory: 3.7/ubuntu
 
 Tags: 3.7.13-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.13-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 45cba1ede73342a01dbeacc348f8f077be4b1079
+GitCommit: fe180abbbcdec93323805133205fc345e67784b9
 Directory: 3.7/alpine
 
 Tags: 3.7.13-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine

--- a/library/tomcat
+++ b/library/tomcat
@@ -15,7 +15,7 @@ GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre7-slim
 
 Tags: 7.0.93-jre7-alpine, 7.0-jre7-alpine, 7-jre7-alpine, 7.0.93-alpine, 7.0-alpine, 7-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6a91f7af8b2449372ad234ed5303160e9be54c18
 Directory: 7/jre7-alpine
 
@@ -30,7 +30,7 @@ GitCommit: 218a0afc0f06a4297981afbbec254c35b909a7c5
 Directory: 7/jre8-slim
 
 Tags: 7.0.93-jre8-alpine, 7.0-jre8-alpine, 7-jre8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6a91f7af8b2449372ad234ed5303160e9be54c18
 Directory: 7/jre8-alpine
 
@@ -45,7 +45,7 @@ GitCommit: e72a07eecdd750daf5690f786fddb4e40fa2c244
 Directory: 8.5/jre8-slim
 
 Tags: 8.5.38-jre8-alpine, 8.5-jre8-alpine, 8-jre8-alpine, jre8-alpine, 8.5.38-alpine, 8.5-alpine, 8-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0c424e7244945e69d564fbc27f644ec20f58e193
 Directory: 8.5/jre8-alpine
 
@@ -70,7 +70,7 @@ GitCommit: ec2d88f0a3b34292c1693e90bdf786e2545a157e
 Directory: 9.0/jre8-slim
 
 Tags: 9.0.16-jre8-alpine, 9.0-jre8-alpine, 9-jre8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f5fc6e54e0ce5cd54254074a0fe152a541ef29c5
 Directory: 9.0/jre8-alpine
 


### PR DESCRIPTION
- `drupal`: 8.5.12, 8.6.11
- `elasticsearch`: 6.6.2 (https://github.com/elastic/dockerfiles/compare/v6.6.1...v6.6.2)
- `ghost`: 2.18.1
- `joomla`: 3.9.4, phpredis 4.3.0
- `kibana`: 6.6.2 (https://github.com/elastic/kibana-docker/compare/6.6.1...6.6.2)
- `logstash`: 6.6.2 (https://github.com/elastic/logstash-docker/compare/6.6.1...6.6.2)
- `matomo`: phpredis 4.3.0
- `mongo`: 3.4.20
- `rabbitmq`: Erlang/OTP 21.3
- `tomcat`: Alpine arm32v7