### PR TITLE
bashbrew: store commit in DOCKER_BUILD_COMMIT build argument

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -90,7 +90,7 @@ func cmdBuild(c *cli.Context) error {
 					}
 					defer archive.Close()
 
-					err = dockerBuild(cacheTag, entry.ArchFile(arch), archive)
+					err = dockerBuild(cacheTag, entry.ArchFile(arch), archive, commit)
 					if err != nil {
 						return cli.NewMultiError(fmt.Errorf(`failed building %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 					}

--- a/bashbrew/go/src/bashbrew/docker.go
+++ b/bashbrew/go/src/bashbrew/docker.go
@@ -143,8 +143,8 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 	}, nil
 }
 
-func dockerBuild(tag string, file string, context io.Reader) error {
-	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm"}
+func dockerBuild(tag string, file string, context io.Reader, commit string) error {
+	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm", "--build-arg", fmt.Sprintf("DOCKER_BUILD_COMMIT=%s", commit)}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = context


### PR DESCRIPTION
This is required in multistage builds when the binary running in the docker image is built in one of the stages and gets its version at compile-time from the SHA-1 of the git commit. This is not possible in Bashbrew as a git archive is passed around and it doesn't have the `.git` directory, so we need something to fallback to.

For example:

```
FROM golang:alpine as bundle
RUN apk add git make
COPY ./ /go/src/project/
ARG DOCKER_BUILD_COMMIT
# This makefile normally grabs the version from the git commit SHA-1, but in bashbrew it can fallback to  DOCKER_BUILD_COMMIT
RUN make -C /go/src/project/cmd/command

FROM alpine
COPY --from=bundle /go/src/project/cmd/command/command-* /usr/bin/command
ENTRYPOINT ["command"]
```