### PR TITLE
update oraclelinux for openssl

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f079c3e69da496b2d4cadbf932ce283e8e3fd18d
+amd64-GitCommit: 42a396765025fd5331a7c29161f32a93cf9ed3a6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5f08815cfa024f9304f40eb403a7a05dec6a2f09
+arm64v8-GitCommit: 898cca49fe34e3031657b2694b2cef38db3c8b02
 Constraints: !aufs
 
 Tags: 7.6, 7, latest


### PR DESCRIPTION
    [AMD64 7.6] 2019-03-13-92
    [AMD64 7-slim] 2019-03-13-22
    [ARM64v8 7.6] 2019-03-13-13
    [ARM64v8 7-slim] 2019-03-13-10

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>