### PR TITLE
Remove unsupported CrateDB 2.1.10 and 2.0.7 images

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -22,8 +22,3 @@ GitCommit: f15780fc923017c66040c4baf79f2efd506655ac
 Tags: 2.2.7, 2.2
 GitCommit: 771c9b60ffbb03c2692e09a2539c7411327d7e3d
 
-Tags: 2.1.10, 2.1
-GitCommit: ed8cda8b567628dd733716dc5c8f507512587783
-
-Tags: 2.0.7, 2.0
-GitCommit: 79d51bb263104ccd2d3c57a5d74c16d6f0466d21


### PR DESCRIPTION
These are long unsupported and their builds are no longer working, due to the removal of the `alpine:3.5` image.