### PR TITLE
Amazon Corretto 11 is GA.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -10,4 +10,4 @@ GitCommit: 00075d9caa52634b489867a1a8c5a146b1695d0a
 Tags: 11, 11.0.2, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: 3ccbeb54d8258c12314b57382762ae0c5cd10871
+GitCommit: 13edf15055f74d5cbe0c3f5f8a0c1665414cadfd


### PR DESCRIPTION
This updates the existing 11-based tags to use the GA of Amazon Corretto 11. The Dockerfile is updated here: https://github.com/corretto/corretto-11-docker/commit/13edf15055f74d5cbe0c3f5f8a0c1665414cadfd

https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-corretto-11-is-now-generally-available/