### PR TITLE
Remove unsupported image

### DIFF
--- a/library/mageia
+++ b/library/mageia
@@ -5,8 +5,3 @@ Tags: 6, latest
 GitCommit: f60e1b20a5e31e72b4f49c878160dfa95f49a911
 GitFetch: refs/heads/dist
 Directory: 6
-
-Tags: 5,5.1
-GitCommit: f60e1b20a5e31e72b4f49c878160dfa95f49a911
-GitFetch: refs/heads/dist
-Directory: 5


### PR DESCRIPTION
Hi,

Mageia 5 is not supported anymore so we are deleting it from docker hub.

Thanks.