### PR TITLE
Update docker image for Ruby 2.5.5 release

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 995719add69339b78bd8cde46183b4902b761add
 Directory: 2.6/alpine3.8
 
-Tags: 2.5.4-stretch, 2.5-stretch, 2.5.4, 2.5
+Tags: 2.5.5-stretch, 2.5-stretch, 2.5.5, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
+GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
 Directory: 2.5/stretch
 
-Tags: 2.5.4-slim-stretch, 2.5-slim-stretch, 2.5.4-slim, 2.5-slim
+Tags: 2.5.5-slim-stretch, 2.5-slim-stretch, 2.5.5-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
+GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.4-alpine3.9, 2.5-alpine3.9, 2.5.4-alpine, 2.5-alpine
+Tags: 2.5.5-alpine3.9, 2.5-alpine3.9, 2.5.5-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
+GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
 Directory: 2.5/alpine3.9
 
-Tags: 2.5.4-alpine3.8, 2.5-alpine3.8
+Tags: 2.5.5-alpine3.8, 2.5-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7baa45a1ff640f8b6a744b8e9b76adb206aeb4
+GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
 Directory: 2.5/alpine3.8
 
 Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4


### PR DESCRIPTION
Hi,

Ruby 2.5.5 has been released two days ago: https://www.ruby-lang.org/en/news/2019/03/15/ruby-2-5-5-released/

And the Ruby Docker images were also updated over at the official Ruby Docker repo: https://github.com/docker-library/ruby/commit/6f3497e40d44651802e1ec8a4647b23a3a63b355

---

I believe this PR adds the updated Ruby 2.5.5 Dockerfiles to the official library (if I did it right!).

---

Steps I took:

- I installed `go` (via `apt install golang`) and [`bashbrew`](https://github.com/docker-library/official-images/tree/master/bashbrew#readme) on my system
- I cloned https://github.com/docker-library/ruby/, `cd`ed into it, and ran this shell script: https://github.com/docker-library/ruby/blob/master/generate-stackbrew-library.sh
  - (as mentioned in the first line comment in this file here: https://github.com/docker-library/official-images/blob/master/library/ruby)
- I cloned [this very repo](https://github.com/docker-library/official-images), and copy/pasted the output of the shell script above to replace my local copy of https://github.com/docker-library/official-images/blob/master/library/ruby
- (And finally, I `git add`ed the updated file, `git commit`ed the change, and `git push`ed it to my fork on GitHub.)

---

It looks right to me at a glance, but I am definitely open to correcting this any way if it's needed.

Thanks to other contributors in #5542, #5382, and #5234 for making it more obvious that outside contributors can do these updates.

_(P.S. I did this the hard way. There is a build script using `docker run` typed out in the previous Ruby update pull requests I just linked to above. On second look, that's the faster/easier way to do this. Go take a look if you're interested in making a Ruby update pull request yourself. :+1: )_