### PR TITLE
Update Mono to 5.x.1 releases (security update)

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -4,25 +4,25 @@ Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
 GitRepo: https://github.com/mono/docker.git
 
-Tags: 5.18.0.225, latest, 5.18.0, 5.18, 5
+Tags: 5.18.1.0, latest, 5.18.1, 5.18, 5
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: d68573b0640b3e191bf41b64745a6f0683a9c17a
-Directory: 5.18.0.225
+GitCommit: 3c2e39edd2bd3eb93f393b4682e41068a25df499
+Directory: 5.18.1.0
 
-Tags: 5.18.0.225-slim, slim, 5.18.0-slim, 5.18-slim, 5-slim
+Tags: 5.18.1.0-slim, slim, 5.18.1-slim, 5.18-slim, 5-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: d68573b0640b3e191bf41b64745a6f0683a9c17a
-Directory: 5.18.0.225/slim
+GitCommit: 3c2e39edd2bd3eb93f393b4682e41068a25df499
+Directory: 5.18.1.0/slim
 
-Tags: 5.16.0.220, 5.16.0, 5.16
+Tags: 5.16.1.0, 5.16.1, 5.16
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: d68573b0640b3e191bf41b64745a6f0683a9c17a
-Directory: 5.16.0.220
+GitCommit: 3c2e39edd2bd3eb93f393b4682e41068a25df499
+Directory: 5.16.1.0
 
-Tags: 5.16.0.220-slim, 5.16.0-slim, 5.16-slim
+Tags: 5.16.1.0-slim, 5.16.1-slim, 5.16-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: d68573b0640b3e191bf41b64745a6f0683a9c17a
-Directory: 5.16.0.220/slim
+GitCommit: 3c2e39edd2bd3eb93f393b4682e41068a25df499
+Directory: 5.16.1.0/slim
 
 Tags: 4.8.0.524, 4.8.0, 4.8, 4
 Architectures: amd64, i386, arm32v7, arm32v5


### PR DESCRIPTION
5.x repos updated to include NuGet 4.8.2 (CVE-2019-0757) and libgdiplus 5.6.1 (no CVE, but a big pile of fuzzer-identified crashers in various image handling methods)