### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fe8361fc2b14587c44f7b6c573e442cf2cbdcd4
+GitCommit: 676cc7748cbbb3fde8491bbd6e5633d5eb1a0ef6
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5fe8361fc2b14587c44f7b6c573e442cf2cbdcd4
+GitCommit: 676cc7748cbbb3fde8491bbd6e5633d5eb1a0ef6
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.13, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fe180abbbcdec93323805133205fc345e67784b9
+GitCommit: 064d595490cc5595f50b98cfc801abbbca2b5afd
 Directory: 3.7/ubuntu
 
 Tags: 3.7.13-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.13-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: fe180abbbcdec93323805133205fc345e67784b9
+GitCommit: 064d595490cc5595f50b98cfc801abbbca2b5afd
 Directory: 3.7/alpine
 
 Tags: 3.7.13-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/676cc77: Update to 3.8.0-beta.3, Erlang/OTP 21.3.1, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/064d595: Update to 3.7.13, Erlang/OTP 21.3.1, OpenSSL 1.1.1b