### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.18.1, 2.18, 2, latest
+Tags: 2.18.2, 2.18, 2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 76e2d36690015a97a4498899ed08c925633eb4c8
+GitCommit: 3e3985cb1f77d94a9d60d0db4e26702f1ed2a4a6
 Directory: 2/debian
 
-Tags: 2.18.1-alpine, 2.18-alpine, 2-alpine, alpine
+Tags: 2.18.2-alpine, 2.18-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 76e2d36690015a97a4498899ed08c925633eb4c8
+GitCommit: 3e3985cb1f77d94a9d60d0db4e26702f1ed2a4a6
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3e3985c: Update to 2.18.2, ghost-cli 1.9.9