### PR TITLE
[Gazebo] EOL v8 and version bump v9

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -19,23 +19,6 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 
 ################################################################################
-# Release: 8
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: gzserver8, gzserver8-xenial
-Architectures: amd64
-GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
-Directory: gazebo/8/ubuntu/xenial/gzserver8
-
-Tags: libgazebo8, libgazebo8-xenial
-Architectures: amd64
-GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
-Directory: gazebo/8/ubuntu/xenial/libgazebo8
-
-
-################################################################################
 # Release: 9
 
 ########################################
@@ -43,12 +26,12 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: cd5b4f73717df2559f021947d8bf195ee86dc3c9
+GitCommit: c9c747cf01b8c81b17e0ffb1f010c46412c3db33
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: cd5b4f73717df2559f021947d8bf195ee86dc3c9
+GitCommit: c9c747cf01b8c81b17e0ffb1f010c46412c3db33
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -56,12 +39,12 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: e1b8c1ff5713777250ce44c7558c394a02c4f72a
+GitCommit: 8e399b77e06de39cd567a4f41aa14dfeb2487bf7
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: e1b8c1ff5713777250ce44c7558c394a02c4f72a
+GitCommit: 8e399b77e06de39cd567a4f41aa14dfeb2487bf7
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 ########################################
@@ -69,12 +52,12 @@ Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 Tags: gzserver9-stretch
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: dbc80c8d10ef0e8259df1b9b23a5bfff26bdd5cc
+GitCommit: 61ca47720bdb0823b7febfc3e4d210c80051fa9a
 Directory: gazebo/9/debian/stretch/gzserver9
 
 Tags: libgazebo9-stretch
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: dbc80c8d10ef0e8259df1b9b23a5bfff26bdd5cc
+GitCommit: 61ca47720bdb0823b7febfc3e4d210c80051fa9a
 Directory: gazebo/9/debian/stretch/libgazebo9
 
 


### PR DESCRIPTION
Context:
https://github.com/docker-library/official-images/pull/5478#issuecomment-468042574
https://github.com/osrf/docker_images/pull/231