### PR TITLE
add arm32v7 architecture for erlang/top 20+, erlang 21.3.2

### DIFF
--- a/library/erlang
+++ b/library/erlang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/ba81527544daf50d27a85b1a6001cc541b742089/generate-stackbrew-library.sh
+# this file is generated via https://github.com/erlang/docker-erlang-otp/blob/b30a46da1409c058f16d6df02310134c65b5236f/generate-stackbrew-library.sh
 
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/erlang/docker-erlang-otp.git
@@ -14,7 +14,7 @@ GitCommit: 69ebec118339f3959f829dfc11fde0b2ce50670e
 Directory: 21/slim
 
 Tags: 21.3.1-alpine, 21.3-alpine, 21-alpine, alpine
-Architectures: amd64, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 69ebec118339f3959f829dfc11fde0b2ce50670e
 Directory: 21/alpine
 
@@ -29,8 +29,8 @@ GitCommit: 75fd24d73a4defe2a48a83b8dabf379a95c51a0c
 Directory: 20/slim
 
 Tags: 20.3.8.20-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine
-Architectures: amd64, arm64v8, i386, s390x, ppc64le
-GitCommit: f581f39cd15aeed548360c8f01b4bfe327236da5
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 46742a8f2df1db797c56bcf9846af35122552bc7
 Directory: 20/alpine
 
 Tags: 19.3.6.13, 19.3.6, 19.3, 19

--- a/library/erlang
+++ b/library/erlang
@@ -3,19 +3,19 @@
 Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/erlang/docker-erlang-otp.git
 
-Tags: 21.3.1, 21.3, 21, latest
+Tags: 21.3.2, 21.3, 21, latest
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 69ebec118339f3959f829dfc11fde0b2ce50670e
+GitCommit: 81dc84940c670b01c8b5c5622b02500f4f77a4b9
 Directory: 21
 
-Tags: 21.3.1-slim, 21.3-slim, 21-slim, slim
+Tags: 21.3.2-slim, 21.3-slim, 21-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 69ebec118339f3959f829dfc11fde0b2ce50670e
+GitCommit: 81dc84940c670b01c8b5c5622b02500f4f77a4b9
 Directory: 21/slim
 
-Tags: 21.3.1-alpine, 21.3-alpine, 21-alpine, alpine
+Tags: 21.3.2-alpine, 21.3-alpine, 21-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 69ebec118339f3959f829dfc11fde0b2ce50670e
+GitCommit: 81dc84940c670b01c8b5c5622b02500f4f77a4b9
 Directory: 21/alpine
 
 Tags: 20.3.8.20, 20.3.8, 20.3, 20


### PR DESCRIPTION
erlang/docker-erlang-otp#82 erlang/docker-erlang-otp#211
Wait for erlang/docker-erlang-otp#212