### PR TITLE
Update open-liberty to run as non-root

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 7c1b64981dac7b982995fd398185a971ad79090b
+GitCommit: f962c616f007a02f84ea00487ea4fca135287f61
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 3671d119357086aa35c802f1ac3004b684272f73
+GitCommit: 7c1b64981dac7b982995fd398185a971ad79090b
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: f962c616f007a02f84ea00487ea4fca135287f61
+GitCommit: 54970cbcd26a09ca3ed1819629a4fef1beef4af2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 54970cbcd26a09ca3ed1819629a4fef1beef4af2
+GitCommit: f962c616f007a02f84ea00487ea4fca135287f61
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Updating Open Liberty to run as non-root.  

We are essentially porting the changes that we had in WebSphere Liberty already.