### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 676cc7748cbbb3fde8491bbd6e5633d5eb1a0ef6
+GitCommit: 9a7e1021e3465a16f5ece00448d435383d143d82
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 676cc7748cbbb3fde8491bbd6e5633d5eb1a0ef6
+GitCommit: 9a7e1021e3465a16f5ece00448d435383d143d82
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -24,9 +24,29 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
+Tags: 3.7.14-rc.1, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 22bead22b2f9ed0d38f65d571edaa338524747bb
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.14-rc.1-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.14-rc.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 22bead22b2f9ed0d38f65d571edaa338524747bb
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.14-rc.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.13, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 064d595490cc5595f50b98cfc801abbbca2b5afd
+GitCommit: c8c861253a8cb47f56acabc030e78f8fa432d580
 Directory: 3.7/ubuntu
 
 Tags: 3.7.13-management, 3.7-management, 3-management, management
@@ -36,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.13-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 064d595490cc5595f50b98cfc801abbbca2b5afd
+GitCommit: c8c861253a8cb47f56acabc030e78f8fa432d580
 Directory: 3.7/alpine
 
 Tags: 3.7.13-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/9a7e102: Update to 3.8.0-beta.3, Erlang/OTP 21.3.2, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/c8c8612: Update to 3.7.13, Erlang/OTP 21.3.2, OpenSSL 1.1.1b