### PR TITLE
add otp-21.2 for Elixir v1.8 & v1.7

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/0b5ffaee45186626b09863a3a91138d9ad63b812/generate-stackbrew-library.sh
+# this file is generated via https://github.com/c0b/docker-elixir/blob/e406adb866c4ca5381b46ca01b501917465c71ed/generate-stackbrew-library.sh
 
 Maintainers: . <c0b@users.noreply.github.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-elixir.git
@@ -14,9 +14,19 @@ GitCommit: 5570afaa6de095a86e98457e1ad1351f92ccfe26
 Directory: 1.8/slim
 
 Tags: 1.8.1-alpine, 1.8-alpine, alpine
-Architectures: amd64, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 5570afaa6de095a86e98457e1ad1351f92ccfe26
 Directory: 1.8/alpine
+
+Tags: 1.8.1-otp-21.2, 1.8-otp-21.2, otp-21.2
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 295ba26f15980a0390726bfd21beaab1869cafca
+Directory: 1.8/otp-21.2
+
+Tags: 1.8.1-otp-21.2-alpine, 1.8-otp-21.2-alpine, otp-21.2-alpine
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 295ba26f15980a0390726bfd21beaab1869cafca
+Directory: 1.8/otp-21.2-alpine
 
 Tags: 1.7.4, 1.7
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
@@ -29,9 +39,19 @@ GitCommit: 7c1f05ca3fd47bdc86cab3f0310068646a31dcac
 Directory: 1.7/slim
 
 Tags: 1.7.4-alpine, 1.7-alpine
-Architectures: amd64, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: 2b7dd2845d27a6dad57bf0047b305375d6182402
 Directory: 1.7/alpine
+
+Tags: 1.7.4-otp-21.2, 1.7-otp-21.2
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 295ba26f15980a0390726bfd21beaab1869cafca
+Directory: 1.7/otp-21.2
+
+Tags: 1.7.4-otp-21.2-alpine, 1.7-otp-21.2-alpine
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 295ba26f15980a0390726bfd21beaab1869cafca
+Directory: 1.7/otp-21.2-alpine
 
 Tags: 1.6.6, 1.6
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le


### PR DESCRIPTION
recently the OTP-21.3 release actually has an incompatibility
in SSL dependencies, which has caused some production deployment
failing, so we need to suppose a special otp-21.2 branch;

also add arm32v7 architecture support for alpine variant, because
of an upstream alpine3.9 fixed compilation issue

for c0b/docker-elixir#110