### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.1.1-php7.1-apache, 5.1-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.1.1-php7.1, 5.1-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.1/apache
 
 Tags: 5.1.1-php7.1-fpm, 5.1-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.1/fpm
 
 Tags: 5.1.1-php7.1-fpm-alpine, 5.1-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.1/fpm-alpine
 
 Tags: 5.1.1-apache, 5.1-apache, 5-apache, apache, 5.1.1, 5.1, 5, latest, 5.1.1-php7.2-apache, 5.1-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.1.1-php7.2, 5.1-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.2/apache
 
 Tags: 5.1.1-fpm, 5.1-fpm, 5-fpm, fpm, 5.1.1-php7.2-fpm, 5.1-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.2/fpm
 
 Tags: 5.1.1-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.1.1-php7.2-fpm-alpine, 5.1-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.2/fpm-alpine
 
 Tags: 5.1.1-php7.3-apache, 5.1-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.1.1-php7.3, 5.1-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.3/apache
 
 Tags: 5.1.1-php7.3-fpm, 5.1-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.3/fpm
 
 Tags: 5.1.1-php7.3-fpm-alpine, 5.1-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: acd229d6d638566a3ccd921d20075182db9e1185
+GitCommit: dd0a4b830a16ec1116a9666eb6db430f773429a7
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/3cfcc9c: Merge pull request https://github.com/docker-library/wordpress/pull/393 from infosiftr/error-logging-configuration
- https://github.com/docker-library/wordpress/commit/dd0a4b8: Add explicit upstream-recommended error logging configuration