### PR TITLE
Update Debian (especially for "jessie-updates" issue)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,95 +7,74 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: f17cb6f96d9749d799e1778ef27aeb2283639413
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3e751c2c2f60037e9231ed94bbd1f95347af2c87
+amd64-GitCommit: 064f343bfa6ebf043aac2bbd4c870256cfe82f5a
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: c10d2c2eac8c01dcf46a4cb9df68794bad8f5190
+arm32v5-GitCommit: 8c0b6019a8ddbfbeb90725e585b59bd2f453c5f2
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 9fcf6bcaa2ba8eff2eaa0a3887b06f124044926c
+arm32v7-GitCommit: 6e49b6ca8b24eda86c3d1cbd1930edcb076a7734
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 33969379cc9ebbffde2fc5ed27145fc233e6b443
+arm64v8-GitCommit: 7e2ebba71a8e881dfd4482bbdb677f3e34428e56
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6eb1abfd94432487332931630a40173ccfe4b154
+i386-GitCommit: 0028791be1d2f994b081a0799966c9c1939931cc
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: d0e3bf3f6d9d5b5efb53b725d95392ef6abf7c01
+ppc64le-GitCommit: 15dcbc0096a3ddb976852136f5ad8234a5c600c1
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 9de2707fb6dccc17a1228e0e185e4a3c07b4d4f6
+s390x-GitCommit: 1b5ca9b1b075b92126769cff1f3e564a366d7882
 
 # buster -- Debian x.y Testing distribution - Not Released
-Tags: buster, buster-20190228
+Tags: buster, buster-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster
 
-Tags: buster-slim, buster-20190228-slim
+Tags: buster-slim, buster-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster/slim
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20190228
+Tags: experimental, experimental-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: experimental
 
 # jessie -- Debian 8.11 Released 23 June 2018
-Tags: jessie, jessie-20190228, 8.11, 8
+Tags: jessie, jessie-20190326, 8.11, 8
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie
 
-Tags: jessie-backports
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: jessie/backports
-
-Tags: jessie-slim, jessie-20190228-slim, 8.11-slim, 8-slim
+Tags: jessie-slim, jessie-20190326-slim, 8.11-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie/slim
 
-# oldoldstable -- Debian 7.11 Released 04 June 2016
-Tags: oldoldstable, oldoldstable-20190228
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: oldoldstable
-
-Tags: oldoldstable-backports
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: oldoldstable/backports
-
-Tags: oldoldstable-slim, oldoldstable-20190228-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: oldoldstable/slim
-
 # oldstable -- Debian 8.11 Released 23 June 2018
-Tags: oldstable, oldstable-20190228
+Tags: oldstable, oldstable-20190326
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable
 
-Tags: oldstable-backports
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: oldstable/backports
-
-Tags: oldstable-slim, oldstable-20190228-slim
+Tags: oldstable-slim, oldstable-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable/slim
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20190228
+Tags: rc-buggy, rc-buggy-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20190228
+Tags: sid, sid-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid
 
-Tags: sid-slim, sid-20190228-slim
+Tags: sid-slim, sid-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid/slim
 
 # stable -- Debian 9.8 Released 16 February 2019
-Tags: stable, stable-20190228
+Tags: stable, stable-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable
 
@@ -103,12 +82,12 @@ Tags: stable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/backports
 
-Tags: stable-slim, stable-20190228-slim
+Tags: stable-slim, stable-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/slim
 
 # stretch -- Debian 9.8 Released 16 February 2019
-Tags: stretch, stretch-20190228, 9.8, 9, latest
+Tags: stretch, stretch-20190326, 9.8, 9, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch
 
@@ -116,37 +95,24 @@ Tags: stretch-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/backports
 
-Tags: stretch-slim, stretch-20190228-slim, 9.8-slim, 9-slim
+Tags: stretch-slim, stretch-20190326-slim, 9.8-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/slim
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20190228
+Tags: testing, testing-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing
 
-Tags: testing-slim, testing-20190228-slim
+Tags: testing-slim, testing-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing/slim
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20190228
+Tags: unstable, unstable-20190326
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable
 
-Tags: unstable-slim, unstable-20190228-slim
+Tags: unstable-slim, unstable-20190326-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable/slim
-
-# wheezy -- Debian 7.11 Released 04 June 2016
-Tags: wheezy, wheezy-20190228, 7.11, 7
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: wheezy
-
-Tags: wheezy-backports
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: wheezy/backports
-
-Tags: wheezy-slim, wheezy-20190228-slim, 7.11-slim, 7-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: wheezy/slim


### PR DESCRIPTION
This also finally removes the EOL wheezy.

See https://github.com/debuerreotype/docker-debian-artifacts/issues/66. :+1: