### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,172 +1,172 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/53d2c23fafa844a8ba3a049df69f00b058e7574f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/58b0eb341cf717c8bc11f215e7a078686cf1e902/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-11-jdk-oraclelinux7, 13-ea-11-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-11-jdk-oracle, 13-ea-11-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-13-jdk-oraclelinux7, 13-ea-13-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-13-jdk-oracle, 13-ea-13-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-9-jdk-alpine3.9, 13-ea-9-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-9-jdk-alpine, 13-ea-9-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-12-jdk-alpine3.9, 13-ea-12-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-12-jdk-alpine, 13-ea-12-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 032278c8c0f77b2d5ba6c63a6cfb2b9ea54aa75d
+GitCommit: 311e8bb2d3d322cf0e00366408dd5e1c3210bfce
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-11-jdk-windowsservercore-ltsc2016, 13-ea-11-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-13-jdk-windowsservercore-ltsc2016, 13-ea-13-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-11-jdk-windowsservercore-1709, 13-ea-11-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-13-jdk-windowsservercore-1709, 13-ea-13-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-11-jdk-windowsservercore-1803, 13-ea-11-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-13-jdk-windowsservercore-1803, 13-ea-13-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-11-jdk-windowsservercore-1809, 13-ea-11-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-11-jdk-windowsservercore, 13-ea-11-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-11-jdk, 13-ea-11, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-13-jdk-windowsservercore-1809, 13-ea-13-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-11-jdk-nanoserver-sac2016, 13-ea-11-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-11-jdk-nanoserver, 13-ea-11-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-13-jdk-nanoserver-sac2016, 13-ea-13-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-13-jdk-nanoserver, 13-ea-13-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 1aeda8a947bb0c1ae64c119972635cf6bcc64025
+GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, 12-jdk-oracle, 12-oracle
-SharedTags: 12-jdk, 12
+Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
+SharedTags: 12-jdk, 12, jdk, latest
 Architectures: amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/oracle
 
-Tags: 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-jdk-windowsservercore-1709, 12-windowsservercore-1709
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1709, 12-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-jdk-windowsservercore-1809, 12-windowsservercore-1809
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, 12-jdk, 12
+Tags: 12-jdk-windowsservercore-1809, 12-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016
-SharedTags: 12-jdk-nanoserver, 12-nanoserver
+Tags: 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 12-jdk-nanoserver, 12-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 836002d04dbbd99e75f1c1dd7213ee391d66628f
+GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle, jdk-oracle, oracle
+Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/oracle
 
-Tags: 11.0.2-jdk-stretch, 11.0.2-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch, jdk-stretch, stretch
-SharedTags: 11.0.2-jdk, 11.0.2, 11.0-jdk, 11.0, 11-jdk, 11, jdk, latest
+Tags: 11.0.2-jdk-stretch, 11.0.2-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
+SharedTags: 11.0.2-jdk, 11.0.2, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jdk
 
-Tags: 11.0.2-jdk-slim-stretch, 11.0.2-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, jdk-slim-stretch, slim-stretch, 11.0.2-jdk-slim, 11.0.2-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim, jdk-slim, slim
+Tags: 11.0.2-jdk-slim-stretch, 11.0.2-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, 11.0.2-jdk-slim, 11.0.2-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jdk/slim
 
-Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, jdk-windowsservercore, windowsservercore
+Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver, jdk-nanoserver, nanoserver
+Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016
+SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.2-jre-stretch, 11.0-jre-stretch, 11-jre-stretch, jre-stretch
-SharedTags: 11.0.2-jre, 11.0-jre, 11-jre, jre
+Tags: 11.0.2-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
+SharedTags: 11.0.2-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jre
 
-Tags: 11.0.2-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, jre-slim-stretch, 11.0.2-jre-slim, 11.0-jre-slim, 11-jre-slim, jre-slim
+Tags: 11.0.2-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, 11.0.2-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
 Directory: 11/jre/slim
 
-Tags: 8u181-jdk-stretch, 8u181-stretch, 8-jdk-stretch, 8-stretch
-SharedTags: 8u181-jdk, 8u181, 8-jdk, 8
+Tags: 8u212-jdk-stretch, 8u212-stretch, 8-jdk-stretch, 8-stretch
+SharedTags: 8u212-jdk, 8u212, 8-jdk, 8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
+GitCommit: b8ce9eff38451de3282b2eb2bcd8b520fb95e1ce
 Directory: 8/jdk
 
-Tags: 8u181-jdk-slim-stretch, 8u181-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u181-jdk-slim, 8u181-slim, 8-jdk-slim, 8-slim
+Tags: 8u212-jdk-slim-stretch, 8u212-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u212-jdk-slim, 8u212-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
+GitCommit: b8ce9eff38451de3282b2eb2bcd8b520fb95e1ce
 Directory: 8/jdk/slim
 
-Tags: 8u191-jdk-alpine3.9, 8u191-alpine3.9, 8-jdk-alpine3.9, 8-alpine3.9, 8u191-jdk-alpine, 8u191-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u201-jdk-alpine3.9, 8u201-alpine3.9, 8-jdk-alpine3.9, 8-alpine3.9, 8u201-jdk-alpine, 8u201-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
+GitCommit: 79a6e42e299701791f8730f801e0728f82c85ea4
 Directory: 8/jdk/alpine
 
 Tags: 8u201-jdk-windowsservercore-ltsc2016, 8u201-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
@@ -204,31 +204,31 @@ GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 8u181-jre-stretch, 8-jre-stretch
-SharedTags: 8u181-jre, 8-jre
+Tags: 8u212-jre-stretch, 8-jre-stretch
+SharedTags: 8u212-jre, 8-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
+GitCommit: b8ce9eff38451de3282b2eb2bcd8b520fb95e1ce
 Directory: 8/jre
 
-Tags: 8u181-jre-slim-stretch, 8-jre-slim-stretch, 8u181-jre-slim, 8-jre-slim
+Tags: 8u212-jre-slim-stretch, 8-jre-slim-stretch, 8u212-jre-slim, 8-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3023e4da10d10e9c9775eabe2d7baac146e7ae1
+GitCommit: b8ce9eff38451de3282b2eb2bcd8b520fb95e1ce
 Directory: 8/jre/slim
 
-Tags: 8u191-jre-alpine3.9, 8-jre-alpine3.9, 8u191-jre-alpine, 8-jre-alpine
+Tags: 8u201-jre-alpine3.9, 8-jre-alpine3.9, 8u201-jre-alpine, 8-jre-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d93be18f4f2d5e8457169cac00e559d953b6028e
+GitCommit: 79a6e42e299701791f8730f801e0728f82c85ea4
 Directory: 8/jre/alpine
 
-Tags: 7u181-jdk-jessie, 7u181-jessie, 7-jdk-jessie, 7-jessie
-SharedTags: 7u181-jdk, 7u181, 7-jdk, 7
+Tags: 7u211-jdk-jessie, 7u211-jessie, 7-jdk-jessie, 7-jessie
+SharedTags: 7u211-jdk, 7u211, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
+GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jdk
 
-Tags: 7u181-jdk-slim-jessie, 7u181-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u181-jdk-slim, 7u181-slim, 7-jdk-slim, 7-slim
+Tags: 7u211-jdk-slim-jessie, 7u211-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u211-jdk-slim, 7u211-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
+GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jdk/slim
 
 Tags: 7u201-jdk-alpine3.9, 7u201-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u201-jdk-alpine, 7u201-alpine, 7-jdk-alpine, 7-alpine
@@ -236,15 +236,15 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
 Directory: 7/jdk/alpine
 
-Tags: 7u181-jre-jessie, 7-jre-jessie
-SharedTags: 7u181-jre, 7-jre
+Tags: 7u211-jre-jessie, 7-jre-jessie
+SharedTags: 7u211-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
+GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jre
 
-Tags: 7u181-jre-slim-jessie, 7-jre-slim-jessie, 7u181-jre-slim, 7-jre-slim
+Tags: 7u211-jre-slim-jessie, 7-jre-slim-jessie, 7u211-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 5a23ec5ab11beacb71f89ec9f9935c52ab7e44bb
+GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jre/slim
 
 Tags: 7u201-jre-alpine3.9, 7-jre-alpine3.9, 7u201-jre-alpine, 7-jre-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/311e8bb: Update to 13-ea+12
- https://github.com/docker-library/openjdk/commit/3ba705f: Update to 13-ea+13
- https://github.com/docker-library/openjdk/commit/d42099b: Update to 7u211, debian 7u211-2.6.17-1~deb8u1
- https://github.com/docker-library/openjdk/commit/aea0404: Update to 12
- https://github.com/docker-library/openjdk/commit/b8ce9ef: Update to 8u212, debian 8u212-b01-1~deb9u1
- https://github.com/docker-library/openjdk/commit/d4ecf99: Merge pull request https://github.com/docker-library/openjdk/pull/294 from luiszimmermann/nss-fix
- https://github.com/docker-library/openjdk/commit/79a6e42: Force install nss in Alpine
- https://github.com/docker-library/openjdk/commit/cb138b5: Update to 13-ea+12