### PR TITLE
Update ELK to 6.7.0

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 6.6.2
-GitCommit: 2b7cab01397ff37510c8970827fa4c399c87d23a
+Tags: 6.7.0
+GitCommit: a1a331cbea5676d959fc796d140228d38d691e3d
 Directory: 6
 
 Tags: 5.6.16, 5.6, 5

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 6.6.2
-GitCommit: bc26b5669948efedd267a9c60e1dc34ee8fbb5f0
+Tags: 6.7.0
+GitCommit: e085150e59f3a1c292e417c7adbc97fbb5cd9f1b
 Directory: 6
 
 Tags: 5.6.16, 5.6, 5

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 6.6.2
-GitCommit: bea296dda8e4f95a3863e3aa0d2d1eecb78babc4
+Tags: 6.7.0
+GitCommit: 40ea47940cb4bf309f2633238ffe434192d262d0
 Directory: 6
 
 Tags: 5.6.16, 5.6, 5


### PR DESCRIPTION
Now with proper links! :+1:

- https://github.com/elastic/logstash-docker/compare/6.6.2..6.7.0
- https://github.com/elastic/dockerfiles/compare/v6.6.2..v6.7.0 (especially https://github.com/elastic/dockerfiles/compare/v6.6.2..v6.7.0#diff-21c4e096c31ca33cf67e2ad16f6dac93)

Slightly better diff of old `kibana` to new `kibana`:

```diff
diff --git a/build/kibana/config/kibana-oss.yml b/build/kibana/config/kibana-oss.yml
deleted file mode 100644
index c49236f..0000000
diff --git a/build/kibana/ssl/kibana.example.org.crt b/build/kibana/ssl/kibana.example.org.crt
deleted file mode 100644
index 11125ea..0000000
diff --git a/build/kibana/ssl/kibana.example.org.key b/build/kibana/ssl/kibana.example.org.key
deleted file mode 100644
index db46f0d..0000000
diff --git a/templates/Dockerfile.j2 b/kibana/Dockerfile
similarity index 18%
rename from templates/Dockerfile.j2
rename to kibana/Dockerfile
index b2d20e6..6a59c41 100644
--- a/templates/Dockerfile.j2
+++ b/kibana/Dockerfile
@@ -1,73 +1,55 @@
-# This Dockerfile was generated from the template at templates/Dockerfile.j2
-{% if artifacts_dir -%}
-{%   set url_root = 'http://localhost:8000/kibana/target' -%}
-{% elif staging_build_num -%}
-{%   set version_tag = elastic_version + '-' + staging_build_num -%}
-{%   set url_root = 'https://staging.elastic.co/%s/downloads/kibana' % version_tag -%}
-{% else -%}
-{%   set version_tag = elastic_version -%}
-{%   set url_root = 'https://artifacts.elastic.co/downloads/kibana' -%}
-{% endif -%}
-
-{% if image_flavor == 'oss' -%}
-{%   set tarball = 'kibana-oss-%s-linux-x86_64.tar.gz' % elastic_version -%}
-{% else -%}
-{%   set tarball = 'kibana-%s-linux-x86_64.tar.gz' % elastic_version -%}
-{% endif -%}
-
-
+#
+# ** THIS IS AN AUTO-GENERATED FILE **
+#
+ 
+################################################################################
+# Build stage 0
+# Extract Kibana and make various file manipulations.
+################################################################################
+FROM centos:7 AS prep_files
+RUN cd /opt && curl --retry 8 -s -L -O https://artifacts.elastic.co/downloads/kibana/kibana-6.7.0-linux-x86_64.tar.gz && cd -
+RUN mkdir /usr/share/kibana
+WORKDIR /usr/share/kibana
+RUN tar --strip-components=1 -zxf /opt/kibana-6.7.0-linux-x86_64.tar.gz
+# Ensure that group permissions are the same as user permissions.
+# This will help when relying on GID-0 to run Kibana, rather than UID-1000.
+# OpenShift does this, for example.
+# REF: https://docs.openshift.org/latest/creating_images/guidelines.html
+RUN chmod -R g=u /usr/share/kibana
+RUN find /usr/share/kibana -type d -exec chmod g+s {} \;
+
+################################################################################
+# Build stage 1
+# Copy prepared files from the previous stage and complete the image.
+################################################################################
 FROM centos:7
 EXPOSE 5601
 
 # Add Reporting dependencies.
 RUN yum update -y && yum install -y fontconfig freetype && yum clean all
 
+# Bring in Kibana from the initial stage.
+COPY --from=prep_files --chown=1000:0 /usr/share/kibana /usr/share/kibana
 WORKDIR /usr/share/kibana
-
-# Set gid to 0 for kibana and make group permission similar to that of user
-# This is needed, for example, for Openshift Open:
-# https://docs.openshift.org/latest/creating_images/guidelines.html
-# and allows Kibana to run with an uid
-RUN curl -Ls {{ url_root }}/{{ tarball }} | tar --strip-components=1 -zxf - && \
-    ln -s /usr/share/kibana /opt/kibana && \
-    chown -R 1000:0 . && \
-    chmod -R g=u /usr/share/kibana && \
-    find /usr/share/kibana -type d -exec chmod g+s {} \;
+RUN ln -s /usr/share/kibana /opt/kibana
 
 ENV ELASTIC_CONTAINER true
 ENV PATH=/usr/share/kibana/bin:$PATH
 
 # Set some Kibana configuration defaults.
-COPY --chown=1000:0 config/kibana-{{ image_flavor }}.yml /usr/share/kibana/config/kibana.yml
+COPY --chown=1000:0 config/kibana.yml /usr/share/kibana/config/kibana.yml
 
 # Add the launcher/wrapper script. It knows how to interpret environment
 # variables and translate them to Kibana CLI options.
 COPY --chown=1000:0 bin/kibana-docker /usr/local/bin/
 
-# Add a self-signed SSL certificate for use in examples.
-COPY --chown=1000:0 ssl/kibana.example.org.* /usr/share/kibana/config/
-
-# Ensure gid 0 write permissions for Openshift.
-RUN find /usr/share/kibana -gid 0 -and -not -perm /g+w -exec chmod g+w {} \;
+# Ensure gid 0 write permissions for OpenShift.
+RUN chmod g+ws /usr/share/kibana && find /usr/share/kibana -gid 0 -and -not -perm /g+w -exec chmod g+w {} \;
 
 # Provide a non-root user to run the process.
-RUN groupadd --gid 1000 kibana && \
-    useradd --uid 1000 --gid 1000 \
-      --home-dir /usr/share/kibana --no-create-home \
-      kibana
-
-USER 1000
+RUN groupadd --gid 1000 kibana && useradd --uid 1000 --gid 1000 --home-dir /usr/share/kibana --no-create-home kibana
+USER kibana
 
-LABEL org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="Elastic" \
-  org.label-schema.name="kibana" \
-  org.label-schema.version="{{ elastic_version }}" \
-  org.label-schema.url="https://www.elastic.co/products/kibana" \
-  org.label-schema.vcs-url="https://github.com/elastic/kibana-docker" \
-{% if image_flavor == 'oss' -%}
-  license="Apache-2.0"
-{% else -%}
-  license="Elastic License"
-{% endif -%}
+LABEL org.label-schema.schema-version="1.0" org.label-schema.vendor="Elastic" org.label-schema.name="kibana" org.label-schema.version="6.7.0" org.label-schema.url="https://www.elastic.co/products/kibana" org.label-schema.vcs-url="https://github.com/elastic/kibana" license="Elastic License"
 
 CMD ["/usr/local/bin/kibana-docker"]
\ No newline at end of file
diff --git a/build/kibana/bin/kibana-docker b/kibana/bin/kibana-docker
similarity index 88%
rename from build/kibana/bin/kibana-docker
rename to kibana/bin/kibana-docker
index 39a4633..7c94ef0 100755
--- a/build/kibana/bin/kibana-docker
+++ b/kibana/bin/kibana-docker
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# ** THIS IS AN AUTO-GENERATED FILE **
+#
 
 # Run Kibana, using environment variables to set longopts defining Kibana's
 # configuration.
@@ -27,31 +30,12 @@ kibana_vars=(
     elasticsearch.sniffInterval
     elasticsearch.sniffOnConnectionFault
     elasticsearch.sniffOnStart
-    elasticsearch.ssl.ca
-    elasticsearch.ssl.cert
     elasticsearch.ssl.certificate
     elasticsearch.ssl.certificateAuthorities
     elasticsearch.ssl.key
     elasticsearch.ssl.keyPassphrase
     elasticsearch.ssl.verificationMode
-    elasticsearch.ssl.verify
     elasticsearch.startupTimeout
-    elasticsearch.tribe.customHeaders
-    elasticsearch.tribe.password
-    elasticsearch.tribe.pingTimeout
-    elasticsearch.tribe.requestHeadersWhitelist
-    elasticsearch.tribe.requestTimeout
-    elasticsearch.tribe.ssl.ca
-    elasticsearch.tribe.ssl.cert
-    elasticsearch.tribe.ssl.certificate
-    elasticsearch.tribe.ssl.certificateAuthorities
-    elasticsearch.tribe.ssl.key
-    elasticsearch.tribe.ssl.keyPassphrase
-    elasticsearch.tribe.ssl.verificationMode
-    elasticsearch.tribe.ssl.verify
-    elasticsearch.tribe.url
-    elasticsearch.tribe.username
-    elasticsearch.url
     elasticsearch.username
     i18n.locale
     kibana.defaultAppId
@@ -104,19 +88,21 @@ kibana_vars=(
     xpack.infra.enabled
     xpack.infra.query.partitionFactor
     xpack.infra.query.partitionSize
-    xpack.infra.sources.default.logAlias
-    xpack.infra.sources.default.metricAlias
     xpack.infra.sources.default.fields.container
     xpack.infra.sources.default.fields.host
+    xpack.infra.sources.default.fields.message
     xpack.infra.sources.default.fields.pod
     xpack.infra.sources.default.fields.tiebreaker
     xpack.infra.sources.default.fields.timestamp
+    xpack.infra.sources.default.logAlias
+    xpack.infra.sources.default.metricAlias
     xpack.ml.enabled
     xpack.monitoring.elasticsearch.password
     xpack.monitoring.elasticsearch.pingTimeout
-    xpack.monitoring.elasticsearch.url
+    xpack.monitoring.elasticsearch.hosts
     xpack.monitoring.elasticsearch.username
     xpack.monitoring.elasticsearch.ssl.certificateAuthorities
+    xpack.monitoring.elasticsearch.ssl.verificationMode
     xpack.monitoring.enabled
     xpack.monitoring.kibana.collection.enabled
     xpack.monitoring.kibana.collection.interval
@@ -124,6 +110,7 @@ kibana_vars=(
     xpack.monitoring.min_interval_seconds
     xpack.monitoring.node_resolver
     xpack.monitoring.report_stats
+    xpack.monitoring.elasticsearch.pingTimeout
     xpack.monitoring.ui.container.elasticsearch.enabled
     xpack.monitoring.ui.container.logstash.enabled
     xpack.monitoring.ui.enabled
@@ -160,7 +147,7 @@ kibana_vars=(
 
 longopts=''
 for kibana_var in ${kibana_vars[*]}; do
-    # 'elasticsearch.url' -> 'ELASTICSEARCH_URL'
+    # 'elasticsearch.hosts' -> 'ELASTICSEARCH_HOSTS'
     env_var=$(echo ${kibana_var^^} | tr . _)
 
     # Indirectly lookup env var values via the name of the var.
diff --git a/build/kibana/config/kibana-full.yml b/kibana/config/kibana.yml
similarity index 15%
rename from build/kibana/config/kibana-full.yml
rename to kibana/config/kibana.yml
index 9831934..fda7023 100644
--- a/build/kibana/config/kibana-full.yml
+++ b/kibana/config/kibana.yml
@@ -1,7 +1,9 @@
----
-# Default Kibana configuration from kibana-docker.
+#
+# ** THIS IS AN AUTO-GENERATED FILE **
+#
 
+# Default Kibana configuration for docker target
 server.name: kibana
 server.host: "0"
-elasticsearch.hosts: http://elasticsearch:9200
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]
 xpack.monitoring.ui.container.elasticsearch.enabled: true
\ No newline at end of file
diff --git a/templates/docker-compose.yml.j2 b/templates/docker-compose.yml.j2
deleted file mode 100644
index c802793..0000000
```