### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,32 +4,17 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 18.09.4-rc1, 18.09-rc, rc, test
+Tags: 18.09.4, 18.09, 18, stable, test, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 6e5ccf3c71e86b98bb75600b4309ccf1bc87775e
-Directory: 18.09-rc
-
-Tags: 18.09.4-rc1-dind, 18.09-rc-dind, rc-dind, test-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 6e5ccf3c71e86b98bb75600b4309ccf1bc87775e
-Directory: 18.09-rc/dind
-
-Tags: 18.09.4-rc1-git, 18.09-rc-git, rc-git, test-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 6e5ccf3c71e86b98bb75600b4309ccf1bc87775e
-Directory: 18.09-rc/git
-
-Tags: 18.09.3, 18.09, 18, stable, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 7411f18388ff3cc475f8b866cd2561f6b7822541
+GitCommit: 3d71bbc03dfd209ef7cc14380e235731daf2690a
 Directory: 18.09
 
-Tags: 18.09.3-dind, 18.09-dind, 18-dind, stable-dind, dind
+Tags: 18.09.4-dind, 18.09-dind, 18-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 65fab2cd767c10f22ee66afa919eda80dbdc8872
 Directory: 18.09/dind
 
-Tags: 18.09.3-git, 18.09-git, 18-git, stable-git, git
+Tags: 18.09.4-git, 18.09-git, 18-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/2724741: Drop 18.09-rc now that 18.09.4 is GA
- https://github.com/docker-library/docker/commit/3d71bbc: Update to 18.09.4