### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,42 +24,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.14-rc.1, 3.7-rc
+Tags: 3.7.14, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 22bead22b2f9ed0d38f65d571edaa338524747bb
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.14-rc.1-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.14-rc.1-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 22bead22b2f9ed0d38f65d571edaa338524747bb
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.14-rc.1-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.13, 3.7, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8c861253a8cb47f56acabc030e78f8fa432d580
+GitCommit: af18eba404f0e3c6cf0ffd7b79492cc4a833b37a
 Directory: 3.7/ubuntu
 
-Tags: 3.7.13-management, 3.7-management, 3-management, management
+Tags: 3.7.14-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.13-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.14-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c8c861253a8cb47f56acabc030e78f8fa432d580
+GitCommit: af18eba404f0e3c6cf0ffd7b79492cc4a833b37a
 Directory: 3.7/alpine
 
-Tags: 3.7.13-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.14-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/af18eba: Update to 3.7.14, Erlang/OTP 21.3.2, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/40e8718: Update to 3.7.14-rc.2, Erlang/OTP 21.3.2, OpenSSL 1.1.1b