### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2.7-7.1.0, 2.7-7.1, 2.7-7, 2.7, 2-7.1.0, 2-7.1, 2-7, 2, 2.7-7.1.0-jessie, 2.7-7.1-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.1.0-jessie, 2-7.1-jessie, 2-7-jessie, 2-jessie
 Architectures: amd64, i386
-GitCommit: bcfd9f2587ef4aa818bf37eb1a6dffa348ba90cf
+GitCommit: d54416e2be73520a490eb0dd2819d8a2b4df3652
 Directory: 2.7
 
 Tags: 2.7-7.1.0-slim, 2.7-7.1-slim, 2.7-7-slim, 2.7-slim, 2-7.1.0-slim, 2-7.1-slim, 2-7-slim, 2-slim, 2.7-7.1.0-slim-jessie, 2.7-7.1-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.1.0-slim-jessie, 2-7.1-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
 Architectures: amd64, i386
-GitCommit: bcfd9f2587ef4aa818bf37eb1a6dffa348ba90cf
+GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
 Directory: 2.7/slim
 
-Tags: 3.5-7.0.0, 3.5-7.0, 3.5-7, 3.5, 3-7.0.0, 3-7.0, 3-7, 3, latest, 3.5-7.0.0-jessie, 3.5-7.0-jessie, 3.5-7-jessie, 3.5-jessie, 3-7.0.0-jessie, 3-7.0-jessie, 3-7-jessie, 3-jessie, jessie
-Architectures: amd64, i386
-GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
+Tags: 3.5-7.0.0, 3.5-7.0, 3.5-7, 3.5, 3-7.0.0, 3-7.0, 3-7, 3, latest, 3.5-7.0.0-stretch, 3.5-7.0-stretch, 3.5-7-stretch, 3.5-stretch, 3-7.0.0-stretch, 3-7.0-stretch, 3-7-stretch, 3-stretch, stretch
+Architectures: amd64, i386, ppc64le, s390x
+GitCommit: b3ee440a1a459e63001454e5a9e1f20da439edab
 Directory: 3.5
 
-Tags: 3.5-7.0.0-slim, 3.5-7.0-slim, 3.5-7-slim, 3.5-slim, 3-7.0.0-slim, 3-7.0-slim, 3-7-slim, 3-slim, slim, 3.5-7.0.0-slim-jessie, 3.5-7.0-slim-jessie, 3.5-7-slim-jessie, 3.5-slim-jessie, 3-7.0.0-slim-jessie, 3-7.0-slim-jessie, 3-7-slim-jessie, 3-slim-jessie, slim-jessie
-Architectures: amd64, i386
-GitCommit: a25dfed4a6f684edfa44947fdb9f198962c5885a
+Tags: 3.5-7.0.0-slim, 3.5-7.0-slim, 3.5-7-slim, 3.5-slim, 3-7.0.0-slim, 3-7.0-slim, 3-7-slim, 3-slim, slim, 3.5-7.0.0-slim-stretch, 3.5-7.0-slim-stretch, 3.5-7-slim-stretch, 3.5-slim-stretch, 3-7.0.0-slim-stretch, 3-7.0-slim-stretch, 3-7-slim-stretch, 3-slim-stretch, slim-stretch
+Architectures: amd64, i386, ppc64le, s390x
+GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
 Directory: 3.5/slim
 
-Tags: 3.6-7.1.0, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.0-jessie, 3.6-7.1-jessie, 3.6-7-jessie, 3.6-jessie
-Architectures: amd64, i386
-GitCommit: 6ec92626b247be066a0c89d86521a00571cc5d44
+Tags: 3.6-7.1.0, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.0-stretch, 3.6-7.1-stretch, 3.6-7-stretch, 3.6-stretch
+Architectures: amd64, i386, s390x
+GitCommit: b3ee440a1a459e63001454e5a9e1f20da439edab
 Directory: 3.6
 
-Tags: 3.6-7.1.0-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.0-slim-jessie, 3.6-7.1-slim-jessie, 3.6-7-slim-jessie, 3.6-slim-jessie
-Architectures: amd64, i386
-GitCommit: 6ec92626b247be066a0c89d86521a00571cc5d44
+Tags: 3.6-7.1.0-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.0-slim-stretch, 3.6-7.1-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch
+Architectures: amd64, i386, s390x
+GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
 Directory: 3.6/slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/b659b85: Merge pull request https://github.com/docker-library/pypy/pull/32 from infosiftr/stretch
- https://github.com/docker-library/pypy/commit/abb5b51: Adjust "libncurses5"-keeping code to keep things differently (turns out the requirement is not IBM arches specific)
- https://github.com/docker-library/pypy/commit/b3ee440: Add support for s390x and ppc64le where possible
- https://github.com/docker-library/pypy/commit/d54416e: Update PyPy 3.x to Debian Stretch