### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-13-jdk-oraclelinux7, 13-ea-13-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-13-jdk-oracle, 13-ea-13-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-14-jdk-oraclelinux7, 13-ea-14-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-14-jdk-oracle, 13-ea-14-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-12-jdk-alpine3.9, 13-ea-12-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-12-jdk-alpine, 13-ea-12-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-14-jdk-alpine3.9, 13-ea-14-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-14-jdk-alpine, 13-ea-14-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 311e8bb2d3d322cf0e00366408dd5e1c3210bfce
+GitCommit: 643875b428551d5e2395e91933e9babc73044bc9
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-13-jdk-windowsservercore-ltsc2016, 13-ea-13-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-14-jdk-windowsservercore-ltsc2016, 13-ea-14-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-13-jdk-windowsservercore-1709, 13-ea-13-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-14-jdk-windowsservercore-1709, 13-ea-14-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-13-jdk-windowsservercore-1803, 13-ea-13-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-14-jdk-windowsservercore-1803, 13-ea-14-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-13-jdk-windowsservercore-1809, 13-ea-13-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-13-jdk-windowsservercore, 13-ea-13-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-13-jdk, 13-ea-13, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-14-jdk-windowsservercore-1809, 13-ea-14-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-13-jdk-nanoserver-sac2016, 13-ea-13-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-13-jdk-nanoserver, 13-ea-13-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-14-jdk-nanoserver-sac2016, 13-ea-14-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-14-jdk-nanoserver, 13-ea-14-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: 3ba705f07740f053707e22695a79d5b0e3ec8516
+GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/643875b: Update to 13-ea+14
- https://github.com/docker-library/openjdk/commit/a316e6b: Update to 13-ea+14