### PR TITLE
Increase test/tests/mysql-*/run.sh with --tries 30

### DIFF
--- a/test/tests/mysql-basics/run.sh
+++ b/test/tests/mysql-basics/run.sh
@@ -35,7 +35,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-. "$dir/../../retry.sh" --tries 20 "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" --tries 30 "echo 'SELECT 1' | mysql"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | mysql
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 0 ]

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -41,7 +41,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-. "$dir/../../retry.sh" --tries 20 "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" --tries 30 "echo 'SELECT 1' | mysql"
 
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 1 ]
 [ "$(echo 'SELECT c FROM test' | mysql)" = 'goodbye!' ]

--- a/test/tests/mysql-log-bin/run.sh
+++ b/test/tests/mysql-log-bin/run.sh
@@ -27,6 +27,6 @@ mysql() {
 		"$@"
 }
 
-. "$dir/../../retry.sh" --tries 20 "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" --tries 30 "echo 'SELECT 1' | mysql"
 
 # yay, must be OK


### PR DESCRIPTION
When testing on Travis CI with my modified [MariaDB Image](https://github.com/alvistack/docker-mariadb), 10.1 tests always failed due to timeout (see https://travis-ci.org/alvistack/docker-mariadb/builds/513918923):

```
+ /home/travis/.docker/official-images/test/run.sh alvistack/mariadb
testing alvistack/mariadb
	'utc' [1/7]...passed
	'cve-2014--shellshock' [2/7]...passed
	'no-hard-coded-passwords' [3/7]...passed
	'override-cmd' [4/7]...passed
	'mysql-basics' [5/7]......................alvistack/mariadb failed to accept connections in a reasonable amount of time!
	'mysql-initdb' [6/7]......................alvistack/mariadb failed to accept connections in a reasonable amount of time!
	'mysql-log-bin' [7/7]......................alvistack/mariadb failed to accept connections in a reasonable amount of time!
```

In case `--tries 20` increased as `--tries 30` the error gone (see https://travis-ci.org/alvistack/docker-mariadb/builds/514490533):

```
+ /home/travis/.docker/official-images/test/run.sh alvistack/mariadb
testing alvistack/mariadb
	'utc' [1/7]...passed
	'cve-2014--shellshock' [2/7]...passed
	'no-hard-coded-passwords' [3/7]...passed
	'override-cmd' [4/7]...passed
	'mysql-basics' [5/7]....................passed
	'mysql-initdb' [6/7].....................passed
	'mysql-log-bin' [7/7].......................passed
```

Also checked with [MariaDB official image 10.1 `docker-entrypoint.sh`](https://github.com/docker-library/mariadb/blob/93f1e9c9082364522c77b94e98299d7d398089f8/10.1/docker-entrypoint.sh#L110), which we are now waiting for 30 seconds dueing initialize, too:

```
		for i in {30..0}; do
			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
				break
			fi
			echo 'MySQL init process in progress...'
			sleep 1
		done
		if [ "$i" = 0 ]; then
			echo >&2 'MySQL init process failed.'
			exit 1
fi
```

This patch should align both `docker-entrypoint.sh` and test cases timeout, and reduce rare case for fail if CI machine is not fast enough.