### PR TITLE
kong 1.1.1

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -3,12 +3,12 @@ GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
 Tags: 1.1.1-alpine, 1.1.1, 1.1, latest
-GitCommit: 8880bcd1f68ac6df9d2d260d0388b0817c5d1aa8
+GitCommit: 9cf28d20dd17f66c957d2a58fe9361a99f92bf09
 GitFetch: refs/tags/1.1.1
 Directory: alpine
 
 Tags: 1.1.1-centos, 1.1-centos
-GitCommit: 8880bcd1f68ac6df9d2d260d0388b0817c5d1aa8
+GitCommit: 9cf28d20dd17f66c957d2a58fe9361a99f92bf09
 GitFetch: refs/tags/1.1.1
 Constraints: !aufs
 Directory: centos


### PR DESCRIPTION
Not sure what the process is our 1.1.1 docker image has a minor issue ( fixed here: https://github.com/Kong/kong-build-tools/commit/0e92a351c2a8d01defb3f027056e2ba1666583bb ) which affects some functionality and fixed the accompanying test here ( https://github.com/Kong/docker-kong/commit/8c44ba24dbe121d3e799217e6260d389c10d6929 ). Since the issue only affects our docker images hoping it's OK to republish them.

If that's not the case perhaps a 1.1.1-1 (latest) and deleting the 1.1.1 tag