### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -124,21 +124,6 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: trusty
 
-Tags: wheezy-curl, oldoldstable-curl
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36
-Directory: wheezy/curl
-
-Tags: wheezy-scm, oldoldstable-scm
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 1845b3f918f69b4c97912b0d4d68a5658458e84f
-Directory: wheezy/scm
-
-Tags: wheezy, oldoldstable
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
-Directory: wheezy
-
 Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/37ab6c0: Remove wheezy (EOL)