### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a7e1021e3465a16f5ece00448d435383d143d82
+GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a7e1021e3465a16f5ece00448d435383d143d82
+GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.14, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af18eba404f0e3c6cf0ffd7b79492cc4a833b37a
+GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
 Directory: 3.7/ubuntu
 
 Tags: 3.7.14-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.14-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: af18eba404f0e3c6cf0ffd7b79492cc4a833b37a
+GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
 Directory: 3.7/alpine
 
 Tags: 3.7.14-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2cceb25: Merge pull request https://github.com/docker-library/rabbitmq/pull/328 from infosiftr/hipe
- https://github.com/docker-library/rabbitmq/commit/a7daf64: Update to 3.7.14, Erlang/OTP 21.3.3, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/f066ff7: Update to 3.8.0-beta.3, Erlang/OTP 21.3.3, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/b7fe20f: Adjust Erlang HiPE compilation to be conditional based on architecture