### PR TITLE
Update docker image for Ruby 2.4.6

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -44,34 +44,34 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
 Directory: 2.5/alpine3.8
 
-Tags: 2.4.5-stretch, 2.4-stretch, 2.4.5, 2.4
+Tags: 2.4.6-stretch, 2.4-stretch, 2.4.6, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/stretch
 
-Tags: 2.4.5-slim-stretch, 2.4-slim-stretch, 2.4.5-slim, 2.4-slim
+Tags: 2.4.6-slim-stretch, 2.4-slim-stretch, 2.4.6-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.5-jessie, 2.4-jessie
+Tags: 2.4.6-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/jessie
 
-Tags: 2.4.5-slim-jessie, 2.4-slim-jessie
+Tags: 2.4.6-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.5-alpine3.9, 2.4-alpine3.9, 2.4.5-alpine, 2.4-alpine
+Tags: 2.4.6-alpine3.9, 2.4-alpine3.9, 2.4.6-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/alpine3.9
 
-Tags: 2.4.5-alpine3.8, 2.4-alpine3.8
+Tags: 2.4.6-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
+GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/alpine3.8
 
 Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3


### PR DESCRIPTION
Adding new ruby version 2.4.6. ( [commit](https://github.com/docker-library/ruby/commit/802421922ef50cfa05c89a3c619992acf4329986) )

Please merge if possible.