### PR TITLE
Update websphere-liberty for springBoot image fix

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: e944d4d56a484b53df12085c05ec81aa067c90f5
+GitCommit: 0de7bdf0673af9bd320ae8eeb247033c697ecddc
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Updating the websphere-liberty images to fix an issue with the /lib.index.cache directory in the springBoot1 and springBoot2 images.  Also included is a fix that shrinks the size of the images overall.