### PR TITLE
Update open-liberty for springBoot image fix

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 0b1345bb3e2ff8058f662620a43f973783b4c0de
+GitCommit: 3a154faa4400d550481154f68dc443135e577b67
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
Updating the open-liberty images to fix an issue with the /lib.index.cache directory not being a symlink in the springBoot1 and springBoot2 images. 