### PR TITLE
Sentry 9.1.0

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,20 +1,20 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/f648178adf33bec68be47550a82850e18deb0cd8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/f58f91fe5dc31bfe77af277dae7002a5542326a9/generate-stackbrew-library.sh
 
 Maintainers: Matt Robenolt <matt@sentry.io> (@mattrobenolt)
 GitRepo: https://github.com/getsentry/docker-sentry.git
 
-Tags: 8.22.0, 8.22, 8
-GitCommit: b7d55c572e0b23c5c537432211823a8677727e1c
-Directory: 8.22
-
-Tags: 8.22.0-onbuild, 8.22-onbuild, 8-onbuild
-GitCommit: b7d55c572e0b23c5c537432211823a8677727e1c
-Directory: 8.22/onbuild
-
-Tags: 9.0.0, 9.0, 9, latest
-GitCommit: f648178adf33bec68be47550a82850e18deb0cd8
+Tags: 9.0.0, 9.0
+GitCommit: 4b3fad46dbe56285629162e059f4f0e89174b0f9
 Directory: 9.0
 
-Tags: 9.0.0-onbuild, 9.0-onbuild, 9-onbuild, onbuild
+Tags: 9.0.0-onbuild, 9.0-onbuild
 GitCommit: ec474d97d968afdf78f4e489b58c68a2fbc46ee2
 Directory: 9.0/onbuild
+
+Tags: 9.1.0, 9.1, 9, latest
+GitCommit: f58f91fe5dc31bfe77af277dae7002a5542326a9
+Directory: 9.1
+
+Tags: 9.1.0-onbuild, 9.1-onbuild, 9-onbuild, onbuild
+GitCommit: f58f91fe5dc31bfe77af277dae7002a5542326a9
+Directory: 9.1/onbuild


### PR DESCRIPTION
🍕 https://github.com/getsentry/sentry/releases/tag/9.1.0 🍕 