### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-14-jdk-oraclelinux7, 13-ea-14-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-14-jdk-oracle, 13-ea-14-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-15-jdk-oraclelinux7, 13-ea-15-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-15-jdk-oracle, 13-ea-15-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-14-jdk-alpine3.9, 13-ea-14-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-14-jdk-alpine, 13-ea-14-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,38 +15,38 @@ Architectures: amd64
 GitCommit: 643875b428551d5e2395e91933e9babc73044bc9
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-14-jdk-windowsservercore-ltsc2016, 13-ea-14-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-15-jdk-windowsservercore-ltsc2016, 13-ea-15-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-14-jdk-windowsservercore-1709, 13-ea-14-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-15-jdk-windowsservercore-1709, 13-ea-15-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-14-jdk-windowsservercore-1803, 13-ea-14-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-15-jdk-windowsservercore-1803, 13-ea-15-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-14-jdk-windowsservercore-1809, 13-ea-14-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-14-jdk-windowsservercore, 13-ea-14-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-14-jdk, 13-ea-14, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-15-jdk-windowsservercore-1809, 13-ea-15-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-14-jdk-nanoserver-sac2016, 13-ea-14-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-14-jdk-nanoserver, 13-ea-14-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-15-jdk-nanoserver-sac2016, 13-ea-15-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-15-jdk-nanoserver, 13-ea-15-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: a316e6bfd44c82c3b5c801767d145f0ecb676aa6
+GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -96,15 +96,15 @@ Architectures: amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/oracle
 
-Tags: 11.0.2-jdk-stretch, 11.0.2-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
-SharedTags: 11.0.2-jdk, 11.0.2, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.3-jdk-stretch, 11.0.3-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
+SharedTags: 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
+GitCommit: 178c542fbb93a8f8a42e331b73a1214c9d8ba81d
 Directory: 11/jdk
 
-Tags: 11.0.2-jdk-slim-stretch, 11.0.2-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, 11.0.2-jdk-slim, 11.0.2-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.3-jdk-slim-stretch, 11.0.3-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, 11.0.3-jdk-slim, 11.0.3-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
+GitCommit: 178c542fbb93a8f8a42e331b73a1214c9d8ba81d
 Directory: 11/jdk/slim
 
 Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
@@ -142,15 +142,15 @@ GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
-Tags: 11.0.2-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
-SharedTags: 11.0.2-jre, 11.0-jre, 11-jre
+Tags: 11.0.3-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
+SharedTags: 11.0.3-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
+GitCommit: 178c542fbb93a8f8a42e331b73a1214c9d8ba81d
 Directory: 11/jre
 
-Tags: 11.0.2-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, 11.0.2-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.3-jre-slim-stretch, 11.0-jre-slim-stretch, 11-jre-slim-stretch, 11.0.3-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: df4cff5b79d52fa311d6dff4c874f191996b583c
+GitCommit: 178c542fbb93a8f8a42e331b73a1214c9d8ba81d
 Directory: 11/jre/slim
 
 Tags: 8u212-jdk-stretch, 8u212-stretch, 8-jdk-stretch, 8-stretch


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/bf1072a: Update to 13-ea+15
- https://github.com/docker-library/openjdk/commit/178c542: Update to 11.0.3, debian 11.0.3+1-1~bpo9+1
- https://github.com/docker-library/openjdk/commit/3cfe1bd: Remove "nss" patch now that it is no longer necessary