### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/35cf993e41e8554876d61d5a438834086a5ae2ee/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/5d977ba3d1c509e3e094f8e98650c6ce25603f71/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -73,33 +73,3 @@ Tags: 2.4.6-alpine3.8, 2.4-alpine3.8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
 Directory: 2.4/alpine3.8
-
-Tags: 2.3.8-stretch, 2.3-stretch, 2.3.8, 2.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/stretch
-
-Tags: 2.3.8-slim-stretch, 2.3-slim-stretch, 2.3.8-slim, 2.3-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/stretch/slim
-
-Tags: 2.3.8-jessie, 2.3-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/jessie
-
-Tags: 2.3.8-slim-jessie, 2.3-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/jessie/slim
-
-Tags: 2.3.8-alpine3.8, 2.3-alpine3.8, 2.3.8-alpine, 2.3-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/alpine3.8
-
-Tags: 2.3.8-alpine3.7, 2.3-alpine3.7
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 31f66490fdb837ddcc5896e3275f2188f2b7b6dd
-Directory: 2.3/alpine3.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/4d1c8fa: Merge pull request https://github.com/docker-library/ruby/pull/278 from infosiftr/eol-2.3
- https://github.com/docker-library/ruby/commit/5d977ba: Remove Ruby 2.3 (EOL)