### PR TITLE
Revert Clear Linux OS to 28410

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@6ba1d518970853ff3ebee4717903a047d916dc98
-base: git://github.com/clearlinux/docker-brew-clearlinux@6ba1d518970853ff3ebee4717903a047d916dc98
+latest: git://github.com/clearlinux/docker-brew-clearlinux@a6c084f67e32d3faf440fdd0c21793f3d83749a7
+base: git://github.com/clearlinux/docker-brew-clearlinux@a6c084f67e32d3faf440fdd0c21793f3d83749a7


### PR DESCRIPTION
Revert Clear Linux OS latest+base images to release 28410.  A problem
was discovered with post update triggers not firing with swupd, which
caused the removal of the statefull trust store.

@bryteise @gtkramer