### PR TITLE
Releasing Neo4j 3.5.4

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -7,12 +7,22 @@
 Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
              Chris Gioran <chris@neo4j.com> (@digitalstain)
 
-Tags: 3.5.3, 3.5, latest
+Tags: 3.5.4, 3.5, latest
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 5a80e2a88fb92e4b10b12d79b28a8070ab2d13fb
+Directory: 3.5.4/community
+
+Tags: 3.5.4-enterprise, 3.5-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 5a80e2a88fb92e4b10b12d79b28a8070ab2d13fb
+Directory: 3.5.4/enterprise
+
+Tags: 3.5.3
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 2bf521bddb65542f583f157f798afa636660b712
 Directory: 3.5.3/community
 
-Tags: 3.5.3-enterprise, 3.5-enterprise, enterprise
+Tags: 3.5.3-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 2bf521bddb65542f583f157f798afa636660b712
 Directory: 3.5.3/enterprise


### PR DESCRIPTION
I'm not sure why the 3.2.14 release is included again, I thought it got merged with https://github.com/docker-library/official-images/pull/5479 ? 
Perhaps that merge got reverted.