### PR TITLE
Add AdoptOpenJDK Images (Includes both HotSpot and Eclipse OpenJ9)

### DIFF
--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -11,7 +11,7 @@ GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-8-jre, hotspot-8-jre, hotspot-jre, jre8u202-b08
+Tags: hotspot-8-jre, hotspot-jre, jre8u202-b08
 Architectures: amd64, ppc64le, s390x
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jre/ubuntu

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -5,43 +5,43 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 #-----------------------------hotspot v8 images---------------------------------
 
-Tags: 8-hotspot, 8-jdk-hotspot, 8u212-b03-jdk-hotspot
+Tags: 8u212-b03-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8-jre-hotspot, 8u212-b03-jre-hotspot
+Tags: 8u212-b03-jre-hotspot, 8-jre-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 #-----------------------------hotspot v11 images--------------------------------
 
-Tags: 11-hotspot, 11-jdk-hotspot, 11.0.3_7-jdk-hotspot
-Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+Tags: 11.0.3_7-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11-jre-hotspot, 11.0.3_7-jre-hotspot
-Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+Tags: 11.0.3_7-jre-hotspot, 11-jre-hotspot
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 #-----------------------------hotspot v12 images--------------------------------
 
-Tags: latest, hotspot, 12-hotspot, 12-jdk-hotspot, 12.0.1_12-jdk-hotspot
-Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+Tags: 12.0.1_12-jdk-hotspot, 12-jdk-hotspot, 12-hotspot, hotspot, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 12-jre-hotspot, 12.0.1_12-jre-hotspot
-Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+Tags: 12.0.1_12-jre-hotspot, 12-jre-hotspot
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 12/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
@@ -49,42 +49,42 @@ File: Dockerfile.hotspot.releases.full
 
 #------------------------------openj9 v8 images---------------------------------
 
-Tags: 8-openj9, 8-jdk-openj9, 8u212-b03-jdk-openj9-0.14.0
+Tags: 8u212-b03-jdk-openj9-0.14.0, 8-jdk-openj9, 8-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8-jre-openj9, 8u212-b03-jre-openj9-0.14.0
+Tags: 8u212-b03-jre-openj9-0.14.0, 8-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 #------------------------------openj9 v11 images--------------------------------
 
-Tags: 11-openj9, 11-jdk-openj9, 11.0.3_7-jdk-openj9-0.14.0
+Tags: 11.0.3_7-jdk-openj9-0.14.0, 11-jdk-openj9, 11-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11-jre-openj9, 11.0.3_7-jre-openj9-0.14.0
+Tags: 11.0.3_7-jre-openj9-0.14.0, 11-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 #------------------------------openj9 v12 images--------------------------------
 
-Tags: openj9, 12-openj9, 12-jdk-openj9, 12.0.1_12-jdk-openj9-0.14.1
+Tags: 12.0.1_12-jdk-openj9-0.14.1, 12-jdk-openj9, 12-openj9, openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 12-jre-openj9, 12.0.1_12-jre-openj9-0.14.1
+Tags: 12.0.1_12-jre-openj9-0.14.1, 12-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
+GitCommit: ba8e2ff59253f16c76878d032a846199d58f453e
 Directory: 12/jre/ubuntu
 File: Dockerfile.openj9.releases.full

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -7,37 +7,37 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 Tags: latest, hotspot, hotspot-8, hotspot-8-jdk, hotspot-jdk, jdk8u202-b08
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-8-jre, hotspot-jre, jre8u202-b08
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-8-jdk-alpine, hotspot-jdk-alpine, jdk8u202-b08-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-8-jre-alpine, hotspot-jre-alpine, jre8u202-b08-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-8-slim, hotspot-slim, hotspot-8-jdk-slim, jdk8u202-b08-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
 Tags: hotspot-8-alpine-slim, hotspot-alpine-slim, hotspot-8-jdk-alpine-slim, jdk8u202-b08-alpine-slim
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.slim
 
@@ -45,37 +45,37 @@ File: Dockerfile.hotspot.releases.slim
 
 Tags: hotspot-11, hotspot-11-jdk, jdk-11.0.2.9
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-11-jre, jre-11.0.2.9
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-11-jdk-alpine, jdk-11.0.2.9-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-11-jre-alpine, jre-11.0.2.9-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-11-slim, hotspot-11-jdk-slim, jdk-11.0.2.9-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
 Tags: hotspot-11-alpine-slim, hotspot-11-jdk-alpine-slim, jdk-11.0.2.9-alpine-slim
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.hotspot.releases.slim
 
@@ -83,37 +83,37 @@ File: Dockerfile.hotspot.releases.slim
 
 Tags: hotspot-12, hotspot-12-jdk, jdk-12.33
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-12-jre, jre-12.33
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-12-jdk-alpine, jdk-12.33-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-12-jre-alpine, jre-12.33-alpine
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
 Tags: hotspot-12-slim, hotspot-12-jdk-slim, jdk-12.33-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
 Tags: hotspot-12-alpine-slim, hotspot-12-jdk-alpine-slim, jdk-12.33-alpine-slim
 Architectures: amd64
-GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.hotspot.releases.slim
 
@@ -123,37 +123,37 @@ File: Dockerfile.hotspot.releases.slim
 
 Tags: openj9, openj9-8, openj9-8-jdk, openj9-jdk, jdk8u202-b08_openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-8-jre, openj9-jre, jre8u202-b08_openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-8-jdk-alpine, openj9-jdk-alpine, jdk8u202-b08_openj9-0.12.1-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-8-jre-alpine, openj9-jre-alpine, jre8u202-b08_openj9-0.12.1-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-8-slim, openj9-slim, openj9-8-jdk-slim, jdk8u202-b08_openj9-0.12.1-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
 Tags: openj9-8-alpine-slim, openj9-alpine-slim, openj9-8-jdk-alpine-slim, jdk8u202-b08_openj9-0.12.1-alpine-slim
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.openj9.releases.slim
 
@@ -161,37 +161,37 @@ File: Dockerfile.openj9.releases.slim
 
 Tags: openj9-11, openj9-11-jdk, jdk-11.0.2.9_openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-11-jre, jre-11.0.2.9_openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-11-jdk-alpine, jdk-11.0.2.9_openj9-0.12.1-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-11-jre-alpine, jre-11.0.2.9_openj9-0.12.1-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-11-slim, openj9-11-jdk-slim, jdk-11.0.2.9_openj9-0.12.1-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
 Tags: openj9-11-alpine-slim, openj9-11-jdk-alpine-slim, jdk-11.0.2.9_openj9-0.12.1-alpine-slim
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.openj9.releases.slim
 
@@ -199,36 +199,36 @@ File: Dockerfile.openj9.releases.slim
 
 Tags: openj9-12, openj9-12-jdk, jdk-12.33_openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-12-jre, jre-12.33_openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-12-jdk-alpine, jdk-12.33_openj9-0.13.0-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-12-jre-alpine, jre-12.33_openj9-0.13.0-alpine
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/alpine
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-12-slim, openj9-12-jdk-slim, jdk-12.33_openj9-0.13.0-slim
 Architectures: amd64, ppc64le, s390x
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
 Tags: openj9-12-alpine-slim, openj9-12-jdk-alpine-slim, jdk-12.33_openj9-0.13.0-alpine-slim
 Architectures: amd64
-GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.openj9.releases.slim

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -5,37 +5,37 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 #-----------------------------hotspot v8 images---------------------------------
 
-Tags: latest, hotspot, hotspot-8, hotspot-8-jdk, hotspot-jdk, jdk8u202-b08
+Tags: 8-hotspot, 8-jdk-hotspot, 8u202-b08-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-8-jre, hotspot-jre, jre8u202-b08
+Tags: 8-jre-hotspot, 8u202-b08-jre-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-8-jdk-alpine, hotspot-jdk-alpine, jdk8u202-b08-alpine
+Tags: 8-jdk-hotspot-alpine, 8u202-b08-jdk-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-8-jre-alpine, hotspot-jre-alpine, jre8u202-b08-alpine
+Tags: 8-jre-hotspot-alpine, 8u202-b08-jre-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-8-slim, hotspot-slim, hotspot-8-jdk-slim, jdk8u202-b08-slim
+Tags: 8-jdk-hotspot-slim, 8u202-b08-jdk-hotspot-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-8-alpine-slim, hotspot-alpine-slim, hotspot-8-jdk-alpine-slim, jdk8u202-b08-alpine-slim
+Tags: 8-jdk-hotspot-alpine-slim, 8u202-b08-jdk-hotspot-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
@@ -43,37 +43,37 @@ File: Dockerfile.hotspot.releases.slim
 
 #-----------------------------hotspot v11 images--------------------------------
 
-Tags: hotspot-11, hotspot-11-jdk, jdk-11.0.2.9
+Tags: 11-hotspot, 11-jdk-hotspot, 11.0.2_9-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-11-jre, jre-11.0.2.9
+Tags: 11-jre-hotspot, 11.0.2_9-jre-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-11-jdk-alpine, jdk-11.0.2.9-alpine
+Tags: 11-jdk-hotspot-alpine, 11.0.2_9-jdk-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-11-jre-alpine, jre-11.0.2.9-alpine
+Tags: 11-jre-hotspot-alpine, 11.0.2_9-jre-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-11-slim, hotspot-11-jdk-slim, jdk-11.0.2.9-slim
+Tags: 11-jdk-hotspot-slim, 11.0.2_9-jdk-hotspot-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-11-alpine-slim, hotspot-11-jdk-alpine-slim, jdk-11.0.2.9-alpine-slim
+Tags: 11-jdk-hotspot-alpine-slim, 11.0.2_9-jdk-hotspot-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
@@ -81,37 +81,37 @@ File: Dockerfile.hotspot.releases.slim
 
 #-----------------------------hotspot v12 images--------------------------------
 
-Tags: hotspot-12, hotspot-12-jdk, jdk-12.33
+Tags: latest, hotspot, 12-hotspot, 12-jdk-hotspot, 12_33-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-12-jre, jre-12.33
+Tags: 12-jre-hotspot, 12_33-jre-hotspot
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-12-jdk-alpine, jdk-12.33-alpine
+Tags: 12-jdk-hotspot-alpine, 12_33-jdk-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-12-jre-alpine, jre-12.33-alpine
+Tags: 12-jre-hotspot-alpine, 12_33-jre-hotspot-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/alpine
 File: Dockerfile.hotspot.releases.full
 
-Tags: hotspot-12-slim, hotspot-12-jdk-slim, jdk-12.33-slim
+Tags: 12-jdk-hotspot-slim, 12_33-jdk-hotspot-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-12-alpine-slim, hotspot-12-jdk-alpine-slim, jdk-12.33-alpine-slim
+Tags: 12-jdk-hotspot-alpine-slim, 12_33-jdk-hotspot-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
@@ -121,37 +121,37 @@ File: Dockerfile.hotspot.releases.slim
 
 #------------------------------openj9 v8 images---------------------------------
 
-Tags: openj9, openj9-8, openj9-8-jdk, openj9-jdk, jdk8u202-b08_openj9-0.12.1
+Tags: 8-openj9, 8-jdk-openj9, 8u202-b08-jdk-openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-8-jre, openj9-jre, jre8u202-b08_openj9-0.12.1
+Tags: 8-jre-openj9, 8u202-b08-jre-openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-8-jdk-alpine, openj9-jdk-alpine, jdk8u202-b08_openj9-0.12.1-alpine
+Tags: 8-jdk-openj9-alpine, 8u202-b08-jdk-openj9-0.12.1-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-8-jre-alpine, openj9-jre-alpine, jre8u202-b08_openj9-0.12.1-alpine
+Tags: 8-jre-openj9-alpine, 8u202-b08-jre-openj9-0.12.1-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jre/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-8-slim, openj9-slim, openj9-8-jdk-slim, jdk8u202-b08_openj9-0.12.1-slim
+Tags: 8-jdk-openj9-slim, 8u202-b08-jdk-openj9-0.12.1-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
-Tags: openj9-8-alpine-slim, openj9-alpine-slim, openj9-8-jdk-alpine-slim, jdk8u202-b08_openj9-0.12.1-alpine-slim
+Tags: 8-jdk-openj9-alpine-slim, 8u202-b08-jdk-openj9-0.12.1-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 8/jdk/alpine
@@ -159,37 +159,37 @@ File: Dockerfile.openj9.releases.slim
 
 #------------------------------openj9 v11 images--------------------------------
 
-Tags: openj9-11, openj9-11-jdk, jdk-11.0.2.9_openj9-0.12.1
+Tags: 11-openj9, 11-jdk-openj9, 11.0.2_9-jdk-openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-11-jre, jre-11.0.2.9_openj9-0.12.1
+Tags: 11-jre-openj9, 11.0.2_9-jre-openj9-0.12.1
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-11-jdk-alpine, jdk-11.0.2.9_openj9-0.12.1-alpine
+Tags: 11-jdk-openj9-alpine, 11.0.2_9-jdk-openj9-0.12.1-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-11-jre-alpine, jre-11.0.2.9_openj9-0.12.1-alpine
+Tags: 11-jre-openj9-alpine, 11.0.2_9-jre-openj9-0.12.1-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jre/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-11-slim, openj9-11-jdk-slim, jdk-11.0.2.9_openj9-0.12.1-slim
+Tags: 11-jdk-openj9-slim, 11.0.2_9-jdk-openj9-0.12.1-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
-Tags: openj9-11-alpine-slim, openj9-11-jdk-alpine-slim, jdk-11.0.2.9_openj9-0.12.1-alpine-slim
+Tags: 11-jdk-openj9-alpine-slim, 11.0.2_9-jdk-openj9-0.12.1-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 11/jdk/alpine
@@ -197,37 +197,37 @@ File: Dockerfile.openj9.releases.slim
 
 #------------------------------openj9 v12 images--------------------------------
 
-Tags: openj9-12, openj9-12-jdk, jdk-12.33_openj9-0.13.0
+Tags: openj9, 12-openj9, 12-jdk-openj9, 12_33-jdk-openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-12-jre, jre-12.33_openj9-0.13.0
+Tags: 12-jre-openj9, 12_33-jre-openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-12-jdk-alpine, jdk-12.33_openj9-0.13.0-alpine
+Tags: 12-jdk-openj9-alpine, 12_33-jdk-openj9-0.13.0-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-12-jre-alpine, jre-12.33_openj9-0.13.0-alpine
+Tags: 12-jre-openj9-alpine, 12_33-jre-openj9-0.13.0-alpine
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jre/alpine
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-12-slim, openj9-12-jdk-slim, jdk-12.33_openj9-0.13.0-slim
+Tags: 12-jdk-openj9-slim, 12_33-jdk-openj9-0.13.0-slim
 Architectures: amd64, ppc64le, s390x
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.slim
 
-Tags: openj9-12-alpine-slim, openj9-12-jdk-alpine-slim, jdk-12.33_openj9-0.13.0-alpine-slim
+Tags: 12-jdk-openj9-alpine-slim, 12_33-jdk-openj9-0.13.0-alpine-slim
 Architectures: amd64
 GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
 Directory: 12/jdk/alpine

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -35,7 +35,7 @@ GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-8-slim-alpine, hotspot-slim-alpine, hotspot-8-jdk-slim-alpine, jdk8u202-b08-slim-alpine
+Tags: hotspot-8-alpine-slim, hotspot-alpine-slim, hotspot-8-jdk-alpine-slim, jdk8u202-b08-alpine-slim
 Architectures: amd64
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 8/jdk/alpine
@@ -73,7 +73,7 @@ GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-11-slim-alpine, hotspot-11-jdk-slim-alpine, jdk-11.0.2.9-slim-alpine
+Tags: hotspot-11-alpine-slim, hotspot-11-jdk-alpine-slim, jdk-11.0.2.9-alpine-slim
 Architectures: amd64
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 11/jdk/alpine
@@ -111,7 +111,7 @@ GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.slim
 
-Tags: hotspot-12-slim-alpine, hotspot-12-jdk-slim-alpine, jdk-12.33-slim-alpine
+Tags: hotspot-12-alpine-slim, hotspot-12-jdk-alpine-slim, jdk-12.33-alpine-slim
 Architectures: amd64
 GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
 Directory: 12/jdk/alpine
@@ -200,13 +200,13 @@ File: Dockerfile.openj9.releases.slim
 Tags: openj9-12, openj9-12-jdk, jdk-12.33_openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
 GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
-Directory: 11/jdk/ubuntu
+Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: openj9-12, openj9-12-jre, jre-12.33_openj9-0.13.0
+Tags: openj9-12-jre, jre-12.33_openj9-0.13.0
 Architectures: amd64, ppc64le, s390x
 GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
-Directory: 11/jre/ubuntu
+Directory: 12/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: openj9-12-jdk-alpine, jdk-12.33_openj9-0.13.0-alpine

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -1,0 +1,234 @@
+# AdoptOpenJDK official images for OpenJDK with HotSpot and OpenJDK with Eclipse OpenJ9.
+
+Maintainers: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
+
+#-----------------------------hotspot v8 images---------------------------------
+
+Tags: latest, hotspot, hotspot-8, hotspot-8-jdk, hotspot-jdk, jdk8u202-b08
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-8-jre, hotspot-8-jre, hotspot-jre, jre8u202-b08
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jre/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-8-jdk-alpine, hotspot-jdk-alpine, jdk8u202-b08-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-8-jre-alpine, hotspot-jre-alpine, jre8u202-b08-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jre/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-8-slim, hotspot-slim, hotspot-8-jdk-slim, jdk8u202-b08-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/ubuntu
+File: Dockerfile.hotspot.releases.slim
+
+Tags: hotspot-8-slim-alpine, hotspot-slim-alpine, hotspot-8-jdk-slim-alpine, jdk8u202-b08-slim-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 8/jdk/alpine
+File: Dockerfile.hotspot.releases.slim
+
+#-----------------------------hotspot v11 images--------------------------------
+
+Tags: hotspot-11, hotspot-11-jdk, jdk-11.0.2.9
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-11-jre, jre-11.0.2.9
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jre/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-11-jdk-alpine, jdk-11.0.2.9-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-11-jre-alpine, jre-11.0.2.9-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jre/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-11-slim, hotspot-11-jdk-slim, jdk-11.0.2.9-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/ubuntu
+File: Dockerfile.hotspot.releases.slim
+
+Tags: hotspot-11-slim-alpine, hotspot-11-jdk-slim-alpine, jdk-11.0.2.9-slim-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 11/jdk/alpine
+File: Dockerfile.hotspot.releases.slim
+
+#-----------------------------hotspot v12 images--------------------------------
+
+Tags: hotspot-12, hotspot-12-jdk, jdk-12.33
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jdk/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-12-jre, jre-12.33
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jre/ubuntu
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-12-jdk-alpine, jdk-12.33-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jdk/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-12-jre-alpine, jre-12.33-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jre/alpine
+File: Dockerfile.hotspot.releases.full
+
+Tags: hotspot-12-slim, hotspot-12-jdk-slim, jdk-12.33-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jdk/ubuntu
+File: Dockerfile.hotspot.releases.slim
+
+Tags: hotspot-12-slim-alpine, hotspot-12-jdk-slim-alpine, jdk-12.33-slim-alpine
+Architectures: amd64
+GitCommit: fa579f13f003e98d2a08be21a1ac313d93ec7b1a
+Directory: 12/jdk/alpine
+File: Dockerfile.hotspot.releases.slim
+
+################################################################################
+
+#------------------------------openj9 v8 images---------------------------------
+
+Tags: openj9, openj9-8, openj9-8-jdk, openj9-jdk, jdk8u202-b08_openj9-0.12.1
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jdk/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-8-jre, openj9-jre, jre8u202-b08_openj9-0.12.1
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jre/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-8-jdk-alpine, openj9-jdk-alpine, jdk8u202-b08_openj9-0.12.1-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jdk/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-8-jre-alpine, openj9-jre-alpine, jre8u202-b08_openj9-0.12.1-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jre/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-8-slim, openj9-slim, openj9-8-jdk-slim, jdk8u202-b08_openj9-0.12.1-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jdk/ubuntu
+File: Dockerfile.openj9.releases.slim
+
+Tags: openj9-8-alpine-slim, openj9-alpine-slim, openj9-8-jdk-alpine-slim, jdk8u202-b08_openj9-0.12.1-alpine-slim
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 8/jdk/alpine
+File: Dockerfile.openj9.releases.slim
+
+#------------------------------openj9 v11 images--------------------------------
+
+Tags: openj9-11, openj9-11-jdk, jdk-11.0.2.9_openj9-0.12.1
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jdk/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-11-jre, jre-11.0.2.9_openj9-0.12.1
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jre/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-11-jdk-alpine, jdk-11.0.2.9_openj9-0.12.1-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jdk/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-11-jre-alpine, jre-11.0.2.9_openj9-0.12.1-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jre/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-11-slim, openj9-11-jdk-slim, jdk-11.0.2.9_openj9-0.12.1-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jdk/ubuntu
+File: Dockerfile.openj9.releases.slim
+
+Tags: openj9-11-alpine-slim, openj9-11-jdk-alpine-slim, jdk-11.0.2.9_openj9-0.12.1-alpine-slim
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jdk/alpine
+File: Dockerfile.openj9.releases.slim
+
+#------------------------------openj9 v12 images--------------------------------
+
+Tags: openj9-12, openj9-12-jdk, jdk-12.33_openj9-0.13.0
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jdk/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-12, openj9-12-jre, jre-12.33_openj9-0.13.0
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 11/jre/ubuntu
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-12-jdk-alpine, jdk-12.33_openj9-0.13.0-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 12/jdk/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-12-jre-alpine, jre-12.33_openj9-0.13.0-alpine
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 12/jre/alpine
+File: Dockerfile.openj9.releases.full
+
+Tags: openj9-12-slim, openj9-12-jdk-slim, jdk-12.33_openj9-0.13.0-slim
+Architectures: amd64, ppc64le, s390x
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 12/jdk/ubuntu
+File: Dockerfile.openj9.releases.slim
+
+Tags: openj9-12-alpine-slim, openj9-12-jdk-alpine-slim, jdk-12.33_openj9-0.13.0-alpine-slim
+Architectures: amd64
+GitCommit: 07b95b67a527248fcef9dd9509a0c80cf86822c1
+Directory: 12/jdk/alpine
+File: Dockerfile.openj9.releases.slim

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -5,230 +5,86 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 #-----------------------------hotspot v8 images---------------------------------
 
-Tags: 8-hotspot, 8-jdk-hotspot, 8u202-b08-jdk-hotspot
+Tags: 8-hotspot, 8-jdk-hotspot, 8u212-b03-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8-jre-hotspot, 8u202-b08-jre-hotspot
+Tags: 8-jre-hotspot, 8u212-b03-jre-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8-jdk-hotspot-alpine, 8u202-b08-jdk-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 8-jre-hotspot-alpine, 8u202-b08-jre-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jre/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 8-jdk-hotspot-slim, 8u202-b08-jdk-hotspot-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/ubuntu
-File: Dockerfile.hotspot.releases.slim
-
-Tags: 8-jdk-hotspot-alpine-slim, 8u202-b08-jdk-hotspot-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/alpine
-File: Dockerfile.hotspot.releases.slim
-
 #-----------------------------hotspot v11 images--------------------------------
 
-Tags: 11-hotspot, 11-jdk-hotspot, 11.0.2_9-jdk-hotspot
+Tags: 11-hotspot, 11-jdk-hotspot, 11.0.3_7-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11-jre-hotspot, 11.0.2_9-jre-hotspot
+Tags: 11-jre-hotspot, 11.0.3_7-jre-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11-jdk-hotspot-alpine, 11.0.2_9-jdk-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 11-jre-hotspot-alpine, 11.0.2_9-jre-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jre/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 11-jdk-hotspot-slim, 11.0.2_9-jdk-hotspot-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/ubuntu
-File: Dockerfile.hotspot.releases.slim
-
-Tags: 11-jdk-hotspot-alpine-slim, 11.0.2_9-jdk-hotspot-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/alpine
-File: Dockerfile.hotspot.releases.slim
-
 #-----------------------------hotspot v12 images--------------------------------
 
-Tags: latest, hotspot, 12-hotspot, 12-jdk-hotspot, 12_33-jdk-hotspot
+Tags: latest, hotspot, 12-hotspot, 12-jdk-hotspot, 12.0.1_12-jdk-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 12/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 12-jre-hotspot, 12_33-jre-hotspot
+Tags: 12-jre-hotspot, 12.0.1_12-jre-hotspot
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 12/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
-
-Tags: 12-jdk-hotspot-alpine, 12_33-jdk-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 12-jre-hotspot-alpine, 12_33-jre-hotspot-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jre/alpine
-File: Dockerfile.hotspot.releases.full
-
-Tags: 12-jdk-hotspot-slim, 12_33-jdk-hotspot-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/ubuntu
-File: Dockerfile.hotspot.releases.slim
-
-Tags: 12-jdk-hotspot-alpine-slim, 12_33-jdk-hotspot-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/alpine
-File: Dockerfile.hotspot.releases.slim
 
 ################################################################################
 
 #------------------------------openj9 v8 images---------------------------------
 
-Tags: 8-openj9, 8-jdk-openj9, 8u202-b08-jdk-openj9-0.12.1
+Tags: 8-openj9, 8-jdk-openj9, 8u212-b03-jdk-openj9-0.14.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8-jre-openj9, 8u202-b08-jre-openj9-0.12.1
+Tags: 8-jre-openj9, 8u212-b03-jre-openj9-0.14.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8-jdk-openj9-alpine, 8u202-b08-jdk-openj9-0.12.1-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 8-jre-openj9-alpine, 8u202-b08-jre-openj9-0.12.1-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jre/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 8-jdk-openj9-slim, 8u202-b08-jdk-openj9-0.12.1-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/ubuntu
-File: Dockerfile.openj9.releases.slim
-
-Tags: 8-jdk-openj9-alpine-slim, 8u202-b08-jdk-openj9-0.12.1-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 8/jdk/alpine
-File: Dockerfile.openj9.releases.slim
-
 #------------------------------openj9 v11 images--------------------------------
 
-Tags: 11-openj9, 11-jdk-openj9, 11.0.2_9-jdk-openj9-0.12.1
+Tags: 11-openj9, 11-jdk-openj9, 11.0.3_7-jdk-openj9-0.14.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11-jre-openj9, 11.0.2_9-jre-openj9-0.12.1
+Tags: 11-jre-openj9, 11.0.3_7-jre-openj9-0.14.0
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11-jdk-openj9-alpine, 11.0.2_9-jdk-openj9-0.12.1-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 11-jre-openj9-alpine, 11.0.2_9-jre-openj9-0.12.1-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jre/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 11-jdk-openj9-slim, 11.0.2_9-jdk-openj9-0.12.1-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/ubuntu
-File: Dockerfile.openj9.releases.slim
-
-Tags: 11-jdk-openj9-alpine-slim, 11.0.2_9-jdk-openj9-0.12.1-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 11/jdk/alpine
-File: Dockerfile.openj9.releases.slim
-
 #------------------------------openj9 v12 images--------------------------------
 
-Tags: openj9, 12-openj9, 12-jdk-openj9, 12_33-jdk-openj9-0.13.0
+Tags: openj9, 12-openj9, 12-jdk-openj9, 12.0.1_12-jdk-openj9-0.14.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 12/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 12-jre-openj9, 12_33-jre-openj9-0.13.0
+Tags: 12-jre-openj9, 12.0.1_12-jre-openj9-0.14.1
 Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
+GitCommit: f03f05b24c4b0712a86ab9d8b19a9cb0ca9cdaba
 Directory: 12/jre/ubuntu
 File: Dockerfile.openj9.releases.full
-
-Tags: 12-jdk-openj9-alpine, 12_33-jdk-openj9-0.13.0-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 12-jre-openj9-alpine, 12_33-jre-openj9-0.13.0-alpine
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jre/alpine
-File: Dockerfile.openj9.releases.full
-
-Tags: 12-jdk-openj9-slim, 12_33-jdk-openj9-0.13.0-slim
-Architectures: amd64, ppc64le, s390x
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/ubuntu
-File: Dockerfile.openj9.releases.slim
-
-Tags: 12-jdk-openj9-alpine-slim, 12_33-jdk-openj9-0.13.0-alpine-slim
-Architectures: amd64
-GitCommit: d304b93e74b513db102bb3f32482d4027fff01f2
-Directory: 12/jdk/alpine
-File: Dockerfile.openj9.releases.slim

--- a/test/config.sh
+++ b/test/config.sh
@@ -20,6 +20,7 @@ imageTests[:onbuild]+='
 
 testAlias+=(
 	[amazoncorretto]='openjdk'
+	[adoptopenjdk]='openjdk'
 	[iojs]='node'
 	[jruby]='ruby'
 	[pypy]='python'


### PR DESCRIPTION
-	[x] associated with or contacted upstream?
        - Yes, this is from the [AdoptOpenJDK](https://adoptopenjdk.net/) community, and I'm the maintainer for the current AdoptOpenJDK docker images.
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
        - Language Runtime
-	[x] is it reasonably popular, or does it solve a particular use case well?
        - The current [AdoptOpenJDK docker images](https://hub.docker.com/u/adoptopenjdk) have over 1.8M pulls across releases and the tarballs from the same site have over [20M](https://dash.adoptopenjdk.net/) downloads.
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
        - Docs [PR](https://github.com/docker-library/docs/pull/1461)
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
         - The dockerfiles and scripts have been derived from the [ibmjava](https://hub.docker.com/_/ibmjava/) official images.
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)