### PR TITLE
Update to Flink 1.8.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,65 +1,15 @@
-# this file is generated via https://github.com/docker-flink/docker-flink/blob/7086bb154b8b70a0b44b91f27165e09019c08247/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-flink/docker-flink/blob/7d8df571a05c8b55521170a5f89786c91fdda071/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/docker-flink/docker-flink.git
-
-Tags: 1.6.4-hadoop24-scala_2.11, 1.6.4-hadoop24, 1.6-hadoop24
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop24-scala_2.11-debian
-
-Tags: 1.6.4-hadoop26-scala_2.11, 1.6.4-hadoop26, 1.6-hadoop26
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop26-scala_2.11-debian
-
-Tags: 1.6.4-hadoop27-scala_2.11, 1.6.4-hadoop27, 1.6-hadoop27
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop27-scala_2.11-debian
-
-Tags: 1.6.4-hadoop28-scala_2.11, 1.6.4-hadoop28, 1.6-hadoop28
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop28-scala_2.11-debian
-
-Tags: 1.6.4-scala_2.11, 1.6-scala_2.11, 1.6.4, 1.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/scala_2.11-debian
-
-Tags: 1.6.4-hadoop24-scala_2.11-alpine, 1.6.4-hadoop24-alpine, 1.6-hadoop24-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop24-scala_2.11-alpine
-
-Tags: 1.6.4-hadoop26-scala_2.11-alpine, 1.6.4-hadoop26-alpine, 1.6-hadoop26-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop26-scala_2.11-alpine
-
-Tags: 1.6.4-hadoop27-scala_2.11-alpine, 1.6.4-hadoop27-alpine, 1.6-hadoop27-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop27-scala_2.11-alpine
-
-Tags: 1.6.4-hadoop28-scala_2.11-alpine, 1.6.4-hadoop28-alpine, 1.6-hadoop28-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/hadoop28-scala_2.11-alpine
-
-Tags: 1.6.4-scala_2.11-alpine, 1.6-scala_2.11-alpine, 1.6.4-alpine, 1.6-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.6/scala_2.11-alpine
 
 Tags: 1.7.2-hadoop24-scala_2.11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop24-scala_2.11-debian
 
-Tags: 1.7.2-hadoop24-scala_2.12, 1.7.2-hadoop24, 1.7-hadoop24, hadoop24
+Tags: 1.7.2-hadoop24-scala_2.12, 1.7.2-hadoop24, 1.7-hadoop24
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop24-scala_2.12-debian
@@ -69,7 +19,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop26-scala_2.11-debian
 
-Tags: 1.7.2-hadoop26-scala_2.12, 1.7.2-hadoop26, 1.7-hadoop26, hadoop26
+Tags: 1.7.2-hadoop26-scala_2.12, 1.7.2-hadoop26, 1.7-hadoop26
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop26-scala_2.12-debian
@@ -79,7 +29,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop27-scala_2.11-debian
 
-Tags: 1.7.2-hadoop27-scala_2.12, 1.7.2-hadoop27, 1.7-hadoop27, hadoop27
+Tags: 1.7.2-hadoop27-scala_2.12, 1.7.2-hadoop27, 1.7-hadoop27
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop27-scala_2.12-debian
@@ -89,17 +39,17 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop28-scala_2.11-debian
 
-Tags: 1.7.2-hadoop28-scala_2.12, 1.7.2-hadoop28, 1.7-hadoop28, hadoop28
+Tags: 1.7.2-hadoop28-scala_2.12, 1.7.2-hadoop28, 1.7-hadoop28
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop28-scala_2.12-debian
 
-Tags: 1.7.2-scala_2.11, 1.7-scala_2.11, scala_2.11
+Tags: 1.7.2-scala_2.11, 1.7-scala_2.11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/scala_2.11-debian
 
-Tags: 1.7.2-scala_2.12, 1.7-scala_2.12, scala_2.12, 1.7.2, 1.7, latest
+Tags: 1.7.2-scala_2.12, 1.7-scala_2.12, 1.7.2, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/scala_2.12-debian
@@ -109,7 +59,7 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop24-scala_2.11-alpine
 
-Tags: 1.7.2-hadoop24-scala_2.12-alpine, 1.7.2-hadoop24-alpine, 1.7-hadoop24-alpine, hadoop24-alpine
+Tags: 1.7.2-hadoop24-scala_2.12-alpine, 1.7.2-hadoop24-alpine, 1.7-hadoop24-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop24-scala_2.12-alpine
@@ -119,7 +69,7 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop26-scala_2.11-alpine
 
-Tags: 1.7.2-hadoop26-scala_2.12-alpine, 1.7.2-hadoop26-alpine, 1.7-hadoop26-alpine, hadoop26-alpine
+Tags: 1.7.2-hadoop26-scala_2.12-alpine, 1.7.2-hadoop26-alpine, 1.7-hadoop26-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop26-scala_2.12-alpine
@@ -129,7 +79,7 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop27-scala_2.11-alpine
 
-Tags: 1.7.2-hadoop27-scala_2.12-alpine, 1.7.2-hadoop27-alpine, 1.7-hadoop27-alpine, hadoop27-alpine
+Tags: 1.7.2-hadoop27-scala_2.12-alpine, 1.7.2-hadoop27-alpine, 1.7-hadoop27-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop27-scala_2.12-alpine
@@ -139,17 +89,37 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop28-scala_2.11-alpine
 
-Tags: 1.7.2-hadoop28-scala_2.12-alpine, 1.7.2-hadoop28-alpine, 1.7-hadoop28-alpine, hadoop28-alpine
+Tags: 1.7.2-hadoop28-scala_2.12-alpine, 1.7.2-hadoop28-alpine, 1.7-hadoop28-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/hadoop28-scala_2.12-alpine
 
-Tags: 1.7.2-scala_2.11-alpine, 1.7-scala_2.11-alpine, scala_2.11-alpine
+Tags: 1.7.2-scala_2.11-alpine, 1.7-scala_2.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/scala_2.11-alpine
 
-Tags: 1.7.2-scala_2.12-alpine, 1.7-scala_2.12-alpine, scala_2.12-alpine, 1.7.2-alpine, 1.7-alpine, alpine
+Tags: 1.7.2-scala_2.12-alpine, 1.7-scala_2.12-alpine, 1.7.2-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
 Directory: 1.7/scala_2.12-alpine
+
+Tags: 1.8.0-scala_2.11, 1.8-scala_2.11, scala_2.11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Directory: 1.8/scala_2.11-debian
+
+Tags: 1.8.0-scala_2.12, 1.8-scala_2.12, scala_2.12, 1.8.0, 1.8, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Directory: 1.8/scala_2.12-debian
+
+Tags: 1.8.0-scala_2.11-alpine, 1.8-scala_2.11-alpine, scala_2.11-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Directory: 1.8/scala_2.11-alpine
+
+Tags: 1.8.0-scala_2.12-alpine, 1.8-scala_2.12-alpine, scala_2.12-alpine, 1.8.0-alpine, 1.8-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Directory: 1.8/scala_2.12-alpine


### PR DESCRIPTION
This update adds Flink 1.8.0 and removes Flink 1.6.

We have not yet been able to make improvements to how GPG keys are handled (re: discussion on #5576), but the matrix of builds is shrinking due to not publishing Hadoop-bundled images and hopefully we will be able to work on this within the next few months.