### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-15-jdk-oraclelinux7, 13-ea-15-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-15-jdk-oracle, 13-ea-15-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-16-jdk-oraclelinux7, 13-ea-16-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-16-jdk-oracle, 13-ea-16-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-14-jdk-alpine3.9, 13-ea-14-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-14-jdk-alpine, 13-ea-14-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,38 +15,38 @@ Architectures: amd64
 GitCommit: 643875b428551d5e2395e91933e9babc73044bc9
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-15-jdk-windowsservercore-ltsc2016, 13-ea-15-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-16-jdk-windowsservercore-ltsc2016, 13-ea-16-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-15-jdk-windowsservercore-1709, 13-ea-15-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-16-jdk-windowsservercore-1709, 13-ea-16-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
+SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-1709
 Constraints: windowsservercore-1709
 
-Tags: 13-ea-15-jdk-windowsservercore-1803, 13-ea-15-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-16-jdk-windowsservercore-1803, 13-ea-16-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-15-jdk-windowsservercore-1809, 13-ea-15-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-15-jdk-windowsservercore, 13-ea-15-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-15-jdk, 13-ea-15, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-16-jdk-windowsservercore-1809, 13-ea-16-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-15-jdk-nanoserver-sac2016, 13-ea-15-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-15-jdk-nanoserver, 13-ea-15-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
+Tags: 13-ea-16-jdk-nanoserver-sac2016, 13-ea-16-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
+SharedTags: 13-ea-16-jdk-nanoserver, 13-ea-16-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
 Architectures: windows-amd64
-GitCommit: bf1072ab57caa868bbe13683ca4e9e6169010f05
+GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/nanoserver-sac2016
 Constraints: nanoserver-sac2016
 
@@ -231,9 +231,9 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jdk/slim
 
-Tags: 7u201-jdk-alpine3.9, 7u201-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u201-jdk-alpine, 7u201-alpine, 7-jdk-alpine, 7-alpine
+Tags: 7u211-jdk-alpine3.9, 7u211-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u211-jdk-alpine, 7u211-alpine, 7-jdk-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
+GitCommit: bc2fcfad89194727ec8a9334730af6ff4d8c44a7
 Directory: 7/jdk/alpine
 
 Tags: 7u211-jre-jessie, 7-jre-jessie
@@ -247,7 +247,7 @@ Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
 Directory: 7/jre/slim
 
-Tags: 7u201-jre-alpine3.9, 7-jre-alpine3.9, 7u201-jre-alpine, 7-jre-alpine
+Tags: 7u211-jre-alpine3.9, 7-jre-alpine3.9, 7u211-jre-alpine, 7-jre-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7cc605aead56177b2c86fecd9e0875378f8ce3d
+GitCommit: bc2fcfad89194727ec8a9334730af6ff4d8c44a7
 Directory: 7/jre/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/7cda38d: Update to 13-ea+16
- https://github.com/docker-library/openjdk/commit/bc2fcfa: Update to 7u211, alpine 7.211.2.6.17-r0