### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
+GitCommit: 4a36c1eeeb76e959673ce79c6b6b7ff2dfd40080
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
+GitCommit: 4a36c1eeeb76e959673ce79c6b6b7ff2dfd40080
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.14, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
+GitCommit: 5a092345c2ad935af817421273edca34a0ce7864
 Directory: 3.7/ubuntu
 
 Tags: 3.7.14-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.14-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cceb25f6b9088c474e400adc4081047135e7656
+GitCommit: 5a092345c2ad935af817421273edca34a0ce7864
 Directory: 3.7/alpine
 
 Tags: 3.7.14-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/5a09234: Update to 3.7.14, Erlang/OTP 21.3.4, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/4a36c1e: Update to 3.8.0-beta.3, Erlang/OTP 21.3.4, OpenSSL 1.1.1b