### PR TITLE
Update hello-world

### DIFF
--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/88475d7d4cfb43feda2b74a5bfdaf5ff8f964fb1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
+GitCommit: 88475d7d4cfb43feda2b74a5bfdaf5ff8f964fb1
 
 Tags: linux
 SharedTags: latest
@@ -16,26 +16,12 @@ arm32v7-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm32v7-Directory: arm32v7/hello-world
 arm64v8-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 arm64v8-Directory: arm64v8/hello-world
-i386-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
+i386-GitCommit: f7fe37d6506b67d1e650e0bbcc5d608e101e3bb7
 i386-Directory: i386/hello-world
 ppc64le-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 ppc64le-Directory: ppc64le/hello-world
 s390x-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 s390x-Directory: s390x/hello-world
-
-Tags: nanoserver-sac2016
-SharedTags: nanoserver, latest
-Architectures: windows-amd64
-windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
-windows-amd64-Directory: amd64/hello-world/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
-Tags: nanoserver-1709
-SharedTags: nanoserver, latest
-Architectures: windows-amd64
-windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
-windows-amd64-Directory: amd64/hello-world/nanoserver-1709
-Constraints: nanoserver-1709
 
 Tags: nanoserver-1803
 SharedTags: nanoserver, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/hello-world/commit/88475d7: Remove nanoserver:sac2016 (EOL)
- https://github.com/docker-library/hello-world/commit/61b2cae: Merge pull request https://github.com/docker-library/hello-world/pull/55 from infosiftr/eol-1709
- https://github.com/docker-library/hello-world/commit/070ec65: Remove Windows 1709 (EOL)
- https://github.com/docker-library/hello-world/commit/f7fe37d: Add i386 binary changes