### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/58b0eb341cf717c8bc11f215e7a078686cf1e902/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/91d42d242a68fa0b8a4cd598c9fac670d4807544/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -22,13 +22,6 @@ GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-16-jdk-windowsservercore-1709, 13-ea-16-windowsservercore-1709, 13-ea-jdk-windowsservercore-1709, 13-ea-windowsservercore-1709, 13-jdk-windowsservercore-1709, 13-windowsservercore-1709
-SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
-Architectures: windows-amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
-Directory: 13/jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 13-ea-16-jdk-windowsservercore-1803, 13-ea-16-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
 SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
@@ -43,13 +36,6 @@ GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-16-jdk-nanoserver-sac2016, 13-ea-16-nanoserver-sac2016, 13-ea-jdk-nanoserver-sac2016, 13-ea-nanoserver-sac2016, 13-jdk-nanoserver-sac2016, 13-nanoserver-sac2016
-SharedTags: 13-ea-16-jdk-nanoserver, 13-ea-16-nanoserver, 13-ea-jdk-nanoserver, 13-ea-nanoserver, 13-jdk-nanoserver, 13-nanoserver
-Architectures: windows-amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
-Directory: 13/jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
 Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
 SharedTags: 12-jdk, 12, jdk, latest
 Architectures: amd64
@@ -62,13 +48,6 @@ Architectures: windows-amd64
 GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
-
-Tags: 12-jdk-windowsservercore-1709, 12-windowsservercore-1709, jdk-windowsservercore-1709, windowsservercore-1709
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
-Architectures: windows-amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
-Directory: 12/jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
 
 Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
@@ -83,13 +62,6 @@ Architectures: windows-amd64
 GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 12-jdk-nanoserver-sac2016, 12-nanoserver-sac2016, jdk-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 12-jdk-nanoserver, 12-nanoserver, jdk-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
-Directory: 12/jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
 
 Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64
@@ -114,13 +86,6 @@ GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.2-jdk-windowsservercore-1709, 11.0.2-windowsservercore-1709, 11.0-jdk-windowsservercore-1709, 11.0-windowsservercore-1709, 11-jdk-windowsservercore-1709, 11-windowsservercore-1709
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
-Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
 SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
 Architectures: windows-amd64
@@ -134,13 +99,6 @@ Architectures: windows-amd64
 GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 11.0.2-jdk-nanoserver-sac2016, 11.0.2-nanoserver-sac2016, 11.0-jdk-nanoserver-sac2016, 11.0-nanoserver-sac2016, 11-jdk-nanoserver-sac2016, 11-nanoserver-sac2016
-SharedTags: 11.0.2-jdk-nanoserver, 11.0.2-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
-Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
 
 Tags: 11.0.3-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
 SharedTags: 11.0.3-jre, 11.0-jre, 11-jre
@@ -176,13 +134,6 @@ GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u201-jdk-windowsservercore-1709, 8u201-windowsservercore-1709, 8-jdk-windowsservercore-1709, 8-windowsservercore-1709
-SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
-Architectures: windows-amd64
-GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
-Directory: 8/jdk/windows/windowsservercore-1709
-Constraints: windowsservercore-1709
-
 Tags: 8u201-jdk-windowsservercore-1803, 8u201-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
 SharedTags: 8u201-jdk-windowsservercore, 8u201-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
 Architectures: windows-amd64
@@ -196,13 +147,6 @@ Architectures: windows-amd64
 GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 8u201-jdk-nanoserver-sac2016, 8u201-nanoserver-sac2016, 8-jdk-nanoserver-sac2016, 8-nanoserver-sac2016
-SharedTags: 8u201-jdk-nanoserver, 8u201-nanoserver, 8-jdk-nanoserver, 8-nanoserver
-Architectures: windows-amd64
-GitCommit: 9850ebc9cb840b259aebcf4de1f19cc3b7621810
-Directory: 8/jdk/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
 
 Tags: 8u212-jre-stretch, 8-jre-stretch
 SharedTags: 8u212-jre, 8-jre


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/91d42d2: Remove nanoserver:sac2016 (EOL)
- https://github.com/docker-library/openjdk/commit/7b22a74: Merge pull request https://github.com/docker-library/openjdk/pull/304 from infosiftr/eol-1709
- https://github.com/docker-library/openjdk/commit/ea3b955: Remove Windows 1709 (EOL)