### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/1613dc652631b3d8654d288fd679b290be37fb30/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/ddb228343a2433319f0b7e2dc6a2b884447f732c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -37,13 +37,6 @@ GitCommit: 8f2f8502c173fbbcf33fcde5566ca53ad1070ae8
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12.4-nanoserver-sac2016, 1.12-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
-SharedTags: 1.12.4-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: 8f2f8502c173fbbcf33fcde5566ca53ad1070ae8
-Directory: 1.12/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016
-
 Tags: 1.11.9-stretch, 1.11-stretch
 SharedTags: 1.11.9, 1.11
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -80,10 +73,3 @@ Architectures: windows-amd64
 GitCommit: 631c9d2f3a2c2bbfa77cbc0b8824890ca7ab7bac
 Directory: 1.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 1.11.9-nanoserver-sac2016, 1.11-nanoserver-sac2016
-SharedTags: 1.11.9-nanoserver, 1.11-nanoserver
-Architectures: windows-amd64
-GitCommit: 631c9d2f3a2c2bbfa77cbc0b8824890ca7ab7bac
-Directory: 1.11/windows/nanoserver-sac2016
-Constraints: nanoserver-sac2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/ddb2283: Remove nanoserver:sac2016 (EOL)