### PR TITLE
Update Amazon Corretto 8 and 11 for April 2019 security releases.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -2,12 +2,12 @@ Maintainers: Amazon Corretto Team (@corretto),
              Eric Edens (@ericedens),
              iliana weller (@ilianaw)
 
-Tags: 8, 8u202, 8-al2-full, latest
+Tags: 8, 8u212, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: 00075d9caa52634b489867a1a8c5a146b1695d0a
+GitCommit: 01450dcc396d8ffac22c6de24e6a62fa9fd3ee05
 
-Tags: 11, 11.0.2, 11-al2-full
+Tags: 11, 11.0.3, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: 13edf15055f74d5cbe0c3f5f8a0c1665414cadfd
+GitCommit: 0b311f7144b833e789165173a83a2022987dfb7b


### PR DESCRIPTION
Updates to the 8u212 security baseline and the 11.0.3 security baseline.

In addition, the Dockerfile for 8 now uses the generic RPM pattern
that we adopted in 11, which allows us to push updates quicker
to users.

8: https://github.com/corretto/corretto-8-docker/commit/01450dcc396d8ffac22c6de24e6a62fa9fd3ee05
11: https://github.com/corretto/corretto-11-docker/commit/0b311f7144b833e789165173a83a2022987dfb7b