### PR TITLE
[nats-streaming] Release v0.14.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 
-Tags: 0.12.2-linux, linux
-SharedTags: 0.12.2, latest
+Tags: 0.14.0-linux, linux
+SharedTags: 0.14.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+amd64-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 amd64-Directory: amd64
-arm32v6-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+arm32v6-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+arm32v7-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+arm64v8-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 arm64v8-Directory: arm64v8
 
-Tags: 0.12.2-nanoserver, nanoserver
-SharedTags: 0.12.2, latest
+Tags: 0.14.0-nanoserver, nanoserver
+SharedTags: 0.14.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+windows-amd64-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.12.2-windowsservercore, windowsservercore
+Tags: 0.14.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 4a217adb9547624fd8ffa7119bd4bcc5343142c9
+windows-amd64-GitCommit: c96a0716deaf93f663b5a65b9ede1b26fae5a0a3
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.14.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>