### PR TITLE
Bump Traefik to v2.0.0-alpha4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,21 +1,21 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-alpha3, 2.0.0-alpha3, v2.0, 2.0, faisselle
+Tags: v2.0.0-alpha4, 2.0.0-alpha4, v2.0, 2.0, faisselle
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0f1b09187679d0959032232f057b9d5348e6a663
+GitCommit: 443c6cee375ea3e2436b117df8535f05e9854385
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v2.0.0-alpha3-alpine, 2.0.0-alpha3-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
+Tags: v2.0.0-alpha4-alpine, 2.0.0-alpha4-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 0f1b09187679d0959032232f057b9d5348e6a663
+GitCommit: 443c6cee375ea3e2436b117df8535f05e9854385
 Directory: alpine
 
-Tags: v2.0.0-alpha3-nanoserver, 2.0.0-alpha3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha3-nanoserver-sac2016, 2.0.0-alpha3-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
+Tags: v2.0.0-alpha4-nanoserver, 2.0.0-alpha4-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha4-nanoserver-sac2016, 2.0.0-alpha4-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 0f1b09187679d0959032232f057b9d5348e6a663
+GitCommit: 443c6cee375ea3e2436b117df8535f05e9854385
 Directory: windows
 Constraints: nanoserver-sac2016
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v2.0.0-alpha4.

/cc @mmatur @emilevauge

Cheers
