### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -10,9 +10,9 @@ Architectures: amd64
 GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-14-jdk-alpine3.9, 13-ea-14-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-14-jdk-alpine, 13-ea-14-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-16-jdk-alpine3.9, 13-ea-16-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-16-jdk-alpine, 13-ea-16-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 643875b428551d5e2395e91933e9babc73044bc9
+GitCommit: 45c21bc4b2492f962d726eb31b1535ca15c4a726
 Directory: 13/jdk/alpine
 
 Tags: 13-ea-16-jdk-windowsservercore-ltsc2016, 13-ea-16-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
@@ -36,30 +36,30 @@ GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
-SharedTags: 12-jdk, 12, jdk, latest
+Tags: 12.0.1-jdk-oraclelinux7, 12.0.1-oraclelinux7, 12.0-jdk-oraclelinux7, 12.0-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12.0.1-jdk-oracle, 12.0.1-oracle, 12.0-jdk-oracle, 12.0-oracle, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
+SharedTags: 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
+GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
 Directory: 12/jdk/oracle
 
-Tags: 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
+Tags: 12.0.1-jdk-windowsservercore-ltsc2016, 12.0.1-windowsservercore-ltsc2016, 12.0-jdk-windowsservercore-ltsc2016, 12.0-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
+GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
+Tags: 12.0.1-jdk-windowsservercore-1803, 12.0.1-windowsservercore-1803, 12.0-jdk-windowsservercore-1803, 12.0-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
+GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12-jdk-windowsservercore-1809, 12-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12-jdk, 12, jdk, latest
+Tags: 12.0.1-jdk-windowsservercore-1809, 12.0.1-windowsservercore-1809, 12.0-jdk-windowsservercore-1809, 12.0-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: aea0404de13a28d0dedb511f19a69e71efee512b
+GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/07af3ff: Update to 12.0.1
- https://github.com/docker-library/openjdk/commit/45c21bc: Update to 13-ea+16