### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2.7-7.1.0, 2.7-7.1, 2.7-7, 2.7, 2-7.1.0, 2-7.1, 2-7, 2, 2.7-7.1.0-jessie, 2.7-7.1-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.1.0-jessie, 2-7.1-jessie, 2-7-jessie, 2-jessie
+Tags: 2.7-7.1.1, 2.7-7.1, 2.7-7, 2.7, 2-7.1.1, 2-7.1, 2-7, 2, 2.7-7.1.1-jessie, 2.7-7.1-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.1.1-jessie, 2-7.1-jessie, 2-7-jessie, 2-jessie
 Architectures: amd64, i386
-GitCommit: d54416e2be73520a490eb0dd2819d8a2b4df3652
+GitCommit: f1cf0a1612c182313f93ab54bf0b1d288b95cf3d
 Directory: 2.7
 
-Tags: 2.7-7.1.0-slim, 2.7-7.1-slim, 2.7-7-slim, 2.7-slim, 2-7.1.0-slim, 2-7.1-slim, 2-7-slim, 2-slim, 2.7-7.1.0-slim-jessie, 2.7-7.1-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.1.0-slim-jessie, 2-7.1-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
+Tags: 2.7-7.1.1-slim, 2.7-7.1-slim, 2.7-7-slim, 2.7-slim, 2-7.1.1-slim, 2-7.1-slim, 2-7-slim, 2-slim, 2.7-7.1.1-slim-jessie, 2.7-7.1-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.1.1-slim-jessie, 2-7.1-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
 Architectures: amd64, i386
-GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
+GitCommit: f1cf0a1612c182313f93ab54bf0b1d288b95cf3d
 Directory: 2.7/slim
 
 Tags: 3.5-7.0.0, 3.5-7.0, 3.5-7, 3.5, 3-7.0.0, 3-7.0, 3-7, 3, latest, 3.5-7.0.0-stretch, 3.5-7.0-stretch, 3.5-7-stretch, 3.5-stretch, 3-7.0.0-stretch, 3-7.0-stretch, 3-7-stretch, 3-stretch, stretch
@@ -24,12 +24,12 @@ Architectures: amd64, i386, ppc64le, s390x
 GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
 Directory: 3.5/slim
 
-Tags: 3.6-7.1.0, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.0-stretch, 3.6-7.1-stretch, 3.6-7-stretch, 3.6-stretch
+Tags: 3.6-7.1.1, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.1-stretch, 3.6-7.1-stretch, 3.6-7-stretch, 3.6-stretch
 Architectures: amd64, i386, s390x
-GitCommit: b3ee440a1a459e63001454e5a9e1f20da439edab
+GitCommit: 113b29602a8a490730425df7a0ea14632ca7bfb8
 Directory: 3.6
 
-Tags: 3.6-7.1.0-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.0-slim-stretch, 3.6-7.1-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch
+Tags: 3.6-7.1.1-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.1-slim-stretch, 3.6-7.1-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, i386, s390x
-GitCommit: abb5b517964511ac622572f07f54c21d58849dfe
+GitCommit: 113b29602a8a490730425df7a0ea14632ca7bfb8
 Directory: 3.6/slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/113b296: Update pypy3.6 to 7.1.1, pip 19.0.3
- https://github.com/docker-library/pypy/commit/f1cf0a1: Update pypy2.7 to 7.1.1, pip 19.0.3