### PR TITLE
Update Backdrop to 1.12.6

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -5,10 +5,10 @@ GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.10.1, 1.10, 1, 1.10.1-apache, 1.10-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 7cc189d199f92b981c1e2dc71c4d2d3aa4f4fa45
+GitCommit: d0e9a5029f1eb3eaf5bd06f74fd72403c069e31f
 Directory: 1/apache
 
 Tags: 1.10.1-fpm, 1.10-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 7cc189d199f92b981c1e2dc71c4d2d3aa4f4fa45
+GitCommit: d0e9a5029f1eb3eaf5bd06f74fd72403c069e31f
 Directory: 1/fpm


### PR DESCRIPTION
Update Backdrop to the latest secure version. 
1.12.6 was released today with security fixes.