### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.3, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e95c7cd5084637421bb0a256afc7c26e8347f1f3
+GitCommit: 5a60b96907bd967e57d1b6611be811d000c2a1b2
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.3-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.3-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e95c7cd5084637421bb0a256afc7c26e8347f1f3
+GitCommit: 5a60b96907bd967e57d1b6611be811d000c2a1b2
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.3-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.14, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4845abe0e3946d389d695aed3988b3e62ba8b88c
+GitCommit: 4d62051f86b7d015a3092d8d5e26edc49bcb0088
 Directory: 3.7/ubuntu
 
 Tags: 3.7.14-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.14-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4845abe0e3946d389d695aed3988b3e62ba8b88c
+GitCommit: 4d62051f86b7d015a3092d8d5e26edc49bcb0088
 Directory: 3.7/alpine
 
 Tags: 3.7.14-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e834da3: Update to 3.8.0-beta.3, Erlang/OTP 21.3.6, OpenSSL 1.1.1b
- https://github.com/docker-library/rabbitmq/commit/4b262bb: Update to 3.7.14, Erlang/OTP 21.3.6, OpenSSL 1.1.1b

:thinking: we just merged an erlang bump in `rabbitmq` yesterday with #5762. And this is another erlang bump. It looks like the fix is the following:

>  --- Fixed Bugs and Malfunctions ---
>
>  OTP-15054    Application(s): ssl
>               Related Id(s): ERIERL-346
>
>               With the default BEAST Mitigation strategy for TLS 1.0
>               an empty TLS fragment could be sent after a one-byte
>               fragment. This glitch has been fixed.
>
> \- http://erlang.org/download/OTP-21.3.6.README

@tianon, Should we still go ahead with this extra churn or can we wait for another change?