### PR TITLE
Add websphere-liberty ifix support and add PH06340 ifix

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 0de7bdf0673af9bd320ae8eeb247033c697ecddc
+GitCommit: 18c3896a4a91706bc25079c51c7b7b2d79714df8
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Adding ifix support to the websphere-liberty Docker images, and adding the 19003 ifix for PH06340.