### PR TITLE
Update Amazon Corretto 8 to 8.212.04.2

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -5,7 +5,7 @@ Maintainers: Amazon Corretto Team (@corretto),
 Tags: 8, 8u212, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: 01450dcc396d8ffac22c6de24e6a62fa9fd3ee05
+GitCommit: bf467741277301c9faba765a98bd23638aece5a2
 
 Tags: 11, 11.0.3, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git


### PR DESCRIPTION
8.212.04.2 improves handling of TrueType fonts (JDK-8219066).

Change logs are at: https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/change-log.html