### PR TITLE
[maven] maven 3.6.1 on amazoncorretto-8

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -73,5 +73,5 @@ Directory: amazoncorretto-11
 
 Tags: 3.6.1-amazoncorretto-8, 3.6-amazoncorretto-8, 3-amazoncorretto-8
 Architectures: amd64
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
+GitCommit: b7890c3af48387de72563b71d72b79bb9a328894
 Directory: amazoncorretto-8


### PR DESCRIPTION
Build failed due to missing gzip