### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-16-jdk-oraclelinux7, 13-ea-16-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-16-jdk-oracle, 13-ea-16-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-17-jdk-oraclelinux7, 13-ea-17-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-17-jdk-oracle, 13-ea-17-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
+GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-16-jdk-alpine3.9, 13-ea-16-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-16-jdk-alpine, 13-ea-16-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,24 +15,24 @@ Architectures: amd64
 GitCommit: 45c21bc4b2492f962d726eb31b1535ca15c4a726
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-16-jdk-windowsservercore-ltsc2016, 13-ea-16-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-17-jdk-windowsservercore-ltsc2016, 13-ea-17-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
+GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-16-jdk-windowsservercore-1803, 13-ea-16-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-17-jdk-windowsservercore-1803, 13-ea-17-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
+GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-16-jdk-windowsservercore-1809, 13-ea-16-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-16-jdk-windowsservercore, 13-ea-16-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-16-jdk, 13-ea-16, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-17-jdk-windowsservercore-1809, 13-ea-17-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 7cda38d3a921ef9b1f0ba5eb6a0eb325575d3b4c
+GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -63,11 +63,6 @@ GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.2-jdk-oraclelinux7, 11.0.2-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7, 11.0.2-jdk-oracle, 11.0.2-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
-Architectures: amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/oracle
-
 Tags: 11.0.3-jdk-stretch, 11.0.3-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
 SharedTags: 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -78,27 +73,6 @@ Tags: 11.0.3-jdk-slim-stretch, 11.0.3-slim-stretch, 11.0-jdk-slim-stretch, 11.0-
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 178c542fbb93a8f8a42e331b73a1214c9d8ba81d
 Directory: 11/jdk/slim
-
-Tags: 11.0.2-jdk-windowsservercore-ltsc2016, 11.0.2-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
-Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 11.0.2-jdk-windowsservercore-1803, 11.0.2-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
-Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
-Tags: 11.0.2-jdk-windowsservercore-1809, 11.0.2-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.2-jdk-windowsservercore, 11.0.2-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
-Architectures: windows-amd64
-GitCommit: 37dbf0917c384321c6c0faa5db00586c4448325f
-Directory: 11/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
 
 Tags: 11.0.3-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
 SharedTags: 11.0.3-jre, 11.0-jre, 11-jre


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6d1b3ad: Update to 13-ea+17
- https://github.com/docker-library/openjdk/commit/dd94554: Merge pull request https://github.com/docker-library/openjdk/pull/305 from infosiftr/eol-oracle-11
- https://github.com/docker-library/openjdk/commit/1308097: Remove all 11-oracle variants (https://jdk.java.net/11/ EOL)