### PR TITLE
Swift: Restore 5.0-bionic and 5.0-xenial tags

### DIFF
--- a/library/swift
+++ b/library/swift
@@ -7,11 +7,11 @@ Maintainers: Ted Kremenek <kremenek@apple.com> (@tkremenek),
 GitRepo: https://github.com/apple/swift-docker.git
 
 
-Tags: 5.0.1, 5.0,  5.0.1-bionic, bionic, latest
+Tags: 5.0.1, 5.0,  5.0.1-bionic, 5.0-bionic, bionic, latest
 GitCommit: 0aafffef619fb3b1824c968cbbe2fba4ba41bd26
 Directory: 5.0/ubuntu/18.04
 
-Tags: 5.0.1-xenial, xenial
+Tags: 5.0.1-xenial, 5.0-xenial, xenial
 GitCommit: 0aafffef619fb3b1824c968cbbe2fba4ba41bd26
 Directory: 5.0/ubuntu/16.04
 


### PR DESCRIPTION
#5787 updated the tags for Swift 5.0.1 but removed `5.0-bionic` and `5.0-xenial` tags.

This wasn't correct. Just like `5.0.1` and `5.0` are the same thing, `5.0.1-bionic` and `5.0-bionic` should be too.

CC: @shahmishal 