### PR TITLE
Consul: backport minor tag releases

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,7 +1,31 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.4.4, latest
+Tags: 1.4.4, 1.4, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: c5cfe2b2554acdbd06add9e71373b65d167b1ade
+Directory: 0.X
+
+Tags: 1.2.4, 1.2
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: af95a2ec9c44fea90458ede561984b2366c57887
+Directory: 0.X
+
+Tags: 1.1.1, 1.1
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 82e4bf74b3d2fa57172f32fd06a981e97929d59c
+Directory: 0.X
+
+Tags: 1.0.8, 1.0
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 3095259fe32be886341fb80d72a6d202a4a808e1
+Directory: 0.X
+
+Tags: 0.9.4, 0.9
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 068a08f88d9e3b313022ac5790c7f884b5aae601
 Directory: 0.X


### PR DESCRIPTION
We want to just create an X.Y tag for each of the latest patch releases to point to the latest minor release.

I just copied the entries from the last releases back to 0.9 and added a minor tag to them. If you prefer I remove the old X.Y.Z tags, let me know and I can remove them and keep just the (X.Y) tags.