### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -6,50 +6,50 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 11.2, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e80419825e4bab4e749bc61334570ffc261ea5e
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 11
 
 Tags: 11.2-alpine, 11-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c3b27f1433ad81675afb386a182098dc867e3e8
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 11/alpine
 
 Tags: 10.7, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef04f3055bab11b10d3d5c41a659acfacf2c850b
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 10
 
 Tags: 10.7-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc305ee1c59d93ac1808108edda6556b879374a4
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 10/alpine
 
 Tags: 9.6.12, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9610d18de51c189c9d4b0197c408e2e3bfb7917
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.6
 
 Tags: 9.6.12-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 122fb0bdcc8058166d7535d30724278efbe41e86
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.6/alpine
 
 Tags: 9.5.16, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58793919b63a1e0b2a9797b857bf435276e28436
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.5
 
 Tags: 9.5.16-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c6da877bba4184e5e112032f52e36bcabccc6ce8
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.5/alpine
 
 Tags: 9.4.21, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23d28bb5957e74cfa1167262fffaddab1bdea4d6
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.4
 
 Tags: 9.4.21-alpine, 9.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fd5c083fcfb276b9cc2299057a8c6c8431bc3b0a
+GitCommit: 85aadc08c347cd20f199902c4b8b4f736341c3b8
 Directory: 9.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/e521526: Remove "backwards compatibility" entrypoint symlink in 12+
- https://github.com/docker-library/postgres/commit/03db72f: Remove UUID variability now that 9.3 is gone (per comment in "update.sh")
- https://github.com/docker-library/postgres/commit/59e5a64: Merge pull request https://github.com/docker-library/postgres/pull/568 from infosiftr/pr-309
- https://github.com/docker-library/postgres/commit/85aadc0: Move end of line comment to its own line to improve readability