### PR TITLE
[node]: update tags for v12

### DIFF
--- a/library/node
+++ b/library/node
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/8c0a9f2c144904631cf783bdd57b4a19300e6b1f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/4d82413e5678c529bb665657e2e8c83e613f44d0/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
@@ -63,32 +63,32 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 53fd280cdd46a4caf63b82f8c269dfbb84895546
 Directory: 6/stretch-slim
 
-Tags: 12.0.0-alpine, 12.0-alpine
+Tags: 12.0.0-alpine, 12.0-alpine, 12-alpine, current-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 29e4ef051ed7a0d55554fc6df53d1be02089e307
 Directory: 12/alpine
 
-Tags: 12.0.0-stretch, 12.0-stretch, 12.0.0, 12.0
+Tags: 12.0.0-stretch, 12.0-stretch, 12-stretch, current-stretch, stretch, 12.0.0, 12.0, 12, current, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 29e4ef051ed7a0d55554fc6df53d1be02089e307
 Directory: 12/stretch
 
-Tags: 12.0.0-stretch-slim, 12.0-stretch-slim, 12.0.0-slim, 12.0-slim
+Tags: 12.0.0-stretch-slim, 12.0-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.0.0-slim, 12.0-slim, 12-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 29e4ef051ed7a0d55554fc6df53d1be02089e307
 Directory: 12/stretch-slim
 
-Tags: 11.14.0-alpine, 11.14-alpine, 11-alpine, current-alpine, alpine
+Tags: 11.14.0-alpine, 11.14-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 5a6a5e91999358c5b04fddd6c22a9a4eb0bf3fbf
 Directory: 11/alpine
 
-Tags: 11.14.0-stretch, 11.14-stretch, 11-stretch, current-stretch, stretch, 11.14.0, 11.14, 11, current, latest
+Tags: 11.14.0-stretch, 11.14-stretch, 11-stretch, 11.14.0, 11.14, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 974b70c72e027365003bc1d6e47c8cf6ec46a54d
 Directory: 11/stretch
 
-Tags: 11.14.0-stretch-slim, 11.14-stretch-slim, 11-stretch-slim, current-stretch-slim, stretch-slim, 11.14.0-slim, 11.14-slim, 11-slim, current-slim, slim
+Tags: 11.14.0-stretch-slim, 11.14-stretch-slim, 11-stretch-slim, 11.14.0-slim, 11.14-slim, 11-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 974b70c72e027365003bc1d6e47c8cf6ec46a54d
 Directory: 11/stretch-slim
@@ -120,10 +120,10 @@ Directory: 10/stretch-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: 6998705ad6ced12fe5913cb23142367eb46c4416
+GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 6998705ad6ced12fe5913cb23142367eb46c4416
+GitCommit: 69c8a5f448f46f9e34d7fb577eca79ba01f6864d
 Directory: chakracore/10


### PR DESCRIPTION
Forgot the tags for the new version 12 in https://github.com/docker-library/official-images/pull/5789