### PR TITLE
Consul: removing older versions after backport tags

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -5,27 +5,3 @@ Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: c5cfe2b2554acdbd06add9e71373b65d167b1ade
 Directory: 0.X
-
-Tags: 1.2.4, 1.2
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: af95a2ec9c44fea90458ede561984b2366c57887
-Directory: 0.X
-
-Tags: 1.1.1, 1.1
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 82e4bf74b3d2fa57172f32fd06a981e97929d59c
-Directory: 0.X
-
-Tags: 1.0.8, 1.0
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 3095259fe32be886341fb80d72a6d202a4a808e1
-Directory: 0.X
-
-Tags: 0.9.4, 0.9
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 068a08f88d9e3b313022ac5790c7f884b5aae601
-Directory: 0.X


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/5794 added a minor release tag to publish backports for older releases, now we want to remove those from the supported image list and just show the latest one. 