### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-2.1.0-php7.1, cli-2.1-php7.1, cli-2-php7.1, cli-php7.1
+Tags: cli-2.2.0-php7.1, cli-2.2-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
+GitCommit: 841f2801d0a6d0cf73321a5554d6bade4c143417
 Directory: php7.1/cli
 
-Tags: cli-2.1.0, cli-2.1, cli-2, cli, cli-2.1.0-php7.2, cli-2.1-php7.2, cli-2-php7.2, cli-php7.2
+Tags: cli-2.2.0, cli-2.2, cli-2, cli, cli-2.2.0-php7.2, cli-2.2-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: aecdd7dcc8e9dd923d3096d353fa70d63de26a1b
+GitCommit: 841f2801d0a6d0cf73321a5554d6bade4c143417
 Directory: php7.2/cli
 
-Tags: cli-2.1.0-php7.3, cli-2.1-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.2.0-php7.3, cli-2.2-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f36a09ba86bc6f53326a36975f79bcf35bed7f9b
+GitCommit: 841f2801d0a6d0cf73321a5554d6bade4c143417
 Directory: php7.3/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/841f280: Update to cli 2.2.0