### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.6, 1.9, 1, latest
+Tags: 1.9.7, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9fd5e8fbbf8898027be1fed2aef616495fc09174
+GitCommit: 0c413bb0564b8a1c66b006e9041a6ef3d91759f9
 Directory: 1.9
 
-Tags: 1.9.6-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.7-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9fd5e8fbbf8898027be1fed2aef616495fc09174
+GitCommit: 0c413bb0564b8a1c66b006e9041a6ef3d91759f9
 Directory: 1.9/alpine
 
 Tags: 1.8.19, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0c413bb: Update to 1.9.7