### PR TITLE
Update websphere-liberty to 19.0.0.4

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,37 +2,64 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 18c3896a4a91706bc25079c51c7b7b2d79714df8
+GitCommit: 6c1cb64cb8d297120b599f28549e8d148375e8e9
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
 Directory: beta
 
-Tags: 19.0.0.3-kernel, kernel
+Tags: 19.0.0.4-kernel, kernel
+Directory: ga/19.0.0.4/kernel
+
+Tags: 19.0.0.4-javaee8, javaee8, latest
+Directory: ga/19.0.0.4/javaee8
+
+Tags: 19.0.0.4-webProfile8, webProfile8
+Directory: ga/19.0.0.4/webProfile8
+
+Tags: 19.0.0.4-microProfile1, microProfile1
+Directory: ga/19.0.0.4/microProfile1
+
+Tags: 19.0.0.4-microProfile2, microProfile2
+Directory: ga/19.0.0.4/microProfile2
+
+Tags: 19.0.0.4-springBoot2, springBoot2
+Directory: ga/19.0.0.4/springBoot2
+
+Tags: 19.0.0.4-springBoot1, springBoot1
+Directory: ga/19.0.0.4/springBoot1
+
+Tags: 19.0.0.4-webProfile7, webProfile7
+Directory: ga/19.0.0.4/webProfile7
+
+Tags: 19.0.0.4-javaee7, javaee7
+Directory: ga/19.0.0.4/javaee7
+
+Tags: 19.0.0.3-kernel
 Directory: ga/19.0.0.3/kernel
 
-Tags: 19.0.0.3-javaee8, javaee8, latest
+Tags: 19.0.0.3-javaee8
 Directory: ga/19.0.0.3/javaee8
 
-Tags: 19.0.0.3-webProfile8, webProfile8
+Tags: 19.0.0.3-webProfile8
 Directory: ga/19.0.0.3/webProfile8
 
-Tags: 19.0.0.3-microProfile1, microProfile1
+Tags: 19.0.0.3-microProfile1
 Directory: ga/19.0.0.3/microProfile1
 
-Tags: 19.0.0.3-microProfile2, microProfile2
+Tags: 19.0.0.3-microProfile2
 Directory: ga/19.0.0.3/microProfile2
 
-Tags: 19.0.0.3-springBoot2, springBoot2
+Tags: 19.0.0.3-springBoot2
 Directory: ga/19.0.0.3/springBoot2
 
-Tags: 19.0.0.3-springBoot1, springBoot1
+Tags: 19.0.0.3-springBoot1
 Directory: ga/19.0.0.3/springBoot1
 
-Tags: 19.0.0.3-webProfile7, webProfile7
+Tags: 19.0.0.3-webProfile7
 Directory: ga/19.0.0.3/webProfile7
 
-Tags: 19.0.0.3-javaee7, javaee7
+Tags: 19.0.0.3-javaee7
 Directory: ga/19.0.0.3/javaee7
 
 Tags: 18.0.0.4-kernel
@@ -61,30 +88,3 @@ Directory: ga/18.0.0.4/webProfile7
 
 Tags: 18.0.0.4-javaee7
 Directory: ga/18.0.0.4/javaee7
-
-Tags: 18.0.0.3-kernel
-Directory: ga/18.0.0.3/kernel
-
-Tags: 18.0.0.3-javaee8
-Directory: ga/18.0.0.3/javaee8
-
-Tags: 18.0.0.3-webProfile8
-Directory: ga/18.0.0.3/webProfile8
-
-Tags: 18.0.0.3-microProfile1
-Directory: ga/18.0.0.3/microProfile1
-
-Tags: 18.0.0.3-microProfile2
-Directory: ga/18.0.0.3/microProfile2
-
-Tags: 18.0.0.3-springBoot2
-Directory: ga/18.0.0.3/springBoot2
-
-Tags: 18.0.0.3-springBoot1
-Directory: ga/18.0.0.3/springBoot1
-
-Tags: 18.0.0.3-webProfile7
-Directory: ga/18.0.0.3/webProfile7
-
-Tags: 18.0.0.3-javaee7
-Directory: ga/18.0.0.3/javaee7


### PR DESCRIPTION
Updating WebSphere Liberty to 19.0.0.4.  Also keeping the previous two long-term support releases (19.0.0.3 and 18.0.0.4), and removing 18.0.0.3.