### PR TITLE
Update open-liberty to 19.0.0.4

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 3a154faa4400d550481154f68dc443135e577b67
+GitCommit: d18e7c06e8b180d57cb0906e8e663be288e9e046
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
Update to the newly released Open Liberty version 19.0.0.4.