### PR TITLE
Update Solr 6.6.6 and 8.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,77 +4,92 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 7.7.1, 7.7, 7, latest
+Tags: 8.0.0, 8.0, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Directory: 8.0
+
+Tags: 8.0.0-alpine, 8.0-alpine, 8-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Directory: 8.0/alpine
+
+Tags: 8.0.0-slim, 8.0-slim, 8-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Directory: 8.0/slim
+
+Tags: 7.7.1, 7.7, 7
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.7
 
-Tags: 7.7.1-alpine, 7.7-alpine, 7-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b9921de4e848a3188445c1f0311d33fec0024a0
+Tags: 7.7.1-alpine, 7.7-alpine, 7-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.7/alpine
 
-Tags: 7.7.1-slim, 7.7-slim, 7-slim, slim
+Tags: 7.7.1-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b9921de4e848a3188445c1f0311d33fec0024a0
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.6
 
 Tags: 7.6.0-alpine, 7.6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.6/alpine
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.5
 
 Tags: 7.5.0-alpine, 7.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.5/alpine
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 7.5/slim
 
-Tags: 6.6.5, 6.6, 6
+Tags: 6.6.6, 6.6, 6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 6.6
 
-Tags: 6.6.5-alpine, 6.6-alpine, 6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+Tags: 6.6.6-alpine, 6.6-alpine, 6-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 6.6/alpine
 
-Tags: 6.6.5-slim, 6.6-slim, 6-slim
+Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a52ebbb74db723e7afa7a3abcd46f34ed2013a58
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 5.5
 
 Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 5.5/alpine
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d61313b443fb798a3a4e873d2255216e7b5c3a69
+GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
 Directory: 5.5/slim


### PR DESCRIPTION
This update adds Solr 6.6.0 ([announcement](http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201904.mbox/browser)), and Solr 8.0.0 ([announcement](http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201903.mbox/browser))

The `solr:8` versions and beyond use a different on-disk layout in the docker image. See https://github.com/docker-solr/docker-solr/pull/210 for details. To take advantage of this new version you will most likely need to modify your deployment.