### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-17-jdk-oraclelinux7, 13-ea-17-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-17-jdk-oracle, 13-ea-17-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-18-jdk-oraclelinux7, 13-ea-18-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-18-jdk-oracle, 13-ea-18-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
+GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-16-jdk-alpine3.9, 13-ea-16-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-16-jdk-alpine, 13-ea-16-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,24 +15,24 @@ Architectures: amd64
 GitCommit: 45c21bc4b2492f962d726eb31b1535ca15c4a726
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-17-jdk-windowsservercore-ltsc2016, 13-ea-17-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-18-jdk-windowsservercore-ltsc2016, 13-ea-18-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
+GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-17-jdk-windowsservercore-1803, 13-ea-17-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-18-jdk-windowsservercore-1803, 13-ea-18-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
+GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-17-jdk-windowsservercore-1809, 13-ea-17-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-17-jdk-windowsservercore, 13-ea-17-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-17-jdk, 13-ea-17, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-18-jdk-windowsservercore-1809, 13-ea-18-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 6d1b3ad0f620b617c4a0d5df88de4a68933222c6
+GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/331cbcc: Update to 13-ea+18