### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0c413bb0564b8a1c66b006e9041a6ef3d91759f9
 Directory: 1.9/alpine
 
-Tags: 1.8.19, 1.8
+Tags: 1.8.20, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
+GitCommit: 98ef1bbd299fbcdc5604a91d867ddcbeb02a32e2
 Directory: 1.8
 
-Tags: 1.8.19-alpine, 1.8-alpine
+Tags: 1.8.20-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b28cb99a56e39f27d49117ea9d34a652a2c55d47
+GitCommit: 98ef1bbd299fbcdc5604a91d867ddcbeb02a32e2
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/98ef1bb: Update to 1.8.20