### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -29,7 +29,7 @@ Architectures: amd64, arm64v8, i386, ppc64le
 GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
 Directory: 10.0
 
-Tags: 5.5.63-trusty, 5.5-trusty, 5-trusty, 5.5.63, 5.5, 5
+Tags: 5.5.64-trusty, 5.5-trusty, 5-trusty, 5.5.64, 5.5, 5
 Architectures: amd64, i386, ppc64le
-GitCommit: 93f1e9c9082364522c77b94e98299d7d398089f8
+GitCommit: 2621ad0b229384856f43ba586e5c9f81a9b9532d
 Directory: 5.5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mariadb/commit/2621ad0: Update to 5.5.64+maria-1~trusty