### PR TITLE
Update websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 6c1cb64cb8d297120b599f28549e8d148375e8e9
+GitCommit: f648a80c48e140db69380aa4af8d419e109a6431
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
The main fix in this commit is that we know properly setup the permissions inside `configure.sh` AFTER we run `installUtility`, which brings in new features / files with incorrect permissions.  This was causing the container to not start when using a different user than 1001.  

Another small change is that we're explicitly adding `openssl`, since we rely on that package and we were told it would be soon removed from our base Java layer.