### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.21.0, 2.21, 2, latest
+Tags: 2.21.1, 2.21, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9a12514dcb26aa9ec2620cb4b1f0991f10396a89
+GitCommit: 5eee31a4e96b87b93d7b03dc269fb3dd90302ba5
 Directory: 2/debian
 
-Tags: 2.21.0-alpine, 2.21-alpine, 2-alpine, alpine
+Tags: 2.21.1-alpine, 2.21-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a12514dcb26aa9ec2620cb4b1f0991f10396a89
+GitCommit: 5eee31a4e96b87b93d7b03dc269fb3dd90302ba5
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/5eee31a: Update to 2.21.1, ghost-cli 1.10.0