### PR TITLE
Update node.js v11 from v11.14.0 to v11.15.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -78,19 +78,19 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 6ef8d23119e8d19d2b0da3d9d4127f64a8fa4338
 Directory: 12/stretch-slim
 
-Tags: 11.14.0-alpine, 11.14-alpine, 11-alpine
+Tags: 11.15.0-alpine, 11.15-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a6a5e91999358c5b04fddd6c22a9a4eb0bf3fbf
+GitCommit: e8c9f49af6d18100ecb0093cbea4bae18f1271d9
 Directory: 11/alpine
 
-Tags: 11.14.0-stretch, 11.14-stretch, 11-stretch, 11.14.0, 11.14, 11
+Tags: 11.15.0-stretch, 11.15-stretch, 11-stretch, 11.15.0, 11.15, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 974b70c72e027365003bc1d6e47c8cf6ec46a54d
+GitCommit: e8c9f49af6d18100ecb0093cbea4bae18f1271d9
 Directory: 11/stretch
 
-Tags: 11.14.0-stretch-slim, 11.14-stretch-slim, 11-stretch-slim, 11.14.0-slim, 11.14-slim, 11-slim
+Tags: 11.15.0-stretch-slim, 11.15-stretch-slim, 11-stretch-slim, 11.15.0-slim, 11.15-slim, 11-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 974b70c72e027365003bc1d6e47c8cf6ec46a54d
+GitCommit: e8c9f49af6d18100ecb0093cbea4bae18f1271d9
 Directory: 11/stretch-slim
 
 Tags: 10.15.3-jessie, 10.15-jessie, 10-jessie, dubnium-jessie, lts-jessie
@@ -120,10 +120,11 @@ Directory: 10/stretch-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: 0c87cf70c6da4f3abd092e1b3a3374e9a049ed98
+GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 0c87cf70c6da4f3abd092e1b3a3374e9a049ed98
+GitCommit: 69c8a5f448f46f9e34d7fb577eca79ba01f6864d
 Directory: chakracore/10
+


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/1031
- https://nodejs.org/en/blog/release/v11.15.0/
- https://github.com/nodejs/node/releases/tag/v11.15.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.15.0