### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-18-jdk-oraclelinux7, 13-ea-18-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-18-jdk-oracle, 13-ea-18-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-19-jdk-oraclelinux7, 13-ea-19-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-19-jdk-oracle, 13-ea-19-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
+GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-16-jdk-alpine3.9, 13-ea-16-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-16-jdk-alpine, 13-ea-16-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,24 +15,24 @@ Architectures: amd64
 GitCommit: 45c21bc4b2492f962d726eb31b1535ca15c4a726
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-18-jdk-windowsservercore-ltsc2016, 13-ea-18-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-19-jdk-windowsservercore-ltsc2016, 13-ea-19-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
+GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-18-jdk-windowsservercore-1803, 13-ea-18-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-19-jdk-windowsservercore-1803, 13-ea-19-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
+GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-18-jdk-windowsservercore-1809, 13-ea-18-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-18-jdk-windowsservercore, 13-ea-18-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-18-jdk, 13-ea-18, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-19-jdk-windowsservercore-1809, 13-ea-19-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 331cbccfae0c0261d1cc92c85efba9e6c3542eea
+GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/c5e74a8: Update to 13-ea+19