### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,13 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2017-10-10
-Tags: 5.5.0, 5.5, 5
-Architectures: amd64, arm32v5, arm32v7
-GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
-Directory: 5
-# Docker EOL: 2019-04-10
-
 # Last Modified: 2018-10-30
 Tags: 6.5.0, 6.5, 6
 Architectures: amd64, arm32v5, arm32v7
@@ -31,3 +24,10 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 28213c0ec6bfadb6c8f7c45b7f67bf8e53b0655f
 Directory: 8
 # Docker EOL: 2020-08-22
+
+# Last Modified: 2019-05-03
+Tags: 9.1.0, 9.1, 9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 067197794df278e6be14a76a3e0ec80e9ad86941
+Directory: 9
+# Docker EOL: 2020-11-03


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/c2066bb: Remove GCC 5 (Docker EOL: 2019-04-10)
- https://github.com/docker-library/gcc/commit/9a4f950: Merge pull request https://github.com/docker-library/gcc/pull/56 from J0WI/gcc9
- https://github.com/docker-library/gcc/commit/0671977: Add GCC 9.1