### PR TITLE
Add varnish

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,0 +1,13 @@
+# this file was generated using https://github.com/varnish/docker-varnish/blob/82ba69727be4e78de5a3e07a63e8b62d92ab958d/populate.sh
+Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
+GitRepo: https://github.com/varnish/docker-varnish.git
+
+Tags: 6.2, 6.2.0-1, 6.2.0, 6, latest, fresh
+Architectures: amd64
+Directory: fresh/debian
+GitCommit: 82ba69727be4e78de5a3e07a63e8b62d92ab958d
+
+Tags: 6.0, 6.0.3-1, 6.0.3, stable
+Architectures: amd64
+Directory: stable/debian
+GitCommit: 82ba69727be4e78de5a3e07a63e8b62d92ab958d


### PR DESCRIPTION
# Context

This PR is going to compete with #4404, with a smaller scope, but hopefully more maintainability. 

Mainly, the images only target `amd64`, leverage the upstream packages on [packagecloud.io](https://packagecloud.io/varnishcache/), and are debian only at the moment (alpine upport is definitely possible, but I want to validate my approach on this PR first).

Ahead of the checklist:

- I am a Varnish Software employee
- the category for the image is "service" I believe
- I'm not a docker expert, and while I read the guidelines, there may be some mistakes left, I'll fix them as soon as you point them out

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)

cheers!