### PR TITLE
Update python-hy and hylang tests

### DIFF
--- a/test/tests/hylang-sh/container.hy
+++ b/test/tests/hylang-sh/container.hy
@@ -2,7 +2,7 @@
   (+ 2 2)
   (print))
 
-(import [subprocess] [sys])
+(import subprocess sys)
 (subprocess.check_call [sys.executable "-m" "pip" "install" "-q" "sh"])
 
 (import [sh [echo]])

--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -16,11 +16,11 @@ fi
 
 # Hy is complicated, and uses Python's internal AST representation directly, and thus Hy releases usually lag behind a little on major Python releases (and we don't want that to gum up our tests)
 # see https://github.com/hylang/hy/issues/1111 for example breakage
-if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 7) or sys.version_info[0] > 3)'; then
-	echo >&2 'skipping Hy test -- not allowed on Python 3.7+ (yet!)'
+if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 8) or sys.version_info[0] > 3)'; then
+	echo >&2 'skipping Hy test -- not allowed on Python 3.8+ (yet!)'
 	cat expected-std-out.txt # cheaters gunna cheat
 	exit
 fi
 
-pip install -q 'hy==0.13.0'
+pip install -q 'hy==0.16.0'
 hy ./container.hy


### PR DESCRIPTION
Python 3.7 support was added in [0.15.0](https://github.com/hylang/hy/releases/tag/0.15.0). Using `0.16.0` since it is the newest.

(test output is very noisy since `pip` is complaining about `19.1.1` from `19.1`)

```console
$ bashbrew list --uniq python pypy | xargs ./test/run.sh -t python-hy
testing python:3.8.0a3-stretch
	'python-hy' [1/1]...skipping Hy test -- not allowed on Python 3.8+ (yet!)
passed
testing python:3.8.0a3-slim-stretch
	'python-hy' [1/1]...skipping Hy test -- not allowed on Python 3.8+ (yet!)
passed
testing python:3.8.0a3-alpine3.9
	'python-hy' [1/1]...skipping Hy test -- not allowed on Python 3.8+ (yet!)
passed
testing python:3.8.0a3-windowsservercore-ltsc2016
	image has no tests...skipping
testing python:3.8.0a3-windowsservercore-1803
	image has no tests...skipping
testing python:3.8.0a3-windowsservercore-1809
	image has no tests...skipping
testing python:3.7.3-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.7.3-slim-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.7.3-alpine3.9
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.7.3-alpine3.8
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.7.3-windowsservercore-ltsc2016
	image has no tests...skipping
testing python:3.7.3-windowsservercore-1803
	image has no tests...skipping
testing python:3.7.3-windowsservercore-1809
	image has no tests...skipping
testing python:3.6.8-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-slim-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-jessie
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-slim-jessie
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-alpine3.9
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-alpine3.8
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.6.8-windowsservercore-ltsc2016
	image has no tests...skipping
testing python:3.6.8-windowsservercore-1803
	image has no tests...skipping
testing python:3.6.8-windowsservercore-1809
	image has no tests...skipping
testing python:3.5.7-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.5.7-slim-stretch
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.5.7-jessie
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.5.7-slim-jessie
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.5.7-alpine3.9
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:3.5.7-alpine3.8
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-stretch
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-slim-stretch
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-jessie
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-slim-jessie
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-alpine3.9
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-alpine3.8
	'python-hy' [1/1]...DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing python:2.7.16-windowsservercore-ltsc2016
	image has no tests...skipping
testing python:2.7.16-windowsservercore-1803
	image has no tests...skipping
testing python:2.7.16-windowsservercore-1809
	image has no tests...skipping
testing pypy:2.7-7.1.1
	'python-hy' [1/1]...DEPRECATION: A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing pypy:2.7-7.1.1-slim
	'python-hy' [1/1]...DEPRECATION: A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: A future version of pip will drop support for Python 2.7.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing pypy:3.5-7.0.0
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing pypy:3.5-7.0.0-slim
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing pypy:3.6-7.1.1
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
testing pypy:3.6-7.1.1-slim
	'python-hy' [1/1]...WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
WARNING: You are using pip version 19.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
passed
```