### PR TITLE
Test wordpress against MariaDB

### DIFF
--- a/test/tests/wordpress-apache-run/run.sh
+++ b/test/tests/wordpress-apache-run/run.sh
@@ -6,7 +6,7 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 # Use a client image with curl for testing
 clientImage='buildpack-deps:buster-curl'
 
-mysqlImage='mysql:5.7'
+mysqlImage='mariadb:10.3'
 serverImage="$1"
 
 # Create an instance of the container-under-test

--- a/test/tests/wordpress-fpm-run/run.sh
+++ b/test/tests/wordpress-fpm-run/run.sh
@@ -15,7 +15,7 @@ RUN set -x && apt-get update && apt-get install -y libfcgi0ldbl && rm -rf /var/l
 ENTRYPOINT ["cgi-fcgi"]
 EOF
 
-mysqlImage='mysql:5.7'
+mysqlImage='mariadb:10.3'
 
 # Create an instance of the container-under-test
 mysqlCid="$(docker run -d -e MYSQL_ROOT_PASSWORD="test-$RANDOM-password-$RANDOM-$$" "$mysqlImage")"


### PR DESCRIPTION
Motivation: most distros (including CentOS, Debian, Fedora, openSUSE, RedHat, SLES and Ubuntu) have moved to MariaDB.
Upstream requirements: https://wordpress.org/about/requirements/