### PR TITLE
Update BusyBox (especially for CVE-2019-5021)

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/80983244a361f41572d23a85fb8376c3c89083fb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/035e6292125c75fac0b3b3b1d334b64781e41e23/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 80983244a361f41572d23a85fb8376c3c89083fb
+GitCommit: 035e6292125c75fac0b3b3b1d334b64781e41e23
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 04a10fb9f74112630b491ee8abf2a4fed09119a2
+amd64-GitCommit: 54245fc8495d2b69cf6bad72af387eb628604c6a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7f4d843405970f9561589842e7ef3d484364782e
+arm32v5-GitCommit: 7cc0a2e3d7216f467f3e8105607760c275c23382
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: cbdd3089868ee8949b363bd9d3610c34e00f945d
+arm32v6-GitCommit: dff3c7ddbd0deefbc0d661ec3c55e73c868794d3
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: ac4106b2531ce2aa2f37cff79eb8b4afc80ead56
+arm32v7-GitCommit: 683152d55ea49d82a483b31749126642c875d2da
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 225ed72e5e025a2aa6386275656ad230d280f6d0
+arm64v8-GitCommit: 2bc2d19be0e99699e69be0a422e669e0e68bd57f
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 0a040f85007f484f3a2a9e74a1d0805125e84bdc
+i386-GitCommit: a0db14c5d7f8f3a9de91776fd8da2806445fec89
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: b600bacdc273325f99b8170dfd65b10faba02260
+ppc64le-GitCommit: 96f57d30722a72683a3c88e8e2a40f72a6fb6c74
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: d7fad7fbd640f809ce55de0897837277a7bcd3a3
+s390x-GitCommit: 9806ac302606d01d13da8db0fdb50b425d56bed6
 
 Tags: 1.30.1-uclibc, 1.30-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
We should probably merge #5880 first so we can run that test against this and make sure it's actually fixed. :smile: