### PR TITLE
Added armv7hl image for mageia 6

### DIFF
--- a/library/mageia
+++ b/library/mageia
@@ -2,6 +2,10 @@ Maintainers: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 GitRepo: https://github.com/juanluisbaptiste/docker-brew-mageia.git
 
 Tags: 6, latest
-GitCommit: f60e1b20a5e31e72b4f49c878160dfa95f49a911
-GitFetch: refs/heads/dist
-Directory: 6
+Architectures: amd64, arm32v7
+amd64-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
+amd64-Directory: 6/x86_64
+amd64-GitFetch: refs/heads/dist
+arm32v7-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
+arm32v7-GitFetch: refs/heads/dist
+arm32v7-Directory: 6/armv7h1

--- a/library/mageia
+++ b/library/mageia
@@ -7,7 +7,7 @@ amd64-Directory: 6/x86_64
 amd64-GitFetch: refs/heads/dist
 arm32v7-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
 arm32v7-GitFetch: refs/heads/dist
-arm32v7-Directory: 6/armv7h1
+arm32v7-Directory: 6/armv7hl
 
 Tags: 6, latest
 Architectures: amd64, arm32v7

--- a/library/mageia
+++ b/library/mageia
@@ -1,5 +1,6 @@
 Maintainers: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 GitRepo: https://github.com/juanluisbaptiste/docker-brew-mageia.git
+GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
 
 amd64-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
 amd64-Directory: 6/x86_64

--- a/library/mageia
+++ b/library/mageia
@@ -1,11 +1,12 @@
 Maintainers: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 GitRepo: https://github.com/juanluisbaptiste/docker-brew-mageia.git
 
-Tags: 6, latest
-Architectures: amd64, arm32v7
 amd64-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
 amd64-Directory: 6/x86_64
 amd64-GitFetch: refs/heads/dist
 arm32v7-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
 arm32v7-GitFetch: refs/heads/dist
 arm32v7-Directory: 6/armv7h1
+
+Tags: 6, latest
+Architectures: amd64, arm32v7

--- a/library/mageia
+++ b/library/mageia
@@ -1,13 +1,9 @@
 Maintainers: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 GitRepo: https://github.com/juanluisbaptiste/docker-brew-mageia.git
 GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
-
-amd64-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
-amd64-Directory: 6/x86_64
-amd64-GitFetch: refs/heads/dist
-arm32v7-GitCommit: e7ffd1ff77c5914b7f46a6cee2373acfb0bf60f5
-arm32v7-GitFetch: refs/heads/dist
-arm32v7-Directory: 6/armv7hl
+GitFetch: refs/heads/dist
 
 Tags: 6, latest
 Architectures: amd64, arm32v7
+amd64-Directory: 6/x86_64
+arm32v7-Directory: 6/armv7hl


### PR DESCRIPTION
Hi,

We have added support for armv7hl to the mageia 6 image, let me know if there's any mistake with the file format.