### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -10,9 +10,9 @@ Architectures: amd64
 GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
 Directory: 13/jdk/oracle
 
-Tags: 13-ea-16-jdk-alpine3.9, 13-ea-16-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-16-jdk-alpine, 13-ea-16-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-19-jdk-alpine3.9, 13-ea-19-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-19-jdk-alpine, 13-ea-19-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 45c21bc4b2492f962d726eb31b1535ca15c4a726
+GitCommit: 1398299a268f339254a94b606113d1627dec342e
 Directory: 13/jdk/alpine
 
 Tags: 13-ea-19-jdk-windowsservercore-ltsc2016, 13-ea-19-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/1398299: Update to 13-ea+19