### PR TITLE
WIP: Add Slackware Linux base image

### DIFF
--- a/library/slackware
+++ b/library/slackware
@@ -1,0 +1,16 @@
+Maintainers: Vincent Batts <vbatts@slackware.com> (@vbatts)
+GitRepo: https://github.com/vbatts/slackware-container.git
+
+Tags: current
+Architectures: arm32v7, i386, amd64
+GitFetch: refs/heads/master
+GitCommit: 9e6bff30f84ecb8b573808ec799e7d49e5010fa6
+arm32v7-Directory: slackwarearm-current/
+i386-Directory: slackware-current/
+amd64-Directory: slackware64-current/
+
+Tags: 14.2, latest
+Architectures: arm32v7, i386, amd64
+arm32v7-Directory: slackwarearm-14.2/
+i386-Directory: slackware-14.2/
+amd64-Directory: slackware64-14.2/


### PR DESCRIPTION
- [ ] The current slackware repository [1], should be forked at the slackware organization [2], e.g, `vbatts/slackware-container` -> `slackware/slackware-docker`
- [ ] Create metadata for official-images [3], (See: https://github.com/oxr463/official-images/commit/df93eefd540705bfae467bc35524009ea10e35d9).
- [ ] Create documentation for official-images [4].

[1]: https://github.com/vbatts/slackware-container
[2]: https://github.com/slackware
[3]: https://github.com/docker-library/official-images
[4]: https://github.com/docker-library/docs