### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-19-jdk-oraclelinux7, 13-ea-19-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-19-jdk-oracle, 13-ea-19-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-20-jdk-oraclelinux7, 13-ea-20-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-20-jdk-oracle, 13-ea-20-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
+GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-19-jdk-alpine3.9, 13-ea-19-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-19-jdk-alpine, 13-ea-19-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,24 +15,24 @@ Architectures: amd64
 GitCommit: 1398299a268f339254a94b606113d1627dec342e
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-19-jdk-windowsservercore-ltsc2016, 13-ea-19-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-20-jdk-windowsservercore-ltsc2016, 13-ea-20-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
+GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-19-jdk-windowsservercore-1803, 13-ea-19-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-20-jdk-windowsservercore-1803, 13-ea-20-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
+GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-19-jdk-windowsservercore-1809, 13-ea-19-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-19-jdk-windowsservercore, 13-ea-19-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-19-jdk, 13-ea-19, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-20-jdk-windowsservercore-1809, 13-ea-20-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c5e74a82a6c33b71d7d075caf48ce955ffd8a7b8
+GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -138,15 +138,15 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ec1553cccfb87c5f53a38555771fa6d13cebfcba
 Directory: 8/jre/alpine
 
-Tags: 7u211-jdk-jessie, 7u211-jessie, 7-jdk-jessie, 7-jessie
-SharedTags: 7u211-jdk, 7u211, 7-jdk, 7
+Tags: 7u221-jdk-jessie, 7u221-jessie, 7-jdk-jessie, 7-jessie
+SharedTags: 7u221-jdk, 7u221, 7-jdk, 7
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
+GitCommit: 8259a15a9118fbe624e47979d34fac3ea7059ac4
 Directory: 7/jdk
 
-Tags: 7u211-jdk-slim-jessie, 7u211-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u211-jdk-slim, 7u211-slim, 7-jdk-slim, 7-slim
+Tags: 7u221-jdk-slim-jessie, 7u221-slim-jessie, 7-jdk-slim-jessie, 7-slim-jessie, 7u221-jdk-slim, 7u221-slim, 7-jdk-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
+GitCommit: 8259a15a9118fbe624e47979d34fac3ea7059ac4
 Directory: 7/jdk/slim
 
 Tags: 7u211-jdk-alpine3.9, 7u211-alpine3.9, 7-jdk-alpine3.9, 7-alpine3.9, 7u211-jdk-alpine, 7u211-alpine, 7-jdk-alpine, 7-alpine
@@ -154,15 +154,15 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bc2fcfad89194727ec8a9334730af6ff4d8c44a7
 Directory: 7/jdk/alpine
 
-Tags: 7u211-jre-jessie, 7-jre-jessie
-SharedTags: 7u211-jre, 7-jre
+Tags: 7u221-jre-jessie, 7-jre-jessie
+SharedTags: 7u221-jre, 7-jre
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
+GitCommit: 8259a15a9118fbe624e47979d34fac3ea7059ac4
 Directory: 7/jre
 
-Tags: 7u211-jre-slim-jessie, 7-jre-slim-jessie, 7u211-jre-slim, 7-jre-slim
+Tags: 7u221-jre-slim-jessie, 7-jre-slim-jessie, 7u221-jre-slim, 7-jre-slim
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: d42099bde3dc0696981917ae48baebb1ff2ab368
+GitCommit: 8259a15a9118fbe624e47979d34fac3ea7059ac4
 Directory: 7/jre/slim
 
 Tags: 7u211-jre-alpine3.9, 7-jre-alpine3.9, 7u211-jre-alpine, 7-jre-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8259a15: Update to 7u221, debian 7u221-2.6.18-1~deb8u1
- https://github.com/docker-library/openjdk/commit/c1738e7: Update to 13-ea+20