### PR TITLE
update crate 3.2 to lastest 3.2.8 release

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -9,9 +9,9 @@ Tags: 3.3.2, 3.3, latest
 Architectures: amd64, arm64v8
 GitCommit: 446fb7cd0c7060a34364da76d771fcd51fc4e090
 
-Tags: 3.2.7, 3.2
+Tags: 3.2.8, 3.2
 Architectures: amd64, arm64v8
-GitCommit: daf383f50a6369415bd7f83a220395caef2e561e
+GitCommit: cd46c51f77fabac4abd60ca29f7da82faaaf2b5f
 
 Tags: 3.1.6, 3.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
There has been a never version of 3.2 for some time already, but the version has never been updated.