### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 1.9.7, 1.9, 1, latest
+Tags: 1.9.8, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c413bb0564b8a1c66b006e9041a6ef3d91759f9
+GitCommit: 53052317a4b4394388600bca0e60551388b03269
 Directory: 1.9
 
-Tags: 1.9.7-alpine, 1.9-alpine, 1-alpine, alpine
+Tags: 1.9.8-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c413bb0564b8a1c66b006e9041a6ef3d91759f9
+GitCommit: 53052317a4b4394388600bca0e60551388b03269
 Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5305231: Update to 1.9.8