### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.22.0, 2.22, 2, latest
+Tags: 2.22.1, 2.22, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e615d9c71459c4a3f81d9611d6ef0293e8bdf6c1
+GitCommit: 3113ecab0d1edaa9e66ac4c75920114dc16496eb
 Directory: 2/debian
 
-Tags: 2.22.0-alpine, 2.22-alpine, 2-alpine, alpine
+Tags: 2.22.1-alpine, 2.22-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e615d9c71459c4a3f81d9611d6ef0293e8bdf6c1
+GitCommit: 3113ecab0d1edaa9e66ac4c75920114dc16496eb
 Directory: 2/alpine
 
 Tags: 1.25.7, 1.25, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3113eca: Update to 2.22.1, ghost-cli 1.10.0