### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0.4, 5.0, 5, latest, 5.0.4-stretch, 5.0-stretch, 5-stretch, stretch
+Tags: 5.0.5, 5.0, 5, latest, 5.0.5-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcc0a2a343ce499b78ca617987e8621e7d31515b
+GitCommit: 6845f6d4940f94c50a9f1bf16e07058d0fe4bc4f
 Directory: 5.0
 
-Tags: 5.0.4-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.4-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
+Tags: 5.0.5-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.5-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: dcc0a2a343ce499b78ca617987e8621e7d31515b
+GitCommit: 6845f6d4940f94c50a9f1bf16e07058d0fe4bc4f
 Directory: 5.0/32bit
 
-Tags: 5.0.4-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.4-alpine3.9, 5.0-alpine3.9, 5-alpine3.9, alpine3.9
+Tags: 5.0.5-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.5-alpine3.9, 5.0-alpine3.9, 5-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcc0a2a343ce499b78ca617987e8621e7d31515b
+GitCommit: 6845f6d4940f94c50a9f1bf16e07058d0fe4bc4f
 Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-stretch, 4.0-stretch, 4-stretch


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/6845f6d: Update to 5.0.5