### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-20-jdk-oraclelinux7, 13-ea-20-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-20-jdk-oracle, 13-ea-20-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-21-jdk-oraclelinux7, 13-ea-21-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-21-jdk-oracle, 13-ea-21-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-21-jdk, 13-ea-21, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
+GitCommit: ac186a1549186876b0d05babd4d909f209f27d59
 Directory: 13/jdk/oracle
 
 Tags: 13-ea-19-jdk-alpine3.9, 13-ea-19-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-19-jdk-alpine, 13-ea-19-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
@@ -15,24 +15,24 @@ Architectures: amd64
 GitCommit: 1398299a268f339254a94b606113d1627dec342e
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-20-jdk-windowsservercore-ltsc2016, 13-ea-20-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-21-jdk-windowsservercore-ltsc2016, 13-ea-21-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-21-jdk-windowsservercore, 13-ea-21-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-21-jdk, 13-ea-21, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
+GitCommit: ac186a1549186876b0d05babd4d909f209f27d59
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-20-jdk-windowsservercore-1803, 13-ea-20-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-21-jdk-windowsservercore-1803, 13-ea-21-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-21-jdk-windowsservercore, 13-ea-21-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-21-jdk, 13-ea-21, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
+GitCommit: ac186a1549186876b0d05babd4d909f209f27d59
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-20-jdk-windowsservercore-1809, 13-ea-20-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-20-jdk-windowsservercore, 13-ea-20-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-20-jdk, 13-ea-20, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-21-jdk-windowsservercore-1809, 13-ea-21-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-21-jdk-windowsservercore, 13-ea-21-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-21-jdk, 13-ea-21, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: c1738e789f9790f724708be0f019efbec1d1ae42
+GitCommit: ac186a1549186876b0d05babd4d909f209f27d59
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/ac186a1: Update to 13-ea+21