### PR TITLE
[nats-streaming] Release v0.14.2

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,28 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 
-Tags: 0.14.1-linux, linux
-SharedTags: 0.14.1, latest
+Tags: 0.14.2-linux, linux
+SharedTags: 0.14.2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+amd64-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 amd64-Directory: amd64
-arm32v6-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+arm32v6-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+arm32v7-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+arm64v8-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 arm64v8-Directory: arm64v8
 
-Tags: 0.14.1-nanoserver, nanoserver
-SharedTags: 0.14.1, latest
+Tags: 0.14.2-nanoserver, nanoserver
+SharedTags: 0.14.2, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+windows-amd64-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 windows-amd64-Directory: windows/nanoserver
 Constraints: nanoserver
 
-Tags: 0.14.1-windowsservercore, windowsservercore
+Tags: 0.14.2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 0eeb762923f2360f66a660936f75cfec30f558d9
+windows-amd64-GitCommit: c318f1ca410327bebd6a5fcbd4f371326dc11359
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.14.2)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>