### PR TITLE
Update influxdata images

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -1,6 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 40e00f536f486492e514a192285b55d0e8887667
+GitCommit: df5692d3ebc883fee52ede21bb75749174f8b0a5
 
 Tags: 1.5, 1.5.0, 1.5.0.1
 Architectures: amd64, arm32v7, arm64v8

--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 101c4c05423f2eb3389bbe516d3ec3de215878d2
+GitCommit: df5692d3ebc883fee52ede21bb75749174f8b0a5
 
 Tags: 1.5, 1.5.4
 Architectures: amd64, arm32v7, arm64v8

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,6 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: dd5970be24ad1c8fd1816acae66e69a03266375b
+GitCommit: df5692d3ebc883fee52ede21bb75749174f8b0a5
 
 Tags: 1.4, 1.4.1
 Architectures: amd64, arm32v7, arm64v8

--- a/library/telegraf
+++ b/library/telegraf
@@ -1,6 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: e634c07845190c8bf3798271770e4e8b5c91ad3e
+GitCommit: 56529df4a46eaac4a83c87d9f36f3ba328b4676a
 
 Tags: 1.8, 1.8.3
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
Upgrading the alpine images to use 3.9 as the base and including the
tzdata package in the telegraf alpine images.