### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,52 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
+Tags: 2.0-dev4, 2.0-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 47b2abd20419ebb6659daff2f289dcba18dbbf76
+Directory: 2.0-rc
+
+Tags: 2.0-dev4-alpine, 2.0-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 47b2abd20419ebb6659daff2f289dcba18dbbf76
+Directory: 2.0-rc/alpine
+
 Tags: 1.9.8, 1.9, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53052317a4b4394388600bca0e60551388b03269
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.9
 
 Tags: 1.9.8-alpine, 1.9-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53052317a4b4394388600bca0e60551388b03269
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98ef1bbd299fbcdc5604a91d867ddcbeb02a32e2
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.8
 
 Tags: 1.8.20-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98ef1bbd299fbcdc5604a91d867ddcbeb02a32e2
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ff254cfc41e9877ebb9b8e48a22a41888ee0171
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.7/alpine
 
 Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.6
 
 Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.6/alpine
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a2d233b1a42e255b8e4097d50d2241b97bd446e
+GitCommit: 2c49aafa4925bf68402c003542f3f82c94cb2c0f
 Directory: 1.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/14a0e31: Merge pull request https://github.com/docker-library/haproxy/pull/88 from TimWolla/2.0-rc
- https://github.com/docker-library/haproxy/commit/47b2abd: Update 2.0-rc to 2.0-dev4
- https://github.com/docker-library/haproxy/commit/2c49aaf: Add USE_GETADDRINFO=1 to build options
- https://github.com/docker-library/haproxy/commit/6e01c91: Add HAProxy 2.0-rc (2.0-dev3)