### PR TITLE
Update Zookeeper to 3.5.5

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,12 +1,12 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
-Tags: 3.4.14, 3.4, latest
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d06286660ebfe25b6842a208f3fcde363fad8e35
+Tags: 3.4.14, 3.4
+Architectures: amd64
+GitCommit: 01d134a4dcb1676d7efe9d0c64c5e0cfdba6fb27
 Directory: 3.4.14
 
-Tags: 3.5.4-beta, 3.5
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d06286660ebfe25b6842a208f3fcde363fad8e35
-Directory: 3.5.4-beta
+Tags: 3.5.5, 3.5, latest
+Architectures: amd64
+GitCommit: 01d134a4dcb1676d7efe9d0c64c5e0cfdba6fb27
+Directory: 3.5.5


### PR DESCRIPTION
* Use openjdk:8-jre-slim as a base image
* Drop architectures to amd64