### PR TITLE
[maven] Adopt changes from openjdk image

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -2,13 +2,13 @@ Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
 GitRepo: https://github.com/carlossg/docker-maven.git
 
 Tags: 3.6.1-jdk-11-slim, 3.6.1-slim, 3.6-jdk-11-slim, 3.6-slim, 3-jdk-11-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
+Architectures: amd64, arm64v8
+GitCommit: 966c1657b1629cdb547692ac8e48b491a9961892
 Directory: jdk-11-slim
 
 Tags: 3.6.1-jdk-11, 3.6.1, 3.6-jdk-11, 3.6, 3-jdk-11, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
+Architectures: amd64, arm64v8
+GitCommit: 966c1657b1629cdb547692ac8e48b491a9961892
 Directory: jdk-11
 
 Tags: 3.6.1-jdk-12, 3.6-jdk-12, 3-jdk-12
@@ -16,43 +16,18 @@ Architectures: amd64
 GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
 Directory: jdk-12
 
-Tags: 3.6.1-jdk-13-alpine, 3.6-jdk-13-alpine, 3-jdk-13-alpine
-Architectures: amd64
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
-Directory: jdk-13-alpine
-
 Tags: 3.6.1-jdk-13, 3.6-jdk-13, 3-jdk-13
 Architectures: amd64
 GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
 Directory: jdk-13
 
-Tags: 3.6.1-jdk-7-alpine, 3.6-jdk-7-alpine, 3-jdk-7-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
-Directory: jdk-7-alpine
-
-Tags: 3.6.1-jdk-7-slim, 3.6-jdk-7-slim, 3-jdk-7-slim
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
-Directory: jdk-7-slim
-
-Tags: 3.6.1-jdk-7, 3.6-jdk-7, 3-jdk-7
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
-Directory: jdk-7
-
-Tags: 3.6.1-jdk-8-alpine, 3.6.1-alpine, 3.6-jdk-8-alpine, 3.6-alpine, 3-jdk-8-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
-Directory: jdk-8-alpine
-
 Tags: 3.6.1-jdk-8-slim, 3.6-jdk-8-slim, 3-jdk-8-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64
 GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
 Directory: jdk-8-slim
 
 Tags: 3.6.1-jdk-8, 3.6-jdk-8, 3-jdk-8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64
 GitCommit: 671605eb62f155b14d600b6941095a16e0b06f5e
 Directory: jdk-8
 


### PR DESCRIPTION
Remove jdk-7, alpine
Drop to amd64 for jdk-8, amd64 and arm64v8 for jdk-11

https://github.com/docker-library/openjdk/pull/322