### PR TITLE
Update perl image for 5.30 (and remove 5.24)

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,19 +1,31 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 9c264844428eaef70ec0c8eefc213cae53fdf12f
+GitCommit: 92233bc5293c2eb17f3019f329cc67fd96d92bcf
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.28, 5.28.2
+Tags: latest, 5, 5.30, 5.30.0
+Directory: 5.030.000-main
+
+Tags: slim, 5-slim, 5.30-slim, 5.30.0-slim
+Directory: 5.030.000-slim
+
+Tags: threaded, 5-threaded, 5.30-threaded, 5.30.0-threaded
+Directory: 5.030.000-main,threaded
+
+Tags: slim-threaded, 5-slim-threaded, 5.30-slim-threaded, 5.30.0-slim-threaded
+Directory: 5.030.000-slim,threaded
+
+Tags: 5.28, 5.28.2
 Directory: 5.028.002-main
 
-Tags: slim, 5-slim, 5.28-slim, 5.28.2-slim
+Tags: 5.28-slim, 5.28.2-slim
 Directory: 5.028.002-slim
 
-Tags: threaded, 5-threaded, 5.28-threaded, 5.28.2-threaded
+Tags: 5.28-threaded, 5.28.2-threaded
 Directory: 5.028.002-main,threaded
 
-Tags: slim-threaded, 5-slim-threaded, 5.28-slim-threaded, 5.28.2-slim-threaded
+Tags: 5.28-slim-threaded, 5.28.2-slim-threaded
 Directory: 5.028.002-slim,threaded
 
 Tags: 5.26, 5.26.3
@@ -27,15 +39,3 @@ Directory: 5.026.003-main,threaded
 
 Tags: 5.26-slim-threaded, 5.26.3-slim-threaded
 Directory: 5.026.003-slim,threaded
-
-Tags: 5.24, 5.24.4
-Directory: 5.024.004-main
-
-Tags: 5.24-slim, 5.24.4-slim
-Directory: 5.024.004-slim
-
-Tags: 5.24-threaded, 5.24.4-threaded
-Directory: 5.024.004-main,threaded
-
-Tags: 5.24-slim-threaded, 5.24.4-slim-threaded
-Directory: 5.024.004-slim,threaded


### PR DESCRIPTION
- Update to Perl 5.30.0
- Remove Perl 5.24.4

https://github.com/Perl/docker-perl/pull/64