### PR TITLE
Add Solr 8.1.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,95 +1,75 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/4e1e9472f2426202d7fa7706ce272a4cbeb669c4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/d6e4780449d3517718e794e59c46214ee3a79f50/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.0.0, 8.0, 8, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Tags: 8.1.1, 8.1, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: 02fff54d99672ee2666bff6f96f008996fb3e3b8
+Directory: 8.1
+
+Tags: 8.1.1-slim, 8.1-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 02fff54d99672ee2666bff6f96f008996fb3e3b8
+Directory: 8.1/slim
+
+Tags: 8.0.0, 8.0
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 8.0
 
-Tags: 8.0.0-alpine, 8.0-alpine, 8-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 8.0/alpine
-
-Tags: 8.0.0-slim, 8.0-slim, 8-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Tags: 8.0.0-slim, 8.0-slim
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 8.0/slim
 
 Tags: 7.7.1, 7.7, 7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.7
 
-Tags: 7.7.1-alpine, 7.7-alpine, 7-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 7.7/alpine
-
 Tags: 7.7.1-slim, 7.7-slim, 7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.6
 
-Tags: 7.6.0-alpine, 7.6-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 7.6/alpine
-
 Tags: 7.6.0-slim, 7.6-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.5
 
-Tags: 7.5.0-alpine, 7.5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 7.5/alpine
-
 Tags: 7.5.0-slim, 7.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64, arm64v8
+GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64
+GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
 Directory: 6.6
 
-Tags: 6.6.6-alpine, 6.6-alpine, 6-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 6.6/alpine
-
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64
+GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64
+GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
 Directory: 5.5
 
-Tags: 5.5.5-alpine, 5.5-alpine, 5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
-Directory: 5.5/alpine
-
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f7a6e812247d00f9f3c293993e26d6d041c119e
+Architectures: amd64
+GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
 Directory: 5.5/slim


### PR DESCRIPTION
Solr 8.1.1 Announcement: http://mail-archives.us.apache.org/mod_mbox/www-announce/201905.mbox/%3C6452A774-13ED-4B0C-8590-C7FBDD511D94@apache.org%3E
Changes: http://lucene.apache.org/solr/8_1_1/changes/Changes.html

Also removes Alpine and JRE versions
See https://github.com/docker-solr/docker-solr/issues/213