### PR TITLE
Update Flink images

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,125 +1,65 @@
-# this file is generated via https://github.com/docker-flink/docker-flink/blob/7d8df571a05c8b55521170a5f89786c91fdda071/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-flink/docker-flink/blob/46cf0bdf4275d3820eace673eed38ea8a947d158/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/docker-flink/docker-flink.git
 
 Tags: 1.7.2-hadoop24-scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop24-scala_2.11-debian
 
 Tags: 1.7.2-hadoop24-scala_2.12, 1.7.2-hadoop24, 1.7-hadoop24
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop24-scala_2.12-debian
 
 Tags: 1.7.2-hadoop26-scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop26-scala_2.11-debian
 
 Tags: 1.7.2-hadoop26-scala_2.12, 1.7.2-hadoop26, 1.7-hadoop26
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop26-scala_2.12-debian
 
 Tags: 1.7.2-hadoop27-scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop27-scala_2.11-debian
 
 Tags: 1.7.2-hadoop27-scala_2.12, 1.7.2-hadoop27, 1.7-hadoop27
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop27-scala_2.12-debian
 
 Tags: 1.7.2-hadoop28-scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop28-scala_2.11-debian
 
 Tags: 1.7.2-hadoop28-scala_2.12, 1.7.2-hadoop28, 1.7-hadoop28
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/hadoop28-scala_2.12-debian
 
 Tags: 1.7.2-scala_2.11, 1.7-scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/scala_2.11-debian
 
 Tags: 1.7.2-scala_2.12, 1.7-scala_2.12, 1.7.2, 1.7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.7/scala_2.12-debian
 
-Tags: 1.7.2-hadoop24-scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop24-scala_2.11-alpine
-
-Tags: 1.7.2-hadoop24-scala_2.12-alpine, 1.7.2-hadoop24-alpine, 1.7-hadoop24-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop24-scala_2.12-alpine
-
-Tags: 1.7.2-hadoop26-scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop26-scala_2.11-alpine
-
-Tags: 1.7.2-hadoop26-scala_2.12-alpine, 1.7.2-hadoop26-alpine, 1.7-hadoop26-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop26-scala_2.12-alpine
-
-Tags: 1.7.2-hadoop27-scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop27-scala_2.11-alpine
-
-Tags: 1.7.2-hadoop27-scala_2.12-alpine, 1.7.2-hadoop27-alpine, 1.7-hadoop27-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop27-scala_2.12-alpine
-
-Tags: 1.7.2-hadoop28-scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop28-scala_2.11-alpine
-
-Tags: 1.7.2-hadoop28-scala_2.12-alpine, 1.7.2-hadoop28-alpine, 1.7-hadoop28-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/hadoop28-scala_2.12-alpine
-
-Tags: 1.7.2-scala_2.11-alpine, 1.7-scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/scala_2.11-alpine
-
-Tags: 1.7.2-scala_2.12-alpine, 1.7-scala_2.12-alpine, 1.7.2-alpine, 1.7-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f94159f1b7bc5dec7af195d191d100e2a02333
-Directory: 1.7/scala_2.12-alpine
-
 Tags: 1.8.0-scala_2.11, 1.8-scala_2.11, scala_2.11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.8/scala_2.11-debian
 
 Tags: 1.8.0-scala_2.12, 1.8-scala_2.12, scala_2.12, 1.8.0, 1.8, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
+Architectures: amd64
+GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
 Directory: 1.8/scala_2.12-debian
-
-Tags: 1.8.0-scala_2.11-alpine, 1.8-scala_2.11-alpine, scala_2.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
-Directory: 1.8/scala_2.11-alpine
-
-Tags: 1.8.0-scala_2.12-alpine, 1.8-scala_2.12-alpine, scala_2.12-alpine, 1.8.0-alpine, 1.8-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8808e12164f02f0b0e84c0f06d9fb0aa4ad19b60
-Directory: 1.8/scala_2.12-alpine


### PR DESCRIPTION
Per docker-library/openjdk#322, the upstream openjdk images no longer
support alpine as well as some previously-supported architectures.

Refs docker-flink/docker-flink#79