### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.4, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a89c4e4f7ff7cff9df094d7a136a7ad8b80597e4
+GitCommit: 767bbb918feda84b4bada1295d5888ec381d5126
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.4-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.4-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a89c4e4f7ff7cff9df094d7a136a7ad8b80597e4
+GitCommit: 767bbb918feda84b4bada1295d5888ec381d5126
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.4-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.15, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e5669ca28b54c6fa07e9767a63e7a01d61cd57a
+GitCommit: dbbe820acaac916a975ccca45ea1a3662fd4ac59
 Directory: 3.7/ubuntu
 
 Tags: 3.7.15-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.15-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e5669ca28b54c6fa07e9767a63e7a01d61cd57a
+GitCommit: dbbe820acaac916a975ccca45ea1a3662fd4ac59
 Directory: 3.7/alpine
 
 Tags: 3.7.15-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/dbbe820: Update to 3.7.15, Erlang/OTP 21.3.8.2, OpenSSL 1.1.1c
- https://github.com/docker-library/rabbitmq/commit/767bbb9: Update to 3.8.0-beta.4, Erlang/OTP 21.3.8.2, OpenSSL 1.1.1c
- https://github.com/docker-library/rabbitmq/commit/e2ddb26: Update the openssl bits of the template to include the full list of all OpenSSL maintainer's key fingerprints (new release is not signed by Matt Caswell)