### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -66,12 +66,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.3-jdk-stretch, 11.0.3-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
 SharedTags: 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 11/jdk
 
 Tags: 11.0.3-jdk-slim-stretch, 11.0.3-slim-stretch, 11.0-jdk-slim-stretch, 11.0-slim-stretch, 11-jdk-slim-stretch, 11-slim-stretch, 11.0.3-jdk-slim, 11.0.3-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 11/jdk/slim
 
 Tags: 11.0.3-jdk-windowsservercore-1809, 11.0.3-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
@@ -98,12 +98,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u212-b04-jdk-stretch, 8u212-b04-stretch, 8u212-jdk-stretch, 8u212-stretch, 8-jdk-stretch, 8-stretch
 SharedTags: 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
 Architectures: amd64
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 8/jdk
 
 Tags: 8u212-b04-jdk-slim-stretch, 8u212-b04-slim-stretch, 8u212-jdk-slim-stretch, 8u212-slim-stretch, 8-jdk-slim-stretch, 8-slim-stretch, 8u212-b04-jdk-slim, 8u212-b04-slim, 8u212-jdk-slim, 8u212-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 8/jdk/slim
 
 Tags: 8u212-b04-jdk-windowsservercore-1809, 8u212-b04-windowsservercore-1809, 8u212-jdk-windowsservercore-1809, 8u212-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
@@ -130,12 +130,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u212-b04-jre-stretch, 8u212-jre-stretch, 8-jre-stretch
 SharedTags: 8u212-b04-jre, 8u212-jre, 8-jre
 Architectures: amd64
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 8/jre
 
 Tags: 8u212-b04-jre-slim-stretch, 8u212-jre-slim-stretch, 8-jre-slim-stretch, 8u212-b04-jre-slim, 8u212-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: 282961c4ca0be09af7a556e38b8d5be0c2db0608
+GitCommit: 1733ab9061cf1a076dc0566e40edb600fc434db4
 Directory: 8/jre/slim
 
 Tags: 8u212-b04-jre-windowsservercore-1809, 8u212-jre-windowsservercore-1809, 8-jre-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/45a4390: Merge pull request https://github.com/docker-library/openjdk/pull/328 from infosiftr/ca-certificates
- https://github.com/docker-library/openjdk/commit/a81e9d7: Rename "oracle" templates to namespace them appropriately as well
- https://github.com/docker-library/openjdk/commit/1733ab9: Auto-update "cacerts" bundle via Debian's "ca-certificates" package