### PR TITLE
Update rocket.chat

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 1.1.0, 1.1, 1, latest
-GitCommit: 425c967b5938cf2a594808f5a87eebefd322a8ec
+Tags: 1.1.1, 1.1, 1, latest
+GitCommit: bd53daee1aadcba946e8fcf53d379726790363a9


### PR DESCRIPTION
Changes:

- https://github.com/RocketChat/Docker.Official.Image/commit/bd53dae: Update to 1.1.1
- https://github.com/RocketChat/Docker.Official.Image/commit/66c5fba: Fix rs.initiate to use proper replicaset name
- https://github.com/RocketChat/Docker.Official.Image/commit/45e8342: adding replica set to mongo as required by v1.0 (https://github.com/RocketChat/Docker.Official.Image/pull/83)