### PR TITLE
update oraclelinux for bind

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 24239f1bcc5080501919f31cf8edc8de8d2b628f
+amd64-GitCommit: bf2545567869d3deaa6a2d7350f8975bba023bde
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4971a9cc0609f2d4658598a99d32c7a0594fb54a
+arm64v8-GitCommit: 820ed349064a65de07a890fc8687389a0b2ee745
 Constraints: !aufs
 
 Tags: 7.6, 7, latest


### PR DESCRIPTION
	[AMD64 7.6] 2019-05-29-96
	[ARM64v8 7.6] 2019-05-30-15

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>