### PR TITLE
Fixing workarea permissions in websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,8 +1,7 @@
-Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
-             Andy Naumann <naumann@us.ibm.com> (@naumanna),
+Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: c495d9fb6638b8753a13b4432b606b7dfc30d084
+GitCommit: be4349167c4a5540c739e127bd52075d472976b3
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
We had a regression in a recent update where our container would fail to start on OpenShift if the customer was not using our `configure.sh` script - which although strongly recommended, is not mandatory.

This PR fixes the permissions so that the containers start fine without using the `configure.sh` script.