### PR TITLE
[ROS] Update ROS2 repository signing key

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -163,12 +163,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 
@@ -180,10 +180,10 @@ Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/crystal/ubuntu/bionic/ros-base


### PR DESCRIPTION
Update ros2 templates with latest signing key for ROS 2 apt repositories.
Context: https://discourse.ros.org/t/key-rotation-for-ros-2-apt-repositories/9363
Related: https://github.com/osrf/docker_images/pull/266