### PR TITLE
Update Backdrop to 1.13.2

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -1,7 +1,7 @@
 Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy),
-             Jen Lampton <jen+docker@jeneration.com> (@jenlampton)
-             Pol Dellaiera <pol.dellaiera@protonmail.com> (@drupol)
+             Jen Lampton <jen+docker@jeneration.com> (@jenlampton),
+             Pol Dellaiera <pol.dellaiera@protonmail.com> (@drupol),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 

--- a/library/backdrop
+++ b/library/backdrop
@@ -1,14 +1,16 @@
 Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy),
              Jen Lampton <jen+docker@jeneration.com> (@jenlampton)
+             Pol Dellaiera <pol.dellaiera@protonmail.com> (@drupol)
+             Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.10.1, 1.10, 1, 1.10.1-apache, 1.10-apache, 1-apache, apache, latest
+Tags: 1.13.2, 1.13, 1, 1.13.2-apache, 1.13-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: d0e9a5029f1eb3eaf5bd06f74fd72403c069e31f
+GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
 Directory: 1/apache
 
-Tags: 1.10.1-fpm, 1.10-fpm, 1-fpm, fpm
+Tags: 1.13.1-fpm, 1.13-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: d0e9a5029f1eb3eaf5bd06f74fd72403c069e31f
+GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -10,7 +10,7 @@ Architectures: amd64, arm64v8
 GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
 Directory: 1/apache
 
-Tags: 1.13.1-fpm, 1.13-fpm, 1-fpm, fpm
+Tags: 1.13.2-fpm, 1.13-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
 GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
 Directory: 1/fpm


### PR DESCRIPTION
1.13.2 got released a couple of days ago: https://github.com/backdrop/backdrop/releases/tag/1.13.2

Respective commit in the https://github.com/backdrop-ops/backdrop-docker.git repo: by @drupol: https://github.com/backdrop-ops/backdrop-docker/commit/1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f

PS: I have also updated the version numbers as er previous request by @tianon in https://github.com/docker-library/official-images/pull/5765#discussion_r276769727