### PR TITLE
Follow restriction of the official Java / Tomcat Docker images:

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -1,19 +1,11 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/docker
-GitCommit: 8dba373fb091d941f4266e98ec1d7e5d2d481d6c
+GitCommit: 59af509cbad0944fbbf2ad3cdb103d24e330cbec
 
 Tags: 7.5.7, 7.5, latest
-Architectures: amd64, arm32v7, arm64v8, i386
+Architectures: amd64
 Directory: 7.5/7.5.7
 
-Tags: 7.5.7-alpine, 7.5-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386
-Directory: 7.5/7.5.7/alpine
-
-Tags: 7.4.8, 7.4
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 7.4/7.4.8
-
-Tags: 7.4.8-alpine, 7.4-alpine
-Architectures: amd64, arm32v6, arm64v8, i386
-Directory: 7.4/7.4.8/alpine
+Tags: 7.5.7-slim, 7.5-slim, slim
+Architectures: amd64
+Directory: 7.5/7.5.7/slim


### PR DESCRIPTION
docker-library/openjdk#322
docker-library/tomcat#158

Please notify us if a new arch will be supported (arm, i386) and if alpine will do a comeback.

Thx !