### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0-dev4, 2.0-rc
+Tags: 2.0-dev5, 2.0-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47b2abd20419ebb6659daff2f289dcba18dbbf76
+GitCommit: 6dd6f543785e6f09eec72eff0ef3b1537823d18b
 Directory: 2.0-rc
 
-Tags: 2.0-dev4-alpine, 2.0-rc-alpine
+Tags: 2.0-dev5-alpine, 2.0-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47b2abd20419ebb6659daff2f289dcba18dbbf76
+GitCommit: 6dd6f543785e6f09eec72eff0ef3b1537823d18b
 Directory: 2.0-rc/alpine
 
 Tags: 1.9.8, 1.9, 1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6dd6f54: Update to 2.0-dev5