### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0-beta.4, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 767bbb918feda84b4bada1295d5888ec381d5126
+GitCommit: e4d837bb8732c971b7cc6c2f6f258518eb38da47
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.0-beta.4-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.0-beta.4-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 767bbb918feda84b4bada1295d5888ec381d5126
+GitCommit: e4d837bb8732c971b7cc6c2f6f258518eb38da47
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.0-beta.4-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.15, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dbbe820acaac916a975ccca45ea1a3662fd4ac59
+GitCommit: 3ba621a74d5f355b07cfd498dfeccc1f1b7f7c31
 Directory: 3.7/ubuntu
 
 Tags: 3.7.15-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.15-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: dbbe820acaac916a975ccca45ea1a3662fd4ac59
+GitCommit: 3ba621a74d5f355b07cfd498dfeccc1f1b7f7c31
 Directory: 3.7/alpine
 
 Tags: 3.7.15-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/3ba621a: Update to 3.7.15, Erlang/OTP 22.0.2, OpenSSL 1.1.1c
- https://github.com/docker-library/rabbitmq/commit/e4d837b: Update to 3.8.0-beta.4, Erlang/OTP 22.0.2, OpenSSL 1.1.1c
- https://github.com/docker-library/rabbitmq/commit/46e2f60: Merge pull request https://github.com/docker-library/rabbitmq/pull/340 from infosiftr/erlang-22
- https://github.com/docker-library/rabbitmq/commit/2802b66: Update to Erlang 22 (and drop HiPE support)