### PR TITLE
Revert "arangodb 3.4.6"

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,6 +7,6 @@
 3.2.17: https://github.com/arangodb/arangodb-docker@b4c22ad8bf4facbbc7c3b24e985251a09fcdbcec stretch/3.2.17
 3.3: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
 3.3.23: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
-3.4: https://github.com/arangodb/arangodb-docker@6a7c227dcc28830ad8ea9eb273f5f43969fe506a alpine/3.4.6
-3.4.6: https://github.com/arangodb/arangodb-docker@6a7c227dcc28830ad8ea9eb273f5f43969fe506a alpine/3.4.6
-latest: https://github.com/arangodb/arangodb-docker@6a7c227dcc28830ad8ea9eb273f5f43969fe506a alpine/3.4.6
+3.4: https://github.com/arangodb/arangodb-docker@716b882665133ceddb1fac06a8d260c8779938a0 alpine/3.4.5
+3.4.5: https://github.com/arangodb/arangodb-docker@716b882665133ceddb1fac06a8d260c8779938a0 alpine/3.4.5
+latest: https://github.com/arangodb/arangodb-docker@716b882665133ceddb1fac06a8d260c8779938a0 alpine/3.4.5


### PR DESCRIPTION
ArangoDB 3.4.6 has been revoked. The current upstream stable version is 3.4.5.