### PR TITLE
Additional official images for open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,104 +1,338 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 000a096c445bc96e89b59b11517e511ff82ac17c
+GitCommit: f8ef13ee34d2ca56ddada65a3774a8a542c6312d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm
-Directory: official/kernel/java8/ibmjava
+Directory: official/19.0.0.x/kernel/java8/ibmjava
 
 Tags: kernel-java8-ibmsfj
-Directory: official/kernel/java8/ibmsfj
+Directory: official/19.0.0.x/kernel/java8/ibmsfj
 Architectures: amd64
 
+Tags: kernel-java8-openj9
+Directory: official/19.0.0.x/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: kernel-java11
-Directory: official/kernel/java11/openj9
+Directory: official/19.0.0.x/kernel/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8, webProfile8-java8-ibm
-Directory: official/webProfile8/java8/ibmjava
+Directory: official/19.0.0.x/webProfile8/java8/ibmjava
 
 Tags: webProfile8-java8-ibmsfj
-Directory: official/webProfile8/java8/ibmsfj
+Directory: official/19.0.0.x/webProfile8/java8/ibmsfj
 Architectures: amd64
 
+Tags: webProfile8-java8-openj9
+Directory: official/19.0.0.x/webProfile8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: webProfile8-java11
-Directory: official/webProfile8/java11/openj9
+Directory: official/19.0.0.x/webProfile8/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee8, javaee8-java8-ibm, latest
-Directory: official/javaee8/java8/ibmjava
+Directory: official/19.0.0.x/javaee8/java8/ibmjava
 
 Tags: javaee8-java8-ibmsfj
-Directory: official/javaee8/java8/ibmsfj
+Directory: official/19.0.0.x/javaee8/java8/ibmsfj
 Architectures: amd64
 
+Tags: javaee8-java8-openj9
+Directory: official/19.0.0.x/javaee8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: javaee8-java11
-Directory: official/javaee8/java11/openj9
+Directory: official/19.0.0.x/javaee8/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile1, microProfile1-java8-ibm
-Directory: official/microProfile1/java8/ibmjava
+Directory: official/19.0.0.x/microProfile1/java8/ibmjava
 
 Tags: microProfile1-java8-ibmsfj
-Directory: official/microProfile1/java8/ibmsfj
+Directory: official/19.0.0.x/microProfile1/java8/ibmsfj
 Architectures: amd64
 
+Tags: microProfile1-java8-openj9
+Directory: official/19.0.0.x/microProfile1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: microProfile1-java11
-Directory: official/microProfile1/java11/openj9
+Directory: official/19.0.0.x/microProfile1/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2, microProfile2-java8-ibm
-Directory: official/microProfile2/java8/ibmjava
+Directory: official/19.0.0.x/microProfile2/java8/ibmjava
 
 Tags: microProfile2-java8-ibmsfj
-Directory: official/microProfile2/java8/ibmsfj
+Directory: official/19.0.0.x/microProfile2/java8/ibmsfj
 Architectures: amd64
 
+Tags: microProfile2-java8-openj9
+Directory: official/19.0.0.x/microProfile2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: microProfile2-java11
-Directory: official/microProfile2/java11/openj9
+Directory: official/19.0.0.x/microProfile2/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2, springBoot2-java8-ibm
-Directory: official/springBoot2/java8/ibmjava
+Directory: official/19.0.0.x/springBoot2/java8/ibmjava
 
 Tags: springBoot2-java8-ibmsfj
-Directory: official/springBoot2/java8/ibmsfj
+Directory: official/19.0.0.x/springBoot2/java8/ibmsfj
 Architectures: amd64
 
+Tags: springBoot2-java8-openj9
+Directory: official/19.0.0.x/springBoot2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: springBoot2-java11
-Directory: official/springBoot2/java11/openj9
+Directory: official/19.0.0.x/springBoot2/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile7, webProfile7-java8-ibm
-Directory: official/webProfile7/java8/ibmjava
+Directory: official/19.0.0.x/webProfile7/java8/ibmjava
 
 Tags: webProfile7-java8-ibmsfj
-Directory: official/webProfile7/java8/ibmsfj
+Directory: official/19.0.0.x/webProfile7/java8/ibmsfj
 Architectures: amd64
 
+Tags: webProfile7-java8-openj9
+Directory: official/19.0.0.x/webProfile7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: webProfile7-java11
-Directory: official/webProfile7/java11/openj9
+Directory: official/19.0.0.x/webProfile7/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee7, javaee7-java8-ibm
-Directory: official/javaee7/java8/ibmjava
+Directory: official/19.0.0.x/javaee7/java8/ibmjava
 
 Tags: javaee7-java8-ibmsfj
-Directory: official/javaee7/java8/ibmsfj
+Directory: official/19.0.0.x/javaee7/java8/ibmsfj
 Architectures: amd64
 
+Tags: javaee7-java8-openj9
+Directory: official/19.0.0.x/javaee7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: javaee7-java11
-Directory: official/javaee7/java11/openj9
+Directory: official/19.0.0.x/javaee7/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot1, springBoot1-java8-ibm
-Directory: official/springBoot1/java8/ibmjava
+Directory: official/19.0.0.x/springBoot1/java8/ibmjava
 
 Tags: springBoot1-java8-ibmsfj
-Directory: official/springBoot1/java8/ibmsfj
+Directory: official/19.0.0.x/springBoot1/java8/ibmsfj
 Architectures: amd64
 
+Tags: springBoot1-java8-openj9
+Directory: official/19.0.0.x/springBoot1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: springBoot1-java11
-Directory: official/springBoot1/java11/openj9
+Directory: official/19.0.0.x/springBoot1/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-kernel, 19.0.0.3-kernel-java8-ibm
+Directory: official/19.0.0.3/kernel/java8/ibmjava
+
+Tags: 19.0.0.3-kernel-java8-ibmsfj
+Directory: official/19.0.0.3/kernel/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-kernel-java8-openj9
+Directory: official/19.0.0.3/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-webProfile8, 19.0.0.3-webProfile8-java8-ibm
+Directory: official/19.0.0.3/webProfile8/java8/ibmjava
+
+Tags: 19.0.0.3-webProfile8-java8-ibmsfj
+Directory: official/19.0.0.3/webProfile8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-webProfile8-java8-openj9
+Directory: official/19.0.0.3/webProfile8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-javaee8, 19.0.0.3-javaee8-java8-ibm
+Directory: official/19.0.0.3/javaee8/java8/ibmjava
+
+Tags: 19.0.0.3-javaee8-java8-ibmsfj
+Directory: official/19.0.0.3/javaee8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-javaee8-java8-openj9
+Directory: official/19.0.0.3/javaee8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-microProfile1, 19.0.0.3-microProfile1-java8-ibm
+Directory: official/19.0.0.3/microProfile1/java8/ibmjava
+
+Tags: 19.0.0.3-microProfile1-java8-ibmsfj
+Directory: official/19.0.0.3/microProfile1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-microProfile1-java8-openj9
+Directory: official/19.0.0.3/microProfile1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-microProfile2, 19.0.0.3-microProfile2-java8-ibm
+Directory: official/19.0.0.3/microProfile2/java8/ibmjava
+
+Tags: 19.0.0.3-microProfile2-java8-ibmsfj
+Directory: official/19.0.0.3/microProfile2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-microProfile2-java8-openj9
+Directory: official/19.0.0.3/microProfile2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-springBoot2, 19.0.0.3-springBoot2-java8-ibm
+Directory: official/19.0.0.3/springBoot2/java8/ibmjava
+
+Tags: 19.0.0.3-springBoot2-java8-ibmsfj
+Directory: official/19.0.0.3/springBoot2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-springBoot2-java8-openj9
+Directory: official/19.0.0.3/springBoot2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-webProfile7, 19.0.0.3-webProfile7-java8-ibm
+Directory: official/19.0.0.3/webProfile7/java8/ibmjava
+
+Tags: 19.0.0.3-webProfile7-java8-ibmsfj
+Directory: official/19.0.0.3/webProfile7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-webProfile7-java8-openj9
+Directory: official/19.0.0.3/webProfile7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-javaee7, 19.0.0.3-javaee7-java8-ibm
+Directory: official/19.0.0.3/javaee7/java8/ibmjava
+
+Tags: 19.0.0.3-javaee7-java8-ibmsfj
+Directory: official/19.0.0.3/javaee7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-javaee7-java8-openj9
+Directory: official/19.0.0.3/javaee7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.3-springBoot1, 19.0.0.3-springBoot1-java8-ibm
+Directory: official/19.0.0.3/springBoot1/java8/ibmjava
+
+Tags: 19.0.0.3-springBoot1-java8-ibmsfj
+Directory: official/19.0.0.3/springBoot1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.3-springBoot1-java8-openj9
+Directory: official/19.0.0.3/springBoot1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-kernel, 18.0.0.4-kernel-java8-ibm
+Directory: official/18.0.0.4/kernel/java8/ibmjava
+
+Tags: 18.0.0.4-kernel-java8-ibmsfj
+Directory: official/18.0.0.4/kernel/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-kernel-java8-openj9
+Directory: official/18.0.0.4/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-webProfile8, 18.0.0.4-webProfile8-java8-ibm
+Directory: official/18.0.0.4/webProfile8/java8/ibmjava
+
+Tags: 18.0.0.4-webProfile8-java8-ibmsfj
+Directory: official/18.0.0.4/webProfile8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-webProfile8-java8-openj9
+Directory: official/18.0.0.4/webProfile8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-javaee8, 18.0.0.4-javaee8-java8-ibm
+Directory: official/18.0.0.4/javaee8/java8/ibmjava
+
+Tags: 18.0.0.4-javaee8-java8-ibmsfj
+Directory: official/18.0.0.4/javaee8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-javaee8-java8-openj9
+Directory: official/18.0.0.4/javaee8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-microProfile1, 18.0.0.4-microProfile1-java8-ibm
+Directory: official/18.0.0.4/microProfile1/java8/ibmjava
+
+Tags: 18.0.0.4-microProfile1-java8-ibmsfj
+Directory: official/18.0.0.4/microProfile1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-microProfile1-java8-openj9
+Directory: official/18.0.0.4/microProfile1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-microProfile2, 18.0.0.4-microProfile2-java8-ibm
+Directory: official/18.0.0.4/microProfile2/java8/ibmjava
+
+Tags: 18.0.0.4-microProfile2-java8-ibmsfj
+Directory: official/18.0.0.4/microProfile2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-microProfile2-java8-openj9
+Directory: official/18.0.0.4/microProfile2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-springBoot2, 18.0.0.4-springBoot2-java8-ibm
+Directory: official/18.0.0.4/springBoot2/java8/ibmjava
+
+Tags: 18.0.0.4-springBoot2-java8-ibmsfj
+Directory: official/18.0.0.4/springBoot2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-springBoot2-java8-openj9
+Directory: official/18.0.0.4/springBoot2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-webProfile7, 18.0.0.4-webProfile7-java8-ibm
+Directory: official/18.0.0.4/webProfile7/java8/ibmjava
+
+Tags: 18.0.0.4-webProfile7-java8-ibmsfj
+Directory: official/18.0.0.4/webProfile7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-webProfile7-java8-openj9
+Directory: official/18.0.0.4/webProfile7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-javaee7, 18.0.0.4-javaee7-java8-ibm
+Directory: official/18.0.0.4/javaee7/java8/ibmjava
+
+Tags: 18.0.0.4-javaee7-java8-ibmsfj
+Directory: official/18.0.0.4/javaee7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-javaee7-java8-openj9
+Directory: official/18.0.0.4/javaee7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 18.0.0.4-springBoot1, 18.0.0.4-springBoot1-java8-ibm
+Directory: official/18.0.0.4/springBoot1/java8/ibmjava
+
+Tags: 18.0.0.4-springBoot1-java8-ibmsfj
+Directory: official/18.0.0.4/springBoot1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 18.0.0.4-springBoot1-java8-openj9
+Directory: official/18.0.0.4/springBoot1/java8/openj9
 Architectures: amd64, ppc64le, s390x


### PR DESCRIPTION
Adding the following to the open-liberty official images:

- Java 8 openj9 based images.
- Versioned images for the last two quarter releases, to provide stable releases requested by customers.