### PR TITLE
Updated mainline nginx to 1.17.0.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,24 +3,24 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.15.12, mainline, 1, 1.15, latest
+Tags: 1.17.0, mainline, 1, 1.17, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5123eea0d29c8d13df17d782f15679458ff899e
+GitCommit: b749353968a57ebd9da17e12d23f1a5fb62f9de9
 Directory: mainline/stretch
 
-Tags: 1.15.12-perl, mainline-perl, 1-perl, 1.15-perl, perl
+Tags: 1.17.0-perl, mainline-perl, 1-perl, 1.17-perl, perl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5123eea0d29c8d13df17d782f15679458ff899e
+GitCommit: b749353968a57ebd9da17e12d23f1a5fb62f9de9
 Directory: mainline/stretch-perl
 
-Tags: 1.15.12-alpine, mainline-alpine, 1-alpine, 1.15-alpine, alpine
+Tags: 1.17.0-alpine, mainline-alpine, 1-alpine, 1.17-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e5123eea0d29c8d13df17d782f15679458ff899e
+GitCommit: b749353968a57ebd9da17e12d23f1a5fb62f9de9
 Directory: mainline/alpine
 
-Tags: 1.15.12-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.15-alpine-perl, alpine-perl
+Tags: 1.17.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.17-alpine-perl, alpine-perl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e5123eea0d29c8d13df17d782f15679458ff899e
+GitCommit: b749353968a57ebd9da17e12d23f1a5fb62f9de9
 Directory: mainline/alpine-perl
 
 Tags: 1.16.0, stable, 1.16


### PR DESCRIPTION
This is a potentially breaking change (UID/GID changed to be consistent between the variants), documented in a separate PR to the docs repo. 