### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.23.1, 2.23, 2, latest
+Tags: 2.23.2, 2.23, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e406137638f0533d56b47843b15b983db1474ea3
+GitCommit: 530ad7ba01b22d7f7a15d1ab51afb6703697c15a
 Directory: 2/debian
 
-Tags: 2.23.1-alpine, 2.23-alpine, 2-alpine, alpine
+Tags: 2.23.2-alpine, 2.23-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: e406137638f0533d56b47843b15b983db1474ea3
+GitCommit: 530ad7ba01b22d7f7a15d1ab51afb6703697c15a
 Directory: 2/alpine
 
 Tags: 1.25.8, 1.25, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/530ad7b: Update to 2.23.2, ghost-cli 1.11.0