### PR TITLE
[nats-streaming] Release v0.15.1

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,28 +1,34 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 
-Tags: 0.14.3-linux, linux
-SharedTags: 0.14.3, latest
+Tags: 0.15.1-linux, linux
+SharedTags: 0.15.1, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 amd64-Directory: amd64
-arm32v6-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+arm32v6-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+arm32v7-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+arm64v8-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 arm64v8-Directory: arm64v8
 
-Tags: 0.14.3-nanoserver, nanoserver
-SharedTags: 0.14.3, latest
+Tags: 0.15.1-nanoserver, nanoserver
+SharedTags: 0.15.1, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 windows-amd64-Directory: windows/nanoserver
-Constraints: nanoserver
+Constraints: nanoserver-1803
 
-Tags: 0.14.3-windowsservercore, windowsservercore
+Tags: 0.15.1-nanoserver-1809, nanoserver-1809
 Architectures: windows-amd64
-windows-amd64-GitCommit: 01cc58532225a68bf89c7891334ba6627bd46470
+windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+windows-amd64-Directory: windows/nanoserver2019
+Constraints: nanoserver-1809
+
+Tags: 0.15.1-windowsservercore, windowsservercore
+Architectures: windows-amd64
+windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
 windows-amd64-Directory: windows/windowsservercore
-Constraints: windowsservercore
+Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.15.1)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>