### PR TITLE
clojure: update alpine variant arch to support arm64

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -9,7 +9,7 @@ Tags: openjdk-8-lein, openjdk-8-lein-2.9.1, lein-2.9.1, lein, latest
 Directory: target/openjdk-8/debian/lein
 
 Tags: openjdk-8-lein-alpine, openjdk-8-lein-2.9.1-alpine, lein-2.9.1-alpine, lein-alpine, alpine
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: target/openjdk-8/alpine/lein
 
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.2, boot-2.8.2, boot


### PR DESCRIPTION
I've tested building the image on an arm64 host. This would help downstream [edgexfoundry/edgex-ui-clojure](https://github.com/edgexfoundry/edgex-ui-clojure).

Have I edited the correct file to drive an arm64 image being built for the `lein-alpine` tag?

/cc @Quantisan 

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>