### PR TITLE
Update "naughty-from.sh" to account for Windows "latest" images not existing

### DIFF
--- a/naughty-from.sh
+++ b/naughty-from.sh
@@ -17,6 +17,14 @@ _is_naughty() {
 	local from="$1"; shift
 
 	case "$BASHBREW_ARCH=$from" in
+		# a few images that no longer exist (and are thus not permissible)
+		# https://techcommunity.microsoft.com/t5/Containers/Removing-the-latest-Tag-An-Update-on-MCR/ba-p/393045
+		*=mcr.microsoft.com/windows/nanoserver:latest \
+		| *=mcr.microsoft.com/windows/servercore:latest \
+		| *=microsoft/nanoserver:latest \
+		| *=microsoft/windowsservercore:latest \
+		) return 0 ;;
+
 		# a few explicitly permissible exceptions to Santa's naughty list
 		*=scratch \
 		| amd64=docker.elastic.co/elasticsearch/elasticsearch:* \


### PR DESCRIPTION
https://techcommunity.microsoft.com/t5/Containers/Removing-the-latest-Tag-An-Update-on-MCR/ba-p/393045

```console
$ ./naughty-from.sh golang
$ 
```

```console
$ ./naughty-from.sh nats
 - nats:1.4.1-nanoserver (FROM microsoft/nanoserver:latest) [windows-amd64]
 - nats:1.4.1-windowsservercore (FROM microsoft/windowsservercore:latest) [windows-amd64]
$ 
```