### PR TITLE
bashbrew: account for namespaces when sorting repos

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -12,8 +12,7 @@ func cmdBuild(c *cli.Context) error {
 		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
 	}
 
-	namespace := c.String("namespace")
-	repos, err = sortRepos(repos, true, namespace)
+	repos, err = sortRepos(repos, true)
 	if err != nil {
 		return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
 	}
@@ -34,7 +33,7 @@ func cmdBuild(c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 
-		entries, err := r.SortedEntries(true, namespace)
+		entries, err := r.SortedEntries(true)
 		if err != nil {
 			return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 		}

--- a/bashbrew/go/src/bashbrew/cmd-build.go
+++ b/bashbrew/go/src/bashbrew/cmd-build.go
@@ -12,13 +12,13 @@ func cmdBuild(c *cli.Context) error {
 		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
 	}
 
-	repos, err = sortRepos(repos, true)
+	namespace := c.String("namespace")
+	repos, err = sortRepos(repos, true, namespace)
 	if err != nil {
 		return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := c.String("namespace")
 	pull := c.String("pull")
 	switch pull {
 	case "always", "missing", "never":
@@ -34,7 +34,7 @@ func cmdBuild(c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 
-		entries, err := r.SortedEntries(true)
+		entries, err := r.SortedEntries(true, namespace)
 		if err != nil {
 			return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 		}

--- a/bashbrew/go/src/bashbrew/cmd-cat.go
+++ b/bashbrew/go/src/bashbrew/cmd-cat.go
@@ -55,6 +55,9 @@ func cmdCat(c *cli.Context) error {
 		"arch": func() string {
 			return arch
 		},
+		"namespace": func() string {
+			return namespace
+		},
 		"archNamespace": func(arch string) string {
 			return archNamespaces[arch]
 		},

--- a/bashbrew/go/src/bashbrew/cmd-deps.go
+++ b/bashbrew/go/src/bashbrew/cmd-deps.go
@@ -50,7 +50,7 @@ func cmdFamily(parents bool, c *cli.Context) error {
 				continue
 			}
 
-			for _, tag := range r.Tags("", false, entry) {
+			for _, tag := range r.Tags(namespace, false, entry) {
 				network.AddNode(tag, entry)
 			}
 		}
@@ -78,7 +78,7 @@ func cmdFamily(parents bool, c *cli.Context) error {
 					return cli.NewMultiError(fmt.Errorf(`failed fetching/scraping FROM for %q (tags %q, arch %q)`, r.RepoName, entry.TagsString(), entryArch), err)
 				}
 				for _, from := range froms {
-					for _, tag := range r.Tags("", false, entry) {
+					for _, tag := range r.Tags(namespace, false, entry) {
 						network.AddEdge(from, tag)
 					}
 				}
@@ -99,7 +99,7 @@ func cmdFamily(parents bool, c *cli.Context) error {
 				continue
 			}
 
-			for _, tag := range r.Tags("", uniq, entry) {
+			for _, tag := range r.Tags(namespace, uniq, entry) {
 				nodes := []topsortDepthNodes{}
 				if parents {
 					nodes = append(nodes, topsortDepthNodes{

--- a/bashbrew/go/src/bashbrew/cmd-from.go
+++ b/bashbrew/go/src/bashbrew/cmd-from.go
@@ -14,7 +14,6 @@ func cmdFrom(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := ""
 	applyConstraints := c.Bool("apply-constraints")
 
 	for _, repo := range repos {

--- a/bashbrew/go/src/bashbrew/cmd-list.go
+++ b/bashbrew/go/src/bashbrew/cmd-list.go
@@ -14,13 +14,12 @@ func cmdList(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := c.String("namespace")
 	applyConstraints := c.Bool("apply-constraints")
 	onlyRepos := c.Bool("repos")
 
 	buildOrder := c.Bool("build-order")
 	if buildOrder {
-		repos, err = sortRepos(repos, applyConstraints, namespace)
+		repos, err = sortRepos(repos, applyConstraints)
 		if err != nil {
 			return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
 		}
@@ -45,7 +44,7 @@ func cmdList(c *cli.Context) error {
 
 		var entries []*manifest.Manifest2822Entry
 		if buildOrder {
-			entries, err = r.SortedEntries(applyConstraints, namespace)
+			entries, err = r.SortedEntries(applyConstraints)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 			}

--- a/bashbrew/go/src/bashbrew/cmd-list.go
+++ b/bashbrew/go/src/bashbrew/cmd-list.go
@@ -14,13 +14,13 @@ func cmdList(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := ""
+	namespace := c.String("namespace")
 	applyConstraints := c.Bool("apply-constraints")
 	onlyRepos := c.Bool("repos")
 
 	buildOrder := c.Bool("build-order")
 	if buildOrder {
-		repos, err = sortRepos(repos, applyConstraints)
+		repos, err = sortRepos(repos, applyConstraints, namespace)
 		if err != nil {
 			return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
 		}
@@ -45,7 +45,7 @@ func cmdList(c *cli.Context) error {
 
 		var entries []*manifest.Manifest2822Entry
 		if buildOrder {
-			entries, err = r.SortedEntries(applyConstraints)
+			entries, err = r.SortedEntries(applyConstraints, namespace)
 			if err != nil {
 				return cli.NewMultiError(fmt.Errorf(`failed sorting entries list for %q`, repo), err)
 			}

--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -16,7 +16,6 @@ func cmdPush(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := c.String("namespace")
 	dryRun := c.Bool("dry-run")
 	force := c.Bool("force")
 

--- a/bashbrew/go/src/bashbrew/cmd-push.go
+++ b/bashbrew/go/src/bashbrew/cmd-push.go
@@ -16,11 +16,15 @@ func cmdPush(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
+	targetNamespace := c.String("target-namespace")
 	dryRun := c.Bool("dry-run")
 	force := c.Bool("force")
 
-	if namespace == "" {
-		return fmt.Errorf(`"--namespace" is a required flag for "push"`)
+	if targetNamespace == "" {
+		targetNamespace = namespace
+	}
+	if targetNamespace == "" {
+		return fmt.Errorf(`either "--target-namespace" or "--namespace" is a required flag for "push"`)
 	}
 
 	for _, repo := range repos {
@@ -29,7 +33,7 @@ func cmdPush(c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 
-		tagRepo := path.Join(namespace, r.RepoName)
+		tagRepo := path.Join(targetNamespace, r.RepoName)
 		for _, entry := range r.Entries() {
 			if r.SkipConstraints(entry) {
 				continue

--- a/bashbrew/go/src/bashbrew/cmd-put-shared.go
+++ b/bashbrew/go/src/bashbrew/cmd-put-shared.go
@@ -83,7 +83,6 @@ func cmdPutShared(c *cli.Context) error {
 		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
 	}
 
-	namespace := c.String("namespace")
 	dryRun := c.Bool("dry-run")
 	force := c.Bool("force")
 	singleArch := c.Bool("single-arch")

--- a/bashbrew/go/src/bashbrew/cmd-put-shared.go
+++ b/bashbrew/go/src/bashbrew/cmd-put-shared.go
@@ -84,11 +84,15 @@ func cmdPutShared(c *cli.Context) error {
 	}
 
 	dryRun := c.Bool("dry-run")
+	targetNamespace := c.String("target-namespace")
 	force := c.Bool("force")
 	singleArch := c.Bool("single-arch")
 
-	if namespace == "" {
-		return fmt.Errorf(`"--namespace" is a required flag for "put-shared"`)
+	if targetNamespace == "" {
+		targetNamespace = namespace
+	}
+	if targetNamespace == "" {
+		return fmt.Errorf(`either "--target-namespace" or "--namespace" is a required flag for "put-shared"`)
 	}
 
 	for _, repo := range repos {
@@ -97,7 +101,7 @@ func cmdPutShared(c *cli.Context) error {
 			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
 		}
 
-		targetRepo := path.Join(namespace, r.RepoName)
+		targetRepo := path.Join(targetNamespace, r.RepoName)
 
 		sharedTagGroups := []manifest.SharedTagGroup{}
 

--- a/bashbrew/go/src/bashbrew/cmd-tag.go
+++ b/bashbrew/go/src/bashbrew/cmd-tag.go
@@ -14,11 +14,14 @@ func cmdTag(c *cli.Context) error {
 	}
 
 	uniq := c.Bool("uniq")
-	namespace := c.String("namespace")
+	targetNamespace := c.String("target-namespace")
 	dryRun := c.Bool("dry-run")
 
 	if namespace == "" {
 		return fmt.Errorf(`"--namespace" is a required flag for "tag"`)
+	}
+	if targetNamespace == "" {
+		return fmt.Errorf(`"--target-namespace" is a required flag for "tag"`)
 	}
 
 	for _, repo := range repos {
@@ -33,12 +36,13 @@ func cmdTag(c *cli.Context) error {
 			}
 
 			for _, tag := range r.Tags("", uniq, entry) {
-				namespacedTag := path.Join(namespace, tag)
-				fmt.Printf("Tagging %s\n", namespacedTag)
+				sourceTag := path.Join(namespace, tag)
+				targetTag := path.Join(targetNamespace, tag)
+				fmt.Printf("Tagging %s\n", targetTag)
 				if !dryRun {
-					err = dockerTag(tag, namespacedTag)
+					err = dockerTag(sourceTag, targetTag)
 					if err != nil {
-						return cli.NewMultiError(fmt.Errorf(`failed tagging %q as %q`, tag, namespacedTag), err)
+						return cli.NewMultiError(fmt.Errorf(`failed tagging %q as %q`, sourceTag, targetTag), err)
 					}
 				}
 			}

--- a/bashbrew/go/src/bashbrew/cmd-tag.go
+++ b/bashbrew/go/src/bashbrew/cmd-tag.go
@@ -17,9 +17,6 @@ func cmdTag(c *cli.Context) error {
 	targetNamespace := c.String("target-namespace")
 	dryRun := c.Bool("dry-run")
 
-	if namespace == "" {
-		return fmt.Errorf(`"--namespace" is a required flag for "tag"`)
-	}
 	if targetNamespace == "" {
 		return fmt.Errorf(`"--target-namespace" is a required flag for "tag"`)
 	}

--- a/bashbrew/go/src/bashbrew/config.go
+++ b/bashbrew/go/src/bashbrew/config.go
@@ -22,11 +22,11 @@ type FlagsConfigEntry struct {
 	Cache      string
 	Debug      string
 	Unique     string
-	Namespace  string
 	BuildOrder string
 	Pull       string
 
 	Arch                 string
+	Namespace            string
 	Constraints          []string `delim:"," strip:"\n\r\t "`
 	ExclusiveConstraints string
 	ApplyConstraints     string
@@ -50,9 +50,6 @@ func (dst *FlagsConfigEntry) Apply(src FlagsConfigEntry) {
 	if src.Unique != "" {
 		dst.Unique = src.Unique
 	}
-	if src.Namespace != "" {
-		dst.Namespace = src.Namespace
-	}
 	if src.BuildOrder != "" {
 		dst.BuildOrder = src.BuildOrder
 	}
@@ -61,6 +58,9 @@ func (dst *FlagsConfigEntry) Apply(src FlagsConfigEntry) {
 	}
 	if src.Arch != "" {
 		dst.Arch = src.Arch
+	}
+	if src.Namespace != "" {
+		dst.Namespace = src.Namespace
 	}
 	if len(src.Constraints) > 0 {
 		dst.Constraints = src.Constraints[:]
@@ -84,6 +84,7 @@ func (config FlagsConfigEntry) Vars() map[string]map[string]interface{} {
 			"debug":   config.Debug,
 
 			"arch":                  config.Arch,
+			"namespace":             config.Namespace,
 			"constraint":            config.Constraints,
 			"exclusive-constraints": config.ExclusiveConstraints,
 
@@ -92,7 +93,6 @@ func (config FlagsConfigEntry) Vars() map[string]map[string]interface{} {
 
 		"local": {
 			"uniq":        config.Unique,
-			"namespace":   config.Namespace,
 			"build-order": config.BuildOrder,
 			"pull":        config.Pull,
 

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -220,6 +220,7 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
+				commonFlags["namespace"],
 				commonFlags["apply-constraints"],
 				cli.BoolFlag{
 					Name:  "build-order",

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -214,6 +214,10 @@ func main() {
 			Name:  "force",
 			Usage: "always push (skip the clever Hub API lookups that no-op things sooner if a push doesn't seem necessary)",
 		},
+		"target-namespace": cli.StringFlag{
+			Name:  "target-namespace",
+			Usage: `target namespace to act into ("docker tag namespace/repo:tag target-namespace/repo:tag", "docker push target-namespace/repo:tag")`,
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -261,10 +265,7 @@ func main() {
 				commonFlags["all"],
 				commonFlags["uniq"],
 				commonFlags["dry-run"],
-				cli.StringFlag{
-					Name:  "target-namespace",
-					Usage: `target namespace to tag into ("docker tag namespace/repo:tag target-namespace/repo:tag")`,
-				},
+				commonFlags["target-namespace"],
 			},
 			Before: subcommandBeforeFactory("tag"),
 			Action: cmdTag,
@@ -277,6 +278,7 @@ func main() {
 				commonFlags["uniq"],
 				commonFlags["dry-run"],
 				commonFlags["force"],
+				commonFlags["target-namespace"],
 			},
 			Before: subcommandBeforeFactory("push"),
 			Action: cmdPush,
@@ -288,6 +290,7 @@ func main() {
 				commonFlags["all"],
 				commonFlags["dry-run"],
 				commonFlags["force"],
+				commonFlags["target-namespace"],
 				cli.BoolFlag{
 					Name:  "single-arch",
 					Usage: `only act on the current architecture (for pushing "amd64/hello-world:latest", for example)`,

--- a/bashbrew/go/src/bashbrew/main.go
+++ b/bashbrew/go/src/bashbrew/main.go
@@ -22,6 +22,7 @@ var (
 	defaultCache   string
 
 	arch                 string
+	namespace            string
 	constraints          []string
 	exclusiveConstraints bool
 
@@ -32,12 +33,13 @@ var (
 
 	// separated so that FlagsConfig.ApplyTo can access them
 	flagEnvVars = map[string]string{
-		"debug":   "BASHBREW_DEBUG",
-		"arch":    "BASHBREW_ARCH",
-		"config":  "BASHBREW_CONFIG",
-		"library": "BASHBREW_LIBRARY",
-		"cache":   "BASHBREW_CACHE",
-		"pull":    "BASHBREW_PULL",
+		"debug":     "BASHBREW_DEBUG",
+		"arch":      "BASHBREW_ARCH",
+		"namespace": "BASHBREW_NAMESPACE",
+		"config":    "BASHBREW_CONFIG",
+		"library":   "BASHBREW_LIBRARY",
+		"cache":     "BASHBREW_CACHE",
+		"pull":      "BASHBREW_PULL",
 
 		"constraint":     "BASHBREW_CONSTRAINTS",
 		"arch-namespace": "BASHBREW_ARCH_NAMESPACES",
@@ -92,6 +94,11 @@ func main() {
 			Value:  manifest.DefaultArchitecture,
 			EnvVar: flagEnvVars["arch"],
 			Usage:  "the current platform architecture",
+		},
+		cli.StringFlag{
+			Name:   "namespace",
+			EnvVar: flagEnvVars["namespace"],
+			Usage:  "a repo namespace to act upon/in",
 		},
 		cli.StringSliceFlag{
 			Name:   "constraint",
@@ -156,6 +163,7 @@ func main() {
 			noSortFlag = c.GlobalBool("no-sort")
 
 			arch = c.GlobalString("arch")
+			namespace = c.GlobalString("namespace")
 			constraints = c.GlobalStringSlice("constraint")
 			exclusiveConstraints = c.GlobalBool("exclusive-constraints")
 
@@ -189,10 +197,6 @@ func main() {
 			Name:  "uniq, unique",
 			Usage: "only act upon the first tag of each entry",
 		},
-		"namespace": cli.StringFlag{
-			Name:  "namespace",
-			Usage: "a repo namespace to act upon/in",
-		},
 		"apply-constraints": cli.BoolFlag{
 			Name:  "apply-constraints",
 			Usage: "apply Constraints as if repos were building",
@@ -220,7 +224,6 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
-				commonFlags["namespace"],
 				commonFlags["apply-constraints"],
 				cli.BoolFlag{
 					Name:  "build-order",
@@ -240,7 +243,6 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
-				commonFlags["namespace"],
 				cli.StringFlag{
 					Name:   "pull",
 					Value:  "missing",
@@ -258,8 +260,11 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
-				commonFlags["namespace"],
 				commonFlags["dry-run"],
+				cli.StringFlag{
+					Name:  "target-namespace",
+					Usage: `target namespace to tag into ("docker tag namespace/repo:tag target-namespace/repo:tag")`,
+				},
 			},
 			Before: subcommandBeforeFactory("tag"),
 			Action: cmdTag,
@@ -270,7 +275,6 @@ func main() {
 			Flags: []cli.Flag{
 				commonFlags["all"],
 				commonFlags["uniq"],
-				commonFlags["namespace"],
 				commonFlags["dry-run"],
 				commonFlags["force"],
 			},
@@ -282,7 +286,6 @@ func main() {
 			Usage: `update shared tags in the registry (and multi-architecture tags)`,
 			Flags: []cli.Flag{
 				commonFlags["all"],
-				commonFlags["namespace"],
 				commonFlags["dry-run"],
 				commonFlags["force"],
 				cli.BoolFlag{


### PR DESCRIPTION
When sorting repos sort.go looks at the `FROM` lines in the Dockerfiles. If `--namespace` is set it needs to be taken into account as the line will be in the form `FROM <namespace>/<image>[:<tag>]`. This also adds `--namespace` to `bashbrew list` as it also sorts.