### PR TITLE
[security] Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.0.3, 4.0, 4, latest
+Tags: 4.0.4, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff4c604761049c2c5b9d89f178379c81abf3b2ed
+GitCommit: 309ddd33d670d798b0862238a7d70b780f93aa32
 Directory: 4.0
 
-Tags: 4.0.3-passenger, 4.0-passenger, 4-passenger, passenger
+Tags: 4.0.4-passenger, 4.0-passenger, 4-passenger, passenger
 GitCommit: 35af27ca3527e2af63aef04fd71a03aeb18e19c9
 Directory: 4.0/passenger
 
-Tags: 3.4.10, 3.4, 3
+Tags: 3.4.11, 3.4, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f48b663ba6fab3eca2e57e660fe2ed9f17e175e
+GitCommit: c27d3309aea2171325b83442283090dcc6cebddd
 Directory: 3.4
 
-Tags: 3.4.10-passenger, 3.4-passenger, 3-passenger
+Tags: 3.4.11-passenger, 3.4-passenger, 3-passenger
 GitCommit: 35af27ca3527e2af63aef04fd71a03aeb18e19c9
 Directory: 3.4/passenger


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/c27d330: Update to 3.4.11
- https://github.com/docker-library/redmine/commit/309ddd3: Update to 4.0.4

See https://www.redmine.org/news/123 for security details.