### PR TITLE
[ADD] Zabbix components Official docker images

### DIFF
--- a/library/zabbix-agent
+++ b/library/zabbix-agent
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: agent/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: agent/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: agent/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: agent/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: agent/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: agent/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: agent/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: agent/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: agent/ubuntu

--- a/library/zabbix-appliance
+++ b/library/zabbix-appliance
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: zabbix-appliance/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: zabbix-appliance/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: zabbix-appliance/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: zabbix-appliance/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: zabbix-appliance/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: zabbix-appliance/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: zabbix-appliance/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: zabbix-appliance/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: zabbix-appliance/ubuntu

--- a/library/zabbix-java-gateway
+++ b/library/zabbix-java-gateway
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: java-gateway/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: java-gateway/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: java-gateway/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: java-gateway/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: java-gateway/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: java-gateway/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: java-gateway/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: java-gateway/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: java-gateway/ubuntu

--- a/library/zabbix-proxy-mysql
+++ b/library/zabbix-proxy-mysql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-mysql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-mysql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-mysql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-mysql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-mysql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-mysql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-mysql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-mysql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-mysql/ubuntu

--- a/library/zabbix-proxy-sqlite3
+++ b/library/zabbix-proxy-sqlite3
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-sqlite3/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-sqlite3/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: proxy-sqlite3/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-sqlite3/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-sqlite3/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: proxy-sqlite3/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-sqlite3/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-sqlite3/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: proxy-sqlite3/ubuntu

--- a/library/zabbix-server-mysql
+++ b/library/zabbix-server-mysql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-mysql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-mysql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-mysql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-mysql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-mysql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-mysql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-mysql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-mysql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-mysql/ubuntu

--- a/library/zabbix-server-pgsql
+++ b/library/zabbix-server-pgsql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-pgsql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-pgsql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: server-pgsql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-pgsql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-pgsql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: server-pgsql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-pgsql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-pgsql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: server-pgsql/ubuntu

--- a/library/zabbix-web-apache-mysql
+++ b/library/zabbix-web-apache-mysql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-mysql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-mysql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-mysql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-mysql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-mysql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-mysql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-mysql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-mysql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-mysql/ubuntu

--- a/library/zabbix-web-apache-pgsql
+++ b/library/zabbix-web-apache-pgsql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-pgsql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-pgsql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-apache-pgsql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-pgsql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-pgsql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-apache-pgsql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-pgsql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-pgsql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-apache-pgsql/ubuntu

--- a/library/zabbix-web-nginx-mysql
+++ b/library/zabbix-web-nginx-mysql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-mysql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-mysql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-mysql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-mysql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-mysql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-mysql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-mysql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-mysql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-mysql/ubuntu

--- a/library/zabbix-web-nginx-pgsql
+++ b/library/zabbix-web-nginx-pgsql
@@ -1,0 +1,56 @@
+Maintainers: Alexey Pustovalov <alexey.pustovalov@zabbix.com> (@dotneft)
+GitRepo: https://github.com/zabbix/zabbix-docker.git
+
+Tags: alpine-3.0-latest, alpine-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-pgsql/alpine
+
+Tags: centos-3.0-latest, centos-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-pgsql/centos
+
+Tags: ubuntu-3.0-latest, ubuntu-3.0.28
+Architectures: amd64
+GitFetch: refs/heads/3.0
+GitCommit: 048b04add73d1703fd7b7e97c0fbbebb553808cf
+Directory: web-nginx-pgsql/ubuntu
+
+Tags: alpine-4.0-latest, alpine-4.0.9
+Architectures: amd64
+GitFetch: refs/heads/4.0
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-pgsql/alpine
+
+Tags: centos-4.0-latest, centos-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-pgsql/centos
+
+Tags: ubuntu-4.0-latest, ubuntu-4.0.9
+Architectures: amd64                                                                                
+GitFetch: refs/heads/4.0                                                                            
+GitCommit: fab48ed7c9fc3fc4bf0789cef1595942aaeb10ed
+Directory: web-nginx-pgsql/ubuntu
+
+Tags: alpine-4.2.3, alpine-4.2-latest, alpine-latest, latest
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-pgsql/alpine
+
+Tags: centos-4.2.3, centos-4.2-latest, centos-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-pgsql/centos
+
+Tags: ubuntu-4.2.3, ubuntu-4.2-latest, ubuntu-latest                                                                   
+Architectures: amd64
+GitFetch: refs/heads/4.2
+GitCommit: 18c52aa9c94cd7c71d9af4838fd627880551b247
+Directory: web-nginx-pgsql/ubuntu


### PR DESCRIPTION
Added Zabbix components for Official docker images.
These images are related to Zabbix monitoring system components.

Also, please, check [documentation pull request](https://github.com/docker-library/docs/pull/1501).