### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -14,42 +14,42 @@ Architectures: amd64
 GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
 Directory: 7/jdk8-slim
 
-Tags: 8.5.41-jdk8, 8.5-jdk8, 8-jdk8, jdk8, 8.5.41, 8.5, 8, latest
+Tags: 8.5.42-jdk8, 8.5-jdk8, 8-jdk8, jdk8, 8.5.42, 8.5, 8, latest
 Architectures: amd64
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 1c438768f847f4af954a8f63cd6ffbffef076e30
 Directory: 8.5/jdk8
 
-Tags: 8.5.41-jdk8-slim, 8.5-jdk8-slim, 8-jdk8-slim, jdk8-slim, 8.5.41-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.42-jdk8-slim, 8.5-jdk8-slim, 8-jdk8-slim, jdk8-slim, 8.5.42-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 1c438768f847f4af954a8f63cd6ffbffef076e30
 Directory: 8.5/jdk8-slim
 
-Tags: 8.5.41-jdk11, 8.5-jdk11, 8-jdk11, jdk11
+Tags: 8.5.42-jdk11, 8.5-jdk11, 8-jdk11, jdk11
 Architectures: amd64, arm64v8
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 1c438768f847f4af954a8f63cd6ffbffef076e30
 Directory: 8.5/jdk11
 
-Tags: 8.5.41-jdk11-slim, 8.5-jdk11-slim, 8-jdk11-slim, jdk11-slim
+Tags: 8.5.42-jdk11-slim, 8.5-jdk11-slim, 8-jdk11-slim, jdk11-slim
 Architectures: amd64, arm64v8
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 1c438768f847f4af954a8f63cd6ffbffef076e30
 Directory: 8.5/jdk11-slim
 
-Tags: 9.0.20-jdk8, 9.0-jdk8, 9-jdk8
+Tags: 9.0.21-jdk8, 9.0-jdk8, 9-jdk8
 Architectures: amd64
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 32a6acab8417c3812c92887d8cc6660fd4aa4bc4
 Directory: 9.0/jdk8
 
-Tags: 9.0.20-jdk8-slim, 9.0-jdk8-slim, 9-jdk8-slim
+Tags: 9.0.21-jdk8-slim, 9.0-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 32a6acab8417c3812c92887d8cc6660fd4aa4bc4
 Directory: 9.0/jdk8-slim
 
-Tags: 9.0.20-jdk11, 9.0-jdk11, 9-jdk11, 9.0.20, 9.0, 9
+Tags: 9.0.21-jdk11, 9.0-jdk11, 9-jdk11, 9.0.21, 9.0, 9
 Architectures: amd64, arm64v8
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 32a6acab8417c3812c92887d8cc6660fd4aa4bc4
 Directory: 9.0/jdk11
 
-Tags: 9.0.20-jdk11-slim, 9.0-jdk11-slim, 9-jdk11-slim, 9.0.20-slim, 9.0-slim, 9-slim
+Tags: 9.0.21-jdk11-slim, 9.0-jdk11-slim, 9-jdk11-slim, 9.0.21-slim, 9.0-slim, 9-slim
 Architectures: amd64, arm64v8
-GitCommit: 7eae995786f14b4e96010bcc11338724706e30eb
+GitCommit: 32a6acab8417c3812c92887d8cc6660fd4aa4bc4
 Directory: 9.0/jdk11-slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/tomcat/commit/1c43876: Update to 8.5.42, openssl 1.1.0j-1~deb9u1
- https://github.com/docker-library/tomcat/commit/32a6aca: Update to 9.0.21, openssl 1.1.0j-1~deb9u1