### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0-dev6, 2.0-rc
+Tags: 2.0-dev7, 2.0-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 903e20c751ff51a17bfcef5ae130fa59dd42c960
+GitCommit: 898fd1533c9029a22fc2722bc36daa2dc901809a
 Directory: 2.0-rc
 
-Tags: 2.0-dev6-alpine, 2.0-rc-alpine
+Tags: 2.0-dev7-alpine, 2.0-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 903e20c751ff51a17bfcef5ae130fa59dd42c960
+GitCommit: 898fd1533c9029a22fc2722bc36daa2dc901809a
 Directory: 2.0-rc/alpine
 
 Tags: 1.9.8, 1.9, 1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/898fd15: Update to 2.0-dev7