### PR TITLE
update Python 2.6 for oraclelinux 6 and 6-slim

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: bf2545567869d3deaa6a2d7350f8975bba023bde
+amd64-GitCommit: df5eca32170c4cf57315b3b7d12fc76f11a79575
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 820ed349064a65de07a890fc8687389a0b2ee745


### PR DESCRIPTION
	[AMD64 6.10] 2019-06-13-62
	[AMD64 6-slim] 2019-06-13-17

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>