### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/3eb0351b208d739fac35345c85e3c6237c2114ec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/7b4e2066a6655cc20f4e41e39a59500d0a318ddd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -75,21 +75,21 @@ GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
 Directory: 11/jdk/slim
 
 Tags: 11.0.3-jdk-windowsservercore-1809, 11.0.3-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.3-jdk-windowsservercore-1803, 11.0.3-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 11.0.3-jdk-windowsservercore-ltsc2016, 11.0.3-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore
+SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -107,21 +107,21 @@ GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
 Directory: 8/jdk/slim
 
 Tags: 8u212-b04-jdk-windowsservercore-1809, 8u212-b04-windowsservercore-1809, 8u212-jdk-windowsservercore-1809, 8u212-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u212-b04-jdk-windowsservercore-1803, 8u212-b04-windowsservercore-1803, 8u212-jdk-windowsservercore-1803, 8u212-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 8u212-b04-jdk-windowsservercore-ltsc2016, 8u212-b04-windowsservercore-ltsc2016, 8u212-jdk-windowsservercore-ltsc2016, 8u212-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore
+SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
@@ -139,21 +139,21 @@ GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
 Directory: 8/jre/slim
 
 Tags: 8u212-b04-jre-windowsservercore-1809, 8u212-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore
+SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u212-b04-jre-windowsservercore-1803, 8u212-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore
+SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 8u212-b04-jre-windowsservercore-ltsc2016, 8u212-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore
+SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
 Architectures: windows-amd64
 GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
 Directory: 8/jre/windows/windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/93c6948: Update generated README
- https://github.com/docker-library/openjdk/commit/7b4e206: Fix windowsservercore SharedTags on non-oracle variants