### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,50 +1,35 @@
-# this file is generated via https://github.com/docker-library/docker/blob/34503d72ae68c42a5cf3bcef16e2557379970f31/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/6001c15038b05149a83dcc17e1bbeedc92979f6d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 19.03.0-rc2, 19.03-rc, rc, test
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: fded04bc1ec3920a5960a76e398d7ce5f147f6f7
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 6001c15038b05149a83dcc17e1bbeedc92979f6d
 Directory: 19.03-rc
 
 Tags: 19.03.0-rc2-dind, 19.03-rc-dind, rc-dind, test-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 27471a8b93e980bd4c51464ee933ed90fd36bf97
 Directory: 19.03-rc/dind
 
 Tags: 19.03.0-rc2-git, 19.03-rc-git, rc-git, test-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 98ffef81ebfa7601a9ed2f0bf56d78f426bf253c
 Directory: 19.03-rc/git
 
 Tags: 18.09.6, 18.09, 18, stable, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 9633df3ae8a88dfed9ba7f92e8a911249bbe4ec0
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 6001c15038b05149a83dcc17e1bbeedc92979f6d
 Directory: 18.09
 
 Tags: 18.09.6-dind, 18.09-dind, 18-dind, stable-dind, dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 27471a8b93e980bd4c51464ee933ed90fd36bf97
 Directory: 18.09/dind
 
 Tags: 18.09.6-git, 18.09-git, 18-git, stable-git, git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git
-
-Tags: 18.06.3-ce, 18.06.3, 18.06, edge
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 0ea1769704a07017fd9a876590de2feb434d33e2
-Directory: 18.06
-
-Tags: 18.06.3-ce-dind, 18.06.3-dind, 18.06-dind, edge-dind
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 27471a8b93e980bd4c51464ee933ed90fd36bf97
-Directory: 18.06/dind
-
-Tags: 18.06.3-ce-git, 18.06.3-git, 18.06-git, edge-git
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitCommit: 595ad0c92090937dcb7c200900fb97e36d36c412
-Directory: 18.06/git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/6001c15: Revamp architecture detection to be based on what files actually exist in https://download.docker.com/linux/static/
- https://github.com/docker-library/docker/commit/d31c2d3: Remove EOL 18.06 series
- https://github.com/docker-library/docker/commit/bb20c6c: Update generated README