### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/691ea5e3e2f61d291e6f0039eae7296f195fdab1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/1554579b4eb9ff41a5718b43824cf27e6f4893ca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 691ea5e3e2f61d291e6f0039eae7296f195fdab1
+GitCommit: 1554579b4eb9ff41a5718b43824cf27e6f4893ca
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e4e2be466f2d6c6fac0abfc263f054a14897cbe1
+amd64-GitCommit: 277ab500284846f49fa131a3a945587c68bf1f40
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 17c116ec5121f6f4b34918679d851fd8e285b0ab
+arm32v5-GitCommit: 2c2788a770ced2d5f392963d2536ef787f5ef28e
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 19f7d1c8814559dfa3baaaa5aca663e8a6cdccb0
+arm32v6-GitCommit: 7056acea2f59d2c83d20a2fddc7aab9d7d94184c
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 06f3ca0fb3d7255be7194cbd5c54e4030878caee
+arm32v7-GitCommit: 9127bbb8e18aaf071bd5c42b4551c49c8c9f177e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 324eb0f82719598579fe2bef313fa5504e1d0d33
+arm64v8-GitCommit: a45451404d786c2d7a70fc76c9459c3ccd482fb1
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: c119f03cb8a22c93d985d9106d3bbdc7562bf094
+i386-GitCommit: 843b63dd5df5cc8ddeeb25fae8df56d8d937501a
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: e885bce36c7156e567037575419145ed839b1048
+ppc64le-GitCommit: b285477061e6605f778e0e133c68798403a2c7d9
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 96b48d75684025e95155b36be2dfbf1e9dfd248b
+s390x-GitCommit: 349bd9a603cc879edaf00c24b2a692e64d797ab2
 
 Tags: 1.31.0-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/1554579: Update buildroot to 2019.05
- https://github.com/docker-library/busybox/commit/3194dde: Update generated README