### PR TITLE
Update php (add 7.4.0-alpha1, drop jessie+alpine3.8)

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,175 +1,145 @@
-# this file is generated via https://github.com/docker-library/php/blob/5f2b9c2d6036b3ea16a71c562903e27fed939662/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/3a3efd8f02081116e416349dd21b5b9138e92be5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
+Tags: 7.4.0alpha1-cli-stretch, 7.4-rc-cli-stretch, rc-cli-stretch, 7.4.0alpha1-stretch, 7.4-rc-stretch, rc-stretch, 7.4.0alpha1-cli, 7.4-rc-cli, rc-cli, 7.4.0alpha1, 7.4-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/stretch/cli
+
+Tags: 7.4.0alpha1-apache-stretch, 7.4-rc-apache-stretch, rc-apache-stretch, 7.4.0alpha1-apache, 7.4-rc-apache, rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/stretch/apache
+
+Tags: 7.4.0alpha1-fpm-stretch, 7.4-rc-fpm-stretch, rc-fpm-stretch, 7.4.0alpha1-fpm, 7.4-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/stretch/fpm
+
+Tags: 7.4.0alpha1-zts-stretch, 7.4-rc-zts-stretch, rc-zts-stretch, 7.4.0alpha1-zts, 7.4-rc-zts, rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/stretch/zts
+
+Tags: 7.4.0alpha1-cli-alpine3.9, 7.4-rc-cli-alpine3.9, rc-cli-alpine3.9, 7.4.0alpha1-alpine3.9, 7.4-rc-alpine3.9, rc-alpine3.9, 7.4.0alpha1-cli-alpine, 7.4-rc-cli-alpine, rc-cli-alpine, 7.4.0alpha1-alpine, 7.4-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/alpine3.9/cli
+
+Tags: 7.4.0alpha1-fpm-alpine3.9, 7.4-rc-fpm-alpine3.9, rc-fpm-alpine3.9, 7.4.0alpha1-fpm-alpine, 7.4-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/alpine3.9/fpm
+
+Tags: 7.4.0alpha1-zts-alpine3.9, 7.4-rc-zts-alpine3.9, rc-zts-alpine3.9, 7.4.0alpha1-zts-alpine, 7.4-rc-zts-alpine, rc-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: d92a953b086e2864b9bebc06d5e1c388a2c24ec9
+Directory: 7.4-rc/alpine3.9/zts
+
 Tags: 7.3.6-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.6-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.6-cli, 7.3-cli, 7-cli, cli, 7.3.6, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.6-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.6-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.6-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.6-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.6-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.6-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/stretch/zts
 
 Tags: 7.3.6-cli-alpine3.9, 7.3-cli-alpine3.9, 7-cli-alpine3.9, cli-alpine3.9, 7.3.6-alpine3.9, 7.3-alpine3.9, 7-alpine3.9, alpine3.9, 7.3.6-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.6-alpine, 7.3-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/alpine3.9/cli
 
 Tags: 7.3.6-fpm-alpine3.9, 7.3-fpm-alpine3.9, 7-fpm-alpine3.9, fpm-alpine3.9, 7.3.6-fpm-alpine, 7.3-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/alpine3.9/fpm
 
 Tags: 7.3.6-zts-alpine3.9, 7.3-zts-alpine3.9, 7-zts-alpine3.9, zts-alpine3.9, 7.3.6-zts-alpine, 7.3-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.3/alpine3.9/zts
-
-Tags: 7.3.6-cli-alpine3.8, 7.3-cli-alpine3.8, 7-cli-alpine3.8, cli-alpine3.8, 7.3.6-alpine3.8, 7.3-alpine3.8, 7-alpine3.8, alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.3/alpine3.8/cli
-
-Tags: 7.3.6-fpm-alpine3.8, 7.3-fpm-alpine3.8, 7-fpm-alpine3.8, fpm-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.3/alpine3.8/fpm
-
-Tags: 7.3.6-zts-alpine3.8, 7.3-zts-alpine3.8, 7-zts-alpine3.8, zts-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.3/alpine3.8/zts
 
 Tags: 7.2.19-cli-stretch, 7.2-cli-stretch, 7.2.19-stretch, 7.2-stretch, 7.2.19-cli, 7.2-cli, 7.2.19, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.19-apache-stretch, 7.2-apache-stretch, 7.2.19-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.19-fpm-stretch, 7.2-fpm-stretch, 7.2.19-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.19-zts-stretch, 7.2-zts-stretch, 7.2.19-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.19-cli-alpine3.9, 7.2-cli-alpine3.9, 7.2.19-alpine3.9, 7.2-alpine3.9, 7.2.19-cli-alpine, 7.2-cli-alpine, 7.2.19-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/alpine3.9/cli
 
 Tags: 7.2.19-fpm-alpine3.9, 7.2-fpm-alpine3.9, 7.2.19-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/alpine3.9/fpm
 
 Tags: 7.2.19-zts-alpine3.9, 7.2-zts-alpine3.9, 7.2.19-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.2/alpine3.9/zts
-
-Tags: 7.2.19-cli-alpine3.8, 7.2-cli-alpine3.8, 7.2.19-alpine3.8, 7.2-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.2/alpine3.8/cli
-
-Tags: 7.2.19-fpm-alpine3.8, 7.2-fpm-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.2/alpine3.8/fpm
-
-Tags: 7.2.19-zts-alpine3.8, 7.2-zts-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.2/alpine3.8/zts
 
 Tags: 7.1.30-cli-stretch, 7.1-cli-stretch, 7.1.30-stretch, 7.1-stretch, 7.1.30-cli, 7.1-cli, 7.1.30, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/stretch/cli
 
 Tags: 7.1.30-apache-stretch, 7.1-apache-stretch, 7.1.30-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/stretch/apache
 
 Tags: 7.1.30-fpm-stretch, 7.1-fpm-stretch, 7.1.30-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/stretch/fpm
 
 Tags: 7.1.30-zts-stretch, 7.1-zts-stretch, 7.1.30-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/stretch/zts
-
-Tags: 7.1.30-cli-jessie, 7.1-cli-jessie, 7.1.30-jessie, 7.1-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/jessie/cli
-
-Tags: 7.1.30-apache-jessie, 7.1-apache-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/jessie/apache
-
-Tags: 7.1.30-fpm-jessie, 7.1-fpm-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/jessie/fpm
-
-Tags: 7.1.30-zts-jessie, 7.1-zts-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/jessie/zts
 
 Tags: 7.1.30-cli-alpine3.9, 7.1-cli-alpine3.9, 7.1.30-alpine3.9, 7.1-alpine3.9, 7.1.30-cli-alpine, 7.1-cli-alpine, 7.1.30-alpine, 7.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/alpine3.9/cli
 
 Tags: 7.1.30-fpm-alpine3.9, 7.1-fpm-alpine3.9, 7.1.30-fpm-alpine, 7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/alpine3.9/fpm
 
 Tags: 7.1.30-zts-alpine3.9, 7.1-zts-alpine3.9, 7.1.30-zts-alpine, 7.1-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
+GitCommit: a9f19e9df5f7a5b74d72a97439ca5b77b87faa35
 Directory: 7.1/alpine3.9/zts
-
-Tags: 7.1.30-cli-alpine3.8, 7.1-cli-alpine3.8, 7.1.30-alpine3.8, 7.1-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/alpine3.8/cli
-
-Tags: 7.1.30-fpm-alpine3.8, 7.1-fpm-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/alpine3.8/fpm
-
-Tags: 7.1.30-zts-alpine3.8, 7.1-zts-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a7e2de0e8f2b902bc36be6f5d61c0b4fcd1052ff
-Directory: 7.1/alpine3.8/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/9687d42: Merge pull request https://github.com/docker-library/php/pull/842 from infosiftr/drop-jessie
- https://github.com/docker-library/php/commit/3a3efd8: Drop alpine 3.8 and jessie builds; these were only kept around for users to transition to stretch or 3.9 (see https://github.com/docker-library/php/issues/504)
- https://github.com/docker-library/php/commit/191ca54: Merge pull request https://github.com/docker-library/php/pull/840 from infosiftr/7.4-rc
- https://github.com/docker-library/php/commit/a9f19e9: Apply minor changes to non 7.4 versions to make deleting lines easier for 7.4
- https://github.com/docker-library/php/commit/d92a953: Fix build issues on 7.4.0-alpha1
- https://github.com/docker-library/php/commit/3822c17: Update generated README
- https://github.com/docker-library/php/commit/3e9d32b: Add 7.4.0alpha1