### PR TITLE
Updates to Storm

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,15 +1,15 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-
-Tags: 1.0.6, 1.0
-GitCommit: 9986213e09356e2d5230e6af9338052ce858b224
-Directory: 1.0.6
+Architectures: amd64
 
 Tags: 1.1.3, 1.1
-GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
+GitCommit: 2cdf3784eb167e112e21deca4d4be91eb997b672
 Directory: 1.1.3
 
-Tags: 1.2.2, 1.2, latest
-GitCommit: 4e9cdba376be0143ba0f041a1099bb7912b145ef
+Tags: 1.2.2, 1.2
+GitCommit: 2cdf3784eb167e112e21deca4d4be91eb997b672
 Directory: 1.2.2
+
+Tags: 2.0.0, 2.0, latest
+GitCommit: 2cdf3784eb167e112e21deca4d4be91eb997b672
+Directory: 2.0.0


### PR DESCRIPTION
* Add 2.0.0
* Remove 1.0.6 due to EOL
* Migrate to openjdk:8-jre-slim
* Get rid of internal STORM_USER env variable
* Explicitly set UID/GID when creating a user
* Drop architectures to amd64