### PR TITLE
Add version 7.9.0 of Bonita

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -4,12 +4,12 @@ Maintainers: Jérémy Jacquier-Roux <jeremy.jacquier-roux@bonitasoft.org> (@Jere
              Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur)
 GitRepo: https://github.com/Bonitasoft-Community/docker_bonita.git
 
-Tags: 7.7.5, 7.7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: d291374f0cdbf3c78fa8784c4930511dcffba9c9
-Directory: 7.7
-
-Tags: 7.8.4, 7.8, latest
+Tags: 7.8.4, 7.8
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 8e54821e4c81d4dbc3a106e907b145448c7a39f6
 Directory: 7.8
+
+Tags: 7.9.0, 7.9, latest
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 286d63fe3d7c35141e40f3e0ce72c7613867b5c3
+Directory: 7.9


### PR DESCRIPTION
- changes in 7.9.0
    - use `ubuntu:18.04` to follow [OS supported](https://documentation.bonitasoft.com/bonita/7.9/release-notes#toc19) 
        - with this new image we encountered the gpg error `gpg: keyserver receive failed: Cannot assign requested address`. We found that this subject is [discussed into the faq](https://github.com/docker-library/faq#openpgp--gnupg-keys-and-verification).
As in our case the behavior seems different with this new base image and not due to random host down in the pool requested we decided to [had ipv4 pool](https://github.com/bonitasoft/docker/pull/100/commits/39dd4b9508af6117ac1e017a0ad6710e6d61992d) as fallback like it was done into [Sonarqube official container](https://github.com/SonarSource/docker-sonarqube/blob/master/7.7-community/Dockerfile#L24) ([kudos to @tomverin](https://github.com/SonarSource/docker-sonarqube/pull/205)). This simple solution solved our issue.
    - switch to Java 11. This point is described into the documentation [PR related](https://github.com/docker-library/docs/pull/1505)
    - bonita logs are now redirected to standard output and accessible through `docker logs`. The documentation is updated accordingly.
