### PR TITLE
Repaired code in neo4j 3.4.14 and 3.5.6 entrypoint

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -10,20 +10,20 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 
 Tags: 3.5.6, 3.5, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: af59f1d6a03f87c0f391c3fbdb482ccb0cd65b59
+GitCommit: c3d38b9d9fbe589282d4974ce66af1d3f3da0c22
 Directory: 3.5.6/community
 
 Tags: 3.5.6-enterprise, 3.5-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: af59f1d6a03f87c0f391c3fbdb482ccb0cd65b59
+GitCommit: c3d38b9d9fbe589282d4974ce66af1d3f3da0c22
 Directory: 3.5.6/enterprise
 
 Tags: 3.4.14, 3.4
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0449aa9c6a60c0b1e71b9fe4800c7cde716bdeb5
+GitCommit: e3ddc2d97443a058c19cd5997d8c0df48c1956a9
 Directory: 3.4.14/community
 
 Tags: 3.4.14-enterprise, 3.4-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0449aa9c6a60c0b1e71b9fe4800c7cde716bdeb5
+GitCommit: e3ddc2d97443a058c19cd5997d8c0df48c1956a9
 Directory: 3.4.14/enterprise


### PR DESCRIPTION
Some changes were missing in the entrypoint, so I've updated the entrypoint script for both versions. 
Updated the commit hash in the docker library file.