### PR TITLE
Remove "registry:2.5"

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -17,7 +17,3 @@ GitCommit: fc40f1f1051bb4a42ee4661ccaa190c1bd6c6be9
 amd64-Directory: amd64
 arm32v6-Directory: arm
 arm64v8-Directory: arm64
-
-Tags: 2.5.2, 2.5
-GitFetch: refs/heads/registry-v2.5
-GitCommit: f96d9029112d8da459312fb8249802bc4ec6ac21


### PR DESCRIPTION
The branch appears to already have been removed from https://github.com/docker/distribution-library-image, so I think we're safe to remove this here (especially given it's `FROM alpine:3.4`, which is long-since EOL).

Just to be clear, removing tags here will remove them from the "Supported" section on the Hub readme (and will prevent us from spending cycles rebuilding them on the official build servers), but the tags will still be available to users who want them.  (See https://github.com/docker-library/official-images#library-definition-files for more detail on this.)

cc @davidswu @caervs