### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.0, 2.25, 2, latest
+Tags: 2.25.1, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d1a034c9f34609edb96fd8e4926e2985054ddd82
+GitCommit: 95a8ad331124acb5e5884e5391fed17297e710f9
 Directory: 2/debian
 
-Tags: 2.25.0-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.25.1-alpine, 2.25-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d1a034c9f34609edb96fd8e4926e2985054ddd82
+GitCommit: 95a8ad331124acb5e5884e5391fed17297e710f9
 Directory: 2/alpine
 
 Tags: 1.25.8, 1.25, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/95a8ad3: Update to 2.25.1, ghost-cli 1.11.0