### PR TITLE
Remove armv8 support for version prior to 11.x

### DIFF
--- a/library/nuxeo
+++ b/library/nuxeo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nuxeo/docker-nuxeo/blob/be2720e5d69a94e2c8560c119ab0e7f66d8dc2f3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nuxeo/docker-nuxeo/blob/68f31eda0c7d8141812f36b81b6b4430f0de35b3/generate-stackbrew-library.sh
 
 Maintainers: Damien Metzler <dmetzler@nuxeo.com> (@dmetzler),
              Arnaud Kervern <akervern@nuxeo.com> (@akervern)
@@ -20,6 +20,6 @@ GitCommit: f253a2398dbc39b42ca6ff84f2adeda8c1e8287e
 Directory: 9.10
 
 Tags: 10.10, 10, LTS-2019, LTS, FT, latest
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: f253a2398dbc39b42ca6ff84f2adeda8c1e8287e
 Directory: 10.10


### PR DESCRIPTION
Following https://github.com/docker-library/official-images/pull/5457#issuecomment-503754789