### PR TITLE
Bump Traefik to v2.0.0-alpha7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,19 +3,19 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v2.0.0-alpha7, 2.0.0-alpha7, v2.0, 2.0, faisselle
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
+GitCommit: f774f6749b605c425f274847737564ba02627408
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v2.0.0-alpha7-alpine, 2.0.0-alpha7-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
+GitCommit: f774f6749b605c425f274847737564ba02627408
 Directory: alpine
 
 Tags: v2.0.0-alpha7-nanoserver, 2.0.0-alpha7-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha7-nanoserver-sac2016, 2.0.0-alpha7-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
+GitCommit: f774f6749b605c425f274847737564ba02627408
 Directory: windows
 Constraints: nanoserver-sac2016
 

--- a/library/traefik
+++ b/library/traefik
@@ -1,21 +1,21 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-alpha6, 2.0.0-alpha6, v2.0, 2.0, faisselle
+Tags: v2.0.0-alpha7, 2.0.0-alpha7, v2.0, 2.0, faisselle
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 5caa8bfd30ded18ab840957dd6859ae73a912e58
+GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v2.0.0-alpha6-alpine, 2.0.0-alpha6-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
+Tags: v2.0.0-alpha7-alpine, 2.0.0-alpha7-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 5caa8bfd30ded18ab840957dd6859ae73a912e58
+GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
 Directory: alpine
 
-Tags: v2.0.0-alpha6-nanoserver, 2.0.0-alpha6-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha6-nanoserver-sac2016, 2.0.0-alpha6-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
+Tags: v2.0.0-alpha7-nanoserver, 2.0.0-alpha7-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha7-nanoserver-sac2016, 2.0.0-alpha7-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 5caa8bfd30ded18ab840957dd6859ae73a912e58
+GitCommit: 3c28d4d89c30bf4ef89947585254d4c531b4e294
 Directory: windows
 Constraints: nanoserver-sac2016
 

--- a/library/traefik
+++ b/library/traefik
@@ -3,19 +3,19 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v2.0.0-alpha7, 2.0.0-alpha7, v2.0, 2.0, faisselle
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f774f6749b605c425f274847737564ba02627408
+GitCommit: b57f0c107717609f3c925f4fb012acd87e0c8aaa
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
 Tags: v2.0.0-alpha7-alpine, 2.0.0-alpha7-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: f774f6749b605c425f274847737564ba02627408
+GitCommit: b57f0c107717609f3c925f4fb012acd87e0c8aaa
 Directory: alpine
 
 Tags: v2.0.0-alpha7-nanoserver, 2.0.0-alpha7-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha7-nanoserver-sac2016, 2.0.0-alpha7-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: f774f6749b605c425f274847737564ba02627408
+GitCommit: b57f0c107717609f3c925f4fb012acd87e0c8aaa
 Directory: windows
 Constraints: nanoserver-sac2016
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v2.0.0-alpha7.

/cc @mmatur @emilevauge @dtomcej

Cheers
