### PR TITLE
update oraclelinux for python 2.7

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: df5eca32170c4cf57315b3b7d12fc76f11a79575
+amd64-GitCommit: e97d56c375a810f027789ad4bb7d72f37379338d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 820ed349064a65de07a890fc8687389a0b2ee745
+arm64v8-GitCommit: d68fe9217d76729cfc29ac1341485f06cbb39a10
 Constraints: !aufs
 
 Tags: 7.6, 7, latest


### PR DESCRIPTION
	[AMD64 7.5] 2019-06-21-97
	[AMD64 7-slim] 2019-06-21-25
	[ARM64v8 7.5] 2019-06-21-16
	[ARM64v8 7-slim] 2019-06-21-12

Signed-off-by: Laszlo (Laca) Peter <laszlo.peter@oracle.com>