### PR TITLE
Update Open Liberty to 19.0.0.6

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,162 +1,297 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: ee4e20ea4d0795fc63970fabaa9c02803f86dfa1
+GitCommit: 19c93b7ddbc4583222f37ac542a92a76166b7166
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm
-Directory: official/19.0.0.x/kernel/java8/ibmjava
+Directory: official/latest/kernel/java8/ibmjava
 
 Tags: kernel-java8-ibmsfj
-Directory: official/19.0.0.x/kernel/java8/ibmsfj
+Directory: official/latest/kernel/java8/ibmsfj
 Architectures: amd64
 
 Tags: kernel-java8-openj9
-Directory: official/19.0.0.x/kernel/java8/openj9
+Directory: official/latest/kernel/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel-java11
-Directory: official/19.0.0.x/kernel/java11/openj9
+Directory: official/latest/kernel/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel-java12
-Directory: official/19.0.0.x/kernel/java12/openj9
+Directory: official/latest/kernel/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8, webProfile8-java8-ibm
-Directory: official/19.0.0.x/webProfile8/java8/ibmjava
+Directory: official/latest/webProfile8/java8/ibmjava
 
 Tags: webProfile8-java8-ibmsfj
-Directory: official/19.0.0.x/webProfile8/java8/ibmsfj
+Directory: official/latest/webProfile8/java8/ibmsfj
 Architectures: amd64
 
 Tags: webProfile8-java8-openj9
-Directory: official/19.0.0.x/webProfile8/java8/openj9
+Directory: official/latest/webProfile8/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8-java11
-Directory: official/19.0.0.x/webProfile8/java11/openj9
+Directory: official/latest/webProfile8/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8-java12
-Directory: official/19.0.0.x/webProfile8/java12/openj9
+Directory: official/latest/webProfile8/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee8, javaee8-java8-ibm, latest
-Directory: official/19.0.0.x/javaee8/java8/ibmjava
+Directory: official/latest/javaee8/java8/ibmjava
 
 Tags: javaee8-java8-ibmsfj
-Directory: official/19.0.0.x/javaee8/java8/ibmsfj
+Directory: official/latest/javaee8/java8/ibmsfj
 Architectures: amd64
 
 Tags: javaee8-java8-openj9
-Directory: official/19.0.0.x/javaee8/java8/openj9
+Directory: official/latest/javaee8/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee8-java11
-Directory: official/19.0.0.x/javaee8/java11/openj9
+Directory: official/latest/javaee8/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee8-java12
-Directory: official/19.0.0.x/javaee8/java12/openj9
+Directory: official/latest/javaee8/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile1, microProfile1-java8-ibm
-Directory: official/19.0.0.x/microProfile1/java8/ibmjava
+Directory: official/latest/microProfile1/java8/ibmjava
 
 Tags: microProfile1-java8-ibmsfj
-Directory: official/19.0.0.x/microProfile1/java8/ibmsfj
+Directory: official/latest/microProfile1/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile1-java8-openj9
-Directory: official/19.0.0.x/microProfile1/java8/openj9
+Directory: official/latest/microProfile1/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile1-java11
-Directory: official/19.0.0.x/microProfile1/java11/openj9
+Directory: official/latest/microProfile1/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2, microProfile2-java8-ibm
-Directory: official/19.0.0.x/microProfile2/java8/ibmjava
+Directory: official/latest/microProfile2/java8/ibmjava
 
 Tags: microProfile2-java8-ibmsfj
-Directory: official/19.0.0.x/microProfile2/java8/ibmsfj
+Directory: official/latest/microProfile2/java8/ibmsfj
 Architectures: amd64
 
 Tags: microProfile2-java8-openj9
-Directory: official/19.0.0.x/microProfile2/java8/openj9
+Directory: official/latest/microProfile2/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2-java11
-Directory: official/19.0.0.x/microProfile2/java11/openj9
+Directory: official/latest/microProfile2/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2-java12
-Directory: official/19.0.0.x/microProfile2/java12/openj9
+Directory: official/latest/microProfile2/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2, springBoot2-java8-ibm
-Directory: official/19.0.0.x/springBoot2/java8/ibmjava
+Directory: official/latest/springBoot2/java8/ibmjava
 
 Tags: springBoot2-java8-ibmsfj
-Directory: official/19.0.0.x/springBoot2/java8/ibmsfj
+Directory: official/latest/springBoot2/java8/ibmsfj
 Architectures: amd64
 
 Tags: springBoot2-java8-openj9
-Directory: official/19.0.0.x/springBoot2/java8/openj9
+Directory: official/latest/springBoot2/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2-java11
-Directory: official/19.0.0.x/springBoot2/java11/openj9
+Directory: official/latest/springBoot2/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2-java12
-Directory: official/19.0.0.x/springBoot2/java12/openj9
+Directory: official/latest/springBoot2/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile7, webProfile7-java8-ibm
-Directory: official/19.0.0.x/webProfile7/java8/ibmjava
+Directory: official/latest/webProfile7/java8/ibmjava
 
 Tags: webProfile7-java8-ibmsfj
-Directory: official/19.0.0.x/webProfile7/java8/ibmsfj
+Directory: official/latest/webProfile7/java8/ibmsfj
 Architectures: amd64
 
 Tags: webProfile7-java8-openj9
-Directory: official/19.0.0.x/webProfile7/java8/openj9
+Directory: official/latest/webProfile7/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile7-java11
-Directory: official/19.0.0.x/webProfile7/java11/openj9
+Directory: official/latest/webProfile7/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee7, javaee7-java8-ibm
-Directory: official/19.0.0.x/javaee7/java8/ibmjava
+Directory: official/latest/javaee7/java8/ibmjava
 
 Tags: javaee7-java8-ibmsfj
-Directory: official/19.0.0.x/javaee7/java8/ibmsfj
+Directory: official/latest/javaee7/java8/ibmsfj
 Architectures: amd64
 
 Tags: javaee7-java8-openj9
-Directory: official/19.0.0.x/javaee7/java8/openj9
+Directory: official/latest/javaee7/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee7-java11
-Directory: official/19.0.0.x/javaee7/java11/openj9
+Directory: official/latest/javaee7/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot1, springBoot1-java8-ibm
-Directory: official/19.0.0.x/springBoot1/java8/ibmjava
+Directory: official/latest/springBoot1/java8/ibmjava
 
 Tags: springBoot1-java8-ibmsfj
-Directory: official/19.0.0.x/springBoot1/java8/ibmsfj
+Directory: official/latest/springBoot1/java8/ibmsfj
 Architectures: amd64
 
 Tags: springBoot1-java8-openj9
-Directory: official/19.0.0.x/springBoot1/java8/openj9
+Directory: official/latest/springBoot1/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot1-java11
-Directory: official/19.0.0.x/springBoot1/java11/openj9
+Directory: official/latest/springBoot1/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-kernel, 19.0.0.6-kernel-java8-ibm
+Directory: official/19.0.0.6/kernel/java8/ibmjava
+
+Tags: 19.0.0.6-kernel-java8-ibmsfj
+Directory: official/19.0.0.6/kernel/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-kernel-java8-openj9
+Directory: official/19.0.0.6/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-kernel-java11
+Directory: official/19.0.0.6/kernel/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-webProfile8, 19.0.0.6-webProfile8-java8-ibm
+Directory: official/19.0.0.6/webProfile8/java8/ibmjava
+
+Tags: 19.0.0.6-webProfile8-java8-ibmsfj
+Directory: official/19.0.0.6/webProfile8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-webProfile8-java8-openj9
+Directory: official/19.0.0.6/webProfile8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-webProfile8-java11
+Directory: official/19.0.0.6/webProfile8/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-javaee8, 19.0.0.6-javaee8-java8-ibm
+Directory: official/19.0.0.6/javaee8/java8/ibmjava
+
+Tags: 19.0.0.6-javaee8-java8-ibmsfj
+Directory: official/19.0.0.6/javaee8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-javaee8-java8-openj9
+Directory: official/19.0.0.6/javaee8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-javaee8-java11
+Directory: official/19.0.0.6/javaee8/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-microProfile1, 19.0.0.6-microProfile1-java8-ibm
+Directory: official/19.0.0.6/microProfile1/java8/ibmjava
+
+Tags: 19.0.0.6-microProfile1-java8-ibmsfj
+Directory: official/19.0.0.6/microProfile1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-microProfile1-java8-openj9
+Directory: official/19.0.0.6/microProfile1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-microProfile1-java11
+Directory: official/19.0.0.6/microProfile1/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-microProfile2, 19.0.0.6-microProfile2-java8-ibm
+Directory: official/19.0.0.6/microProfile2/java8/ibmjava
+
+Tags: 19.0.0.6-microProfile2-java8-ibmsfj
+Directory: official/19.0.0.6/microProfile2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-microProfile2-java8-openj9
+Directory: official/19.0.0.6/microProfile2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-microProfile2-java11
+Directory: official/19.0.0.6/microProfile2/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-springBoot2, 19.0.0.6-springBoot2-java8-ibm
+Directory: official/19.0.0.6/springBoot2/java8/ibmjava
+
+Tags: 19.0.0.6-springBoot2-java8-ibmsfj
+Directory: official/19.0.0.6/springBoot2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-springBoot2-java8-openj9
+Directory: official/19.0.0.6/springBoot2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-springBoot2-java11
+Directory: official/19.0.0.6/springBoot2/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-webProfile7, 19.0.0.6-webProfile7-java8-ibm
+Directory: official/19.0.0.6/webProfile7/java8/ibmjava
+
+Tags: 19.0.0.6-webProfile7-java8-ibmsfj
+Directory: official/19.0.0.6/webProfile7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-webProfile7-java8-openj9
+Directory: official/19.0.0.6/webProfile7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-webProfile7-java11
+Directory: official/19.0.0.6/webProfile7/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-javaee7, 19.0.0.6-javaee7-java8-ibm
+Directory: official/19.0.0.6/javaee7/java8/ibmjava
+
+Tags: 19.0.0.6-javaee7-java8-ibmsfj
+Directory: official/19.0.0.6/javaee7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-javaee7-java8-openj9
+Directory: official/19.0.0.6/javaee7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-javaee7-java11
+Directory: official/19.0.0.6/javaee7/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-springBoot1, 19.0.0.6-springBoot1-java8-ibm
+Directory: official/19.0.0.6/springBoot1/java8/ibmjava
+
+Tags: 19.0.0.6-springBoot1-java8-ibmsfj
+Directory: official/19.0.0.6/springBoot1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.6-springBoot1-java8-openj9
+Directory: official/19.0.0.6/springBoot1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.6-springBoot1-java11
+Directory: official/19.0.0.6/springBoot1/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.3-kernel, 19.0.0.3-kernel-java8-ibm
@@ -256,103 +391,4 @@ Architectures: amd64
 
 Tags: 19.0.0.3-springBoot1-java8-openj9
 Directory: official/19.0.0.3/springBoot1/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-kernel, 18.0.0.4-kernel-java8-ibm
-Directory: official/18.0.0.4/kernel/java8/ibmjava
-
-Tags: 18.0.0.4-kernel-java8-ibmsfj
-Directory: official/18.0.0.4/kernel/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-kernel-java8-openj9
-Directory: official/18.0.0.4/kernel/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-webProfile8, 18.0.0.4-webProfile8-java8-ibm
-Directory: official/18.0.0.4/webProfile8/java8/ibmjava
-
-Tags: 18.0.0.4-webProfile8-java8-ibmsfj
-Directory: official/18.0.0.4/webProfile8/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-webProfile8-java8-openj9
-Directory: official/18.0.0.4/webProfile8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-javaee8, 18.0.0.4-javaee8-java8-ibm
-Directory: official/18.0.0.4/javaee8/java8/ibmjava
-
-Tags: 18.0.0.4-javaee8-java8-ibmsfj
-Directory: official/18.0.0.4/javaee8/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-javaee8-java8-openj9
-Directory: official/18.0.0.4/javaee8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-microProfile1, 18.0.0.4-microProfile1-java8-ibm
-Directory: official/18.0.0.4/microProfile1/java8/ibmjava
-
-Tags: 18.0.0.4-microProfile1-java8-ibmsfj
-Directory: official/18.0.0.4/microProfile1/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-microProfile1-java8-openj9
-Directory: official/18.0.0.4/microProfile1/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-microProfile2, 18.0.0.4-microProfile2-java8-ibm
-Directory: official/18.0.0.4/microProfile2/java8/ibmjava
-
-Tags: 18.0.0.4-microProfile2-java8-ibmsfj
-Directory: official/18.0.0.4/microProfile2/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-microProfile2-java8-openj9
-Directory: official/18.0.0.4/microProfile2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-springBoot2, 18.0.0.4-springBoot2-java8-ibm
-Directory: official/18.0.0.4/springBoot2/java8/ibmjava
-
-Tags: 18.0.0.4-springBoot2-java8-ibmsfj
-Directory: official/18.0.0.4/springBoot2/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-springBoot2-java8-openj9
-Directory: official/18.0.0.4/springBoot2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-webProfile7, 18.0.0.4-webProfile7-java8-ibm
-Directory: official/18.0.0.4/webProfile7/java8/ibmjava
-
-Tags: 18.0.0.4-webProfile7-java8-ibmsfj
-Directory: official/18.0.0.4/webProfile7/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-webProfile7-java8-openj9
-Directory: official/18.0.0.4/webProfile7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-javaee7, 18.0.0.4-javaee7-java8-ibm
-Directory: official/18.0.0.4/javaee7/java8/ibmjava
-
-Tags: 18.0.0.4-javaee7-java8-ibmsfj
-Directory: official/18.0.0.4/javaee7/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-javaee7-java8-openj9
-Directory: official/18.0.0.4/javaee7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 18.0.0.4-springBoot1, 18.0.0.4-springBoot1-java8-ibm
-Directory: official/18.0.0.4/springBoot1/java8/ibmjava
-
-Tags: 18.0.0.4-springBoot1-java8-ibmsfj
-Directory: official/18.0.0.4/springBoot1/java8/ibmsfj
-Architectures: amd64
-
-Tags: 18.0.0.4-springBoot1-java8-openj9
-Directory: official/18.0.0.4/springBoot1/java8/openj9
 Architectures: amd64, ppc64le, s390x


### PR DESCRIPTION
Update to Open Liberty 19.0.0.6.  Keeping versioned images 19.0.0.6 and 19.0.0.3 now.