### PR TITLE
Update WebSphere Liberty to 19.0.0.6

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 04b7de60f246cf312efa037d388c224d697c3913
+GitCommit: 5b6b96dd1fd50df6b1d1053b5fe169c7b0537d9b
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,38 +1,65 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: be4349167c4a5540c739e127bd52075d472976b3
+GitCommit: 04b7de60f246cf312efa037d388c224d697c3913
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
 Directory: beta
 
-Tags: 19.0.0.5-kernel, kernel
-Directory: ga/19.0.0.5/kernel
+Tags: kernel
+Directory: ga/latest/kernel
 
-Tags: 19.0.0.5-javaee8, javaee8, latest
-Directory: ga/19.0.0.5/javaee8
+Tags: javaee8, latest
+Directory: ga/latest/javaee8
 
-Tags: 19.0.0.5-webProfile8, webProfile8
-Directory: ga/19.0.0.5/webProfile8
+Tags: webProfile8
+Directory: ga/latest/webProfile8
 
-Tags: 19.0.0.5-microProfile1, microProfile1
-Directory: ga/19.0.0.5/microProfile1
+Tags: microProfile1
+Directory: ga/latest/microProfile1
 
-Tags: 19.0.0.5-microProfile2, microProfile2
-Directory: ga/19.0.0.5/microProfile2
+Tags: microProfile2
+Directory: ga/latest/microProfile2
 
-Tags: 19.0.0.5-springBoot2, springBoot2
-Directory: ga/19.0.0.5/springBoot2
+Tags: springBoot2
+Directory: ga/latest/springBoot2
 
-Tags: 19.0.0.5-springBoot1, springBoot1
-Directory: ga/19.0.0.5/springBoot1
+Tags: springBoot1
+Directory: ga/latest/springBoot1
 
-Tags: 19.0.0.5-webProfile7, webProfile7
-Directory: ga/19.0.0.5/webProfile7
+Tags: webProfile7
+Directory: ga/latest/webProfile7
 
-Tags: 19.0.0.5-javaee7, javaee7
-Directory: ga/19.0.0.5/javaee7
+Tags: javaee7
+Directory: ga/latest/javaee7
+
+Tags: 19.0.0.6-kernel
+Directory: ga/19.0.0.6/kernel
+
+Tags: 19.0.0.6-javaee8
+Directory: ga/19.0.0.6/javaee8
+
+Tags: 19.0.0.6-webProfile8
+Directory: ga/19.0.0.6/webProfile8
+
+Tags: 19.0.0.6-microProfile1
+Directory: ga/19.0.0.6/microProfile1
+
+Tags: 19.0.0.6-microProfile2
+Directory: ga/19.0.0.6/microProfile2
+
+Tags: 19.0.0.6-springBoot2
+Directory: ga/19.0.0.6/springBoot2
+
+Tags: 19.0.0.6-springBoot1
+Directory: ga/19.0.0.6/springBoot1
+
+Tags: 19.0.0.6-webProfile7
+Directory: ga/19.0.0.6/webProfile7
+
+Tags: 19.0.0.6-javaee7
+Directory: ga/19.0.0.6/javaee7
 
 Tags: 19.0.0.3-kernel
 Directory: ga/19.0.0.3/kernel
@@ -60,30 +87,3 @@ Directory: ga/19.0.0.3/webProfile7
 
 Tags: 19.0.0.3-javaee7
 Directory: ga/19.0.0.3/javaee7
-
-Tags: 18.0.0.4-kernel
-Directory: ga/18.0.0.4/kernel
-
-Tags: 18.0.0.4-javaee8
-Directory: ga/18.0.0.4/javaee8
-
-Tags: 18.0.0.4-webProfile8
-Directory: ga/18.0.0.4/webProfile8
-
-Tags: 18.0.0.4-microProfile1
-Directory: ga/18.0.0.4/microProfile1
-
-Tags: 18.0.0.4-microProfile2
-Directory: ga/18.0.0.4/microProfile2
-
-Tags: 18.0.0.4-springBoot2
-Directory: ga/18.0.0.4/springBoot2
-
-Tags: 18.0.0.4-springBoot1
-Directory: ga/18.0.0.4/springBoot1
-
-Tags: 18.0.0.4-webProfile7
-Directory: ga/18.0.0.4/webProfile7
-
-Tags: 18.0.0.4-javaee7
-Directory: ga/18.0.0.4/javaee7


### PR DESCRIPTION
Updating WebSphere Liberty to 19.0.0.6.  Now maintaining versioned images for 19.0.0.6 and 19.0.0.3.