### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.1.1
-GitCommit: 99f4e9224b542a9810394c8628977795754c70c3
+Tags: 7.2.0
+GitCommit: 0f90651d2bb17829fc69a497888ad7eac89b3edc
 Directory: 7
 
 Tags: 6.8.1

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.1.1
-GitCommit: 9267a8b724579791a9ad4a20fd816f03f64e9b64
+Tags: 7.2.0
+GitCommit: 3ecc671447bc810f0d81751fd1c104a94657a5e5
 Directory: 7
 
 Tags: 6.8.1

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.1.1
-GitCommit: a1c5be368f33e304c843d497b64f8e574e29bf3c
+Tags: 7.2.0
+GitCommit: 26c49635928bdded0c1bc64df411dbdeb610c3ac
 Directory: 7
 
 Tags: 6.8.1


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/0f90651: Update to 7.2.0

logstash:
- https://github.com/docker-library/logstash/commit/26c4963: Update to 7.2.0
- https://github.com/docker-library/logstash/commit/b660d1f: Point update.sh at elastic/dockerfiles unilaterally now that 7.2 is out

kibana:
- https://github.com/docker-library/kibana/commit/3ecc671: Update to 7.2.0