### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -11,7 +11,7 @@ Directory: 2.0
 
 Tags: 2.0.0-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
 Directory: 2.0/alpine
 
 Tags: 1.9.8, 1.9, 1
@@ -21,7 +21,7 @@ Directory: 1.9
 
 Tags: 1.9.8-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
 Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8
@@ -31,7 +31,7 @@ Directory: 1.8
 
 Tags: 1.8.20-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7
@@ -41,7 +41,7 @@ Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
 Directory: 1.7/alpine
 
 Tags: 1.6.14, 1.6


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/949a43e: Merge pull request https://github.com/docker-library/haproxy/pull/93 from J0WI/alpine10
- https://github.com/docker-library/haproxy/commit/90c276b: Update Alpine to 3.10