### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -26,10 +26,10 @@ Directory: 3.5/slim
 
 Tags: 3.6-7.1.1, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.1-stretch, 3.6-7.1-stretch, 3.6-7-stretch, 3.6-stretch
 Architectures: amd64, i386, s390x
-GitCommit: eb8f5a1379cb955c32678e5b4824f1263af8ab09
+GitCommit: 669ca6492e33303a5f4770fd2ffa009b8b47ced9
 Directory: 3.6
 
 Tags: 3.6-7.1.1-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.1-slim-stretch, 3.6-7.1-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, i386, s390x
-GitCommit: eb8f5a1379cb955c32678e5b4824f1263af8ab09
+GitCommit: 669ca6492e33303a5f4770fd2ffa009b8b47ced9
 Directory: 3.6/slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/669ca64: Update to 7.1.1, pip 19.1.1
- https://github.com/docker-library/pypy/commit/843ed31: Update to 7.1.0, pip 19.1.1
- https://github.com/docker-library/pypy/commit/df2ae1e: Update generated README

(No change -- probably going to look at changing `update.sh` to refuse to update to an older version without some kind of force flag.)