### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,90 +1,90 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/5d977ba3d1c509e3e094f8e98650c6ce25603f71/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/c718c72e1c122feefa8ff8f1a7c84c9c08495bdd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.7.0-preview1-stretch, 2.7-rc-stretch, rc-stretch, 2.7.0-preview1, 2.7-rc, rc
+Tags: 2.7.0-preview1-buster, 2.7-rc-buster, rc-buster, 2.7.0-preview1, 2.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0c1b3c89142267912d8d0b532e206463c7d8ee0
-Directory: 2.7-rc/stretch
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.7-rc/buster
 
-Tags: 2.7.0-preview1-slim-stretch, 2.7-rc-slim-stretch, rc-slim-stretch, 2.7.0-preview1-slim, 2.7-rc-slim, rc-slim
+Tags: 2.7.0-preview1-slim-buster, 2.7-rc-slim-buster, rc-slim-buster, 2.7.0-preview1-slim, 2.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0c1b3c89142267912d8d0b532e206463c7d8ee0
-Directory: 2.7-rc/stretch/slim
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.7-rc/buster/slim
 
-Tags: 2.7.0-preview1-alpine3.9, 2.7-rc-alpine3.9, rc-alpine3.9, 2.7.0-preview1-alpine, 2.7-rc-alpine, rc-alpine
+Tags: 2.7.0-preview1-alpine3.10, 2.7-rc-alpine3.10, rc-alpine3.10, 2.7.0-preview1-alpine, 2.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0c1b3c89142267912d8d0b532e206463c7d8ee0
-Directory: 2.7-rc/alpine3.9
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.7-rc/alpine3.10
 
 Tags: 2.6.3-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.3, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ae0943fa2935b3a13c72ae7d6afa2439145d7fa
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.6/stretch
 
 Tags: 2.6.3-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.3-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ae0943fa2935b3a13c72ae7d6afa2439145d7fa
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.3-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9, 2.6.3-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.3-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.3-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ae0943fa2935b3a13c72ae7d6afa2439145d7fa
-Directory: 2.6/alpine3.9
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.6/alpine3.10
 
-Tags: 2.6.3-alpine3.8, 2.6-alpine3.8, 2-alpine3.8, alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ae0943fa2935b3a13c72ae7d6afa2439145d7fa
-Directory: 2.6/alpine3.8
+Tags: 2.6.3-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.6/alpine3.9
 
 Tags: 2.5.5-stretch, 2.5-stretch, 2.5.5, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.5/stretch
 
 Tags: 2.5.5-slim-stretch, 2.5-slim-stretch, 2.5.5-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.5-alpine3.9, 2.5-alpine3.9, 2.5.5-alpine, 2.5-alpine
+Tags: 2.5.5-alpine3.10, 2.5-alpine3.10, 2.5.5-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
-Directory: 2.5/alpine3.9
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.5/alpine3.10
 
-Tags: 2.5.5-alpine3.8, 2.5-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f3497e40d44651802e1ec8a4647b23a3a63b355
-Directory: 2.5/alpine3.8
+Tags: 2.5.5-alpine3.9, 2.5-alpine3.9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.5/alpine3.9
 
 Tags: 2.4.6-stretch, 2.4-stretch, 2.4.6, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.4/stretch
 
 Tags: 2.4.6-slim-stretch, 2.4-slim-stretch, 2.4.6-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.6-jessie, 2.4-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.4/jessie
 
 Tags: 2.4.6-slim-jessie, 2.4-slim-jessie
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
+GitCommit: aacff4398185738d84232f1685df12306be13114
 Directory: 2.4/jessie/slim
 
-Tags: 2.4.6-alpine3.9, 2.4-alpine3.9, 2.4.6-alpine, 2.4-alpine
+Tags: 2.4.6-alpine3.10, 2.4-alpine3.10, 2.4.6-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
-Directory: 2.4/alpine3.9
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.4/alpine3.10
 
-Tags: 2.4.6-alpine3.8, 2.4-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 802421922ef50cfa05c89a3c619992acf4329986
-Directory: 2.4/alpine3.8
+Tags: 2.4.6-alpine3.9, 2.4-alpine3.9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: aacff4398185738d84232f1685df12306be13114
+Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/21864e7: Merge pull request https://github.com/docker-library/ruby/pull/284 from infosiftr/verify-no-distro-ruby
- https://github.com/docker-library/ruby/commit/aacff43: Add some verification that we have no "distro ruby" packages
- https://github.com/docker-library/ruby/commit/2a6352e: Merge pull request https://github.com/docker-library/ruby/pull/283 from infosiftr/busted
- https://github.com/docker-library/ruby/commit/e46b04d: Add "libgdbm-compat-dev" explicitly in Buster+ on Slim variants
- https://github.com/docker-library/ruby/commit/f8c8256: Switch from "&&" to ";" and use "apt-mark showmanual"+"ldd" method for non-slim Debian too
- https://github.com/docker-library/ruby/commit/c718c72: Replace "stretch" with "buster" for Ruby 2.7-rc given the imminent Debian release
- https://github.com/docker-library/ruby/commit/195d5bc: Merge pull request https://github.com/docker-library/ruby/pull/282 from J0WI/alpine10-tag
- https://github.com/docker-library/ruby/commit/7f8c506: Add tag for Alpine 3.10
- https://github.com/docker-library/ruby/commit/68f67b0: Merge pull request https://github.com/docker-library/ruby/pull/281 from J0WI/alpine10
- https://github.com/docker-library/ruby/commit/486c315: Add Alpine 3.10 and remove Alpine 3.8
- https://github.com/docker-library/ruby/commit/8435142: Update generated README