### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.1, 2.25, 2, latest
+Tags: 2.25.3, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 95a8ad331124acb5e5884e5391fed17297e710f9
+GitCommit: 9aef284520799c855d172d745febea6e3bd6e56d
 Directory: 2/debian
 
-Tags: 2.25.1-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.25.3-alpine, 2.25-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 95a8ad331124acb5e5884e5391fed17297e710f9
+GitCommit: 9aef284520799c855d172d745febea6e3bd6e56d
 Directory: 2/alpine
 
-Tags: 1.25.8, 1.25, 1
+Tags: 1.26.0, 1.26, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6580a99957b8c39cad68b4e497c626c470e9f7f1
+GitCommit: 8eba604d6b6078a318e0a83771ebc8e09f350bf0
 Directory: 1/debian
 
-Tags: 1.25.8-alpine, 1.25-alpine, 1-alpine
+Tags: 1.26.0-alpine, 1.26-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6580a99957b8c39cad68b4e497c626c470e9f7f1
+GitCommit: 8eba604d6b6078a318e0a83771ebc8e09f350bf0
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/8eba604: Update to 1.26.0, ghost-cli 1.11.0
- https://github.com/docker-library/ghost/commit/9aef284: Update to 2.25.3, ghost-cli 1.11.0