### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.0, 2.0, latest
+Tags: 2.0.1, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: 8e656d4403154a7086fb63bd92382c9f8d32af9b
 Directory: 2.0
 
-Tags: 2.0.0-alpine, 2.0-alpine, alpine
+Tags: 2.0.1-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
+GitCommit: 8e656d4403154a7086fb63bd92382c9f8d32af9b
 Directory: 2.0/alpine
 
 Tags: 1.9.8, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.9
 
 Tags: 1.9.8-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.8
 
 Tags: 1.8.20-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90c276b674867319c475d02a64e5c16f5680381e
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.7/alpine
 
 Tags: 1.6.14, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.6
 
 Tags: 1.6.14-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.6/alpine
 
 Tags: 1.5.19, 1.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.5
 
 Tags: 1.5.19-alpine, 1.5-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ad0f0b3b0b2c95e3fabd63113fd94084dbee73a4
+GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
 Directory: 1.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8e656d4: Merge pull request https://github.com/docker-library/haproxy/pull/95 from infosiftr/prometheus-exporter
- https://github.com/docker-library/haproxy/commit/d7a06c7: Update to 2.0.1
- https://github.com/docker-library/haproxy/commit/d21ad45: Enable the inclusion of "contrib/prometheus-exporter/service-prometheus.o" on 2+