### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,29 +1,24 @@
-# this file is generated via https://github.com/docker-library/python/blob/36af2089a0be48ac7fba5c27f935a69cf6fe1d56/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/a8c24b491e15e1eb0cdcc994bbc5ebcaa57e4982/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.8.0b1-stretch, 3.8-rc-stretch, rc-stretch
+Tags: 3.8.0b1-buster, 3.8-rc-buster, rc-buster
 SharedTags: 3.8.0b1, 3.8-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4baab390a3ba83908b869277491c4ce2ca283373
-Directory: 3.8-rc/stretch
+GitCommit: 4fc051f0aa8ef60931474b23567a7f232095d85f
+Directory: 3.8-rc/buster
 
-Tags: 3.8.0b1-slim-stretch, 3.8-rc-slim-stretch, rc-slim-stretch, 3.8.0b1-slim, 3.8-rc-slim, rc-slim
+Tags: 3.8.0b1-slim-buster, 3.8-rc-slim-buster, rc-slim-buster, 3.8.0b1-slim, 3.8-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4baab390a3ba83908b869277491c4ce2ca283373
-Directory: 3.8-rc/stretch/slim
+GitCommit: 4fc051f0aa8ef60931474b23567a7f232095d85f
+Directory: 3.8-rc/buster/slim
 
 Tags: 3.8.0b1-alpine3.10, 3.8-rc-alpine3.10, rc-alpine3.10, 3.8.0b1-alpine, 3.8-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e057559fad64ed81b3da9fad6612a2de8b0ae544
 Directory: 3.8-rc/alpine3.10
-
-Tags: 3.8.0b1-alpine3.9, 3.8-rc-alpine3.9, rc-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4baab390a3ba83908b869277491c4ce2ca283373
-Directory: 3.8-rc/alpine3.9
 
 Tags: 3.8.0b1-windowsservercore-ltsc2016, 3.8-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.8.0b1-windowsservercore, 3.8-rc-windowsservercore, rc-windowsservercore, 3.8.0b1, 3.8-rc, rc


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/a8c24b4: Fix facepalm
- https://github.com/docker-library/python/commit/3dc8cf6: Merge pull request https://github.com/docker-library/python/pull/402 from infosiftr/busted
- https://github.com/docker-library/python/commit/4fc051f: Replace "stretch" with "buster" for Python 3.8-rc given the imminent Debian release