### PR TITLE
Upgrade to 7.9

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -2,10 +2,7 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Julien Lancelot <julien.lancelot@sonarsource.com> (@julienlancelot),
              Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 2a00a59b94b64d52ce202f104c816d4ab73a5837
+GitCommit: 7f8fd12c45f4c7801e08d6b938c3869e0ceebd96
 
-Tags: 6.7.7-community, 6.7-community, lts
-Directory: 6.7.7-community
-
-Tags: 7.8-community, latest
-Directory: 7.8-community
+Tags: 7.9-community, latest, lts
+Directory: 7.9-community


### PR DESCRIPTION
SonarQube 7.9 is the new LTS version, so version 6.7.7 should be no more available