### PR TITLE
[security] Update irssi to 1.2.1

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.2.0, 1.2, 1, latest
+Tags: 1.2.1, 1.2, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec5a36f9e17511c0b9768719db0aeeef1715fe42
+GitCommit: 175c2ab5442cc9a57a5a84ae931108a4b6784a07
 Directory: debian
 
-Tags: 1.2.0-alpine, 1.2-alpine, 1-alpine, alpine
+Tags: 1.2.1-alpine, 1.2-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ec5a36f9e17511c0b9768719db0aeeef1715fe42
+GitCommit: 175c2ab5442cc9a57a5a84ae931108a4b6784a07
 Directory: alpine


### PR DESCRIPTION
https://irssi.org/security/html/irssi_sa_2019_06/
https://irssi.org/2019/06/29/irssi-1.2.1-1.1.3-1.0.8-released/
https://github.com/jessfraz/irssi/issues/22

Changes:

- https://github.com/jessfraz/irssi/commit/175c2ab: Update to 1.2.1
- https://github.com/jessfraz/irssi/commit/fe87d95: Update generated README