### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-26-jdk-oraclelinux7, 13-ea-26-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-26-jdk-oracle, 13-ea-26-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-26-jdk, 13-ea-26, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-27-jdk-oraclelinux7, 13-ea-27-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-27-jdk-oracle, 13-ea-27-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 3f0afc707474b8900b5a0e0aebc7940ac195c232
+GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
@@ -16,24 +16,24 @@ Architectures: amd64
 GitCommit: 1398299a268f339254a94b606113d1627dec342e
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-26-jdk-windowsservercore-1809, 13-ea-26-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-26-jdk-windowsservercore, 13-ea-26-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-26-jdk, 13-ea-26, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-27-jdk-windowsservercore-1809, 13-ea-27-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3f0afc707474b8900b5a0e0aebc7940ac195c232
+GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-26-jdk-windowsservercore-1803, 13-ea-26-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-26-jdk-windowsservercore, 13-ea-26-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-26-jdk, 13-ea-26, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-27-jdk-windowsservercore-1803, 13-ea-27-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3f0afc707474b8900b5a0e0aebc7940ac195c232
+GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-26-jdk-windowsservercore-ltsc2016, 13-ea-26-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-26-jdk-windowsservercore, 13-ea-26-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-26-jdk, 13-ea-26, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-27-jdk-windowsservercore-ltsc2016, 13-ea-27-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 3f0afc707474b8900b5a0e0aebc7940ac195c232
+GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9286973: Update to 13-ea+27