### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 4955634c25411cd05d9c4e0f933de67a89ba7c38
+GitCommit: 110efb84700b77698e8d236786386ac5960e7c42
 Directory: dockerfiles-generated
 
 Tags: 0.17.0-python3.7-stretch, 0.17-python3.7-stretch, 0-python3.7-stretch, python3.7-stretch, 0.17.0-stretch, 0.17-stretch, 0-stretch, stretch
@@ -8,13 +8,13 @@ SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-stretch
 
+Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.7-alpine3.10
+
 Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.9
-
-Tags: 0.17.0-python3.7-alpine3.8, 0.17-python3.7-alpine3.8, 0-python3.7-alpine3.8, python3.7-alpine3.8, 0.17.0-alpine3.8, 0.17-alpine3.8, 0-alpine3.8, alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.7-alpine3.8
 
 Tags: 0.17.0-python3.7-windowsservercore-1809, 0.17-python3.7-windowsservercore-1809, 0-python3.7-windowsservercore-1809, python3.7-windowsservercore-1809, 0.17.0-windowsservercore-1809, 0.17-windowsservercore-1809, 0-windowsservercore-1809, windowsservercore-1809
 SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
@@ -43,13 +43,13 @@ Tags: 0.17.0-python3.6-jessie, 0.17-python3.6-jessie, 0-python3.6-jessie, python
 Architectures: amd64, arm32v5, arm32v7, i386
 File: Dockerfile.python3.6-jessie
 
+Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine3.10, python3.6-alpine3.10
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.6-alpine3.10
+
 Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9, 0.17.0-python3.6-alpine, 0.17-python3.6-alpine, 0-python3.6-alpine, python3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.9
-
-Tags: 0.17.0-python3.6-alpine3.8, 0.17-python3.6-alpine3.8, 0-python3.6-alpine3.8, python3.6-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.6-alpine3.8
 
 Tags: 0.17.0-python3.6-windowsservercore-1809, 0.17-python3.6-windowsservercore-1809, 0-python3.6-windowsservercore-1809, python3.6-windowsservercore-1809
 SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
@@ -78,13 +78,13 @@ Tags: 0.17.0-python3.5-jessie, 0.17-python3.5-jessie, 0-python3.5-jessie, python
 Architectures: amd64, arm32v5, arm32v7, i386
 File: Dockerfile.python3.5-jessie
 
+Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine3.10, python3.5-alpine3.10
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.5-alpine3.10
+
 Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9, 0.17.0-python3.5-alpine, 0.17-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.9
-
-Tags: 0.17.0-python3.5-alpine3.8, 0.17-python3.5-alpine3.8, 0-python3.5-alpine3.8, python3.5-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.5-alpine3.8
 
 Tags: 0.17.0-python2.7-stretch, 0.17-python2.7-stretch, 0-python2.7-stretch, python2.7-stretch
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
@@ -95,13 +95,13 @@ Tags: 0.17.0-python2.7-jessie, 0.17-python2.7-jessie, 0-python2.7-jessie, python
 Architectures: amd64, arm32v5, arm32v7, i386
 File: Dockerfile.python2.7-jessie
 
+Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python2.7-alpine3.10
+
 Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.9
-
-Tags: 0.17.0-python2.7-alpine3.8, 0.17-python2.7-alpine3.8, 0-python2.7-alpine3.8, python2.7-alpine3.8
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python2.7-alpine3.8
 
 Tags: 0.17.0-python2.7-windowsservercore-1809, 0.17-python2.7-windowsservercore-1809, 0-python2.7-windowsservercore-1809, python2.7-windowsservercore-1809
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/110efb8: Add Alpine 3.10 and Debian Buster to possible supported base image variants