### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.3, 2.25, 2, latest
+Tags: 2.25.4, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9aef284520799c855d172d745febea6e3bd6e56d
+GitCommit: 1d4d1317bf6276b9b9f950bb0f5354504b2b9977
 Directory: 2/debian
 
-Tags: 2.25.3-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.25.4-alpine, 2.25-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9aef284520799c855d172d745febea6e3bd6e56d
+GitCommit: 1d4d1317bf6276b9b9f950bb0f5354504b2b9977
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1d4d131: Update to 2.25.4, ghost-cli 1.11.0