### PR TITLE
update oraclelinux for vim 7.4

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e97d56c375a810f027789ad4bb7d72f37379338d
+amd64-GitCommit: 5f779fc53c7d42f7870a42c9cc188514bb081fc7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d68fe9217d76729cfc29ac1341485f06cbb39a10
+arm64v8-GitCommit: 3dccca2ddb59dcb12fea65b965d702089f533f21
 Constraints: !aufs
 
 Tags: 7.6, 7, latest


### PR DESCRIPTION
	[AMD64 7.6] 2019-06-28-98
	[ARM64v8 7.6] 2019-06-28-17

Signed-off-by: Michael Calunod <michael.calunod@oracle.com>