### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -11,9 +11,9 @@ GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
-Tags: 13-ea-19-jdk-alpine3.9, 13-ea-19-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-19-jdk-alpine, 13-ea-19-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-27-jdk-alpine3.9, 13-ea-27-alpine3.9, 13-ea-jdk-alpine3.9, 13-ea-alpine3.9, 13-jdk-alpine3.9, 13-alpine3.9, 13-ea-27-jdk-alpine, 13-ea-27-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 1398299a268f339254a94b606113d1627dec342e
+GitCommit: d368a4f37bed4dc5d0b61ec889c8e7bad438eacf
 Directory: 13/jdk/alpine
 
 Tags: 13-ea-27-jdk-windowsservercore-1809, 13-ea-27-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d368a4f: Update to 13-ea+27