### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/docker-library/php/blob/27cfb7191fdb82d14f0cba3f8ba8b9415252d4c2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/afa08b1838294089a465f97f87ea7a960039fda0/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 7.4.0alpha2-cli-stretch, 7.4-rc-cli-stretch, rc-cli-stretch, 7.4.0alpha2-stretch, 7.4-rc-stretch, rc-stretch, 7.4.0alpha2-cli, 7.4-rc-cli, rc-cli, 7.4.0alpha2, 7.4-rc, rc
+Tags: 7.4.0alpha2-cli-buster, 7.4-rc-cli-buster, rc-cli-buster, 7.4.0alpha2-buster, 7.4-rc-buster, rc-buster, 7.4.0alpha2-cli, 7.4-rc-cli, rc-cli, 7.4.0alpha2, 7.4-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/stretch/cli
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
+Directory: 7.4-rc/buster/cli
 
-Tags: 7.4.0alpha2-apache-stretch, 7.4-rc-apache-stretch, rc-apache-stretch, 7.4.0alpha2-apache, 7.4-rc-apache, rc-apache
+Tags: 7.4.0alpha2-apache-buster, 7.4-rc-apache-buster, rc-apache-buster, 7.4.0alpha2-apache, 7.4-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/stretch/apache
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
+Directory: 7.4-rc/buster/apache
 
-Tags: 7.4.0alpha2-fpm-stretch, 7.4-rc-fpm-stretch, rc-fpm-stretch, 7.4.0alpha2-fpm, 7.4-rc-fpm, rc-fpm
+Tags: 7.4.0alpha2-fpm-buster, 7.4-rc-fpm-buster, rc-fpm-buster, 7.4.0alpha2-fpm, 7.4-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/stretch/fpm
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
+Directory: 7.4-rc/buster/fpm
 
-Tags: 7.4.0alpha2-zts-stretch, 7.4-rc-zts-stretch, rc-zts-stretch, 7.4.0alpha2-zts, 7.4-rc-zts, rc-zts
+Tags: 7.4.0alpha2-zts-buster, 7.4-rc-zts-buster, rc-zts-buster, 7.4.0alpha2-zts, 7.4-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/stretch/zts
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
+Directory: 7.4-rc/buster/zts
 
 Tags: 7.4.0alpha2-cli-alpine3.10, 7.4-rc-cli-alpine3.10, rc-cli-alpine3.10, 7.4.0alpha2-alpine3.10, 7.4-rc-alpine3.10, rc-alpine3.10, 7.4.0alpha2-cli-alpine, 7.4-rc-cli-alpine, rc-cli-alpine, 7.4.0alpha2-alpine, 7.4-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
@@ -39,39 +39,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
 Directory: 7.4-rc/alpine3.10/zts
 
-Tags: 7.4.0alpha2-cli-alpine3.9, 7.4-rc-cli-alpine3.9, rc-cli-alpine3.9, 7.4.0alpha2-alpine3.9, 7.4-rc-alpine3.9, rc-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/alpine3.9/cli
-
-Tags: 7.4.0alpha2-fpm-alpine3.9, 7.4-rc-fpm-alpine3.9, rc-fpm-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/alpine3.9/fpm
-
-Tags: 7.4.0alpha2-zts-alpine3.9, 7.4-rc-zts-alpine3.9, rc-zts-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: bbcc3db890d40e19480f1f7ca9615ee36e88fce4
-Directory: 7.4-rc/alpine3.9/zts
-
 Tags: 7.3.6-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.6-stretch, 7.3-stretch, 7-stretch, stretch, 7.3.6-cli, 7.3-cli, 7-cli, cli, 7.3.6, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.6-apache-stretch, 7.3-apache-stretch, 7-apache-stretch, apache-stretch, 7.3.6-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.6-fpm-stretch, 7.3-fpm-stretch, 7-fpm-stretch, fpm-stretch, 7.3.6-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.6-zts-stretch, 7.3-zts-stretch, 7-zts-stretch, zts-stretch, 7.3.6-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.3/stretch/zts
 
 Tags: 7.3.6-cli-alpine3.10, 7.3-cli-alpine3.10, 7-cli-alpine3.10, cli-alpine3.10, 7.3.6-alpine3.10, 7.3-alpine3.10, 7-alpine3.10, alpine3.10, 7.3.6-cli-alpine, 7.3-cli-alpine, 7-cli-alpine, cli-alpine, 7.3.6-alpine, 7.3-alpine, 7-alpine, alpine
@@ -106,22 +91,22 @@ Directory: 7.3/alpine3.9/zts
 
 Tags: 7.2.19-cli-stretch, 7.2-cli-stretch, 7.2.19-stretch, 7.2-stretch, 7.2.19-cli, 7.2-cli, 7.2.19, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.19-apache-stretch, 7.2-apache-stretch, 7.2.19-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.19-fpm-stretch, 7.2-fpm-stretch, 7.2.19-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.19-zts-stretch, 7.2-zts-stretch, 7.2.19-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 250c2d872d4d52770ecdcecd0ff299c360031ed8
+GitCommit: afa08b1838294089a465f97f87ea7a960039fda0
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.19-cli-alpine3.10, 7.2-cli-alpine3.10, 7.2.19-alpine3.10, 7.2-alpine3.10, 7.2.19-cli-alpine, 7.2-cli-alpine, 7.2.19-alpine, 7.2-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/e8d8d7b: Merge pull request https://github.com/docker-library/php/pull/853 from infosiftr/busted
- https://github.com/docker-library/php/commit/afa08b1: Replace "stretch" with "buster" for PHP 7.4-rc given the imminent Debian release