### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 12-beta2, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 559d29a4f8158c35d6b50870522f532abbabe3e6
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 12
 
 Tags: 12-beta2-alpine, 12-alpine
@@ -16,7 +16,7 @@ Directory: 12/alpine
 
 Tags: 11.4, 11, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 246f8d41d6de8888ba82f27579bc05d9362a8641
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 11
 
 Tags: 11.4-alpine, 11-alpine, alpine
@@ -26,7 +26,7 @@ Directory: 11/alpine
 
 Tags: 10.9, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 59fd787a41ba4fd042f4d169556e70927c323cda
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 10
 
 Tags: 10.9-alpine, 10-alpine
@@ -36,7 +36,7 @@ Directory: 10/alpine
 
 Tags: 9.6.14, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 033f4941dde868055070eff244f23fd0f7b14ae6
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 9.6
 
 Tags: 9.6.14-alpine, 9.6-alpine, 9-alpine
@@ -46,7 +46,7 @@ Directory: 9.6/alpine
 
 Tags: 9.5.18, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04626521017c8f1daa3839e3e5d36a606ec98f80
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 9.5
 
 Tags: 9.5.18-alpine, 9.5-alpine
@@ -56,7 +56,7 @@ Directory: 9.5/alpine
 
 Tags: 9.4.23, 9.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c324b9f3e030855e94b00ae72a4936f7915d1be
+GitCommit: 87b15b6c65ba985ac958e7b35ba787422113066e
 Directory: 9.4
 
 Tags: 9.4.23-alpine, 9.4-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/87b15b6: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/postgres/commit/faf08db: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key