### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.4.6-bionic, 10.4-bionic, 10-bionic, bionic, 10.4.6, 10.4, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ee9cf3e922a2e2b4218c38993aace07192402eda
+GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
 Directory: 10.4
 
 Tags: 10.3.16-bionic, 10.3-bionic, 10.3.16, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 5b833d3bb53298adea162c555f066233f74ff236
+GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
 Directory: 10.3
 
 Tags: 10.2.25-bionic, 10.2-bionic, 10.2.25, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f2ecbc37bcca1c61a2154dd8c677fb17504d443c
+GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
 Directory: 10.2
 
 Tags: 10.1.40-bionic, 10.1-bionic, 10.1.40, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c969655b3c92a1ae3f066e506ab7b32ff4ba4582
+GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
 Directory: 10.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mariadb/commit/9787916: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/mariadb/commit/ee57f77: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key