### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 5.0.5, 5.0, 5, latest, 5.0.5-stretch, 5.0-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6845f6d4940f94c50a9f1bf16e07058d0fe4bc4f
+GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
 Directory: 5.0
 
 Tags: 5.0.5-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.5-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
 Architectures: amd64
-GitCommit: 6845f6d4940f94c50a9f1bf16e07058d0fe4bc4f
+GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
 Directory: 5.0/32bit
 
 Tags: 5.0.5-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.5-alpine3.10, 5.0-alpine3.10, 5-alpine3.10, alpine3.10
@@ -21,12 +21,12 @@ Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-stretch, 4.0-stretch, 4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9519b0469cc8410808b1741c9372394a4b37b1c0
+GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
 Directory: 4.0
 
 Tags: 4.0.14-32bit, 4.0-32bit, 4-32bit, 4.0.14-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
 Architectures: amd64
-GitCommit: 9519b0469cc8410808b1741c9372394a4b37b1c0
+GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
 Directory: 4.0/32bit
 
 Tags: 4.0.14-alpine, 4.0-alpine, 4-alpine, 4.0.14-alpine3.10, 4.0-alpine3.10, 4-alpine3.10


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/916d3d2: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/redis/commit/22f0798: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key