### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -8,7 +8,7 @@ Tags: 3.4.21-xenial, 3.4-xenial
 SharedTags: 3.4.21, 3.4
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/3.4/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: 206d99a55d42d3a7d24ff3c75ace7972c57f2adb
+GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
 Directory: 3.4
 
 Tags: 3.4.21-windowsservercore-ltsc2016, 3.4-windowsservercore-ltsc2016
@@ -22,7 +22,7 @@ Tags: 3.6.13-xenial, 3.6-xenial, 3-xenial
 SharedTags: 3.6.13, 3.6, 3
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/3.6/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: c6d7e7fb21b03905c4796293f9bdbba5227acd75
+GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
 Directory: 3.6
 
 Tags: 3.6.13-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
@@ -36,7 +36,7 @@ Tags: 4.0.10-xenial, 4.0-xenial, 4-xenial, xenial
 SharedTags: 4.0.10, 4.0, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: c93d83e50413651ab3960e96cbedbb47e2397562
+GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
 Directory: 4.0
 
 Tags: 4.0.10-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -57,7 +57,7 @@ Tags: 4.1.13-bionic, 4.1-bionic, unstable-bionic
 SharedTags: 4.1.13, 4.1, unstable
 # see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.1/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: 096bf90f3f86a8dd70e56b2c39590c0ca0bb5dd6
+GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
 Directory: 4.1
 
 Tags: 4.1.13-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
@@ -78,7 +78,7 @@ Tags: 4.2.0-rc2-bionic, 4.2-rc-bionic, rc-bionic
 SharedTags: 4.2.0-rc2, 4.2-rc, rc
 # see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/testing/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: 90a7bac2177b8e7a3c996f796be98e2da6029b10
+GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
 Directory: 4.2-rc
 
 Tags: 4.2.0-rc2-windowsservercore-ltsc2016, 4.2-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/3f117ac: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/mongo/commit/30810ac: Use SKS for Xenial-based images
- https://github.com/docker-library/mongo/commit/e38e0e8: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key