### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 2.25.4, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1d4d1317bf6276b9b9f950bb0f5354504b2b9977
+GitCommit: 6d485f5797c96fae0aef795a38999453d5aa665d
 Directory: 2/debian
 
 Tags: 2.25.4-alpine, 2.25-alpine, 2-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8eba604d6b6078a318e0a83771ebc8e09f350bf0
+GitCommit: 6d485f5797c96fae0aef795a38999453d5aa665d
 Directory: 1/debian
 
 Tags: 1.26.0-alpine, 1.26-alpine, 1-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/6d485f5: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/ghost/commit/9a69ba2: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key