### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.21, 2.1
 Architectures: amd64, arm64v8, i386
-GitCommit: c71c19d1fe8796c15217fd1b8024bb44aa011593
+GitCommit: 5b7eebbf4412cf8b1434cfe6430648c606cdd6de
 Directory: 2.1
 
 Tags: 2.2.14, 2.2, 2
 Architectures: amd64, i386
-GitCommit: 386357f2c90e5a53ad26f610cdc0eb001a67e9f0
+GitCommit: 5b7eebbf4412cf8b1434cfe6430648c606cdd6de
 Directory: 2.2
 
 Tags: 3.0.18, 3.0
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 7d1d7789603d94ec1c8e71d15ef57dacd5cb4dd0
+GitCommit: 5b7eebbf4412cf8b1434cfe6430648c606cdd6de
 Directory: 3.0
 
 Tags: 3.11.4, 3.11, 3, latest
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 064fb4e2682bf9c1909e4cb27225fa74862c9086
+GitCommit: 5b7eebbf4412cf8b1434cfe6430648c606cdd6de
 Directory: 3.11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/5b7eebb: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/cassandra/commit/7b1c4d9: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key
- https://github.com/docker-library/cassandra/commit/d8f3c2a: Update generated README