### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 4.0.4, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 309ddd33d670d798b0862238a7d70b780f93aa32
+GitCommit: 65a4c6007234119dad956fefc97c726319ee76c8
 Directory: 4.0
 
 Tags: 4.0.4-passenger, 4.0-passenger, 4-passenger, passenger
@@ -15,7 +15,7 @@ Directory: 4.0/passenger
 
 Tags: 3.4.11, 3.4, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c27d3309aea2171325b83442283090dcc6cebddd
+GitCommit: 65a4c6007234119dad956fefc97c726319ee76c8
 Directory: 3.4
 
 Tags: 3.4.11-passenger, 3.4-passenger, 3-passenger


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/65a4c60: Use explicit "hkps" for keys.openpgp.org
- https://github.com/docker-library/redmine/commit/19c07b2: Switch from ha.pool.sks-keyservers.net to keys.openpgp.org for fetching Tianon's PGP key
- https://github.com/docker-library/redmine/commit/5b3b2c1: Update generated README