### PR TITLE
upgrade r-base to R 3.6.1 released two days ago

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 3.6.0, latest
+Tags: 3.6.1, latest
 Architectures: amd64, arm64v8
-GitCommit: 81766dfd355860d733d1cac98f583c2f3aa430ac
+GitCommit: 919df9809c677916100cf837be687f6704d6b1b1
 Directory: r-base


### PR DESCRIPTION
Standard upgrade to new upstream for R from two days ago, our container built ~ 12 hours ago