### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,42 +24,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.16-rc.3, 3.7-rc
+Tags: 3.7.16, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 417a82a983d575a4dad9df75aaad3e963c0e9c2f
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.16-rc.3-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.16-rc.3-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 417a82a983d575a4dad9df75aaad3e963c0e9c2f
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.16-rc.3-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.15, 3.7, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7fa749a7be00243709c5a8acc2e9c33d9cd82093
+GitCommit: a6c719b456a2745508511d0d3dc1db667cbdc7e7
 Directory: 3.7/ubuntu
 
-Tags: 3.7.15-management, 3.7-management, 3-management, management
+Tags: 3.7.16-management, 3.7-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.15-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.7.16-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7fa749a7be00243709c5a8acc2e9c33d9cd82093
+GitCommit: a6c719b456a2745508511d0d3dc1db667cbdc7e7
 Directory: 3.7/alpine
 
-Tags: 3.7.15-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.7.16-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/a6c719b: Update to 3.7.16, Erlang/OTP 22.0.5, OpenSSL 1.1.1c