### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 13-ea-27-jdk-oraclelinux7, 13-ea-27-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-27-jdk-oracle, 13-ea-27-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-28-jdk-oraclelinux7, 13-ea-28-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-28-jdk-oracle, 13-ea-28-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-28-jdk, 13-ea-28, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
+GitCommit: 3282f541a228c69304b807b0d832914c51fe3d9e
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
@@ -16,24 +16,24 @@ Architectures: amd64
 GitCommit: d368a4f37bed4dc5d0b61ec889c8e7bad438eacf
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-27-jdk-windowsservercore-1809, 13-ea-27-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-28-jdk-windowsservercore-1809, 13-ea-28-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-28-jdk-windowsservercore, 13-ea-28-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-28-jdk, 13-ea-28, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
+GitCommit: 3282f541a228c69304b807b0d832914c51fe3d9e
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-27-jdk-windowsservercore-1803, 13-ea-27-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-28-jdk-windowsservercore-1803, 13-ea-28-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-28-jdk-windowsservercore, 13-ea-28-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-28-jdk, 13-ea-28, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
+GitCommit: 3282f541a228c69304b807b0d832914c51fe3d9e
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-27-jdk-windowsservercore-ltsc2016, 13-ea-27-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-27-jdk-windowsservercore, 13-ea-27-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-27-jdk, 13-ea-27, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-28-jdk-windowsservercore-ltsc2016, 13-ea-28-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-28-jdk-windowsservercore, 13-ea-28-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-28-jdk, 13-ea-28, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 92869730148f4b7dafbc2f3dc37647242ee7d792
+GitCommit: 3282f541a228c69304b807b0d832914c51fe3d9e
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/3282f54: Update to 13-ea+28