### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.39, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 476e8005868e3f72730d34334fd8cc2262819220
+GitCommit: be1405819a93f642d218499ee9e7aa8dec4245f9
 Directory: 2.4
 
 Tags: 2.4.39-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94cb289a851a111ce91ded7ad1612733cc7d2a84
+GitCommit: be1405819a93f642d218499ee9e7aa8dec4245f9
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/be14058: Move APACHE_DIST_URLS directly into ddist function