### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -26,10 +26,10 @@ Directory: 3.5/slim
 
 Tags: 3.6-7.1.1, 3.6-7.1, 3.6-7, 3.6, 3.6-7.1.1-stretch, 3.6-7.1-stretch, 3.6-7-stretch, 3.6-stretch
 Architectures: amd64, i386, s390x
-GitCommit: 669ca6492e33303a5f4770fd2ffa009b8b47ced9
+GitCommit: 53d39eb9613ef3699a8f75a1ba201669b6ce49a1
 Directory: 3.6
 
 Tags: 3.6-7.1.1-slim, 3.6-7.1-slim, 3.6-7-slim, 3.6-slim, 3.6-7.1.1-slim-stretch, 3.6-7.1-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, i386, s390x
-GitCommit: 669ca6492e33303a5f4770fd2ffa009b8b47ced9
+GitCommit: 53d39eb9613ef3699a8f75a1ba201669b6ce49a1
 Directory: 3.6/slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/d3f932e: Refuse to "update" if the version we scrape is older than the version we already have
- https://github.com/docker-library/pypy/commit/53d39eb: Update to 7.1.1, pip 19.1.1
- https://github.com/docker-library/pypy/commit/024cec3: Update to 7.1.0, pip 19.1.1

I'm opening this to zero us out again -- this includes https://github.com/docker-library/pypy/commit/d3f932e which I mentioned in https://github.com/docker-library/official-images/pull/6163 which should hopefully prevent this in the future.