### PR TITLE
Update httpd debian base image to buster

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.39, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: be1405819a93f642d218499ee9e7aa8dec4245f9
+GitCommit: 35430c6d91ee2e4457028bb23b5b9c6151b59d89
 Directory: 2.4
 
 Tags: 2.4.39-alpine, 2.4-alpine, 2-alpine, alpine


### PR DESCRIPTION
Update httpd debian base image to buster to get TLS1.3 support