### PR TITLE
WIP: Add OpenWrt base image

### DIFF
--- a/library/openwrt
+++ b/library/openwrt
@@ -1,0 +1,7 @@
+Maintainers: Paul Spooren <mail@aparcar.org> (@aparcar)
+GitRepo: https://github.com/openwrt/docker.git
+
+Tags: latest
+Architectures: amd64
+GitFetch: refs/heads/master
+GitCommit: 29e08aee3d96e860f292a83ed42f6d144762bae2


### PR DESCRIPTION
- [ ] Associated with or contacted upstream? Yes, (See: https://github.com/openwrt/docker/issues/6).
- [ ] Does it fit into one of the common categories? base distribution
- [ ] Is it reasonably popular, or does it solve a particular use case well? Yes.
- [ ] Does a documentation PR exist? TODO
- [ ] Dockerization review for best practices and cache gotchas/improvements (ala the official review guidelines)? WIP
- [ ] 2+ dockerization review?
- [ ] Existing official images have been considered as a base? N/A
- [ ] If FROM scratch, tarballs only exist in a single commit within the associated history? TODO
- [ ] Passes current tests? Any simple new tests that might be appropriate to add?