### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.4, 2.25, 2, latest
+Tags: 2.25.6, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6d485f5797c96fae0aef795a38999453d5aa665d
+GitCommit: 3b89e5e644b42abe5387b1feb6300e2e40c8c378
 Directory: 2/debian
 
-Tags: 2.25.4-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.25.6-alpine, 2.25-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d4d1317bf6276b9b9f950bb0f5354504b2b9977
+GitCommit: 3b89e5e644b42abe5387b1feb6300e2e40c8c378
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3b89e5e: Update to 2.25.6, ghost-cli 1.11.0
- https://github.com/docker-library/ghost/commit/c404d2c: Update to 2.25.5, ghost-cli 1.11.0