### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0.5, 5.0, 5, latest, 5.0.5-stretch, 5.0-stretch, 5-stretch, stretch
+Tags: 5.0.5, 5.0, 5, latest, 5.0.5-buster, 5.0-buster, 5-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
+GitCommit: ede954da6de61f1d6a8572db4cd7bdf1278a2815
 Directory: 5.0
 
-Tags: 5.0.5-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.5-32bit-stretch, 5.0-32bit-stretch, 5-32bit-stretch, 32bit-stretch
+Tags: 5.0.5-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.5-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
 Architectures: amd64
-GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
+GitCommit: ede954da6de61f1d6a8572db4cd7bdf1278a2815
 Directory: 5.0/32bit
 
 Tags: 5.0.5-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.5-alpine3.10, 5.0-alpine3.10, 5-alpine3.10, alpine3.10
@@ -19,14 +19,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a767b4701be8de74f252e204e3eadb39c8e38583
 Directory: 5.0/alpine
 
-Tags: 4.0.14, 4.0, 4, 4.0.14-stretch, 4.0-stretch, 4-stretch
+Tags: 4.0.14, 4.0, 4, 4.0.14-buster, 4.0-buster, 4-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
+GitCommit: ede954da6de61f1d6a8572db4cd7bdf1278a2815
 Directory: 4.0
 
-Tags: 4.0.14-32bit, 4.0-32bit, 4-32bit, 4.0.14-32bit-stretch, 4.0-32bit-stretch, 4-32bit-stretch
+Tags: 4.0.14-32bit, 4.0-32bit, 4-32bit, 4.0.14-32bit-buster, 4.0-32bit-buster, 4-32bit-buster
 Architectures: amd64
-GitCommit: 916d3d22527edd7461738396431fb237d39d0b3a
+GitCommit: ede954da6de61f1d6a8572db4cd7bdf1278a2815
 Directory: 4.0/32bit
 
 Tags: 4.0.14-alpine, 4.0-alpine, 4-alpine, 4.0.14-alpine3.10, 4.0-alpine3.10, 4-alpine3.10


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/0d42220: Merge pull request https://github.com/docker-library/redis/pull/197 from J0WI/buster
- https://github.com/docker-library/redis/commit/ede954d: Upgrade to Debian Buster