### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.5.16, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d7ef16344d5c0199a41dba750b2da7f733360cb7
+GitCommit: 015922a5c2c4d74a85e5a23d89bfc150be3b258f
 Directory: debian
 
 Tags: 1.5.16-alpine, 1.5-alpine, 1-alpine, alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/e179579: Merge pull request https://github.com/docker-library/memcached/pull/51 from J0WI/buster
- https://github.com/docker-library/memcached/commit/015922a: Upgrade to Debian Buster