### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 2.0.1, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e656d4403154a7086fb63bd92382c9f8d32af9b
+GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
 Directory: 2.0
 
 Tags: 2.0.1-alpine, 2.0-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 2.0/alpine
 
 Tags: 1.9.8, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
+GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
 Directory: 1.9
 
 Tags: 1.9.8-alpine, 1.9-alpine, 1-alpine
@@ -26,7 +26,7 @@ Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
+GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
 Directory: 1.8
 
 Tags: 1.8.20-alpine, 1.8-alpine
@@ -36,7 +36,7 @@ Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
+GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
 Directory: 1.7
 
 Tags: 1.7.11-alpine, 1.7-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/517adab: Merge pull request https://github.com/docker-library/haproxy/pull/97 from TimWolla/buster
- https://github.com/docker-library/haproxy/commit/11bcb18: Stay on stretch for 1.5 and 1.6
- https://github.com/docker-library/haproxy/commit/f3ff4cd: Upgrade to debian:buster