### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/c718c72e1c122feefa8ff8f1a7c84c9c08495bdd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/3b767347867328b98aefa48e60de95b2190f631e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,85 +6,105 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.7.0-preview1-buster, 2.7-rc-buster, rc-buster, 2.7.0-preview1, 2.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.7-rc/buster
 
 Tags: 2.7.0-preview1-slim-buster, 2.7-rc-slim-buster, rc-slim-buster, 2.7.0-preview1-slim, 2.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.7-rc/buster/slim
 
 Tags: 2.7.0-preview1-alpine3.10, 2.7-rc-alpine3.10, rc-alpine3.10, 2.7.0-preview1-alpine, 2.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.7-rc/alpine3.10
 
-Tags: 2.6.3-stretch, 2.6-stretch, 2-stretch, stretch, 2.6.3, 2.6, 2, latest
+Tags: 2.6.3-buster, 2.6-buster, 2-buster, buster, 2.6.3, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.6/buster
+
+Tags: 2.6.3-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.3-slim, 2.6-slim, 2-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.6/buster/slim
+
+Tags: 2.6.3-stretch, 2.6-stretch, 2-stretch, stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.6/stretch
 
-Tags: 2.6.3-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch, 2.6.3-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.3-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.3-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.3-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.6/alpine3.10
 
 Tags: 2.6.3-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.6/alpine3.9
 
-Tags: 2.5.5-stretch, 2.5-stretch, 2.5.5, 2.5
+Tags: 2.5.5-buster, 2.5-buster, 2.5.5, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.5/buster
+
+Tags: 2.5.5-slim-buster, 2.5-slim-buster, 2.5.5-slim, 2.5-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.5/buster/slim
+
+Tags: 2.5.5-stretch, 2.5-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.5/stretch
 
-Tags: 2.5.5-slim-stretch, 2.5-slim-stretch, 2.5.5-slim, 2.5-slim
+Tags: 2.5.5-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.5-alpine3.10, 2.5-alpine3.10, 2.5.5-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.5/alpine3.10
 
 Tags: 2.5.5-alpine3.9, 2.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.5/alpine3.9
 
-Tags: 2.4.6-stretch, 2.4-stretch, 2.4.6, 2.4
+Tags: 2.4.6-buster, 2.4-buster, 2.4.6, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.4/buster
+
+Tags: 2.4.6-slim-buster, 2.4-slim-buster, 2.4.6-slim, 2.4-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+Directory: 2.4/buster/slim
+
+Tags: 2.4.6-stretch, 2.4-stretch
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.4/stretch
 
-Tags: 2.4.6-slim-stretch, 2.4-slim-stretch, 2.4.6-slim, 2.4-slim
+Tags: 2.4.6-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
 Directory: 2.4/stretch/slim
-
-Tags: 2.4.6-jessie, 2.4-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: aacff4398185738d84232f1685df12306be13114
-Directory: 2.4/jessie
-
-Tags: 2.4.6-slim-jessie, 2.4-slim-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: aacff4398185738d84232f1685df12306be13114
-Directory: 2.4/jessie/slim
 
 Tags: 2.4.6-alpine3.10, 2.4-alpine3.10, 2.4.6-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.4/alpine3.10
 
 Tags: 2.4.6-alpine3.9, 2.4-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aacff4398185738d84232f1685df12306be13114
+GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
 Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/b7e190b: Whitespace fix in alpine images
- https://github.com/docker-library/ruby/commit/ca09048: Merge pull request https://github.com/docker-library/ruby/pull/287 from J0WI/buster
- https://github.com/docker-library/ruby/commit/3b76734: Add Debian Buster and remove Jessie
- https://github.com/docker-library/ruby/commit/04002dd: Update to 2.4.6, rubygems 3.0.3
- https://github.com/docker-library/ruby/commit/a37d0c0: Update to 2.7.0-preview1
- https://github.com/docker-library/ruby/commit/89bfa0e: Update to 2.6.3
- https://github.com/docker-library/ruby/commit/b08d6b8: Update to 2.5.5, rubygems 3.0.3
- https://github.com/docker-library/ruby/commit/be75db3: Merge pull request https://github.com/docker-library/ruby/pull/285 from deivid-rodriguez/prefer_bundle_path__system
- https://github.com/docker-library/ruby/commit/e040029: Prefer `BUNDLE_PATH__SYSTEM=true`