### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,105 +6,105 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.7.0-preview1-buster, 2.7-rc-buster, rc-buster, 2.7.0-preview1, 2.7-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.7-rc/buster
 
 Tags: 2.7.0-preview1-slim-buster, 2.7-rc-slim-buster, rc-slim-buster, 2.7.0-preview1-slim, 2.7-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.7-rc/buster/slim
 
 Tags: 2.7.0-preview1-alpine3.10, 2.7-rc-alpine3.10, rc-alpine3.10, 2.7.0-preview1-alpine, 2.7-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.7-rc/alpine3.10
 
 Tags: 2.6.3-buster, 2.6-buster, 2-buster, buster, 2.6.3, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
 Directory: 2.6/buster
 
 Tags: 2.6.3-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.3-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
 Directory: 2.6/buster/slim
 
 Tags: 2.6.3-stretch, 2.6-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.6/stretch
 
 Tags: 2.6.3-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.3-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.3-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.6/alpine3.10
 
 Tags: 2.6.3-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.6/alpine3.9
 
 Tags: 2.5.5-buster, 2.5-buster, 2.5.5, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
 Directory: 2.5/buster
 
 Tags: 2.5.5-slim-buster, 2.5-slim-buster, 2.5.5-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
 Directory: 2.5/buster/slim
 
 Tags: 2.5.5-stretch, 2.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.5/stretch
 
 Tags: 2.5.5-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.5-alpine3.10, 2.5-alpine3.10, 2.5.5-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.5/alpine3.10
 
 Tags: 2.5.5-alpine3.9, 2.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.5/alpine3.9
 
 Tags: 2.4.6-buster, 2.4-buster, 2.4.6, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/buster
 
 Tags: 2.4.6-slim-buster, 2.4-slim-buster, 2.4.6-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b767347867328b98aefa48e60de95b2190f631e
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/buster/slim
 
 Tags: 2.4.6-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/stretch
 
 Tags: 2.4.6-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e040029c82501556371e9d84a9db607dfb1bba51
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.6-alpine3.10, 2.4-alpine3.10, 2.4.6-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/alpine3.10
 
 Tags: 2.4.6-alpine3.9, 2.4-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7e190bed1efc2521fc51e6dee7243c6aaa974e6
+GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/bffb6ff: Apply https://github.com/docker-library/ruby/pull/289 revert to new Buster variants too
- https://github.com/docker-library/ruby/commit/cc90ea7: Merge pull request https://github.com/docker-library/ruby/pull/289 from deivid-rodriguez/revert_bundle_path_system
- https://github.com/docker-library/ruby/commit/4e90a92: Revert "Prefer `BUNDLE_PATH__SYSTEM=true`"