### PR TITLE
Update matomo

### DIFF
--- a/library/matomo
+++ b/library/matomo
@@ -4,12 +4,12 @@ GitRepo: https://github.com/matomo-org/docker.git
 
 Tags: 3.10.0-apache, 3.10-apache, 3-apache, apache, 3.10.0, 3.10, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3bc18c223ee4327acf5506eed3f2ffe517a027a
+GitCommit: 689757368fff698888c004265e4de99d2bb70265
 Directory: apache
 
 Tags: 3.10.0-fpm, 3.10-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3bc18c223ee4327acf5506eed3f2ffe517a027a
+GitCommit: 689757368fff698888c004265e4de99d2bb70265
 Directory: fpm
 
 Tags: 3.10.0-fpm-alpine, 3.10-fpm-alpine, 3-fpm-alpine, fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/matomo-org/docker/commit/487bc8f: Merge pull request https://github.com/matomo-org/docker/pull/162 from J0WI/stretch
- https://github.com/matomo-org/docker/commit/6897573: Stick on stretch for now due deprecated freetype-config