### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.4.6-bionic, 10.4-bionic, 10-bionic, bionic, 10.4.6, 10.4, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
+GitCommit: 52ea3012bb04d8b62f4a6f7792baa07815467173
 Directory: 10.4
 
 Tags: 10.3.16-bionic, 10.3-bionic, 10.3.16, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
+GitCommit: 52ea3012bb04d8b62f4a6f7792baa07815467173
 Directory: 10.3
 
 Tags: 10.2.25-bionic, 10.2-bionic, 10.2.25, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
+GitCommit: 52ea3012bb04d8b62f4a6f7792baa07815467173
 Directory: 10.2
 
 Tags: 10.1.40-bionic, 10.1-bionic, 10.1.40, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9787916251cc63546d638ea0ef28e55fd2e44868
+GitCommit: 52ea3012bb04d8b62f4a6f7792baa07815467173
 Directory: 10.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mariadb/commit/ef12d14: Merge pull request https://github.com/docker-library/mariadb/pull/255 from J0WI/apt-https
- https://github.com/docker-library/mariadb/commit/59d16d7: Use https to check for updates
- https://github.com/docker-library/mariadb/commit/52ea301: Remove obsolete ca-certificates