### PR TITLE
[nats] Release 2.0.2

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,35 +2,35 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 
-Tags: 2.0.0-linux, linux
-SharedTags: 2.0.0, latest
+Tags: 2.0.2-linux, linux
+SharedTags: 2.0.2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 amd64-Directory: amd64
-arm32v6-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+arm32v6-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+arm32v7-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+arm64v8-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 arm64v8-Directory: arm64v8
 
-Tags: 2.0.0-nanoserver, nanoserver
-SharedTags: 2.0.0, latest
+Tags: 2.0.2-nanoserver, nanoserver, nanoserver-1803
+SharedTags: 2.0.2, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
-windows-amd64-Directory: windows/nanoserver
+windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+windows-amd64-Directory: windows/nanoserver-1803
 Constraints: nanoserver-1803
 
-Tags: 2.0.0-nanoserver-1809, nanoserver-1809
+Tags: 2.0.2-nanoserver-1809, nanoserver-1809
 Architectures: windows-amd64
-windows-amd64-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
-windows-amd64-Directory: windows/nanoserver2019
+windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+windows-amd64-Directory: windows/nanoserver-1809
 Constraints: nanoserver-1809
 
-Tags: 2.0.0-windowsservercore, windowsservercore
+Tags: 2.0.2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: f94c8e5fe7242e29752374eb464ef99954ae53f9
+windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.0.2)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>