### PR TITLE
update oraclelinux for dbus 1.2.24

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5f779fc53c7d42f7870a42c9cc188514bb081fc7
+amd64-GitCommit: 0af911c3d100d33b6329edbbab75561f21084478
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 3dccca2ddb59dcb12fea65b965d702089f533f21


### PR DESCRIPTION
	[AMD64 6.10] 2019-07-10-63

Signed-off-by: Michael Calunod <michael.calunod@oracle.com>