### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.6, 2.25, 2, latest
+Tags: 2.25.8, 2.25, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3b89e5e644b42abe5387b1feb6300e2e40c8c378
+GitCommit: a172abb4e7e3d1811e6d2b3bde81bbcb2192f647
 Directory: 2/debian
 
-Tags: 2.25.6-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.25.8-alpine, 2.25-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b89e5e644b42abe5387b1feb6300e2e40c8c378
+GitCommit: a172abb4e7e3d1811e6d2b3bde81bbcb2192f647
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d13939d: Update to 2.25.7, ghost-cli 1.11.0