### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.1, 2.0, latest
+Tags: 2.0.2, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
+GitCommit: 62909b5215982fca33f05d86a3b4d93691520516
 Directory: 2.0
 
-Tags: 2.0.1-alpine, 2.0-alpine, alpine
+Tags: 2.0.2-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e656d4403154a7086fb63bd92382c9f8d32af9b
+GitCommit: 62909b5215982fca33f05d86a3b4d93691520516
 Directory: 2.0/alpine
 
 Tags: 1.9.8, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/62909b5: Update to 2.0.2