### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -70,126 +70,158 @@ GitCommit: 041df9cd062fe5e8080c46eea4def0b4e08d10e0
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 12.0.1-jdk-oraclelinux7, 12.0.1-oraclelinux7, 12.0-jdk-oraclelinux7, 12.0-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12.0.1-jdk-oracle, 12.0.1-oracle, 12.0-jdk-oracle, 12.0-oracle, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
-SharedTags: 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
+Tags: 12.0.2-jdk-oraclelinux7, 12.0.2-oraclelinux7, 12.0-jdk-oraclelinux7, 12.0-oraclelinux7, 12-jdk-oraclelinux7, 12-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 12.0.2-jdk-oracle, 12.0.2-oracle, 12.0-jdk-oracle, 12.0-oracle, 12-jdk-oracle, 12-oracle, jdk-oracle, oracle
+SharedTags: 12.0.2-jdk, 12.0.2, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: amd64
-GitCommit: 554ff38a160f896ddd7f0fdca1cd34817e253a56
+GitCommit: ab157251df23dd65820061df29cf063449a77fbb
 Directory: 12/jdk/oracle
 Constraints: !aufs
 
-Tags: 12.0.1-jdk-windowsservercore-1809, 12.0.1-windowsservercore-1809, 12.0-jdk-windowsservercore-1809, 12.0-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
+Tags: 12.0.2-jdk-windowsservercore-1809, 12.0.2-windowsservercore-1809, 12.0-jdk-windowsservercore-1809, 12.0-windowsservercore-1809, 12-jdk-windowsservercore-1809, 12-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 12.0.2-jdk-windowsservercore, 12.0.2-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.2-jdk, 12.0.2, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
+GitCommit: ab157251df23dd65820061df29cf063449a77fbb
 Directory: 12/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 12.0.1-jdk-windowsservercore-1803, 12.0.1-windowsservercore-1803, 12.0-jdk-windowsservercore-1803, 12.0-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
+Tags: 12.0.2-jdk-windowsservercore-1803, 12.0.2-windowsservercore-1803, 12.0-jdk-windowsservercore-1803, 12.0-windowsservercore-1803, 12-jdk-windowsservercore-1803, 12-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 12.0.2-jdk-windowsservercore, 12.0.2-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.2-jdk, 12.0.2, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
+GitCommit: ab157251df23dd65820061df29cf063449a77fbb
 Directory: 12/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 12.0.1-jdk-windowsservercore-ltsc2016, 12.0.1-windowsservercore-ltsc2016, 12.0-jdk-windowsservercore-ltsc2016, 12.0-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 12.0.1-jdk-windowsservercore, 12.0.1-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.1-jdk, 12.0.1, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
+Tags: 12.0.2-jdk-windowsservercore-ltsc2016, 12.0.2-windowsservercore-ltsc2016, 12.0-jdk-windowsservercore-ltsc2016, 12.0-windowsservercore-ltsc2016, 12-jdk-windowsservercore-ltsc2016, 12-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 12.0.2-jdk-windowsservercore, 12.0.2-windowsservercore, 12.0-jdk-windowsservercore, 12.0-windowsservercore, 12-jdk-windowsservercore, 12-windowsservercore, jdk-windowsservercore, windowsservercore, 12.0.2-jdk, 12.0.2, 12.0-jdk, 12.0, 12-jdk, 12, jdk, latest
 Architectures: windows-amd64
-GitCommit: 07af3ffded3216b44d69b4f14309fc5a2967e623
+GitCommit: ab157251df23dd65820061df29cf063449a77fbb
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.3-jdk-stretch, 11.0.3-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
-SharedTags: 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.4-jdk-stretch, 11.0.4-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
+SharedTags: 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
+GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
 Directory: 11/jdk
 
-Tags: 11.0.3-jdk-slim-buster, 11.0.3-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.3-jdk-slim, 11.0.3-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.4-jdk-slim-buster, 11.0.4-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.4-jdk-slim, 11.0.4-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 43078a246d7620f518412f458cc689ac869389ac
+GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
 Directory: 11/jdk/slim
 
-Tags: 11.0.3-jdk-windowsservercore-1809, 11.0.3-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.4-jdk-windowsservercore-1809, 11.0.4-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.3-jdk-windowsservercore-1803, 11.0.3-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.4-jdk-windowsservercore-1803, 11.0.4-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.3-jdk-windowsservercore-ltsc2016, 11.0.3-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.3-jdk-windowsservercore, 11.0.3-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.3-jdk, 11.0.3, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.4-jdk-windowsservercore-ltsc2016, 11.0.4-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u212-b04-jdk-stretch, 8u212-b04-stretch, 8u212-jdk-stretch, 8u212-stretch, 8-jdk-stretch, 8-stretch
-SharedTags: 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
+Tags: 11.0.4-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
+SharedTags: 11.0.4-jre, 11.0-jre, 11-jre
+Architectures: amd64, arm64v8
+GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+Directory: 11/jre
+
+Tags: 11.0.4-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.4-jre-slim, 11.0-jre-slim, 11-jre-slim
+Architectures: amd64, arm64v8
+GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+Directory: 11/jre/slim
+
+Tags: 11.0.4-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Architectures: windows-amd64
+GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+Directory: 11/jre/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 11.0.4-jre-windowsservercore-1803, 11.0-jre-windowsservercore-1803, 11-jre-windowsservercore-1803
+SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Architectures: windows-amd64
+GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+Directory: 11/jre/windows/windowsservercore-1803
+Constraints: windowsservercore-1803
+
+Tags: 11.0.4-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Architectures: windows-amd64
+GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+Directory: 11/jre/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 8u222-jdk-stretch, 8u222-stretch, 8-jdk-stretch, 8-stretch
+SharedTags: 8u222-jdk, 8u222, 8-jdk, 8
 Architectures: amd64
-GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jdk
 
-Tags: 8u212-b04-jdk-slim-buster, 8u212-b04-slim-buster, 8u212-jdk-slim-buster, 8u212-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u212-b04-jdk-slim, 8u212-b04-slim, 8u212-jdk-slim, 8u212-slim, 8-jdk-slim, 8-slim
+Tags: 8u222-jdk-slim-buster, 8u222-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u222-jdk-slim, 8u222-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: 43078a246d7620f518412f458cc689ac869389ac
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jdk/slim
 
-Tags: 8u212-b04-jdk-windowsservercore-1809, 8u212-b04-windowsservercore-1809, 8u212-jdk-windowsservercore-1809, 8u212-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
+Tags: 8u222-jdk-windowsservercore-1809, 8u222-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u212-b04-jdk-windowsservercore-1803, 8u212-b04-windowsservercore-1803, 8u212-jdk-windowsservercore-1803, 8u212-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
+Tags: 8u222-jdk-windowsservercore-1803, 8u222-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u212-b04-jdk-windowsservercore-ltsc2016, 8u212-b04-windowsservercore-ltsc2016, 8u212-jdk-windowsservercore-ltsc2016, 8u212-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u212-b04-jdk-windowsservercore, 8u212-b04-windowsservercore, 8u212-jdk-windowsservercore, 8u212-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u212-b04-jdk, 8u212-b04, 8u212-jdk, 8u212, 8-jdk, 8
+Tags: 8u222-jdk-windowsservercore-ltsc2016, 8u222-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u212-b04-jre-stretch, 8u212-jre-stretch, 8-jre-stretch
-SharedTags: 8u212-b04-jre, 8u212-jre, 8-jre
+Tags: 8u222-jre-stretch, 8-jre-stretch
+SharedTags: 8u222-jre, 8-jre
 Architectures: amd64
-GitCommit: da44a9234d75e3d89ea00d679cb6a326cbbbbead
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jre
 
-Tags: 8u212-b04-jre-slim-buster, 8u212-jre-slim-buster, 8-jre-slim-buster, 8u212-b04-jre-slim, 8u212-jre-slim, 8-jre-slim
+Tags: 8u222-jre-slim-buster, 8-jre-slim-buster, 8u222-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: 43078a246d7620f518412f458cc689ac869389ac
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jre/slim
 
-Tags: 8u212-b04-jre-windowsservercore-1809, 8u212-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
+Tags: 8u222-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u212-b04-jre-windowsservercore-1803, 8u212-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
+Tags: 8u222-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
+SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u212-b04-jre-windowsservercore-ltsc2016, 8u212-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u212-b04-jre-windowsservercore, 8u212-jre-windowsservercore, 8-jre-windowsservercore, 8u212-b04-jre, 8u212-jre, 8-jre
+Tags: 8u222-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
+SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 6c8415585bb0a0d4afb4ede869f21d645b310d2e
+GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/572682e: Add 11-jre variants
- https://github.com/docker-library/openjdk/commit/d938a10: Update to 8u222
- https://github.com/docker-library/openjdk/commit/e7c6ade: Update to 11.0.4
- https://github.com/docker-library/openjdk/commit/ab15725: Update to 12.0.2
- https://github.com/docker-library/openjdk/commit/60f179a: Account for https://github.com/AdoptOpenJDK/openjdk-website/commit/3544a19aad2bfd4b19efb165bfbee6bc9a2512d9