### PR TITLE
Update Amazon Corretto 8 and 11 for July 2019 security releases.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -3,12 +3,12 @@ Maintainers: Amazon Corretto Team (@corretto),
              Ziyi Luo (@ziyiluo),
              David Alvarez (@alvdavi)
 
-Tags: 8, 8u212, 8-al2-full, latest
+Tags: 8, 8u222, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: 055b9f36817325fbf5d2469150684ad8a4f4f1e4
+GitCommit: aa6b1dc18c638d9711bb6f130a4219ba402c462f
 
-Tags: 11, 11.0.3, 11-al2-full
+Tags: 11, 11.0.4, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: 0b311f7144b833e789165173a83a2022987dfb7b
+GitCommit: ff33946d1003fdfbec6d5bd0074ed82affc6c76c


### PR DESCRIPTION
Updates Corretto 8 to the 8.222.10.1 security baseline and the Corretto 11 to 11.0.4.11.1 security baseline.

8: [corretto/corretto-8-docker@`aa6b1dc`](https://github.com/corretto/corretto-8-docker/commit/aa6b1dc18c638d9711bb6f130a4219ba402c462f)
11: [corretto/corretto-11-docker@`ff33946`](https://github.com/corretto/corretto-11-docker/commit/ff33946d1003fdfbec6d5bd0074ed82affc6c76c)

Corretto 8:
```
# docker run -t amazon-corretto-8 java -version
openjdk version "1.8.0_222"
OpenJDK Runtime Environment Corretto-8.222.10.1 (build 1.8.0_222-b10)
OpenJDK 64-Bit Server VM Corretto-8.222.10.1 (build 25.222-b10, mixed mode)
```

Corretto 11:
```
# docker run -t amazon-corretto-11 java -version
openjdk version "11.0.4" 2019-07-16 LTS
OpenJDK Runtime Environment Corretto-11.0.4.11.1 (build 11.0.4+11-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.4.11.1 (build 11.0.4+11-LTS, mixed mode)
```