### PR TITLE
Update SapMachine 11 for July 2019 security release 11.0.4.

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,9 +1,9 @@
 Maintainers: Rene Schuenemann <sapmachine@sap.com> (@reshnm)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: 11, 11.0.3, lts
+Tags: 11, 11.0.4, lts
 Architectures: amd64
-GitCommit: 89924265b4359478b58a29207f0dfe7323b18784
+GitCommit: 7346e49a86c5d8a44f6bf71f43b17e832b2d14e6
 Directory: dockerfiles/official/lts
 
 Tags: 12, 12.0.1, latest


### PR DESCRIPTION
Updated SapMachine 11 from 11.0.3 to 11.0.4.