### PR TITLE
[security] Update docker (CVE-2019-13509)

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/docker/blob/6001c15038b05149a83dcc17e1bbeedc92979f6d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/479e4779eec0a17037a5723be5ddd98cdda965f2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -19,17 +19,17 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 98ffef81ebfa7601a9ed2f0bf56d78f426bf253c
 Directory: 19.03-rc/git
 
-Tags: 18.09.7, 18.09, 18, stable, latest
+Tags: 18.09.8, 18.09, 18, stable, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: cbb0ee05d8be7b73d6b482c4a602be137e108f77
+GitCommit: 463595652d2367887b1ffe95ec30caa00179be72
 Directory: 18.09
 
-Tags: 18.09.7-dind, 18.09-dind, 18-dind, stable-dind, dind
+Tags: 18.09.8-dind, 18.09-dind, 18-dind, stable-dind, dind
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 27471a8b93e980bd4c51464ee933ed90fd36bf97
 Directory: 18.09/dind
 
-Tags: 18.09.7-git, 18.09-git, 18-git, stable-git, git
+Tags: 18.09.8-git, 18.09-git, 18-git, stable-git, git
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 91bbc4f7b06c06020d811dafb2266bcd7cf6c06d
 Directory: 18.09/git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/479e477: Fix RC-skipping code for releases without RCs (like 18.09.8)
- https://github.com/docker-library/docker/commit/4635956: Update to 18.09.8