### PR TITLE
Update SapMachine 12 for July 2019 security release 12.0.2.

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -6,7 +6,7 @@ Architectures: amd64
 GitCommit: 7346e49a86c5d8a44f6bf71f43b17e832b2d14e6
 Directory: dockerfiles/official/lts
 
-Tags: 12, 12.0.1, latest
+Tags: 12, 12.0.2, latest
 Architectures: amd64
-GitCommit: 89924265b4359478b58a29207f0dfe7323b18784
+GitCommit: d58f6c1977d616bcd8669d09687acd86199bb219
 Directory: dockerfiles/official/stable


### PR DESCRIPTION
Sorry for the separate PR. 12.0.2 was not ready yesterday. 