### PR TITLE
Update websphere-liberty to 19.0.0.7

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 5b6b96dd1fd50df6b1d1053b5fe169c7b0537d9b
+GitCommit: 3490ca45915923fb8cb3d96e672cf006a62a8aeb
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -21,6 +21,9 @@ Directory: ga/latest/microProfile1
 
 Tags: microProfile2
 Directory: ga/latest/microProfile2
+
+Tags: microProfile3
+Directory: ga/latest/microProfile3
 
 Tags: springBoot2
 Directory: ga/latest/springBoot2


### PR DESCRIPTION
Updating the latest non-versioned images of websphere-liberty to version 19.0.0.7.