### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/05a89bf3e8f7507667edf4349962f1c3996cfd15/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/b806ff0a2624776464ec9c7ecbda16c2c9ec5e69/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 05a89bf3e8f7507667edf4349962f1c3996cfd15
+GitCommit: b806ff0a2624776464ec9c7ecbda16c2c9ec5e69
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c8aad80db26b6c232eab37255c84918fa018172a
+amd64-GitCommit: 4b11c30f87d3033b2abd446c9bc1ef12f96abaa0
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 0606818f7a63e2f2909381fe4f25806e7363003e
+arm32v5-GitCommit: cd305b71286a17d5c042b88ad117bba45969ea81
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 0c469979cf11d68edf65e9fe75ee7c31f195a5a1
+arm32v6-GitCommit: 2296f50908d71b0f8a86afbe5d782e09622cb74c
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 3a9af6886533d5b3adad6d3cb18f6f4bc6f29929
+arm32v7-GitCommit: 09cbf9e893da77030d891bdddba964f15f46ef2f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2d57ec8b00094f3712f2865a3a613663a31d0a43
+arm64v8-GitCommit: 4f741e2e30631d9a1c6f82c4a3bab4a54938ae30
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: ee709c71237e2911d445af2d29e6ed1d5c860575
+i386-GitCommit: 01ff8f3a983a948bca28af93a91050094a4f1946
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9a3c709191abc15f32f4fd5f7c02b215b772a063
+ppc64le-GitCommit: 9d8d5921c51a99d142fc3fc57d8c152d2ba64891
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 189ee5120ecd8ebc039d64b2a5cc19ef0c6b9ecf
+s390x-GitCommit: 2a9497b287e0997a1ef5b48647fdd5df4ca1f758
 
 Tags: 1.31.0-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/b806ff0: Update to Buildroot 2019.05.1, Debian Buster, and consistent semicolons
- https://github.com/docker-library/busybox/commit/e518652: Remove errant trailing space