### PR TITLE
Update Open Liberty to 19.0.0.7

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,7 @@
 Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 19c93b7ddbc4583222f37ac542a92a76166b7166
+GitCommit: 994cf7a115f989174e402888c0249c4b8cf8a231
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm
@@ -93,6 +93,25 @@ Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2-java12
 Directory: official/latest/microProfile2/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: microProfile3, microProfile3-java8-ibm
+Directory: official/latest/microProfile3/java8/ibmjava
+
+Tags: microProfile3-java8-ibmsfj
+Directory: official/latest/microProfile3/java8/ibmsfj
+Architectures: amd64
+
+Tags: microProfile3-java8-openj9
+Directory: official/latest/microProfile3/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: microProfile3-java11
+Directory: official/latest/microProfile3/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: microProfile3-java12
+Directory: official/latest/microProfile3/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2, springBoot2-java8-ibm


### PR DESCRIPTION
Update the latest/non-versioned images of open-liberty to 19.0.0.7.  Also add the new microProfile3 images for this release.