### PR TITLE
Update Mono to 6.0 (new stable) and 5.20/5.18 service releases

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -4,22 +4,32 @@ Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
 GitRepo: https://github.com/mono/docker.git
 
-Tags: 5.20.1.19, latest, 5.20.1, 5.20, 5
+Tags: 6.0.0.313, latest, 6.0.0, 6.0, 6
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: ade499a72e7bec21a1e44810477620fbce5f812c
-Directory: 5.20.1.19
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 6.0.0.313
 
-Tags: 5.20.1.19-slim, slim, 5.20.1-slim, 5.20-slim, 5-slim
+Tags: 6.0.0.313-slim, slim, 6.0.0-slim, 6.0-slim, 6-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: ade499a72e7bec21a1e44810477620fbce5f812c
-Directory: 5.20.1.19/slim
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 6.0.0.313/slim
 
-Tags: 5.18.1.3, 5.18.1, 5.18
+Tags: 5.20.1.34, 5.20.1, 5.20, 5
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: 43bc89890efbb96e059cda9f690ba13c9ae8e386
-Directory: 5.18.1.3
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 5.20.1.34
 
-Tags: 5.18.1.3-slim, 5.18.1-slim, 5.18-slim
+Tags: 5.20.1.34-slim, 5.20.1-slim, 5.20-slim, 5-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: bbd1369006147ff0c2363897d0e651f2efed29b0
-Directory: 5.18.1.3/slim
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 5.20.1.34/slim
+
+Tags: 5.18.1.28, 5.18.1, 5.18
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 5.18.1.28
+
+Tags: 5.18.1.28-slim, 5.18.1-slim, 5.18-slim
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
+Directory: 5.18.1.28/slim


### PR DESCRIPTION
Let's do this thing.