### PR TITLE
Bump Traefik to v2.0.0-beta1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,21 +1,21 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-alpha8, 2.0.0-alpha8, v2.0, 2.0, faisselle
+Tags: v2.0.0-beta1, 2.0.0-beta1, v2.0, 2.0, faisselle
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 70857afb0be3c5b7f9c2be685fdfef62d5dcfa8c
+GitCommit: 48782ee0ce60ac90865ceff1788dd62720762805
 amd64-Directory: scratch/amd64
 arm32v6-Directory: scratch/arm
 arm64v8-Directory: scratch/arm64
 
-Tags: v2.0.0-alpha8-alpine, 2.0.0-alpha8-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
+Tags: v2.0.0-beta1-alpine, 2.0.0-beta1-alpine, v2.0-alpine, 2.0-alpine, faisselle-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 70857afb0be3c5b7f9c2be685fdfef62d5dcfa8c
+GitCommit: 48782ee0ce60ac90865ceff1788dd62720762805
 Directory: alpine
 
-Tags: v2.0.0-alpha8-nanoserver, 2.0.0-alpha8-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-alpha8-nanoserver-sac2016, 2.0.0-alpha8-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
+Tags: v2.0.0-beta1-nanoserver, 2.0.0-beta1-nanoserver, v2.0-nanoserver, 2.0-nanoserver, faisselle-nanoserver, v2.0.0-beta1-nanoserver-sac2016, 2.0.0-beta1-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, faisselle-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 70857afb0be3c5b7f9c2be685fdfef62d5dcfa8c
+GitCommit: 48782ee0ce60ac90865ceff1788dd62720762805
 Directory: windows
 Constraints: nanoserver-sac2016
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v2.0.0-beta1.

/cc @mmatur @emilevauge @dtomcej

Cheers
