### PR TITLE
Update drupal

### DIFF
--- a/library/drupal
+++ b/library/drupal
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 8.7.4-apache, 8.7-apache, 8-apache, apache, 8.7.4, 8.7, 8, latest
+Tags: 8.7.5-apache, 8.7-apache, 8-apache, apache, 8.7.5, 8.7, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 34fc799247d1d7e51f49497bda8a2272198ec512
+GitCommit: 1433ab4554bad2fba7c16f6ce5965ccf771bf88a
 Directory: 8.7/apache
 
-Tags: 8.7.4-fpm, 8.7-fpm, 8-fpm, fpm
+Tags: 8.7.5-fpm, 8.7-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 34fc799247d1d7e51f49497bda8a2272198ec512
+GitCommit: 1433ab4554bad2fba7c16f6ce5965ccf771bf88a
 Directory: 8.7/fpm
 
-Tags: 8.7.4-fpm-alpine, 8.7-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.7.5-fpm-alpine, 8.7-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 34fc799247d1d7e51f49497bda8a2272198ec512
+GitCommit: 1433ab4554bad2fba7c16f6ce5965ccf771bf88a
 Directory: 8.7/fpm-alpine
 
 Tags: 8.6.17-apache, 8.6-apache, 8.6.17, 8.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f52125f5b83b26f488977abe9cfa8adb68a9f706
+GitCommit: b05d762e4fa8ff852649ed6673c5653d9bb18401
 Directory: 8.6/apache
 
 Tags: 8.6.17-fpm, 8.6-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f52125f5b83b26f488977abe9cfa8adb68a9f706
+GitCommit: b05d762e4fa8ff852649ed6673c5653d9bb18401
 Directory: 8.6/fpm
 
 Tags: 8.6.17-fpm-alpine, 8.6-fpm-alpine
@@ -36,12 +36,12 @@ Directory: 8.6/fpm-alpine
 
 Tags: 7.67-apache, 7-apache, 7.67, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f52125f5b83b26f488977abe9cfa8adb68a9f706
+GitCommit: b05d762e4fa8ff852649ed6673c5653d9bb18401
 Directory: 7/apache
 
 Tags: 7.67-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f52125f5b83b26f488977abe9cfa8adb68a9f706
+GitCommit: b05d762e4fa8ff852649ed6673c5653d9bb18401
 Directory: 7/fpm
 
 Tags: 7.67-fpm-alpine, 7-fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/drupal/commit/1433ab4: Update to 8.7.5
- https://github.com/docker-library/drupal/commit/b05d762: Pin Debian variants to stretch for now