### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,22 +24,22 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
-Tags: 3.7.17-rc.1, 3.7-rc
+Tags: 3.7.17-rc.2, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed480de4b514d9b52afb4e67044b6ad2b865c395
+GitCommit: 7a2c773cd4d1b96bbec73f7a71be062b884cdf84
 Directory: 3.7-rc/ubuntu
 
-Tags: 3.7.17-rc.1-management, 3.7-rc-management
+Tags: 3.7.17-rc.2-management, 3.7-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7-rc/ubuntu/management
 
-Tags: 3.7.17-rc.1-alpine, 3.7-rc-alpine
+Tags: 3.7.17-rc.2-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ed480de4b514d9b52afb4e67044b6ad2b865c395
+GitCommit: 7a2c773cd4d1b96bbec73f7a71be062b884cdf84
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.17-rc.1-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.17-rc.2-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7a2c773: Update to 3.7.17-rc.2, Erlang/OTP 22.0.7, OpenSSL 1.1.1c