### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -41,22 +41,22 @@ Directory: 7.4-rc/alpine3.10/zts
 
 Tags: 7.3.7-cli-buster, 7.3-cli-buster, 7-cli-buster, cli-buster, 7.3.7-buster, 7.3-buster, 7-buster, buster, 7.3.7-cli, 7.3-cli, 7-cli, cli, 7.3.7, 7.3, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.3/buster/cli
 
 Tags: 7.3.7-apache-buster, 7.3-apache-buster, 7-apache-buster, apache-buster, 7.3.7-apache, 7.3-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.3/buster/apache
 
 Tags: 7.3.7-fpm-buster, 7.3-fpm-buster, 7-fpm-buster, fpm-buster, 7.3.7-fpm, 7.3-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.3/buster/fpm
 
 Tags: 7.3.7-zts-buster, 7.3-zts-buster, 7-zts-buster, zts-buster, 7.3.7-zts, 7.3-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.3/buster/zts
 
 Tags: 7.3.7-cli-stretch, 7.3-cli-stretch, 7-cli-stretch, cli-stretch, 7.3.7-stretch, 7.3-stretch, 7-stretch, stretch
@@ -111,22 +111,22 @@ Directory: 7.3/alpine3.9/zts
 
 Tags: 7.2.20-cli-buster, 7.2-cli-buster, 7.2.20-buster, 7.2-buster, 7.2.20-cli, 7.2-cli, 7.2.20, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.2/buster/cli
 
 Tags: 7.2.20-apache-buster, 7.2-apache-buster, 7.2.20-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.2/buster/apache
 
 Tags: 7.2.20-fpm-buster, 7.2-fpm-buster, 7.2.20-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.2/buster/fpm
 
 Tags: 7.2.20-zts-buster, 7.2-zts-buster, 7.2.20-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.2/buster/zts
 
 Tags: 7.2.20-cli-stretch, 7.2-cli-stretch, 7.2.20-stretch, 7.2-stretch
@@ -181,22 +181,22 @@ Directory: 7.2/alpine3.9/zts
 
 Tags: 7.1.30-cli-buster, 7.1-cli-buster, 7.1.30-buster, 7.1-buster, 7.1.30-cli, 7.1-cli, 7.1.30, 7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.1/buster/cli
 
 Tags: 7.1.30-apache-buster, 7.1-apache-buster, 7.1.30-apache, 7.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.1/buster/apache
 
 Tags: 7.1.30-fpm-buster, 7.1-fpm-buster, 7.1.30-fpm, 7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.1/buster/fpm
 
 Tags: 7.1.30-zts-buster, 7.1-zts-buster, 7.1.30-zts, 7.1-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1
+GitCommit: a0ce8afda4af0226d3aad0b93103cb4fc5414458
 Directory: 7.1/buster/zts
 
 Tags: 7.1.30-cli-stretch, 7.1-cli-stretch, 7.1.30-stretch, 7.1-stretch


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/a74d01a: Merge pull request https://github.com/docker-library/php/pull/869 from infosiftr/freetype-config
- https://github.com/docker-library/php/commit/a0ce8af: Add temporary "freetype-config" workaround for PHP 7.3, 7.2, and 7.1 on buster