### PR TITLE
update oraclelinux with smaller 8-slim image

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -7,7 +7,7 @@ amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 9c633ff80efaaa9106a28eec3495cbc47cda534e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0e32e6e9a98f167d1da41a445a23ac33dedb0ff1
+arm64v8-GitCommit: 8e9e64fd5886bd4499e05399372caa7332d71589
 Constraints: !aufs
 
 Tags: 8.0, 8


### PR DESCRIPTION
	[ARM64v8 8-slim] 2019-07-25-13

Signed-off-by: Michael Calunod <michael.calunod@oracle.com>