### PR TITLE
library/perl: Support Perls on Debian stretch/buster base

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,41 +1,77 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 92233bc5293c2eb17f3019f329cc67fd96d92bcf
+GitCommit: 01044791941b91f99e970c3f1256d9dc0daee5e4
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.30, 5.30.0
-Directory: 5.030.000-main
+Tags: latest, 5, 5.30, 5.30.0, 5-buster, 5.30-buster, 5.30.0-buster
+Directory: 5.030.000-main-buster
 
-Tags: slim, 5-slim, 5.30-slim, 5.30.0-slim
-Directory: 5.030.000-slim
+Tags: 5-stretch, 5.30-stretch, 5.30.0-stretch
+Directory: 5.030.000-main-stretch
 
-Tags: threaded, 5-threaded, 5.30-threaded, 5.30.0-threaded
-Directory: 5.030.000-main,threaded
+Tags: slim, 5-slim, 5.30-slim, 5.30.0-slim, slim-buster, 5-slim-buster, 5.30-slim-buster, 5.30.0-slim-buster
+Directory: 5.030.000-slim-buster
 
-Tags: slim-threaded, 5-slim-threaded, 5.30-slim-threaded, 5.30.0-slim-threaded
-Directory: 5.030.000-slim,threaded
+Tags: slim-stretch, 5-slim-stretch, 5.30-slim-stretch, 5.30.0-slim-stretch
+Directory: 5.030.000-slim-stretch
 
-Tags: 5.28, 5.28.2
-Directory: 5.028.002-main
+Tags: threaded, 5-threaded, 5.30-threaded, 5.30.0-threaded, threaded-buster, 5-threaded-buster, 5.30-threaded-buster, 5.30.0-threaded-buster
+Directory: 5.030.000-main,threaded-buster
 
-Tags: 5.28-slim, 5.28.2-slim
-Directory: 5.028.002-slim
+Tags: threaded-stretch, 5-threaded-stretch, 5.30-threaded-stretch, 5.30.0-threaded-stretch
+Directory: 5.030.000-main,threaded-stretch
 
-Tags: 5.28-threaded, 5.28.2-threaded
-Directory: 5.028.002-main,threaded
+Tags: slim-threaded, 5-slim-threaded, 5.30-slim-threaded, 5.30.0-slim-threaded, slim-threaded-buster, 5-slim-threaded-buster, 5.30-slim-threaded-buster, 5.30.0-slim-threaded-buster
+Directory: 5.030.000-slim,threaded-buster
 
-Tags: 5.28-slim-threaded, 5.28.2-slim-threaded
-Directory: 5.028.002-slim,threaded
+Tags: slim-threaded-stretch, 5-slim-threaded-stretch, 5.30-slim-threaded-stretch, 5.30.0-slim-threaded-stretch
+Directory: 5.030.000-slim,threaded-stretch
 
-Tags: 5.26, 5.26.3
-Directory: 5.026.003-main
+Tags: 5.28, 5.28.2, 5.28-buster, 5.28.2-buster
+Directory: 5.028.002-main-buster
 
-Tags: 5.26-slim, 5.26.3-slim
-Directory: 5.026.003-slim
+Tags: 5.28-stretch, 5.28.2-stretch
+Directory: 5.028.002-main-stretch
 
-Tags: 5.26-threaded, 5.26.3-threaded
-Directory: 5.026.003-main,threaded
+Tags: 5.28-slim, 5.28.2-slim, 5.28-slim-buster, 5.28.2-slim-buster
+Directory: 5.028.002-slim-buster
 
-Tags: 5.26-slim-threaded, 5.26.3-slim-threaded
-Directory: 5.026.003-slim,threaded
+Tags: 5.28-slim-stretch, 5.28.2-slim-stretch
+Directory: 5.028.002-slim-stretch
+
+Tags: 5.28-threaded, 5.28.2-threaded, 5.28-threaded-buster, 5.28.2-threaded-buster
+Directory: 5.028.002-main,threaded-buster
+
+Tags: 5.28-threaded-stretch, 5.28.2-threaded-stretch
+Directory: 5.028.002-main,threaded-stretch
+
+Tags: 5.28-slim-threaded, 5.28.2-slim-threaded, 5.28-slim-threaded-buster, 5.28.2-slim-threaded-buster
+Directory: 5.028.002-slim,threaded-buster
+
+Tags: 5.28-slim-threaded-stretch, 5.28.2-slim-threaded-stretch
+Directory: 5.028.002-slim,threaded-stretch
+
+Tags: 5.26, 5.26.3, 5.26-buster, 5.26.3-buster
+Directory: 5.026.003-main-buster
+
+Tags: 5.26-stretch, 5.26.3-stretch
+Directory: 5.026.003-main-stretch
+
+Tags: 5.26-slim, 5.26.3-slim, 5.26-slim-buster, 5.26.3-slim-buster
+Directory: 5.026.003-slim-buster
+
+Tags: 5.26-slim-stretch, 5.26.3-slim-stretch
+Directory: 5.026.003-slim-stretch
+
+Tags: 5.26-threaded, 5.26.3-threaded, 5.26-threaded-buster, 5.26.3-threaded-buster
+Directory: 5.026.003-main,threaded-buster
+
+Tags: 5.26-threaded-stretch, 5.26.3-threaded-stretch
+Directory: 5.026.003-main,threaded-stretch
+
+Tags: 5.26-slim-threaded, 5.26.3-slim-threaded, 5.26-slim-threaded-buster, 5.26.3-slim-threaded-buster
+Directory: 5.026.003-slim,threaded-buster
+
+Tags: 5.26-slim-threaded-stretch, 5.26.3-slim-threaded-stretch
+Directory: 5.026.003-slim,threaded-stretch


### PR DESCRIPTION
Provide Perl images built on both Debian 9 (stretch) and Debian
10 (buster) with the latter now set as the default base.

https://github.com/Perl/docker-perl/issues/66
https://github.com/Perl/docker-perl/pull/67