### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-6-jdk-oraclelinux7, 14-ea-6-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-6-jdk-oracle, 14-ea-6-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-6-jdk, 14-ea-6, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-7-jdk-oraclelinux7, 14-ea-7-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-7-jdk-oracle, 14-ea-7-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-7-jdk, 14-ea-7, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: afa64e6e402a56a457a8d928d67024bfaad34aad
+GitCommit: 52f18b0051ad39514c6dea65555bfed14c537598
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
@@ -16,31 +16,31 @@ Architectures: amd64
 GitCommit: 1ec9487ee47d39a46d914633a1b48db99eba7115
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-6-jdk-windowsservercore-1809, 14-ea-6-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-6-jdk-windowsservercore, 14-ea-6-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-6-jdk, 14-ea-6, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-7-jdk-windowsservercore-1809, 14-ea-7-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-7-jdk-windowsservercore, 14-ea-7-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-7-jdk, 14-ea-7, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: afa64e6e402a56a457a8d928d67024bfaad34aad
+GitCommit: 52f18b0051ad39514c6dea65555bfed14c537598
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-6-jdk-windowsservercore-1803, 14-ea-6-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-6-jdk-windowsservercore, 14-ea-6-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-6-jdk, 14-ea-6, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-7-jdk-windowsservercore-1803, 14-ea-7-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-7-jdk-windowsservercore, 14-ea-7-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-7-jdk, 14-ea-7, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: afa64e6e402a56a457a8d928d67024bfaad34aad
+GitCommit: 52f18b0051ad39514c6dea65555bfed14c537598
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-6-jdk-windowsservercore-ltsc2016, 14-ea-6-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-6-jdk-windowsservercore, 14-ea-6-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-6-jdk, 14-ea-6, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-7-jdk-windowsservercore-ltsc2016, 14-ea-7-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-7-jdk-windowsservercore, 14-ea-7-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-7-jdk, 14-ea-7, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: afa64e6e402a56a457a8d928d67024bfaad34aad
+GitCommit: 52f18b0051ad39514c6dea65555bfed14c537598
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-ea-30-jdk-oraclelinux7, 13-ea-30-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-30-jdk-oracle, 13-ea-30-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
-SharedTags: 13-ea-30-jdk, 13-ea-30, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-31-jdk-oraclelinux7, 13-ea-31-oraclelinux7, 13-ea-jdk-oraclelinux7, 13-ea-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, 13-ea-31-jdk-oracle, 13-ea-31-oracle, 13-ea-jdk-oracle, 13-ea-oracle, 13-jdk-oracle, 13-oracle
+SharedTags: 13-ea-31-jdk, 13-ea-31, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: amd64
-GitCommit: 5ed85f0692d4e1818539fe04268900409e410490
+GitCommit: d0e8d5009be0e61063281cc60eadf409b6cf5369
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
@@ -49,24 +49,24 @@ Architectures: amd64
 GitCommit: 44d6908951d61d6f3fc8d08a4c0e7857f0914ee5
 Directory: 13/jdk/alpine
 
-Tags: 13-ea-30-jdk-windowsservercore-1809, 13-ea-30-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
-SharedTags: 13-ea-30-jdk-windowsservercore, 13-ea-30-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-30-jdk, 13-ea-30, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-31-jdk-windowsservercore-1809, 13-ea-31-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809
+SharedTags: 13-ea-31-jdk-windowsservercore, 13-ea-31-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-31-jdk, 13-ea-31, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 5ed85f0692d4e1818539fe04268900409e410490
+GitCommit: d0e8d5009be0e61063281cc60eadf409b6cf5369
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-ea-30-jdk-windowsservercore-1803, 13-ea-30-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
-SharedTags: 13-ea-30-jdk-windowsservercore, 13-ea-30-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-30-jdk, 13-ea-30, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-31-jdk-windowsservercore-1803, 13-ea-31-windowsservercore-1803, 13-ea-jdk-windowsservercore-1803, 13-ea-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803
+SharedTags: 13-ea-31-jdk-windowsservercore, 13-ea-31-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-31-jdk, 13-ea-31, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 5ed85f0692d4e1818539fe04268900409e410490
+GitCommit: d0e8d5009be0e61063281cc60eadf409b6cf5369
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-ea-30-jdk-windowsservercore-ltsc2016, 13-ea-30-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
-SharedTags: 13-ea-30-jdk-windowsservercore, 13-ea-30-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-30-jdk, 13-ea-30, 13-ea-jdk, 13-ea, 13-jdk, 13
+Tags: 13-ea-31-jdk-windowsservercore-ltsc2016, 13-ea-31-windowsservercore-ltsc2016, 13-ea-jdk-windowsservercore-ltsc2016, 13-ea-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016
+SharedTags: 13-ea-31-jdk-windowsservercore, 13-ea-31-windowsservercore, 13-ea-jdk-windowsservercore, 13-ea-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, 13-ea-31-jdk, 13-ea-31, 13-ea-jdk, 13-ea, 13-jdk, 13
 Architectures: windows-amd64
-GitCommit: 5ed85f0692d4e1818539fe04268900409e410490
+GitCommit: d0e8d5009be0e61063281cc60eadf409b6cf5369
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/52f18b0: Update to 14-ea+7
- https://github.com/docker-library/openjdk/commit/d0e8d50: Update to 13-ea+31