### PR TITLE
Add Solr 8.2; add tini and OOM handling

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,72 +4,82 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.1.1, 8.1, 8, latest
+Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 02fff54d99672ee2666bff6f96f008996fb3e3b8
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+Directory: 8.2
+
+Tags: 8.2.0-slim, 8.2-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+Directory: 8.2/slim
+
+Tags: 8.1.1, 8.1
+Architectures: amd64, arm64v8
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
 Directory: 8.1
 
-Tags: 8.1.1-slim, 8.1-slim, 8-slim, slim
+Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 02fff54d99672ee2666bff6f96f008996fb3e3b8
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 3d2bfd1262cdc05e8ed6de9347c7b961157bf136
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 3d2bfd1262cdc05e8ed6de9347c7b961157bf136
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: 71ebabff0dce35b97e796ab0c444276c75d6538e
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: a6ad91bb7bb4373a0342325f3140966cc1c1ab24
+GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
 Directory: 5.5/slim

--- a/library/solr
+++ b/library/solr
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/d6e4780449d3517718e794e59c46214ee3a79f50/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/426f7e3ead0c7671556ed8998fb0d345d1616ea5/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
+GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
 Directory: 5.5/slim

--- a/library/solr
+++ b/library/solr
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 677d032a1dc960be7aa725cd9633f06f139a8aa7
+GitCommit: a89957c6b5242ec4b72e539e39cafe27b7e39a6d
 Directory: 5.5/slim

--- a/library/solr
+++ b/library/solr
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.2.0, 8.2, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: df194f9edff9ce589eb7e77b89043ccc2998329f
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 00f0b8d74924fa004afbdbaa26cc95e8a04753b3
+GitCommit: 5a84f7eb132a215894264d333bd291360a38e637
 Directory: 5.5/slim


### PR DESCRIPTION
Add Solr 8.2
Announcement: http://mail-archives.apache.org/mod_mbox/www-announce/201907.mbox/%3cCAKryLws0zYvj6xy15h+0h3i2nkBJoGWGZ6k4oaupyEyyU8qS+w@mail.gmail.com%3e

On the docker-solr side (see https://github.com/docker-solr/docker-solr/commits/master):
- add tini to the image, and allow it to be run by setting TINI=yes
- allow the setting of OOM=exit/OOM=crash/OOM=script to configure OutOfMemoryError conditions in the JVM
- make sure prometheus-exporter script execute permissions are set
- new committer key