### PR TITLE
Update Amazon Corretto 8 & 11 to support arm64v8 architecture

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -6,9 +6,11 @@ Maintainers: Amazon Corretto Team (@corretto),
 Tags: 8, 8u222, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: aa6b1dc18c638d9711bb6f130a4219ba402c462f
+GitCommit: cd7c7563f35cc12cf50a9a418e5ecaa73810a8e8
+Architectures: amd64, arm64v8
 
 Tags: 11, 11.0.4, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: ff33946d1003fdfbec6d5bd0074ed82affc6c76c
+GitCommit: ef101ef699ac861721faffa22247c32d845a217a
+Architectures: amd64, arm64v8


### PR DESCRIPTION
`arm64v8` support has been added to both Amazon Corretto 8 & 11 docker images!

`amd64` and `arm64v8` share the same git branch and commit id:

8: corretto/corretto-8-docker@cd7c7563
11: corretto/corretto-11-docker@ef101ef69

Thank you!