### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.25.9, 2.25, 2, latest
+Tags: 2.26.0, 2.26, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4603fdf155f25bd60b9944b76da35dfbbb5a7326
+GitCommit: 6afd74f854fc1ee70ee4e4446b1eb4fb8d5e07bb
 Directory: 2/debian
 
-Tags: 2.25.9-alpine, 2.25-alpine, 2-alpine, alpine
+Tags: 2.26.0-alpine, 2.26-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4603fdf155f25bd60b9944b76da35dfbbb5a7326
+GitCommit: 6afd74f854fc1ee70ee4e4446b1eb4fb8d5e07bb
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/6afd74f: Update to 2.26.0, ghost-cli 1.11.0