### PR TITLE
Fedora Update - 20190801.

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -25,7 +25,7 @@ ppc64le-Directory: ppc64le/
 Tags: latest, 30
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/30-updates-candidate
-GitCommit: 314db41ff064dc44c22fc6874a0ed1e25a1595c9
+GitCommit: 974896b0ff0769262d783567d09a1ef4a64086ae
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
@@ -52,9 +52,10 @@ s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
 Tags: rawhide, 31
-Architectures: amd64, arm64v8, s390x
+Architectures: amd64, arm64v8, s390x, ppc64le
 GitFetch: refs/heads/31
-GitCommit: eff492edd5b19922ecca61be6cdc47734b9bebff 
+GitCommit: 6563cce996ad79f7f7cbf6aee2a393428923ce5d
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
+ppc64le-Directory: ppc64le/


### PR DESCRIPTION
Smaller rawhide image.
Add ppc64le image to rawhide.
F30 update.

Signed-off-by: Clement Verna <cverna@tutanota.com>