### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.2.2-php7.1-apache, 5.2-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.2.2-php7.1, 5.2-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.1/apache
 
 Tags: 5.2.2-php7.1-fpm, 5.2-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.1/fpm
 
 Tags: 5.2.2-php7.1-fpm-alpine, 5.2-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.1/fpm-alpine
 
 Tags: 5.2.2-php7.2-apache, 5.2-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.2.2-php7.2, 5.2-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.2/apache
 
 Tags: 5.2.2-php7.2-fpm, 5.2-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.2/fpm
 
 Tags: 5.2.2-php7.2-fpm-alpine, 5.2-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.2/fpm-alpine
 
 Tags: 5.2.2-apache, 5.2-apache, 5-apache, apache, 5.2.2, 5.2, 5, latest, 5.2.2-php7.3-apache, 5.2-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.2.2-php7.3, 5.2-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.3/apache
 
 Tags: 5.2.2-fpm, 5.2-fpm, 5-fpm, fpm, 5.2.2-php7.3-fpm, 5.2-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.3/fpm
 
 Tags: 5.2.2-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.2.2-php7.3-fpm-alpine, 5.2-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: cca618c2e6c1414859162d6f1316652daa8515f7
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
 Tags: cli-2.2.0-php7.1, cli-2.2-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73a28f6489a78e535cc0b4ce986e34a9c9c0a2a1
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.1/cli
 
 Tags: cli-2.2.0-php7.2, cli-2.2-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73a28f6489a78e535cc0b4ce986e34a9c9c0a2a1
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.2/cli
 
 Tags: cli-2.2.0, cli-2.2, cli-2, cli, cli-2.2.0-php7.3, cli-2.2-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73a28f6489a78e535cc0b4ce986e34a9c9c0a2a1
+GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
 Directory: php7.3/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/30f07e5: Merge pull request https://github.com/docker-library/wordpress/pull/421 from infosiftr/error_reporting
- https://github.com/docker-library/wordpress/commit/c9f1ca1: Adjust the value of "error_reporting" to be the semantic equivalent of the suggested "4339" and add "E_PARSE"