### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.0-beta.5, 3.8-rc
+Tags: 3.8.0-beta.6, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d38a86acf3433c51359bd6da62668588a4660e2b
+GitCommit: 2ec310b5a0703baa81b67582cc6778a27363aace
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.0-beta.5-management, 3.8-rc-management
+Tags: 3.8.0-beta.6-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.0-beta.5-alpine, 3.8-rc-alpine
+Tags: 3.8.0-beta.6-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: d38a86acf3433c51359bd6da62668588a4660e2b
+GitCommit: 2ec310b5a0703baa81b67582cc6778a27363aace
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.0-beta.5-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.0-beta.6-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
 Tags: 3.7.17, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 22f59f67a22fa9b8ef054092c474c54ee1ef9c31
+GitCommit: a0a0135181c1b4976fe7be63a00bac5762c86792
 Directory: 3.7/ubuntu
 
 Tags: 3.7.17-management, 3.7-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.17-alpine, 3.7-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 22f59f67a22fa9b8ef054092c474c54ee1ef9c31
+GitCommit: a0a0135181c1b4976fe7be63a00bac5762c86792
 Directory: 3.7/alpine
 
 Tags: 3.7.17-management-alpine, 3.7-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2ec310b: Update to 3.8.0-beta.6, Erlang/OTP 22.0.7, OpenSSL 1.1.1c
- https://github.com/docker-library/rabbitmq/commit/60c979a: Merge pull request https://github.com/docker-library/rabbitmq/pull/358 from infosiftr/spaaaaaace
- https://github.com/docker-library/rabbitmq/commit/a0a0135: Add a line of whitespace between certs in "combined.pem"