### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.26.0, 2.26, 2, latest
+Tags: 2.27.0, 2.27, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6afd74f854fc1ee70ee4e4446b1eb4fb8d5e07bb
+GitCommit: 0ca9298af038b99b239bc9ee29e68ed397fecd74
 Directory: 2/debian
 
-Tags: 2.26.0-alpine, 2.26-alpine, 2-alpine, alpine
+Tags: 2.27.0-alpine, 2.27-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 6afd74f854fc1ee70ee4e4446b1eb4fb8d5e07bb
+GitCommit: 0ca9298af038b99b239bc9ee29e68ed397fecd74
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/0ca9298: Update to 2.27.0, ghost-cli 1.11.0