### PR TITLE
[ros] Remove EOL images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -86,12 +86,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 

--- a/library/ros
+++ b/library/ros
@@ -2,60 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: indigo
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: indigo-ros-core, indigo-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/ros-core
-
-Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/ros-base
-
-Tags: indigo-robot, indigo-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/robot
-
-Tags: indigo-perception, indigo-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/perception
-
-
-################################################################################
-# Release: jade
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: jade-ros-core, jade-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/ros-core
-
-Tags: jade-ros-base, jade-ros-base-trusty, jade
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/ros-base
-
-Tags: jade-robot, jade-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/robot
-
-Tags: jade-perception, jade-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/perception
-
-
-################################################################################
 # Release: kinetic
 
 ########################################
@@ -80,102 +26,6 @@ Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/perception
-
-########################################
-# Distro: debian:jessie
-
-Tags: kinetic-ros-core-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/ros-core
-
-Tags: kinetic-ros-base-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/ros-base
-
-Tags: kinetic-robot-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/robot
-
-Tags: kinetic-perception-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/perception
-
-
-################################################################################
-# Release: lunar
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: lunar-ros-core, lunar-ros-core-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/ros-core
-
-Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/ros-base
-
-Tags: lunar-robot, lunar-robot-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/robot
-
-Tags: lunar-perception, lunar-perception-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/perception
-
-########################################
-# Distro: ubuntu:zesty
-
-Tags: lunar-ros-core-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/ros-core
-
-Tags: lunar-ros-base-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/ros-base
-
-Tags: lunar-robot-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/robot
-
-Tags: lunar-perception-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/perception
-
-########################################
-# Distro: debian:stretch
-
-Tags: lunar-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/ros-core
-
-Tags: lunar-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/ros-base
-
-Tags: lunar-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/robot
-
-Tags: lunar-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/perception
 
 
 ################################################################################
@@ -226,23 +76,6 @@ Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
 GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/debian/stretch/perception
-
-
-################################################################################
-# Release: ardent
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: ardent-ros-core, ardent-ros-core-xenial
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/ardent/ubuntu/xenial/ros-core
-
-Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/ardent/ubuntu/xenial/ros-base
 
 
 ################################################################################


### PR DESCRIPTION
Removes EOL images reintroduced in https://github.com/docker-library/official-images/pull/6401 for one rebuild
Migrates ROS Bouncy to use `snapshots.ros.org` repository for one last rebuild before decommissioning it