### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.3, 2.0, latest
+Tags: 2.0.4, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e52bf417dd69f7a0e37be65bbfd3ab0f1451723a
+GitCommit: 2e948aa9880c8184c8e001bc5416cabf10d507f1
 Directory: 2.0
 
-Tags: 2.0.3-alpine, 2.0-alpine, alpine
+Tags: 2.0.4-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e52bf417dd69f7a0e37be65bbfd3ab0f1451723a
+GitCommit: 2e948aa9880c8184c8e001bc5416cabf10d507f1
 Directory: 2.0/alpine
 
 Tags: 1.9.9, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2e948aa: Update to 2.0.4