### PR TITLE
update oraclelinux for curl

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f0c24703edb340dbc884ffbbdf60f80be69b1910
+amd64-GitCommit: 573754fe56e7e8d570c554e8152fc9606c89561d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 9ad8700fd37bd66518bea4dd4461ebf5b47b3cfc


### PR DESCRIPTION
	[AMD64 8-slim] 2019-08-01-16
	[AMD64 7.6] 2019-07-30-99
	[AMD64 7-slim] 2019-07-30-26

Signed-off-by: Michael Calunod <michael.calunod@oracle.com>