### PR TITLE
Update node.js v10 to 10.16.2 and v12 to 12.8.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -43,72 +43,73 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2a856dabc31fab501ab85a911b93559079684a3a
 Directory: 8/buster-slim
 
-Tags: 12.7.0-alpine, 12.7-alpine, 12-alpine, current-alpine, alpine
+Tags: 12.8.0-alpine, 12.8-alpine, 12-alpine, current-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c80a296e96d33fecd43f9e8c89ff1ef093ee242d
+GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
 Directory: 12/alpine
 
-Tags: 12.7.0-stretch, 12.7-stretch, 12-stretch, current-stretch, stretch, 12.7.0, 12.7, 12, current, latest
+Tags: 12.8.0-stretch, 12.8-stretch, 12-stretch, current-stretch, stretch, 12.8.0, 12.8, 12, current, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c80a296e96d33fecd43f9e8c89ff1ef093ee242d
+GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
 Directory: 12/stretch
 
-Tags: 12.7.0-stretch-slim, 12.7-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.7.0-slim, 12.7-slim, 12-slim, current-slim, slim
+Tags: 12.8.0-stretch-slim, 12.8-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.8.0-slim, 12.8-slim, 12-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c80a296e96d33fecd43f9e8c89ff1ef093ee242d
+GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
 Directory: 12/stretch-slim
 
-Tags: 12.7.0-buster, 12.7-buster, 12-buster, current-buster, buster
+Tags: 12.8.0-buster, 12.8-buster, 12-buster, current-buster, buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6bae0eb339bc5be880f01b652f48fdf939f76590
+GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
 Directory: 12/buster
 
-Tags: 12.7.0-buster-slim, 12.7-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
+Tags: 12.8.0-buster-slim, 12.8-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6bae0eb339bc5be880f01b652f48fdf939f76590
+GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
 Directory: 12/buster-slim
 
-Tags: 10.16.1-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.16.2-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: amd64, arm32v7
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/jessie
 
-Tags: 10.16.1-jessie-slim, 10.16-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
+Tags: 10.16.2-jessie-slim, 10.16-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
 Architectures: amd64, arm32v7
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/jessie-slim
 
-Tags: 10.16.1-alpine, 10.16-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.16.2-alpine, 10.16-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/alpine
 
-Tags: 10.16.1-stretch, 10.16-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.16.1, 10.16, 10, dubnium, lts
+Tags: 10.16.2-stretch, 10.16-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.16.2, 10.16, 10, dubnium, lts
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/stretch
 
-Tags: 10.16.1-stretch-slim, 10.16-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.16.1-slim, 10.16-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.16.2-stretch-slim, 10.16-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.16.2-slim, 10.16-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/stretch-slim
 
-Tags: 10.16.1-buster, 10.16-buster, 10-buster, dubnium-buster, lts-buster
+Tags: 10.16.2-buster, 10.16-buster, 10-buster, dubnium-buster, lts-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/buster
 
-Tags: 10.16.1-buster-slim, 10.16-buster-slim, 10-buster-slim, dubnium-buster-slim, lts-buster-slim
+Tags: 10.16.2-buster-slim, 10.16-buster-slim, 10-buster-slim, dubnium-buster-slim, lts-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f5b60750fedd5df9a17cf9645a8f6dc04608e721
+GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
 Directory: 10/buster-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: 0aae692a71251b60c489c41b7b1f28daa05829e5
+GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 0aae692a71251b60c489c41b7b1f28daa05829e5
+GitCommit: 69c8a5f448f46f9e34d7fb577eca79ba01f6864d
 Directory: chakracore/10
+


### PR DESCRIPTION
- https://github.com/nodejs/docker-node/pull/1087

- https://nodejs.org/en/blog/release/v10.16.2/
- https://github.com/nodejs/node/releases/tag/v10.16.2
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.16.2

- https://nodejs.org/en/blog/release/v12.8.0/
- https://github.com/nodejs/node/releases/tag/v12.8.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.8.0