### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -11,9 +11,9 @@ GitCommit: 738932efd2236c905475115cf34f2a72cd65c02c
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-3-jdk-alpine3.10, 14-ea-3-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-3-jdk-alpine, 14-ea-3-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
+Tags: 14-ea-8-jdk-alpine3.10, 14-ea-8-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-8-jdk-alpine, 14-ea-8-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
 Architectures: amd64
-GitCommit: 1ec9487ee47d39a46d914633a1b48db99eba7115
+GitCommit: 5f603d0b657d0a87212ad16d304a1ce5e2533d82
 Directory: 14/jdk/alpine
 
 Tags: 14-ea-8-jdk-windowsservercore-1809, 14-ea-8-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
@@ -44,9 +44,9 @@ GitCommit: b9ed6f81ba268f52f3010d50e670c81f930ba0aa
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
-Tags: 13-ea-27-jdk-alpine3.10, 13-ea-27-alpine3.10, 13-ea-jdk-alpine3.10, 13-ea-alpine3.10, 13-jdk-alpine3.10, 13-alpine3.10, 13-ea-27-jdk-alpine, 13-ea-27-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
+Tags: 13-ea-32-jdk-alpine3.10, 13-ea-32-alpine3.10, 13-ea-jdk-alpine3.10, 13-ea-alpine3.10, 13-jdk-alpine3.10, 13-alpine3.10, 13-ea-32-jdk-alpine, 13-ea-32-alpine, 13-ea-jdk-alpine, 13-ea-alpine, 13-jdk-alpine, 13-alpine
 Architectures: amd64
-GitCommit: 44d6908951d61d6f3fc8d08a4c0e7857f0914ee5
+GitCommit: aed2d23dbcc88926f8aaab61b3ea4f68506702af
 Directory: 13/jdk/alpine
 
 Tags: 13-ea-32-jdk-windowsservercore-1809, 13-ea-32-windowsservercore-1809, 13-ea-jdk-windowsservercore-1809, 13-ea-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5f603d0: Update to 14-ea+8
- https://github.com/docker-library/openjdk/commit/aed2d23: Update to 13-ea+32