### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2e948aa9880c8184c8e001bc5416cabf10d507f1
 Directory: 2.0/alpine
 
-Tags: 1.9.9, 1.9, 1
+Tags: 1.9.10, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e7b8d457d49816279da11bd4bbb0150de3c175e8
+GitCommit: 9efd6eb655c9ce87ccf6b84a68f2b4e647fff706
 Directory: 1.9
 
-Tags: 1.9.9-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.10-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e7b8d457d49816279da11bd4bbb0150de3c175e8
+GitCommit: 9efd6eb655c9ce87ccf6b84a68f2b4e647fff706
 Directory: 1.9/alpine
 
 Tags: 1.8.20, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9efd6eb: Update to 1.9.10