### PR TITLE
alpine: edge snapshot 20190809

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,10 @@
 Maintainers: Natanael Copa <ncopa@alpinelinux.org> (@ncopa)
 GitRepo: https://github.com/alpinelinux/docker-alpine.git
 
-Tags: 20190707, edge
+Tags: 20190809, edge
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/edge
-GitCommit: 9d620918eb6b7ddbea4ab2c0d1fce85b96b50410
+GitCommit: 045f4c9a0e39770187dfd85a6fb16a1017861928
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
contains busybox-1.31 and musl-1.1.23 + backport patch for
CVE-2019-14697.