### PR TITLE
[ros] remove ROS Bouncy

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -79,23 +79,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: bouncy
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: bouncy-ros-core, bouncy-ros-core-bionic
-Architectures: amd64, arm64v8
-GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
-Directory: ros/bouncy/ubuntu/bionic/ros-core
-
-Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
-Architectures: amd64, arm64v8
-GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
-Directory: ros/bouncy/ubuntu/bionic/ros-base
-
-
-################################################################################
 # Release: crystal
 
 ########################################
@@ -120,10 +103,10 @@ Directory: ros/crystal/ubuntu/bionic/ros-base
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: 30a5aa5b57ff1df58515bebdb44ac2c8e553df28
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: 30a5aa5b57ff1df58515bebdb44ac2c8e553df28
 Directory: ros/dashing/ubuntu/bionic/ros-base


### PR DESCRIPTION
ROS Bouncy is now EOL

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>