### PR TITLE
Add official Friendica image

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -1,48 +1,34 @@
-# This file is generated via https://github.com/friendica/docker/blob/6c821e72f0b676ef543255d1368362f403425722/generate-stackbrew-library.sh
+# This file is generated via https://github.com/friendica/docker/blob/5063b8d381b9a5482e5f1222f434aae3c335b481/generate-stackbrew-library.sh
+
 Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@philipp.info> (@nupplaphil)
 GitRepo: https://github.com/friendica/docker.git
 
-Tags: 2019.09-apache, apache, stable-apache, 2019.09, latest, stable
+Tags: 2019.12-apache, apache, stable-apache, 2019.12, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.09/apache
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2019.12/apache
 
-Tags: 2019.09-fpm, fpm, stable-fpm
+Tags: 2019.12-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.09/fpm
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2019.12/fpm
 
-Tags: 2019.09-fpm-alpine, fpm-alpine, stable-fpm-alpine
+Tags: 2019.12-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.09/fpm-alpine
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2019.12/fpm-alpine
 
-Tags: 2019.12-dev-apache, dev-apache, 2019.12-dev, dev
+Tags: 2020.03-dev-apache, dev-apache, 2020.03-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-dev/apache
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2020.03-dev/apache
 
-Tags: 2019.12-dev-fpm, dev-fpm
+Tags: 2020.03-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-dev/fpm
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2020.03-dev/fpm
 
-Tags: 2019.12-dev-fpm-alpine, dev-fpm-alpine
+Tags: 2020.03-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-dev/fpm-alpine
-
-Tags: 2019.12-rc-apache, rc-apache, 2019.12-rc, rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-rc/apache
-
-Tags: 2019.12-rc-fpm, rc-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-rc/fpm
-
-Tags: 2019.12-rc-fpm-alpine, rc-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
-Directory: 2019.12-rc/fpm-alpine
+GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+Directory: 2020.03-dev/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -5,30 +5,30 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2019.12-apache, apache, stable-apache, 2019.12, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2019.12/apache
 
 Tags: 2019.12-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2019.12/fpm
 
 Tags: 2019.12-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2019.12/fpm-alpine
 
 Tags: 2020.03-dev-apache, dev-apache, 2020.03-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2020.03-dev/apache
 
 Tags: 2020.03-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2020.03-dev/fpm
 
 Tags: 2020.03-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
+GitCommit: 611f5cf09129fa23ee507ac89f32cfde3c80d557
 Directory: 2020.03-dev/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -5,30 +5,30 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2019.12-apache, apache, stable-apache, 2019.12, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2019.12/apache
 
 Tags: 2019.12-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2019.12/fpm
 
 Tags: 2019.12-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2019.12/fpm-alpine
 
 Tags: 2020.03-dev-apache, dev-apache, 2020.03-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2020.03-dev/apache
 
 Tags: 2020.03-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2020.03-dev/fpm
 
 Tags: 2020.03-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5063b8d381b9a5482e5f1222f434aae3c335b481
+GitCommit: eea8fbdd84f7d33ce6edcaf73f26666633508d24
 Directory: 2020.03-dev/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -1,0 +1,33 @@
+# This file is generated via https://github.com/friendica/docker/blob/6c821e72f0b676ef543255d1368362f403425722/generate-stackbrew-library.sh
+Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@philipp.info> (@nupplaphil)
+GitRepo: https://github.com/friendica/docker.git
+
+Tags: 2019.09-apache, apache, stable-apache, 2019.09, latest, stable
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.09/apache
+
+Tags: 2019.09-fpm, fpm, stable-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.09/fpm
+
+Tags: 2019.09-fpm-alpine, fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.09/fpm-alpine
+
+Tags: 2019.12-dev-apache, dev-apache, 2019.12-dev, dev
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.12-dev/apache
+
+Tags: 2019.12-dev-fpm, dev-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.12-dev/fpm
+
+Tags: 2019.12-dev-fpm-alpine, dev-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+Directory: 2019.12-dev/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -4,30 +4,45 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2019.09-apache, apache, stable-apache, 2019.09, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.09/apache
 
 Tags: 2019.09-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.09/fpm
 
 Tags: 2019.09-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.09/fpm-alpine
 
 Tags: 2019.12-dev-apache, dev-apache, 2019.12-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.12-dev/apache
 
 Tags: 2019.12-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.12-dev/fpm
 
 Tags: 2019.12-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 616a762d568155523cca8506cfc5774bd323c69d
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
 Directory: 2019.12-dev/fpm-alpine
+
+Tags: 2019.12-rc-apache, rc-apache, 2019.12-rc, rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
+Directory: 2019.12-rc/apache
+
+Tags: 2019.12-rc-fpm, rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
+Directory: 2019.12-rc/fpm
+
+Tags: 2019.12-rc-fpm-alpine, rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 7a74b4c0b9348987cd7595de2e1200c1d83cfe8d
+Directory: 2019.12-rc/fpm-alpine


### PR DESCRIPTION
We, the Friendica upstream team (@mrpetovan @annando and I) want to add the Friendica image to the official image repository - see https://github.com/friendica/docker/issues/74 .

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/friendica
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1551
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)