### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: 035d5baa91016103e8f5231b6d589054381b0f55
 Directory: 8
 # Docker EOL: 2020-08-22
 
-# Last Modified: 2019-05-03
-Tags: 9.1.0, 9.1, 9, latest
+# Last Modified: 2019-08-12
+Tags: 9.2.0, 9.2, 9, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 035d5baa91016103e8f5231b6d589054381b0f55
+GitCommit: 65cee66f798434200d4efd651d97b4427bb82570
 Directory: 9
-# Docker EOL: 2020-11-03
+# Docker EOL: 2021-02-12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/65cee66: Update to 9.2.0