### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.27.0, 2.27, 2, latest
+Tags: 2.28.0, 2.28, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0ca9298af038b99b239bc9ee29e68ed397fecd74
+GitCommit: 3c9bdb8fca6397c92b2b70e905aed1113ddb5a9d
 Directory: 2/debian
 
-Tags: 2.27.0-alpine, 2.27-alpine, 2-alpine, alpine
+Tags: 2.28.0-alpine, 2.28-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ca9298af038b99b239bc9ee29e68ed397fecd74
+GitCommit: 3c9bdb8fca6397c92b2b70e905aed1113ddb5a9d
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3c9bdb8: Update to 2.28.0, ghost-cli 1.11.0