### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/4888a23bd174482198c489b8905a10de22741b7b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/2f757af6d12f4239cf5541455b011921ee4c06d1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -32,65 +32,44 @@ GitCommit: c6d7e7fb21b03905c4796293f9bdbba5227acd75
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.12-xenial, 4.0-xenial, 4-xenial, xenial
-SharedTags: 4.0.12, 4.0, 4, latest
+Tags: 4.0.12-xenial, 4.0-xenial
+SharedTags: 4.0.12, 4.0
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 Architectures: amd64, arm64v8
 GitCommit: 56dd5c86b7a329b944845ea782fb98a3384d8d4e
 Directory: 4.0
 
-Tags: 4.0.12-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.0.12-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.12, 4.0, 4, latest
+Tags: 4.0.12-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
+SharedTags: 4.0.12-windowsservercore, 4.0-windowsservercore, 4.0.12, 4.0
 Architectures: windows-amd64
 GitCommit: 56dd5c86b7a329b944845ea782fb98a3384d8d4e
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.12-windowsservercore-1803, 4.0-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.0.12-windowsservercore, 4.0-windowsservercore, 4-windowsservercore, windowsservercore, 4.0.12, 4.0, 4, latest
+Tags: 4.0.12-windowsservercore-1803, 4.0-windowsservercore-1803
+SharedTags: 4.0.12-windowsservercore, 4.0-windowsservercore, 4.0.12, 4.0
 Architectures: windows-amd64
 GitCommit: 56dd5c86b7a329b944845ea782fb98a3384d8d4e
 Directory: 4.0/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 4.1.13-bionic, 4.1-bionic, unstable-bionic
-SharedTags: 4.1.13, 4.1, unstable
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.1/multiverse/
+Tags: 4.2.0-bionic, 4.2-bionic, 4-bionic, bionic
+SharedTags: 4.2.0, 4.2, 4, latest
+# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: 3f117ac35a947ddff307aee85ecd5abe9e3a0fe1
-Directory: 4.1
+GitCommit: 2f757af6d12f4239cf5541455b011921ee4c06d1
+Directory: 4.2
 
-Tags: 4.1.13-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016, unstable-windowsservercore-ltsc2016
-SharedTags: 4.1.13-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.13, 4.1, unstable
+Tags: 4.2.0-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.2.0-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.0, 4.2, 4, latest
 Architectures: windows-amd64
-GitCommit: 385d26429b42f0de1b97b1df48964af8b191f8fe
-Directory: 4.1/windows/windowsservercore-ltsc2016
+GitCommit: 2f757af6d12f4239cf5541455b011921ee4c06d1
+Directory: 4.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.13-windowsservercore-1803, 4.1-windowsservercore-1803, unstable-windowsservercore-1803
-SharedTags: 4.1.13-windowsservercore, 4.1-windowsservercore, unstable-windowsservercore, 4.1.13, 4.1, unstable
+Tags: 4.2.0-windowsservercore-1803, 4.2-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
+SharedTags: 4.2.0-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.0, 4.2, 4, latest
 Architectures: windows-amd64
-GitCommit: 385d26429b42f0de1b97b1df48964af8b191f8fe
-Directory: 4.1/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
-Tags: 4.2.0-rc8-bionic, 4.2-rc-bionic, rc-bionic
-SharedTags: 4.2.0-rc8, 4.2-rc, rc
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/testing/multiverse/
-Architectures: amd64, arm64v8
-GitCommit: d08fed53123c22ab9ffa94c7a835df19c8145619
-Directory: 4.2-rc
-
-Tags: 4.2.0-rc8-windowsservercore-ltsc2016, 4.2-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 4.2.0-rc8-windowsservercore, 4.2-rc-windowsservercore, rc-windowsservercore, 4.2.0-rc8, 4.2-rc, rc
-Architectures: windows-amd64
-GitCommit: a3a213fd2b4b2c26c71408761534fc7eaafe517f
-Directory: 4.2-rc/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 4.2.0-rc8-windowsservercore-1803, 4.2-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 4.2.0-rc8-windowsservercore, 4.2-rc-windowsservercore, rc-windowsservercore, 4.2.0-rc8, 4.2-rc, rc
-Architectures: windows-amd64
-GitCommit: a3a213fd2b4b2c26c71408761534fc7eaafe517f
-Directory: 4.2-rc/windows/windowsservercore-1803
+GitCommit: 2f757af6d12f4239cf5541455b011921ee4c06d1
+Directory: 4.2/windows/windowsservercore-1803
 Constraints: windowsservercore-1803


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/2f757af: Add 4.2.0 GA release (removes 4.1)