### PR TITLE
[nats] Release 2.0.4

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,35 +2,35 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 
-Tags: 2.0.2-linux, linux
-SharedTags: 2.0.2, latest
+Tags: 2.0.4-linux, linux
+SharedTags: 2.0.4, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 amd64-Directory: amd64
-arm32v6-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+arm32v6-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+arm32v7-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+arm64v8-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 arm64v8-Directory: arm64v8
 
-Tags: 2.0.2-nanoserver, nanoserver, nanoserver-1803
-SharedTags: 2.0.2, latest
+Tags: 2.0.4-nanoserver, nanoserver, nanoserver-1803
+SharedTags: 2.0.4, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 windows-amd64-Directory: windows/nanoserver-1803
 Constraints: nanoserver-1803
 
-Tags: 2.0.2-nanoserver-1809, nanoserver-1809
+Tags: 2.0.4-nanoserver-1809, nanoserver-1809
 Architectures: windows-amd64
-windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 windows-amd64-Directory: windows/nanoserver-1809
 Constraints: nanoserver-1809
 
-Tags: 2.0.2-windowsservercore, windowsservercore
+Tags: 2.0.4-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 1d19738cad8d4e2c654ead45c2b5cbe3b9f29c83
+windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.0.4)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>