### PR TITLE
Updated mainline nginx to 1.17.3, stable to 1.16.1

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,42 +3,42 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.17.2, mainline, 1, 1.17, latest
+Tags: 1.17.3, mainline, 1, 1.17, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c817e28dd68b6daa33265a8cb527b1c4cd723b59
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: mainline/buster
 
-Tags: 1.17.2-perl, mainline-perl, 1-perl, 1.17-perl, perl
+Tags: 1.17.3-perl, mainline-perl, 1-perl, 1.17-perl, perl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c817e28dd68b6daa33265a8cb527b1c4cd723b59
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: mainline/buster-perl
 
-Tags: 1.17.2-alpine, mainline-alpine, 1-alpine, 1.17-alpine, alpine
+Tags: 1.17.3-alpine, mainline-alpine, 1-alpine, 1.17-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c817e28dd68b6daa33265a8cb527b1c4cd723b59
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: mainline/alpine
 
-Tags: 1.17.2-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.17-alpine-perl, alpine-perl
+Tags: 1.17.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.17-alpine-perl, alpine-perl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: c817e28dd68b6daa33265a8cb527b1c4cd723b59
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: mainline/alpine-perl
 
-Tags: 1.16.0, stable, 1.16
+Tags: 1.16.1, stable, 1.16
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a052e07b2c283df9960375ee40be50c5c462a7e
-Directory: stable/stretch
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
+Directory: stable/buster
 
-Tags: 1.16.0-perl, stable-perl, 1.16-perl
+Tags: 1.16.1-perl, stable-perl, 1.16-perl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a052e07b2c283df9960375ee40be50c5c462a7e
-Directory: stable/stretch-perl
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
+Directory: stable/buster-perl
 
-Tags: 1.16.0-alpine, stable-alpine, 1.16-alpine
+Tags: 1.16.1-alpine, stable-alpine, 1.16-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a052e07b2c283df9960375ee40be50c5c462a7e
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: stable/alpine
 
-Tags: 1.16.0-alpine-perl, stable-alpine-perl, 1.16-alpine-perl
+Tags: 1.16.1-alpine-perl, stable-alpine-perl, 1.16-alpine-perl
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a052e07b2c283df9960375ee40be50c5c462a7e
+GitCommit: e3bbc1131a683dabf868268e62b9d3fbd250191b
 Directory: stable/alpine-perl


### PR DESCRIPTION
These updates are addressed to fix recently discovered security issues related to HTTP/2 protocol implementation in nginx:

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9511
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9516