### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-2.2.0-php7.1, cli-2.2-php7.1, cli-2-php7.1, cli-php7.1
+Tags: cli-2.3.0-php7.1, cli-2.3-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
+GitCommit: 1283fde76747fe5992e714b782b01a65e9973a47
 Directory: php7.1/cli
 
-Tags: cli-2.2.0-php7.2, cli-2.2-php7.2, cli-2-php7.2, cli-php7.2
+Tags: cli-2.3.0-php7.2, cli-2.3-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
+GitCommit: 1283fde76747fe5992e714b782b01a65e9973a47
 Directory: php7.2/cli
 
-Tags: cli-2.2.0, cli-2.2, cli-2, cli, cli-2.2.0-php7.3, cli-2.2-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.3.0, cli-2.3, cli-2, cli, cli-2.3.0-php7.3, cli-2.3-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c9f1ca12b6fa8181dee161dfc5ce1692eeaef1d1
+GitCommit: 1283fde76747fe5992e714b782b01a65e9973a47
 Directory: php7.3/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/1283fde: Update to cli 2.3.0