### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/7e21408e1f6ffe1809fb76bbfc1d9f1bb20e54bb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/e39d62579f239513fbb71808a2586c84a9944d7d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -51,59 +51,59 @@ GitCommit: 88b5e2b06f35a9bd7ae91dd3a534be8dcf9be8c7
 Directory: 1.13-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.12.8-buster, 1.12-buster, 1-buster, buster
-SharedTags: 1.12.8, 1.12, 1, latest
+Tags: 1.12.9-buster, 1.12-buster, 1-buster, buster
+SharedTags: 1.12.9, 1.12, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/buster
 
-Tags: 1.12.8-stretch, 1.12-stretch, 1-stretch, stretch
+Tags: 1.12.9-stretch, 1.12-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/stretch
 
-Tags: 1.12.8-alpine3.10, 1.12-alpine3.10, 1-alpine3.10, alpine3.10, 1.12.8-alpine, 1.12-alpine, 1-alpine, alpine
+Tags: 1.12.9-alpine3.10, 1.12-alpine3.10, 1-alpine3.10, alpine3.10, 1.12.9-alpine, 1.12-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/alpine3.10
 
-Tags: 1.12.8-alpine3.9, 1.12-alpine3.9, 1-alpine3.9, alpine3.9
+Tags: 1.12.9-alpine3.9, 1.12-alpine3.9, 1-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/alpine3.9
 
-Tags: 1.12.8-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.12.8-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.8, 1.12, 1, latest
+Tags: 1.12.9-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.9, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12.8-windowsservercore-1803, 1.12-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.12.8-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.8, 1.12, 1, latest
+Tags: 1.12.9-windowsservercore-1803, 1.12-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.9, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12.8-windowsservercore-1809, 1.12-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.12.8-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.8, 1.12, 1, latest
+Tags: 1.12.9-windowsservercore-1809, 1.12-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1-windowsservercore, windowsservercore, 1.12.9, 1.12, 1, latest
 Architectures: windows-amd64
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12.8-nanoserver-1803, 1.12-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
-SharedTags: 1.12.8-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.12.9-nanoserver-1803, 1.12-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
+SharedTags: 1.12.9-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.12.8-nanoserver-1809, 1.12-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.12.8-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.12.9-nanoserver-1809, 1.12-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.12.9-nanoserver, 1.12-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 07bcd8df6f16890e8d13d982e9495800037ea0a5
+GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
 Directory: 1.12/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/2f6469f: Update to 1.12.9
- https://github.com/docker-library/golang/commit/e39d625: Use slightly more defensive COPY parsing