### PR TITLE
[nats-streaming] Release v0.16.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,34 +1,34 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 
-Tags: 0.15.1-linux, linux
-SharedTags: 0.15.1, latest
+Tags: 0.16.0-linux, linux
+SharedTags: 0.16.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+amd64-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 amd64-Directory: amd64
-arm32v6-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+arm32v6-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+arm32v7-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+arm64v8-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 arm64v8-Directory: arm64v8
 
-Tags: 0.15.1-nanoserver, nanoserver
-SharedTags: 0.15.1, latest
+Tags: 0.16.0-nanoserver, nanoserver, nanoserver-1803
+SharedTags: 0.16.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
-windows-amd64-Directory: windows/nanoserver
+windows-amd64-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
+windows-amd64-Directory: windows/nanoserver-1803
 Constraints: nanoserver-1803
 
-Tags: 0.15.1-nanoserver-1809, nanoserver-1809
+Tags: 0.16.0-nanoserver-1809, nanoserver-1809
 Architectures: windows-amd64
-windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
-windows-amd64-Directory: windows/nanoserver2019
+windows-amd64-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
+windows-amd64-Directory: windows/nanoserver-1809
 Constraints: nanoserver-1809
 
-Tags: 0.15.1-windowsservercore, windowsservercore
+Tags: 0.16.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: f786858e5806c3d34532f6cdeab41f9bf26e6e01
+windows-amd64-GitCommit: ed069d4902a57e52f5c6ddbc9c33361c269c5d16
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.16.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>