### PR TITLE
[security] Update node.js to 8.16.1, 10.16.3, and 12.8.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,104 +3,104 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.16.0-jessie, 8.16-jessie, 8-jessie, carbon-jessie
+Tags: 8.16.1-jessie, 8.16-jessie, 8-jessie, carbon-jessie
 Architectures: amd64, arm32v7, i386
-GitCommit: 7e47b378c42b03ae6afae704c5bf5b724aae2b92
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/jessie
 
-Tags: 8.16.0-jessie-slim, 8.16-jessie-slim, 8-jessie-slim, carbon-jessie-slim
+Tags: 8.16.1-jessie-slim, 8.16-jessie-slim, 8-jessie-slim, carbon-jessie-slim
 Architectures: amd64, arm32v7, i386
-GitCommit: 7e47b378c42b03ae6afae704c5bf5b724aae2b92
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/jessie-slim
 
-Tags: 8.16.0-alpine, 8.16-alpine, 8-alpine, carbon-alpine
+Tags: 8.16.1-alpine, 8.16-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e47b378c42b03ae6afae704c5bf5b724aae2b92
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/alpine
 
-Tags: 8.16.0-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.16.1-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8dbfa5c7cac9dca9145c6f429cd2c4f11176707
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/onbuild
 
-Tags: 8.16.0-stretch, 8.16-stretch, 8-stretch, carbon-stretch, 8.16.0, 8.16, 8, carbon
+Tags: 8.16.1-stretch, 8.16-stretch, 8-stretch, carbon-stretch, 8.16.1, 8.16, 8, carbon
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e47b378c42b03ae6afae704c5bf5b724aae2b92
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/stretch
 
-Tags: 8.16.0-stretch-slim, 8.16-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.16.0-slim, 8.16-slim, 8-slim, carbon-slim
+Tags: 8.16.1-stretch-slim, 8.16-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.16.1-slim, 8.16-slim, 8-slim, carbon-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e47b378c42b03ae6afae704c5bf5b724aae2b92
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/stretch-slim
 
-Tags: 8.16.0-buster, 8.16-buster, 8-buster, carbon-buster
+Tags: 8.16.1-buster, 8.16-buster, 8-buster, carbon-buster
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a856dabc31fab501ab85a911b93559079684a3a
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/buster
 
-Tags: 8.16.0-buster-slim, 8.16-buster-slim, 8-buster-slim, carbon-buster-slim
+Tags: 8.16.1-buster-slim, 8.16-buster-slim, 8-buster-slim, carbon-buster-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a856dabc31fab501ab85a911b93559079684a3a
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/buster-slim
 
-Tags: 12.8.0-alpine, 12.8-alpine, 12-alpine, current-alpine, alpine
+Tags: 12.8.1-alpine, 12.8-alpine, 12-alpine, current-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 12/alpine
 
-Tags: 12.8.0-stretch, 12.8-stretch, 12-stretch, current-stretch, stretch, 12.8.0, 12.8, 12, current, latest
+Tags: 12.8.1-stretch, 12.8-stretch, 12-stretch, current-stretch, stretch, 12.8.1, 12.8, 12, current, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 12/stretch
 
-Tags: 12.8.0-stretch-slim, 12.8-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.8.0-slim, 12.8-slim, 12-slim, current-slim, slim
+Tags: 12.8.1-stretch-slim, 12.8-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.8.1-slim, 12.8-slim, 12-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 12/stretch-slim
 
-Tags: 12.8.0-buster, 12.8-buster, 12-buster, current-buster, buster
+Tags: 12.8.1-buster, 12.8-buster, 12-buster, current-buster, buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 12/buster
 
-Tags: 12.8.0-buster-slim, 12.8-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
+Tags: 12.8.1-buster-slim, 12.8-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04daea3cdd2a34571d06fbbe74bcee305dd1d7bc
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 12/buster-slim
 
-Tags: 10.16.2-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie
+Tags: 10.16.3-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie
 Architectures: amd64, arm32v7
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/jessie
 
-Tags: 10.16.2-jessie-slim, 10.16-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
+Tags: 10.16.3-jessie-slim, 10.16-jessie-slim, 10-jessie-slim, dubnium-jessie-slim, lts-jessie-slim
 Architectures: amd64, arm32v7
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/jessie-slim
 
-Tags: 10.16.2-alpine, 10.16-alpine, 10-alpine, dubnium-alpine, lts-alpine
+Tags: 10.16.3-alpine, 10.16-alpine, 10-alpine, dubnium-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/alpine
 
-Tags: 10.16.2-stretch, 10.16-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.16.2, 10.16, 10, dubnium, lts
+Tags: 10.16.3-stretch, 10.16-stretch, 10-stretch, dubnium-stretch, lts-stretch, 10.16.3, 10.16, 10, dubnium, lts
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/stretch
 
-Tags: 10.16.2-stretch-slim, 10.16-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.16.2-slim, 10.16-slim, 10-slim, dubnium-slim, lts-slim
+Tags: 10.16.3-stretch-slim, 10.16-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.16.3-slim, 10.16-slim, 10-slim, dubnium-slim, lts-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/stretch-slim
 
-Tags: 10.16.2-buster, 10.16-buster, 10-buster, dubnium-buster, lts-buster
+Tags: 10.16.3-buster, 10.16-buster, 10-buster, dubnium-buster, lts-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/buster
 
-Tags: 10.16.2-buster-slim, 10.16-buster-slim, 10-buster-slim, dubnium-buster-slim, lts-buster-slim
+Tags: 10.16.3-buster-slim, 10.16-buster-slim, 10-buster-slim, dubnium-buster-slim, lts-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2524f98f3bcedcfc943a52feb519adf0ee0e3629
+GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 10/buster-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8


### PR DESCRIPTION
@nodejs is the maintainer according to https://github.com/docker-library/official-images/blob/862ee92cb5adb6c572391da7e3fde048daa257f3/library/node#L3, but I'm not sure that is right.

per release process in https://github.com/nodejs/security-wg/blob/master/processes/security_release_process.md#release-day

cc: @mhdawson 

