### PR TITLE
update notary to 0.6.1-2

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,10 +1,10 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: ee9401173fbe4c672f3e3e71b0881d21f2112eca
+GitCommit: 278bbe63ea6bfb67974fe969c77e02049fe47ab7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: server-0.6.1-1, server
+Tags: server-0.6.1-2, server
 Directory: notary-server
 
-Tags: signer-0.6.1-1, signer
+Tags: signer-0.6.1-2, signer
 Directory: notary-signer


### PR DESCRIPTION
updates the Dockerfile to use alpine 3.10 and Go 1.12.8 (tagged as 0.6.1-2; https://github.com/docker/notary-official-images/commit/278bbe63ea6bfb67974fe969c77e02049fe47ab7)

relates to https://github.com/docker/notary-official-images/pull/17