### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.4, 2.0, latest
+Tags: 2.0.5, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e948aa9880c8184c8e001bc5416cabf10d507f1
+GitCommit: c6235dddf03c8ee0cbc998904bb4dd3899cd37bb
 Directory: 2.0
 
-Tags: 2.0.4-alpine, 2.0-alpine, alpine
+Tags: 2.0.5-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e948aa9880c8184c8e001bc5416cabf10d507f1
+GitCommit: c6235dddf03c8ee0cbc998904bb4dd3899cd37bb
 Directory: 2.0/alpine
 
 Tags: 1.9.10, 1.9, 1
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9efd6eb655c9ce87ccf6b84a68f2b4e647fff706
 Directory: 1.9/alpine
 
-Tags: 1.8.20, 1.8
+Tags: 1.8.21, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
+GitCommit: 3dbb06aa772a093dab4b88660f8470a4f28de310
 Directory: 1.8
 
-Tags: 1.8.20-alpine, 1.8-alpine
+Tags: 1.8.21-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
+GitCommit: 3dbb06aa772a093dab4b88660f8470a4f28de310
 Directory: 1.8/alpine
 
 Tags: 1.7.11, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3dbb06a: Update to 1.8.21
- https://github.com/docker-library/haproxy/commit/c6235dd: Update to 2.0.5