### PR TITLE
alpine: bump 3.10.2 and add a `3` tag

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.1, 3.10, latest
+Tags: 3.10.2, 3.10, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: 34fd41e9b9901d7b346a22c670e5875a84ecfc35
+GitCommit: da78fcf5c5da55092aa82a97095274b3df648866
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fixes https://github.com/alpinelinux/docker-alpine/issues/21