### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,7 +1,8 @@
-Maintainers: Andy Naumann <naumann@us.ibm.com> (@naumanna),
+Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
+             Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 994cf7a115f989174e402888c0249c4b8cf8a231
+GitCommit: fa460c97c3e082f1e541a8f397b87663a74d54eb
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
Updating to pickup Open Liberty `19.0.0.8` and fixing the `bin/sh` issues.