### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.28.1, 2.28, 2, latest
+Tags: 2.29.0, 2.29, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 90ea94153526a04e835186c17716deb1e73fd61d
+GitCommit: 3218eafd372a59d9bc35afa91ff2d28cb25e527b
 Directory: 2/debian
 
-Tags: 2.28.1-alpine, 2.28-alpine, 2-alpine, alpine
+Tags: 2.29.0-alpine, 2.29-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 90ea94153526a04e835186c17716deb1e73fd61d
+GitCommit: 3218eafd372a59d9bc35afa91ff2d28cb25e527b
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3218eaf: Update to 2.29.0, ghost-cli 1.11.0