### PR TITLE
arangodb 3.5.0 and arangodb 3.4.7

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,5 +1,6 @@
 # maintainer: Frank Celler <info@arangodb.com> (@fceller)
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
+# maintainer: Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
 
 2.8: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
 2.8.11: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
@@ -7,6 +8,8 @@
 3.2.17: https://github.com/arangodb/arangodb-docker@b4c22ad8bf4facbbc7c3b24e985251a09fcdbcec stretch/3.2.17
 3.3: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
 3.3.23: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
-3.4: https://github.com/arangodb/arangodb-docker@930d315e04b231549a86f127ca9d2462eeaf2ebb alpine/3.4.7
-3.4.7: https://github.com/arangodb/arangodb-docker@930d315e04b231549a86f127ca9d2462eeaf2ebb alpine/3.4.7
-latest: https://github.com/arangodb/arangodb-docker@930d315e04b231549a86f127ca9d2462eeaf2ebb alpine/3.4.7
+3.4: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.4.7
+3.4.7: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.4.7
+3.5: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0
+3.5.0: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0
+latest: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0


### PR DESCRIPTION
Updated ArangoDB to 3.5.0 and renew for 3.4.7.