### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -19,6 +19,21 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
 Directory: bionic
 
+Tags: bullseye-curl, testing-curl
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3c71697594e9eef1d673df9f1d379fdc0f7ff111
+Directory: bullseye/curl
+
+Tags: bullseye-scm, testing-scm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3c71697594e9eef1d673df9f1d379fdc0f7ff111
+Directory: bullseye/scm
+
+Tags: bullseye, testing
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3c71697594e9eef1d673df9f1d379fdc0f7ff111
+Directory: bullseye
+
 Tags: buster-curl, stable-curl, curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/aa76cb2: Merge pull request https://github.com/docker-library/buildpack-deps/pull/97 from vicamo/for-upstream/add-debian-bullseye
- https://github.com/docker-library/buildpack-deps/commit/3c71697: Add Debian Bullseye