### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.0-beta.6, 3.8-rc
+Tags: 3.8.0-beta.7, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2ec310b5a0703baa81b67582cc6778a27363aace
+GitCommit: 8a5c57be054b3bbe8b93cda97c05cb0fb485ca7f
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.0-beta.6-management, 3.8-rc-management
+Tags: 3.8.0-beta.7-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.0-beta.6-alpine, 3.8-rc-alpine
+Tags: 3.8.0-beta.7-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 2ec310b5a0703baa81b67582cc6778a27363aace
+GitCommit: 8a5c57be054b3bbe8b93cda97c05cb0fb485ca7f
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.0-beta.6-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.0-beta.7-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8a5c57b: Update to 3.8.0-beta.7, Erlang/OTP 22.0.7, OpenSSL 1.1.1c