### PR TITLE
[varnish] keep ca-certificates around

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,13 +1,13 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/82ba69727be4e78de5a3e07a63e8b62d92ab958d/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/b7f54428d14d6c5c9758f741a74f4b6d329212f1/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: 6.2, 6.2.0-1, 6.2.0, 6, latest, fresh
 Architectures: amd64
 Directory: fresh/debian
-GitCommit: 82ba69727be4e78de5a3e07a63e8b62d92ab958d
+GitCommit: b7f54428d14d6c5c9758f741a74f4b6d329212f1
 
 Tags: 6.0, 6.0.3-1, 6.0.3, stable
 Architectures: amd64
 Directory: stable/debian
-GitCommit: 82ba69727be4e78de5a3e07a63e8b62d92ab958d
+GitCommit: b7f54428d14d6c5c9758f741a74f4b6d329212f1


### PR DESCRIPTION
`apt-transport-https` was left in the image to allow people to call `apt update`, removing `ca-certificate` prevents it.