### PR TITLE
arangodb 3.4.7 and 3.5.0 (less CVEs)

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -8,8 +8,8 @@
 3.2.17: https://github.com/arangodb/arangodb-docker@b4c22ad8bf4facbbc7c3b24e985251a09fcdbcec stretch/3.2.17
 3.3: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
 3.3.23: https://github.com/arangodb/arangodb-docker@24db8fa0429ce6fa1f7d56e54c9bb3da51c32b3e stretch/3.3.23
-3.4: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.4.7
-3.4.7: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.4.7
-3.5: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0
-3.5.0: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0
-latest: https://github.com/arangodb/arangodb-docker@8e2f64800a7a7e5e8c88e4573a58ab70ab01cc9c alpine/3.5.0
+3.4: https://github.com/arangodb/arangodb-docker@b2ecb91f1d8e4ae3fe66b59abff364d01d49625a alpine/3.4.7
+3.4.7: https://github.com/arangodb/arangodb-docker@b2ecb91f1d8e4ae3fe66b59abff364d01d49625a alpine/3.4.7
+3.5: https://github.com/arangodb/arangodb-docker@b2ecb91f1d8e4ae3fe66b59abff364d01d49625a alpine/3.5.0
+3.5.0: https://github.com/arangodb/arangodb-docker@b2ecb91f1d8e4ae3fe66b59abff364d01d49625a alpine/3.5.0
+latest: https://github.com/arangodb/arangodb-docker@b2ecb91f1d8e4ae3fe66b59abff364d01d49625a alpine/3.5.0


### PR DESCRIPTION
Try to address some CVEs that are detected in multiple layers, but not present in actual final images.