### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.29.0, 2.29, 2, latest
+Tags: 2.29.1, 2.29, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3218eafd372a59d9bc35afa91ff2d28cb25e527b
+GitCommit: ef8c18269c6eaaf4d9f1ab49afd2e030b649b052
 Directory: 2/debian
 
-Tags: 2.29.0-alpine, 2.29-alpine, 2-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 3218eafd372a59d9bc35afa91ff2d28cb25e527b
+Tags: 2.29.1-alpine, 2.29-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ef8c18269c6eaaf4d9f1ab49afd2e030b649b052
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1
@@ -20,6 +20,6 @@ GitCommit: 6d485f5797c96fae0aef795a38999453d5aa665d
 Directory: 1/debian
 
 Tags: 1.26.0-alpine, 1.26-alpine, 1-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8eba604d6b6078a318e0a83771ebc8e09f350bf0
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/ef8c182: Update to 2.29.1, ghost-cli 1.11.0