### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,6 +24,26 @@ Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
+Tags: 3.7.18-beta.1, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8290b5b3c215c63b8eb1c003f6239c7a06f88c7f
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.18-beta.1-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.18-beta.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 8290b5b3c215c63b8eb1c003f6239c7a06f88c7f
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.18-beta.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.17, 3.7, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0a0135181c1b4976fe7be63a00bac5762c86792


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8290b5b: Update to 3.7.18-beta.1, Erlang/OTP 22.0.7, OpenSSL 1.1.1c