### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-10-jdk-oraclelinux7, 14-ea-10-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-10-jdk-oracle, 14-ea-10-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-10-jdk, 14-ea-10, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-11-jdk-oraclelinux7, 14-ea-11-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-11-jdk-oracle, 14-ea-11-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-11-jdk, 14-ea-11, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 09c008262a9eb3748da68be6eeb2c31e1ff48e38
+GitCommit: 0b27ae01321952c764c24c5f79c146fce11ec8a7
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
@@ -16,24 +16,24 @@ Architectures: amd64
 GitCommit: 5f603d0b657d0a87212ad16d304a1ce5e2533d82
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-10-jdk-windowsservercore-1809, 14-ea-10-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-10-jdk-windowsservercore, 14-ea-10-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-10-jdk, 14-ea-10, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-11-jdk-windowsservercore-1809, 14-ea-11-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-11-jdk-windowsservercore, 14-ea-11-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-11-jdk, 14-ea-11, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 09c008262a9eb3748da68be6eeb2c31e1ff48e38
+GitCommit: 0b27ae01321952c764c24c5f79c146fce11ec8a7
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-10-jdk-windowsservercore-1803, 14-ea-10-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-10-jdk-windowsservercore, 14-ea-10-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-10-jdk, 14-ea-10, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-11-jdk-windowsservercore-1803, 14-ea-11-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-11-jdk-windowsservercore, 14-ea-11-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-11-jdk, 14-ea-11, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 09c008262a9eb3748da68be6eeb2c31e1ff48e38
+GitCommit: 0b27ae01321952c764c24c5f79c146fce11ec8a7
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-10-jdk-windowsservercore-ltsc2016, 14-ea-10-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-10-jdk-windowsservercore, 14-ea-10-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-10-jdk, 14-ea-10, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-11-jdk-windowsservercore-ltsc2016, 14-ea-11-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-11-jdk-windowsservercore, 14-ea-11-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-11-jdk, 14-ea-11, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 09c008262a9eb3748da68be6eeb2c31e1ff48e38
+GitCommit: 0b27ae01321952c764c24c5f79c146fce11ec8a7
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0b27ae0: Update to 14-ea+11