### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/openjdk.git
 Tags: 14-ea-11-jdk-oraclelinux7, 14-ea-11-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-11-jdk-oracle, 14-ea-11-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
 SharedTags: 14-ea-11-jdk, 14-ea-11, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 0b27ae01321952c764c24c5f79c146fce11ec8a7
+GitCommit: 7efc7a9956ea7f0f55fc752ca18a55e193d9c55a
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
@@ -40,7 +40,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 13-jdk-oraclelinux7, 13-oraclelinux7, 13-jdk-oracle, 13-oracle
 SharedTags: 13-jdk, 13
 Architectures: amd64
-GitCommit: aeb02a53ca43da29d6e820e5fe485db7ba03b879
+GitCommit: 7efc7a9956ea7f0f55fc752ca18a55e193d9c55a
 Directory: 13/jdk/oracle
 Constraints: !aufs
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/aa54394: Merge pull request https://github.com/docker-library/openjdk/pull/352 from infosiftr/binutils
- https://github.com/docker-library/openjdk/commit/7efc7a9: Add binutils for objcopy to fix `jlink --strip-debug` on oracle 13+