### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.29.1, 2.29, 2, latest
+Tags: 2.30.1, 2.30, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ef8c18269c6eaaf4d9f1ab49afd2e030b649b052
+GitCommit: 039c7d554fbb628ead03f97d50b1b5e762d9bb3a
 Directory: 2/debian
 
-Tags: 2.29.1-alpine, 2.29-alpine, 2-alpine, alpine
+Tags: 2.30.1-alpine, 2.30-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef8c18269c6eaaf4d9f1ab49afd2e030b649b052
+GitCommit: 039c7d554fbb628ead03f97d50b1b5e762d9bb3a
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/039c7d5: Update to 2.30.1, ghost-cli 1.11.0