### PR TITLE
Node: Update node.js v12 from v12.9.0 to v12.9.1

### DIFF
--- a/library/node
+++ b/library/node
@@ -43,29 +43,29 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/buster-slim
 
-Tags: 12.9.0-alpine, 12.9-alpine, 12-alpine, current-alpine, alpine
+Tags: 12.9.1-alpine, 12.9-alpine, 12-alpine, current-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d27ed99d96923967171052947a07662e7bf7b7b
+GitCommit: 3c8db579b7cc363280a96a6b66d6ff6f4e4b0826
 Directory: 12/alpine
 
-Tags: 12.9.0-stretch, 12.9-stretch, 12-stretch, current-stretch, stretch, 12.9.0, 12.9, 12, current, latest
+Tags: 12.9.1-stretch, 12.9-stretch, 12-stretch, current-stretch, stretch, 12.9.1, 12.9, 12, current, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8d27ed99d96923967171052947a07662e7bf7b7b
+GitCommit: 3c8db579b7cc363280a96a6b66d6ff6f4e4b0826
 Directory: 12/stretch
 
-Tags: 12.9.0-stretch-slim, 12.9-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.9.0-slim, 12.9-slim, 12-slim, current-slim, slim
+Tags: 12.9.1-stretch-slim, 12.9-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.9.1-slim, 12.9-slim, 12-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8d27ed99d96923967171052947a07662e7bf7b7b
+GitCommit: 3c8db579b7cc363280a96a6b66d6ff6f4e4b0826
 Directory: 12/stretch-slim
 
-Tags: 12.9.0-buster, 12.9-buster, 12-buster, current-buster, buster
+Tags: 12.9.1-buster, 12.9-buster, 12-buster, current-buster, buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8d27ed99d96923967171052947a07662e7bf7b7b
+GitCommit: 3c8db579b7cc363280a96a6b66d6ff6f4e4b0826
 Directory: 12/buster
 
-Tags: 12.9.0-buster-slim, 12.9-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
+Tags: 12.9.1-buster-slim, 12.9-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8d27ed99d96923967171052947a07662e7bf7b7b
+GitCommit: 3c8db579b7cc363280a96a6b66d6ff6f4e4b0826
 Directory: 12/buster-slim
 
 Tags: 10.16.3-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie
@@ -105,10 +105,10 @@ Directory: 10/buster-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 741bef243a8587332e20d150c38ecb3949a3d06d
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 8c0a9f2c144904631cf783bdd57b4a19300e6b1f
+GitCommit: 741bef243a8587332e20d150c38ecb3949a3d06d
 Directory: chakracore/10


### PR DESCRIPTION
Update node.js v12 from v12.9.0 to v12.9.1

The bot failed to create this...

https://travis-ci.com/nodejs/docker-node/jobs/228408596