### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -19,92 +19,92 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.7-rc/alpine3.10
 
-Tags: 2.6.3-buster, 2.6-buster, 2-buster, buster, 2.6.3, 2.6, 2, latest
+Tags: 2.6.4-buster, 2.6-buster, 2-buster, buster, 2.6.4, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/buster
 
-Tags: 2.6.3-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.3-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.4-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.4-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/buster/slim
 
-Tags: 2.6.3-stretch, 2.6-stretch, 2-stretch, stretch
+Tags: 2.6.4-stretch, 2.6-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/stretch
 
-Tags: 2.6.3-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
+Tags: 2.6.4-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.3-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.3-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.4-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.4-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/alpine3.10
 
-Tags: 2.6.3-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
+Tags: 2.6.4-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
 Directory: 2.6/alpine3.9
 
-Tags: 2.5.5-buster, 2.5-buster, 2.5.5, 2.5
+Tags: 2.5.6-buster, 2.5-buster, 2.5.6, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/buster
 
-Tags: 2.5.5-slim-buster, 2.5-slim-buster, 2.5.5-slim, 2.5-slim
+Tags: 2.5.6-slim-buster, 2.5-slim-buster, 2.5.6-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bffb6ff1fbe37874ed506a15eb1bb7faffca589b
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/buster/slim
 
-Tags: 2.5.5-stretch, 2.5-stretch
+Tags: 2.5.6-stretch, 2.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/stretch
 
-Tags: 2.5.5-slim-stretch, 2.5-slim-stretch
+Tags: 2.5.6-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.5-alpine3.10, 2.5-alpine3.10, 2.5.5-alpine, 2.5-alpine
+Tags: 2.5.6-alpine3.10, 2.5-alpine3.10, 2.5.6-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/alpine3.10
 
-Tags: 2.5.5-alpine3.9, 2.5-alpine3.9
+Tags: 2.5.6-alpine3.9, 2.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
 Directory: 2.5/alpine3.9
 
-Tags: 2.4.6-buster, 2.4-buster, 2.4.6, 2.4
+Tags: 2.4.7-buster, 2.4-buster, 2.4.7, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/buster
 
-Tags: 2.4.6-slim-buster, 2.4-slim-buster, 2.4.6-slim, 2.4-slim
+Tags: 2.4.7-slim-buster, 2.4-slim-buster, 2.4.7-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/buster/slim
 
-Tags: 2.4.6-stretch, 2.4-stretch
+Tags: 2.4.7-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/stretch
 
-Tags: 2.4.6-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.7-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.6-alpine3.10, 2.4-alpine3.10, 2.4.6-alpine, 2.4-alpine
+Tags: 2.4.7-alpine3.10, 2.4-alpine3.10, 2.4.7-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/alpine3.10
 
-Tags: 2.4.6-alpine3.9, 2.4-alpine3.9
+Tags: 2.4.7-alpine3.9, 2.4-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
+GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
 Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/6a7df7a: Update to 2.6.4
- https://github.com/docker-library/ruby/commit/a545699: Update to 2.4.7, rubygems 3.0.3
- https://github.com/docker-library/ruby/commit/32f51b6: Update to 2.5.6, rubygems 3.0.3