### PR TITLE
Update Flink images

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,75 +1,25 @@
-# this file is generated via https://github.com/docker-flink/docker-flink/blob/01e41867c9270cd4dd44970cdbe53ff665e0c9e3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-flink/docker-flink/blob/89abc4a50ec8810c558a8b24891f69f375a19f71/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/docker-flink/docker-flink.git
 
-Tags: 1.7.2-hadoop24-scala_2.11
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop24-scala_2.11-debian
-
-Tags: 1.7.2-hadoop24-scala_2.12, 1.7.2-hadoop24, 1.7-hadoop24
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop24-scala_2.12-debian
-
-Tags: 1.7.2-hadoop26-scala_2.11
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop26-scala_2.11-debian
-
-Tags: 1.7.2-hadoop26-scala_2.12, 1.7.2-hadoop26, 1.7-hadoop26
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop26-scala_2.12-debian
-
-Tags: 1.7.2-hadoop27-scala_2.11
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop27-scala_2.11-debian
-
-Tags: 1.7.2-hadoop27-scala_2.12, 1.7.2-hadoop27, 1.7-hadoop27
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop27-scala_2.12-debian
-
-Tags: 1.7.2-hadoop28-scala_2.11
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop28-scala_2.11-debian
-
-Tags: 1.7.2-hadoop28-scala_2.12, 1.7.2-hadoop28, 1.7-hadoop28
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/hadoop28-scala_2.12-debian
-
-Tags: 1.7.2-scala_2.11, 1.7-scala_2.11
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/scala_2.11-debian
-
-Tags: 1.7.2-scala_2.12, 1.7-scala_2.12, 1.7.2, 1.7
-Architectures: amd64
-GitCommit: f96f07a516dbd4d9544d22c5272006ccd0b988d6
-Directory: 1.7/scala_2.12-debian
-
 Tags: 1.8.1-scala_2.11, 1.8-scala_2.11
 Architectures: amd64
-GitCommit: 60c582b1422f77a336bafb89fb9ae4f1965027a8
+GitCommit: 29f5bebe0261f3103a49a5cab5de982d4d16fb76
 Directory: 1.8/scala_2.11-debian
 
 Tags: 1.8.1-scala_2.12, 1.8-scala_2.12, 1.8.1, 1.8
 Architectures: amd64
-GitCommit: 60c582b1422f77a336bafb89fb9ae4f1965027a8
+GitCommit: 29f5bebe0261f3103a49a5cab5de982d4d16fb76
 Directory: 1.8/scala_2.12-debian
 
 Tags: 1.9.0-scala_2.11, 1.9-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 96ba1b82f27b6d551828e470a2f4058a5874653d
+GitCommit: 29f5bebe0261f3103a49a5cab5de982d4d16fb76
 Directory: 1.9/scala_2.11-debian
 
 Tags: 1.9.0-scala_2.12, 1.9-scala_2.12, scala_2.12, 1.9.0, 1.9, latest
 Architectures: amd64
-GitCommit: 96ba1b82f27b6d551828e470a2f4058a5874653d
+GitCommit: 29f5bebe0261f3103a49a5cab5de982d4d16fb76
 Directory: 1.9/scala_2.12-debian


### PR DESCRIPTION
Sorry for the churn here.

This removes an older version of Flink and updates the entrypoint script
for docker-flink/docker-flink#82.