### PR TITLE
Update golang to 1.13rc2

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,49 +5,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.13rc1-buster, 1.13-rc-buster, rc-buster
-SharedTags: 1.13rc1, 1.13-rc, rc
+Tags: 1.13rc2-buster, 1.13-rc-buster, rc-buster
+SharedTags: 1.13rc2, 1.13-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/buster
 
-Tags: 1.13rc1-alpine3.10, 1.13-rc-alpine3.10, rc-alpine3.10, 1.13rc1-alpine, 1.13-rc-alpine, rc-alpine
+Tags: 1.13rc2-alpine3.10, 1.13-rc-alpine3.10, rc-alpine3.10, 1.13rc2-alpine, 1.13-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/alpine3.10
 
-Tags: 1.13rc1-windowsservercore-ltsc2016, 1.13-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.13rc1-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc1, 1.13-rc, rc
+Tags: 1.13rc2-windowsservercore-ltsc2016, 1.13-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.13rc2-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc2, 1.13-rc, rc
 Architectures: windows-amd64
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13rc1-windowsservercore-1803, 1.13-rc-windowsservercore-1803, rc-windowsservercore-1803
-SharedTags: 1.13rc1-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc1, 1.13-rc, rc
+Tags: 1.13rc2-windowsservercore-1803, 1.13-rc-windowsservercore-1803, rc-windowsservercore-1803
+SharedTags: 1.13rc2-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc2, 1.13-rc, rc
 Architectures: windows-amd64
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.13rc1-windowsservercore-1809, 1.13-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.13rc1-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc1, 1.13-rc, rc
+Tags: 1.13rc2-windowsservercore-1809, 1.13-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.13rc2-windowsservercore, 1.13-rc-windowsservercore, rc-windowsservercore, 1.13rc2, 1.13-rc, rc
 Architectures: windows-amd64
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.13rc1-nanoserver-1803, 1.13-rc-nanoserver-1803, rc-nanoserver-1803
-SharedTags: 1.13rc1-nanoserver, 1.13-rc-nanoserver, rc-nanoserver
+Tags: 1.13rc2-nanoserver-1803, 1.13-rc-nanoserver-1803, rc-nanoserver-1803
+SharedTags: 1.13rc2-nanoserver, 1.13-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.13rc1-nanoserver-1809, 1.13-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.13rc1-nanoserver, 1.13-rc-nanoserver, rc-nanoserver
+Tags: 1.13rc2-nanoserver-1809, 1.13-rc-nanoserver-1809, rc-nanoserver-1809
+SharedTags: 1.13rc2-nanoserver, 1.13-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 955434214f9ef9c4b41aa513041845cc49595af7
+GitCommit: 3a6407a6ff134ef6a0364ac061b0808f990ea14e
 Directory: 1.13-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

https://github.com/docker-library/golang/commit/3a6407a6ff134ef6a0364ac061b0808f990ea14e

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>