### PR TITLE
Release of GeoNetwork 3.8.0

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,13 +1,22 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/40ed4dce1cba141b69baffd2eac833e7f59d12aa/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/f5f6c7c39d1a3d5260a68d21086e062a511bf487/generate-stackbrew-library.sh
 
-Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1)
+Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
+     Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: 3.6.0, 3.6, latest
-GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
+Tags: 3.6.0, 3.6
+GitCommit: e249c6031a55559392204a2c3ef8e8f8d11545a5
 Directory: 3.6.0
 
-Tags: 3.6.0-postgres, 3.6-postgres, postgres
+Tags: 3.6.0-postgres, 3.6-postgres
 GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
 Directory: 3.6.0/postgres
+
+Tags: 3.8.0, 3.8, latest
+GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
+Directory: 3.8.0
+
+Tags: 3.8.0-postgres, 3.8-postgres, postgres
+GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
+Directory: 3.8.0/postgres

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/f5f6c7c39d1a3d5260a68d21086e062a511bf487/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/27a30d076d7358917d9f0d06577ff856f2e8e2b6/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64
 
 Tags: 3.6.0, 3.6
 GitCommit: e249c6031a55559392204a2c3ef8e8f8d11545a5


### PR DESCRIPTION
Updated official GN version to its latest release (3.8.0), to catch up with the [latest changes on the image code](https://github.com/geonetwork/docker-geonetwork).

Also updated base image of all the releases to use `tomcat:8.5-jdk8` instead of the deprecated `jre-8` version. Removed all the architectures not supported by the new base image.