### PR TITLE
Bump Traefik to v2.0.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,7 +1,7 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-rc2, 2.0.0-rc1, v2.0, 2.0, montdor
+Tags: v2.0.0-rc2, 2.0.0-rc2, v2.0, 2.0, montdor
 Architectures: amd64, arm64v8, arm32v6
 GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: scratch

--- a/library/traefik
+++ b/library/traefik
@@ -6,12 +6,12 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: scratch
 
-Tags: v2.0.0-rc2-alpine, 2.0.0-rc1-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
+Tags: v2.0.0-rc2-alpine, 2.0.0-rc2-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
 Architectures: amd64, arm64v8, arm32v6
 GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: alpine
 
-Tags: v2.0.0-rc2-nanoserver, 2.0.0-rc1-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc2-nanoserver-sac2016, 2.0.0-rc1-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
+Tags: v2.0.0-rc2-nanoserver, 2.0.0-rc2-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc2-nanoserver-sac2016, 2.0.0-rc2-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
 Architectures: windows-amd64
 GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: windows/sac2016

--- a/library/traefik
+++ b/library/traefik
@@ -1,19 +1,19 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-rc1, 2.0.0-rc1, v2.0, 2.0, montdor
+Tags: v2.0.0-rc2, 2.0.0-rc1, v2.0, 2.0, montdor
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: cf77451bbd3fa4a46020edbf2e5e7df63ad9cf97
+GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: scratch
 
-Tags: v2.0.0-rc1-alpine, 2.0.0-rc1-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
+Tags: v2.0.0-rc2-alpine, 2.0.0-rc1-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: cf77451bbd3fa4a46020edbf2e5e7df63ad9cf97
+GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: alpine
 
-Tags: v2.0.0-rc1-nanoserver, 2.0.0-rc1-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc1-nanoserver-sac2016, 2.0.0-rc1-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
+Tags: v2.0.0-rc2-nanoserver, 2.0.0-rc1-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc2-nanoserver-sac2016, 2.0.0-rc1-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: cf77451bbd3fa4a46020edbf2e5e7df63ad9cf97
+GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
 Directory: windows/sac2016
 Constraints: nanoserver-sac2016
 


### PR DESCRIPTION
Hello,

This PR updates Traefik to v2.0.0-rc2.

/cc @mmatur @emilevauge @juliens 

Cheers
