### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/b806ff0a2624776464ec9c7ecbda16c2c9ec5e69/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/321c63f0c4f23a59c213be28a3c14f4d7cdfbb1f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: b806ff0a2624776464ec9c7ecbda16c2c9ec5e69
+GitCommit: 321c63f0c4f23a59c213be28a3c14f4d7cdfbb1f
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4b11c30f87d3033b2abd446c9bc1ef12f96abaa0
+amd64-GitCommit: 04f6ab4f9c7ae51402cf5bfda84fadf30353d8ed
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: cd305b71286a17d5c042b88ad117bba45969ea81
+arm32v5-GitCommit: 84f0e92c4446f8dddca0bbdb0fa798a468b54d49
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 2296f50908d71b0f8a86afbe5d782e09622cb74c
+arm32v6-GitCommit: 21b20bfcd9c75e7c72c3299e7f6256e8e92601f8
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 09cbf9e893da77030d891bdddba964f15f46ef2f
+arm32v7-GitCommit: 356b00a630b59d13d2aa1d963f254ed8c0f6ed9e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4f741e2e30631d9a1c6f82c4a3bab4a54938ae30
+arm64v8-GitCommit: 1b4dfaab852f7787ed3b4b5b940a48bc69fe4fd8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 01ff8f3a983a948bca28af93a91050094a4f1946
+i386-GitCommit: b9b3667ac90f63aaa01b44a6b0baa06af1e74366
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9d8d5921c51a99d142fc3fc57d8c152d2ba64891
+ppc64le-GitCommit: 2957509064ed35b32a8eb3ee0a494a7c3b68ed59
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2a9497b287e0997a1ef5b48647fdd5df4ca1f758
+s390x-GitCommit: 27f04fb4e18b22cc1ebb9fe223da12c06cd0cccf
 
 Tags: 1.31.0-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/321c63f: Update Buildroot to 2019.08
- https://github.com/docker-library/busybox/commit/de019d8: Update generated README