### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -11,9 +11,9 @@ GitCommit: dec3c117d0c8fa9462bd1d475f3c5aae5a4d85f9
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-8-jdk-alpine3.10, 14-ea-8-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-8-jdk-alpine, 14-ea-8-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
+Tags: 14-ea-12-jdk-alpine3.10, 14-ea-12-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-12-jdk-alpine, 14-ea-12-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
 Architectures: amd64
-GitCommit: 5f603d0b657d0a87212ad16d304a1ce5e2533d82
+GitCommit: b57ab1457d190f313c46ffbec2b994b041b4d08c
 Directory: 14/jdk/alpine
 
 Tags: 14-ea-12-jdk-windowsservercore-1809, 14-ea-12-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/b57ab14: Update to 14-ea+12
- https://github.com/docker-library/openjdk/commit/0ad03ab: Update generated README