### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,6 +8,6 @@ Tags: 7.3.1
 GitCommit: 4c895ab3753726b22c25f03b17155d84c14d8931
 Directory: 7
 
-Tags: 6.8.2
-GitCommit: c0d76b639100772a683dcca7112965812e8cae70
+Tags: 6.8.3
+GitCommit: 3fd5624019e3fe0550c09211f0443c2653119223
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -8,6 +8,6 @@ Tags: 7.3.1
 GitCommit: 644633fee0f4c15e9bbbd2c1cdb00e5c1a8f7ffc
 Directory: 7
 
-Tags: 6.8.2
-GitCommit: 649eaa8423334d8780c80d7eb4dc7b5325a72361
+Tags: 6.8.3
+GitCommit: d22fd0db711dbe593f7a6b2673c44b9e699fcdd6
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -8,6 +8,6 @@ Tags: 7.3.1
 GitCommit: 040afba995876cf26184ef0036b89c65df200971
 Directory: 7
 
-Tags: 6.8.2
-GitCommit: 7bd7406709bc3af4ab29ca7556f12be697d2c95c
+Tags: 6.8.3
+GitCommit: 346baa394828982908410b99d4d7fe25e07153e3
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/3fd5624: Update to 6.8.3
- https://github.com/docker-library/elasticsearch/commit/5d107b3: Update generated README

logstash:
- https://github.com/docker-library/logstash/commit/346baa3: Update to 6.8.3
- https://github.com/docker-library/logstash/commit/8587970: Update generated README

kibana:
- https://github.com/docker-library/kibana/commit/d22fd0d: Update to 6.8.3
- https://github.com/docker-library/kibana/commit/d2cc8d1: Update generated README