### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-12-jdk-oraclelinux7, 14-ea-12-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-12-jdk-oracle, 14-ea-12-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-12-jdk, 14-ea-12, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-13-jdk-oraclelinux7, 14-ea-13-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-13-jdk-oracle, 14-ea-13-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: dec3c117d0c8fa9462bd1d475f3c5aae5a4d85f9
+GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
@@ -16,24 +16,24 @@ Architectures: amd64
 GitCommit: b57ab1457d190f313c46ffbec2b994b041b4d08c
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-12-jdk-windowsservercore-1809, 14-ea-12-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-12-jdk-windowsservercore, 14-ea-12-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-12-jdk, 14-ea-12, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-13-jdk-windowsservercore-1809, 14-ea-13-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: dec3c117d0c8fa9462bd1d475f3c5aae5a4d85f9
+GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-12-jdk-windowsservercore-1803, 14-ea-12-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-12-jdk-windowsservercore, 14-ea-12-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-12-jdk, 14-ea-12, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-13-jdk-windowsservercore-1803, 14-ea-13-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: dec3c117d0c8fa9462bd1d475f3c5aae5a4d85f9
+GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-12-jdk-windowsservercore-ltsc2016, 14-ea-12-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-12-jdk-windowsservercore, 14-ea-12-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-12-jdk, 14-ea-12, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-13-jdk-windowsservercore-ltsc2016, 14-ea-13-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: dec3c117d0c8fa9462bd1d475f3c5aae5a4d85f9
+GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d2d90df: Update to 14-ea+13