### PR TITLE
Lib definition file for opendistro for elasticsearch official image

### DIFF
--- a/library/opendistro-for-elasticsearch
+++ b/library/opendistro-for-elasticsearch
@@ -1,6 +1,5 @@
-Maintainers: opendistro-for-elasticsearch (@opendistroforelasticsearch),
-             Alolita Sharma (@alolitas),
-             Rishabh Singh (@rishabh6788)
+Maintainers: opendistro-for-elasticsearch <opensearch-infra@amazon.com>  (@opendistroforelasticsearch),
+
 GitRepo:     https://github.com/opendistro-for-elasticsearch/opendistro-build.git
 
 GitCommit:   8cd7aec13ccde0562ab3b0b700206a315bfb6832

--- a/library/opendistro-for-elasticsearch
+++ b/library/opendistro-for-elasticsearch
@@ -1,0 +1,9 @@
+Maintainers: opendistro-for-elasticsearch (@opendistroforelasticsearch)
+             Alolita Sharma (@alolitas)
+             Rishabh Singh (@rishabh6788)
+GitRepo:     https://github.com/opendistro-for-elasticsearch/opendistro-build.git
+
+GitCommit:   8cd7aec13ccde0562ab3b0b700206a315bfb6832
+
+Tags:        1, 1.0, 1.0.0, 1.0.1, 1.0.2, 1.1.0, latest
+Directory:   docker

--- a/library/opendistro-for-elasticsearch
+++ b/library/opendistro-for-elasticsearch
@@ -1,5 +1,5 @@
-Maintainers: opendistro-for-elasticsearch (@opendistroforelasticsearch)
-             Alolita Sharma (@alolitas)
+Maintainers: opendistro-for-elasticsearch (@opendistroforelasticsearch),
+             Alolita Sharma (@alolitas),
              Rishabh Singh (@rishabh6788)
 GitRepo:     https://github.com/opendistro-for-elasticsearch/opendistro-build.git
 

--- a/library/opendistro-for-elasticsearch
+++ b/library/opendistro-for-elasticsearch
@@ -1,7 +1,5 @@
-Maintainers: opendistro-for-elasticsearch <opensearch-infra@amazon.com>  (@opendistroforelasticsearch),
-
+Maintainers: opendistro-for-elasticsearch <opensearch-infra@amazon.com>  (@opendistroforelasticsearch)
 GitRepo:     https://github.com/opendistro-for-elasticsearch/opendistro-build.git
-
 GitCommit:   8cd7aec13ccde0562ab3b0b700206a315bfb6832
 
 Tags:        1, 1.0, 1.0.0, 1.0.1, 1.0.2, 1.1.0, latest


### PR DESCRIPTION
This PR adds an official image containing [Opendistro for Elasticsearch](https://hub.docker.com/r/amazon/opendistro-for-elasticsearch).

The image contains open distribution for Elasticsearch 