### PR TITLE
Update websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,9 +1,8 @@
 Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
-             Andy Naumann <naumann@us.ibm.com> (@naumanna),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 441260eac9b8ccd9f860fc3f64ce6b8bfa925d1f
+GitCommit: 60d69d604ab8356ee269daa767231dcab0e5fa71
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Ensuring our keystore config generation is backwards compatible with earlier Docker images.