### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -16,7 +16,7 @@ Directory: bionic/scm
 
 Tags: bionic, 18.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: bionic
 
 Tags: bullseye-curl, testing-curl
@@ -31,7 +31,7 @@ Directory: bullseye/scm
 
 Tags: bullseye, testing
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c71697594e9eef1d673df9f1d379fdc0f7ff111
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: bullseye
 
 Tags: buster-curl, stable-curl, curl
@@ -46,7 +46,7 @@ Directory: buster/scm
 
 Tags: buster, stable, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: buster
 
 Tags: cosmic-curl, 18.10-curl
@@ -61,7 +61,7 @@ Directory: cosmic/scm
 
 Tags: cosmic, 18.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: cosmic
 
 Tags: disco-curl, 19.04-curl
@@ -76,7 +76,7 @@ Directory: disco/scm
 
 Tags: disco, 19.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: disco
 
 Tags: eoan-curl, 19.10-curl
@@ -91,7 +91,7 @@ Directory: eoan/scm
 
 Tags: eoan, 19.10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f5fa2e64174be2821552587b23f7d84b1dae71c
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: eoan
 
 Tags: jessie-curl, oldoldstable-curl
@@ -106,7 +106,7 @@ Directory: jessie/scm
 
 Tags: jessie, oldoldstable
 Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: jessie
 
 Tags: sid-curl, unstable-curl
@@ -121,7 +121,7 @@ Directory: sid/scm
 
 Tags: sid, unstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: sid
 
 Tags: stretch-curl, oldstable-curl
@@ -136,7 +136,7 @@ Directory: stretch/scm
 
 Tags: stretch, oldstable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: stretch
 
 Tags: xenial-curl, 16.04-curl
@@ -151,5 +151,5 @@ Directory: xenial/scm
 
 Tags: xenial, 16.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff09b5c5288f4643056bd7938268d749e9f8a2db
+GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: xenial


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/698002f: Merge pull request https://github.com/docker-library/buildpack-deps/pull/98 from infosiftr/libmaxminddb-dev
- https://github.com/docker-library/buildpack-deps/commit/cd0058f: Replace (defunct) "libgeoip-dev" with "libmaxminddb-dev" (where available)
- https://github.com/docker-library/buildpack-deps/commit/b418e27: Remove outdated reference to wheezy in update.sh
- https://github.com/docker-library/buildpack-deps/commit/847ff5a: Update generated README