### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: fa460c97c3e082f1e541a8f397b87663a74d54eb
+GitCommit: b3207b755c5ded9ac105b9746632fcccb70e7abf
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm


### PR DESCRIPTION
Corresponding update from #6605 - ensuring the TLS support is backwards compatible with older images.