### PR TITLE
Bump Traefik to v2.0.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,19 +1,19 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-rc2, 2.0.0-rc2, v2.0, 2.0, montdor
+Tags: v2.0.0-rc3, 2.0.0-rc3, v2.0, 2.0, montdor
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
+GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: scratch
 
-Tags: v2.0.0-rc2-alpine, 2.0.0-rc2-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
+Tags: v2.0.0-rc3-alpine, 2.0.0-rc3-alpine, v2.0-alpine, 2.0-alpine, montdor-alpine
 Architectures: amd64, arm64v8, arm32v6
-GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
+GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: alpine
 
-Tags: v2.0.0-rc2-nanoserver, 2.0.0-rc2-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc2-nanoserver-sac2016, 2.0.0-rc2-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
+Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-sac2016, 2.0.0-rc3-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
 Architectures: windows-amd64
-GitCommit: 5de2ba0bde779c08d99a87f70cf46fd24c185f68
+GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: windows/sac2016
 Constraints: nanoserver-sac2016
 

--- a/library/traefik
+++ b/library/traefik
@@ -11,12 +11,6 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: alpine
 
-Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-1809, 2.0.0-rc3-nanoserver-1809, v2.0-nanoserver-1809, 2.0-nanoserver-1809, montdor-nanoserver-1809
-Architectures: windows-amd64
-GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
-Directory: windows/1809
-Constraints: nanoserver-1809
-
 Tags: v1.7.14, 1.7.14, v1.7, 1.7, maroilles, latest
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 1220871969fc11f5e619bba4de3355e695fe3061

--- a/library/traefik
+++ b/library/traefik
@@ -11,7 +11,7 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: alpine
 
-Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-1809, 2.0.0-rc3-nanoserver-sac2016, v2.0-nanoserver-1809, 2.0-nanoserver-1809, montdor-nanoserver-1809
+Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-1809, 2.0.0-rc3-nanoserver-1809, v2.0-nanoserver-1809, 2.0-nanoserver-1809, montdor-nanoserver-1809
 Architectures: windows-amd64
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: windows/1809

--- a/library/traefik
+++ b/library/traefik
@@ -11,11 +11,11 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: alpine
 
-Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-sac2016, 2.0.0-rc3-nanoserver-sac2016, v2.0-nanoserver-sac2016, 2.0-nanoserver-sac2016, montdor-nanoserver-sac2016
+Tags: v2.0.0-rc3-nanoserver, 2.0.0-rc3-nanoserver, v2.0-nanoserver, 2.0-nanoserver, montdor-nanoserver, v2.0.0-rc3-nanoserver-1809, 2.0.0-rc3-nanoserver-sac2016, v2.0-nanoserver-1809, 2.0-nanoserver-1809, montdor-nanoserver-1809
 Architectures: windows-amd64
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
-Directory: windows/sac2016
-Constraints: nanoserver-sac2016
+Directory: windows/1809
+Constraints: nanoserver-1809
 
 Tags: v1.7.14, 1.7.14, v1.7, 1.7, maroilles, latest
 Architectures: amd64, arm32v6, arm64v8
@@ -28,9 +28,3 @@ Tags: v1.7.14-alpine, 1.7.14-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine, 
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 1220871969fc11f5e619bba4de3355e695fe3061
 Directory: alpine
-
-Tags: v1.7.14-nanoserver, 1.7.14-nanoserver, v1.7-nanoserver, 1.7-nanoserver, maroilles-nanoserver, v1.7.14-nanoserver-sac2016, 1.7.14-nanoserver-sac2016, v1.7-nanoserver-sac2016, 1.7-nanoserver-sac2016, maroilles-nanoserver-sac2016, nanoserver, nanoserver-sac2016
-Architectures: windows-amd64
-GitCommit: 1220871969fc11f5e619bba4de3355e695fe3061
-Directory: windows
-Constraints: nanoserver-sac2016


### PR DESCRIPTION
Hello,

This PR updates Traefik to v2.0.0-rc3.

/cc @mmatur @emilevauge @juliens 

Cheers
