### PR TITLE
Bump Traefik to v1.7.15

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -11,14 +11,12 @@ Architectures: amd64, arm64v8, arm32v6
 GitCommit: 65a0466cd3336a0fd048ef4b06cd9a08a9edae6e
 Directory: alpine
 
-Tags: v1.7.14, 1.7.14, v1.7, 1.7, maroilles, latest
+Tags: v1.7.15, 1.7.15, v1.7, 1.7, maroilles, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 1220871969fc11f5e619bba4de3355e695fe3061
-amd64-Directory: scratch/amd64
-arm32v6-Directory: scratch/arm
-arm64v8-Directory: scratch/arm64
+GitCommit: 7fdb3306ad96133928541d5305b771173aab0313
+Directory: scratch
 
-Tags: v1.7.14-alpine, 1.7.14-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine, alpine
+Tags: v1.7.15-alpine, 1.7.15-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 1220871969fc11f5e619bba4de3355e695fe3061
+GitCommit: 7fdb3306ad96133928541d5305b771173aab0313
 Directory: alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to v1.7.15.

/cc @mmatur @emilevauge @juliens 

Cheers
