### PR TITLE
Add TomEE 7.0.6 on Java 8

### DIFF
--- a/library/tomee
+++ b/library/tomee
@@ -1,6 +1,6 @@
 Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars), Otavio Santana <otaviojava@apache.org> (@otaviojava), Jonathan Gallimore <jgallimore@apache.org> (@jgallimore)
 GitRepo: https://github.com/tomitribe/docker-tomee.git
-GitCommit: 52efab45bc8f74a1ce70f1e5cd03b52eb139e1f3
+GitCommit: fbe01211d21051406ffaae5bdf41d1f629caf58f
 Architectures: amd64
 
 Tags: 8-jre-1.7.5-jaxrs
@@ -32,6 +32,15 @@ Directory: 8-jre-7.0.5-plus
 
 Tags: 8-jre-7.0.5-webprofile
 Directory: 8-jre-7.0.5-webprofile
+
+Tags: 8-jre-7.0.6-plume
+Directory: 8-jre-7.0.6-plume
+
+Tags: 8-jre-7.0.6-plus
+Directory: 8-jre-7.0.6-plus
+
+Tags: 8-jre-7.0.6-webprofile
+Directory: 8-jre-7.0.6-webprofile
 
 Tags: 8-jre-7.1.0-plume
 Directory: 8-jre-7.1.0-plume


### PR DESCRIPTION
This PR adds TomEE 7.0.6 on Java 8 to the available TomEE images.