### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-13-jdk-oraclelinux7, 14-ea-13-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-13-jdk-oracle, 14-ea-13-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-14-jdk-oraclelinux7, 14-ea-14-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-14-jdk-oracle, 14-ea-14-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-14-jdk, 14-ea-14, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
+GitCommit: 70db83bbbbcc0a6e9406ff695581e82fe4d84a1d
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
@@ -16,24 +16,24 @@ Architectures: amd64
 GitCommit: b57ab1457d190f313c46ffbec2b994b041b4d08c
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-13-jdk-windowsservercore-1809, 14-ea-13-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-14-jdk-windowsservercore-1809, 14-ea-14-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-14-jdk-windowsservercore, 14-ea-14-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-14-jdk, 14-ea-14, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
+GitCommit: 70db83bbbbcc0a6e9406ff695581e82fe4d84a1d
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-13-jdk-windowsservercore-1803, 14-ea-13-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-14-jdk-windowsservercore-1803, 14-ea-14-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-14-jdk-windowsservercore, 14-ea-14-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-14-jdk, 14-ea-14, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
+GitCommit: 70db83bbbbcc0a6e9406ff695581e82fe4d84a1d
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-13-jdk-windowsservercore-ltsc2016, 14-ea-13-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-13-jdk-windowsservercore, 14-ea-13-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-13-jdk, 14-ea-13, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-14-jdk-windowsservercore-ltsc2016, 14-ea-14-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-14-jdk-windowsservercore, 14-ea-14-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-14-jdk, 14-ea-14, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: d2d90df1bb8d4f7b711f494be5ab2ace567ae8a9
+GitCommit: 70db83bbbbcc0a6e9406ff695581e82fe4d84a1d
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
@@ -96,12 +96,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.4-jdk-stretch, 11.0.4-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
 SharedTags: 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 11/jdk
 
 Tags: 11.0.4-jdk-slim-buster, 11.0.4-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.4-jdk-slim, 11.0.4-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 11/jdk/slim
 
 Tags: 11.0.4-jdk-windowsservercore-1809, 11.0.4-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
@@ -128,12 +128,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.4-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
 SharedTags: 11.0.4-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 11/jre
 
 Tags: 11.0.4-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.4-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 11/jre/slim
 
 Tags: 11.0.4-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
@@ -160,12 +160,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u222-jdk-stretch, 8u222-stretch, 8-jdk-stretch, 8-stretch
 SharedTags: 8u222-jdk, 8u222, 8-jdk, 8
 Architectures: amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 8/jdk
 
 Tags: 8u222-jdk-slim-buster, 8u222-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u222-jdk-slim, 8u222-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 8/jdk/slim
 
 Tags: 8u222-jdk-windowsservercore-1809, 8u222-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
@@ -192,12 +192,12 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u222-jre-stretch, 8-jre-stretch
 SharedTags: 8u222-jre, 8-jre
 Architectures: amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 8/jre
 
 Tags: 8u222-jre-slim-buster, 8-jre-slim-buster, 8u222-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 451e66427f3c53fada288aaff950617c5864745f
 Directory: 8/jre/slim
 
 Tags: 8u222-jre-windowsservercore-1809, 8-jre-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/70db83b: Update to 14-ea+14
- https://github.com/docker-library/openjdk/commit/9375e32: Merge pull request https://github.com/docker-library/openjdk/pull/356 from infosiftr/no-self-sigs-only
- https://github.com/docker-library/openjdk/commit/451e664: Apply no-self-sigs-only as necessary