### PR TITLE
Bump Traefik to v2.0.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,29 +1,29 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-rc4, 2.0.0-rc4, v2.0, 2.0, montdor
-Architectures: amd64, arm64v8, arm32v6
-GitCommit: 9895566e03b5800b431d5ee89a7b56b39f612b59
-Directory: alpine
-
-Tags: v2.0.0-rc4-windowsservercore-1809, 2.0.0-rc4-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809
+Tags: v2.0.0-windowsservercore-1809, 2.0.0-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 9895566e03b5800b431d5ee89a7b56b39f612b59
+GitCommit: 9954ed014366d9def23b3d695e38cad339ff14bc
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.16, 1.7.16, v1.7, 1.7, maroilles, latest
+Tags: v2.0.0, 2.0.0, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
+GitCommit: 9954ed014366d9def23b3d695e38cad339ff14bc
+Directory: alpine
+
+Tags: v1.7.16-windowsservercore-1809, 1.7.16-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Architectures: windows-amd64
 GitCommit: c35c242498450bb31333770ec3bce26260020d6f
-Directory: scratch
+Directory: windows/1809
+Constraints: windowsservercore-1809
 
 Tags: v1.7.16-alpine, 1.7.16-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: c35c242498450bb31333770ec3bce26260020d6f
 Directory: alpine
 
-Tags: v1.7.16-windowsservercore-1809, 1.7.16-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
+Tags: v1.7.16, 1.7.16, v1.7, 1.7, maroilles
+Architectures: amd64, arm32v6, arm64v8
 GitCommit: c35c242498450bb31333770ec3bce26260020d6f
-Directory: windows/1809
-Constraints: windowsservercore-1809
+Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to v2.0.0.

/cc @mmatur @emilevauge

Cheers
