### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.5, 2.0, latest
+Tags: 2.0.6, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c6235dddf03c8ee0cbc998904bb4dd3899cd37bb
+GitCommit: 3c15abf52542d1e8765cc675cbba05fc3eeb9d04
 Directory: 2.0
 
-Tags: 2.0.5-alpine, 2.0-alpine, alpine
+Tags: 2.0.6-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
+GitCommit: 3c15abf52542d1e8765cc675cbba05fc3eeb9d04
 Directory: 2.0/alpine
 
 Tags: 1.9.10, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3c15abf: Update to 2.0.6