### PR TITLE
Add SapMachine 13

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -6,7 +6,7 @@ Architectures: amd64
 GitCommit: 7346e49a86c5d8a44f6bf71f43b17e832b2d14e6
 Directory: dockerfiles/official/lts
 
-Tags: 12, 12.0.2, latest
+Tags: 13, latest
 Architectures: amd64
-GitCommit: d58f6c1977d616bcd8669d09687acd86199bb219
+GitCommit: 613ec0132bdb274ed8d0cf1fdabefb3ead3b9d9d
 Directory: dockerfiles/official/stable


### PR DESCRIPTION
SapMachine 13 replaces SapMachine 12 as latest stable release.