### PR TITLE
Add an ubuntu Kong image which includes arm64

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,16 +2,24 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 1.3.0-alpine, 1.3.0, 1.3, latest
-GitCommit: 21f7761927809788e0bbd6c9f2ecdc661afe5f84
+Tags: 1.3.0-alpine, 1.3.0, 1.3, alpine, latest
+GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
 GitFetch: refs/tags/1.3.0
 Directory: alpine
+Architectures: amd64
 
-Tags: 1.3.0-centos, 1.3-centos
-GitCommit: 21f7761927809788e0bbd6c9f2ecdc661afe5f84
+Tags: 1.3.0-ubuntu, 1.3-ubuntu, ubuntu
+GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
+GitFetch: refs/tags/1.3.0
+Directory: ubuntu
+Architectures: amd64, arm64v8
+
+Tags: 1.3.0-centos, 1.3-centos, centos
+GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
 GitFetch: refs/tags/1.3.0
 Constraints: !aufs
 Directory: centos
+Architectures: amd64
 
 Tags: 1.2.2-alpine, 1.2.2, 1.2
 GitCommit: 9a6d1a06b2e768949fda9ae7b30b747437fe388c


### PR DESCRIPTION
We're buildling Ubuntu (xenial) arm64 assets so to make Kong available via docker on arm64 adding an Ubuntu based image.

I debated including an `arm64` tag on the Ubuntu image for convenience (ie `docker run kong:arm64`) but wasn't sure if that was advisable