### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -4,148 +4,136 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/tomcat.git
 
-Tags: 9.0.24-jdk13-openjdk-oracle, 9.0-jdk13-openjdk-oracle, 9-jdk13-openjdk-oracle
+Tags: 9.0.26-jdk13-openjdk-oracle, 9.0-jdk13-openjdk-oracle, 9-jdk13-openjdk-oracle
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk13/openjdk-oracle
 Constraints: !aufs
 
-Tags: 9.0.24-jdk12-openjdk-oracle, 9.0-jdk12-openjdk-oracle, 9-jdk12-openjdk-oracle
-Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
-Directory: 9.0/jdk12/openjdk-oracle
-Constraints: !aufs
-
-Tags: 9.0.24-jdk12-adoptopenjdk-hotspot, 9.0-jdk12-adoptopenjdk-hotspot, 9-jdk12-adoptopenjdk-hotspot
+Tags: 9.0.26-jdk12-adoptopenjdk-hotspot, 9.0-jdk12-adoptopenjdk-hotspot, 9-jdk12-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk12/adoptopenjdk-hotspot
 
-Tags: 9.0.24-jdk12-adoptopenjdk-openj9, 9.0-jdk12-adoptopenjdk-openj9, 9-jdk12-adoptopenjdk-openj9
+Tags: 9.0.26-jdk12-adoptopenjdk-openj9, 9.0-jdk12-adoptopenjdk-openj9, 9-jdk12-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk12/adoptopenjdk-openj9
 
-Tags: 9.0.24-jdk11-openjdk, 9.0-jdk11-openjdk, 9-jdk11-openjdk, 9.0.24-jdk11, 9.0-jdk11, 9-jdk11, 9.0.24, 9.0, 9
+Tags: 9.0.26-jdk11-openjdk, 9.0-jdk11-openjdk, 9-jdk11-openjdk, 9.0.26-jdk11, 9.0-jdk11, 9-jdk11, 9.0.26, 9.0, 9
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk11/openjdk
 
-Tags: 9.0.24-jdk11-openjdk-slim, 9.0-jdk11-openjdk-slim, 9-jdk11-openjdk-slim
+Tags: 9.0.26-jdk11-openjdk-slim, 9.0-jdk11-openjdk-slim, 9-jdk11-openjdk-slim
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk11/openjdk-slim
 
-Tags: 9.0.24-jdk11-adoptopenjdk-hotspot, 9.0-jdk11-adoptopenjdk-hotspot, 9-jdk11-adoptopenjdk-hotspot
+Tags: 9.0.26-jdk11-adoptopenjdk-hotspot, 9.0-jdk11-adoptopenjdk-hotspot, 9-jdk11-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk11/adoptopenjdk-hotspot
 
-Tags: 9.0.24-jdk11-adoptopenjdk-openj9, 9.0-jdk11-adoptopenjdk-openj9, 9-jdk11-adoptopenjdk-openj9
+Tags: 9.0.26-jdk11-adoptopenjdk-openj9, 9.0-jdk11-adoptopenjdk-openj9, 9-jdk11-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk11/adoptopenjdk-openj9
 
-Tags: 9.0.24-jdk11-corretto, 9.0-jdk11-corretto, 9-jdk11-corretto
+Tags: 9.0.26-jdk11-corretto, 9.0-jdk11-corretto, 9-jdk11-corretto
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk11/corretto
 
-Tags: 9.0.24-jdk8-openjdk, 9.0-jdk8-openjdk, 9-jdk8-openjdk, 9.0.24-jdk8, 9.0-jdk8, 9-jdk8
+Tags: 9.0.26-jdk8-openjdk, 9.0-jdk8-openjdk, 9-jdk8-openjdk, 9.0.26-jdk8, 9.0-jdk8, 9-jdk8
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk8/openjdk
 
-Tags: 9.0.24-jdk8-openjdk-slim, 9.0-jdk8-openjdk-slim, 9-jdk8-openjdk-slim
+Tags: 9.0.26-jdk8-openjdk-slim, 9.0-jdk8-openjdk-slim, 9-jdk8-openjdk-slim
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk8/openjdk-slim
 
-Tags: 9.0.24-jdk8-adoptopenjdk-hotspot, 9.0-jdk8-adoptopenjdk-hotspot, 9-jdk8-adoptopenjdk-hotspot
+Tags: 9.0.26-jdk8-adoptopenjdk-hotspot, 9.0-jdk8-adoptopenjdk-hotspot, 9-jdk8-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk8/adoptopenjdk-hotspot
 
-Tags: 9.0.24-jdk8-adoptopenjdk-openj9, 9.0-jdk8-adoptopenjdk-openj9, 9-jdk8-adoptopenjdk-openj9
+Tags: 9.0.26-jdk8-adoptopenjdk-openj9, 9.0-jdk8-adoptopenjdk-openj9, 9-jdk8-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk8/adoptopenjdk-openj9
 
-Tags: 9.0.24-jdk8-corretto, 9.0-jdk8-corretto, 9-jdk8-corretto
+Tags: 9.0.26-jdk8-corretto, 9.0-jdk8-corretto, 9-jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: 576a39f9c78870657da9a76499370bcf2d9cb3ad
 Directory: 9.0/jdk8/corretto
 
-Tags: 8.5.45-jdk13-openjdk-oracle, 8.5-jdk13-openjdk-oracle, 8-jdk13-openjdk-oracle, jdk13-openjdk-oracle
+Tags: 8.5.46-jdk13-openjdk-oracle, 8.5-jdk13-openjdk-oracle, 8-jdk13-openjdk-oracle, jdk13-openjdk-oracle
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk13/openjdk-oracle
 Constraints: !aufs
 
-Tags: 8.5.45-jdk12-openjdk-oracle, 8.5-jdk12-openjdk-oracle, 8-jdk12-openjdk-oracle, jdk12-openjdk-oracle
-Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
-Directory: 8.5/jdk12/openjdk-oracle
-Constraints: !aufs
-
-Tags: 8.5.45-jdk12-adoptopenjdk-hotspot, 8.5-jdk12-adoptopenjdk-hotspot, 8-jdk12-adoptopenjdk-hotspot, jdk12-adoptopenjdk-hotspot
+Tags: 8.5.46-jdk12-adoptopenjdk-hotspot, 8.5-jdk12-adoptopenjdk-hotspot, 8-jdk12-adoptopenjdk-hotspot, jdk12-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk12/adoptopenjdk-hotspot
 
-Tags: 8.5.45-jdk12-adoptopenjdk-openj9, 8.5-jdk12-adoptopenjdk-openj9, 8-jdk12-adoptopenjdk-openj9, jdk12-adoptopenjdk-openj9
+Tags: 8.5.46-jdk12-adoptopenjdk-openj9, 8.5-jdk12-adoptopenjdk-openj9, 8-jdk12-adoptopenjdk-openj9, jdk12-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk12/adoptopenjdk-openj9
 
-Tags: 8.5.45-jdk11-openjdk, 8.5-jdk11-openjdk, 8-jdk11-openjdk, jdk11-openjdk, 8.5.45-jdk11, 8.5-jdk11, 8-jdk11, jdk11
+Tags: 8.5.46-jdk11-openjdk, 8.5-jdk11-openjdk, 8-jdk11-openjdk, jdk11-openjdk, 8.5.46-jdk11, 8.5-jdk11, 8-jdk11, jdk11
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk11/openjdk
 
-Tags: 8.5.45-jdk11-openjdk-slim, 8.5-jdk11-openjdk-slim, 8-jdk11-openjdk-slim, jdk11-openjdk-slim
+Tags: 8.5.46-jdk11-openjdk-slim, 8.5-jdk11-openjdk-slim, 8-jdk11-openjdk-slim, jdk11-openjdk-slim
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk11/openjdk-slim
 
-Tags: 8.5.45-jdk11-adoptopenjdk-hotspot, 8.5-jdk11-adoptopenjdk-hotspot, 8-jdk11-adoptopenjdk-hotspot, jdk11-adoptopenjdk-hotspot
+Tags: 8.5.46-jdk11-adoptopenjdk-hotspot, 8.5-jdk11-adoptopenjdk-hotspot, 8-jdk11-adoptopenjdk-hotspot, jdk11-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk11/adoptopenjdk-hotspot
 
-Tags: 8.5.45-jdk11-adoptopenjdk-openj9, 8.5-jdk11-adoptopenjdk-openj9, 8-jdk11-adoptopenjdk-openj9, jdk11-adoptopenjdk-openj9
+Tags: 8.5.46-jdk11-adoptopenjdk-openj9, 8.5-jdk11-adoptopenjdk-openj9, 8-jdk11-adoptopenjdk-openj9, jdk11-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk11/adoptopenjdk-openj9
 
-Tags: 8.5.45-jdk11-corretto, 8.5-jdk11-corretto, 8-jdk11-corretto, jdk11-corretto
+Tags: 8.5.46-jdk11-corretto, 8.5-jdk11-corretto, 8-jdk11-corretto, jdk11-corretto
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk11/corretto
 
-Tags: 8.5.45-jdk8-openjdk, 8.5-jdk8-openjdk, 8-jdk8-openjdk, jdk8-openjdk, 8.5.45-jdk8, 8.5-jdk8, 8-jdk8, jdk8, 8.5.45, 8.5, 8, latest
+Tags: 8.5.46-jdk8-openjdk, 8.5-jdk8-openjdk, 8-jdk8-openjdk, jdk8-openjdk, 8.5.46-jdk8, 8.5-jdk8, 8-jdk8, jdk8, 8.5.46, 8.5, 8, latest
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk8/openjdk
 
-Tags: 8.5.45-jdk8-openjdk-slim, 8.5-jdk8-openjdk-slim, 8-jdk8-openjdk-slim, jdk8-openjdk-slim
+Tags: 8.5.46-jdk8-openjdk-slim, 8.5-jdk8-openjdk-slim, 8-jdk8-openjdk-slim, jdk8-openjdk-slim
 Architectures: amd64
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk8/openjdk-slim
 
-Tags: 8.5.45-jdk8-adoptopenjdk-hotspot, 8.5-jdk8-adoptopenjdk-hotspot, 8-jdk8-adoptopenjdk-hotspot, jdk8-adoptopenjdk-hotspot
+Tags: 8.5.46-jdk8-adoptopenjdk-hotspot, 8.5-jdk8-adoptopenjdk-hotspot, 8-jdk8-adoptopenjdk-hotspot, jdk8-adoptopenjdk-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk8/adoptopenjdk-hotspot
 
-Tags: 8.5.45-jdk8-adoptopenjdk-openj9, 8.5-jdk8-adoptopenjdk-openj9, 8-jdk8-adoptopenjdk-openj9, jdk8-adoptopenjdk-openj9
+Tags: 8.5.46-jdk8-adoptopenjdk-openj9, 8.5-jdk8-adoptopenjdk-openj9, 8-jdk8-adoptopenjdk-openj9, jdk8-adoptopenjdk-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk8/adoptopenjdk-openj9
 
-Tags: 8.5.45-jdk8-corretto, 8.5-jdk8-corretto, 8-jdk8-corretto, jdk8-corretto
+Tags: 8.5.46-jdk8-corretto, 8.5-jdk8-corretto, 8-jdk8-corretto, jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
+GitCommit: d52ac18aaed6fcd6b13177d3bd557bea2ce6d608
 Directory: 8.5/jdk8/corretto
 
 Tags: 7.0.96-jdk8-openjdk, 7.0-jdk8-openjdk, 7-jdk8-openjdk, 7.0.96-jdk8, 7.0-jdk8, 7-jdk8, 7.0.96, 7.0, 7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/tomcat/commit/2aef48d: Remove OpenJDK 12 variants (now EOL)