### PR TITLE
Haskell GHC 8.8.1

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,10 +3,10 @@ Maintainers: Darin Morrison <darinmorrison+git@gmail.com> (@freebroccolo),
              Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi)
 GitRepo: https://github.com/freebroccolo/docker-haskell
 
-Tags: 8.6.5, 8.6, 8, latest
-GitCommit: 7fd359b8dab3bf543832eb1ff34e1a46eef262a7
-Directory: 8.6
+Tags: 8.8.1, 8.8, 8, latest
+GitCommit: 50cf25ae9a6faf49b9bae25e7da4b855f9918455
+Directory: 8.8
 
-Tags: 8.4.4, 8.4
-GitCommit: 03467e1a14543d83d33833e669249a3c42f7b7c8
-Directory: 8.4
+Tags: 8.6.5, 8.6
+GitCommit: 50cf25ae9a6faf49b9bae25e7da4b855f9918455
+Directory: 8.6


### PR DESCRIPTION
Add 8.8.1 and drop 8.4.4. It is intentional to not update extra components in the 8.6 image to be more compatible with existing ecosystem.