### PR TITLE
[nats] Release v2.1.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,35 +2,35 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 
-Tags: 2.0.4-linux, linux
-SharedTags: 2.0.4, latest
+Tags: 2.1.0-linux, linux
+SharedTags: 2.1.0, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+amd64-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 amd64-Directory: amd64
-arm32v6-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+arm32v6-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 arm32v6-Directory: arm32v6
-arm32v7-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+arm32v7-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 arm32v7-Directory: arm32v7
-arm64v8-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+arm64v8-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 arm64v8-Directory: arm64v8
 
-Tags: 2.0.4-nanoserver, nanoserver, nanoserver-1803
-SharedTags: 2.0.4, latest
+Tags: 2.1.0-nanoserver, nanoserver, nanoserver-1803
+SharedTags: 2.1.0, latest
 Architectures: windows-amd64
-windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+windows-amd64-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 windows-amd64-Directory: windows/nanoserver-1803
 Constraints: nanoserver-1803
 
-Tags: 2.0.4-nanoserver-1809, nanoserver-1809
+Tags: 2.1.0-nanoserver-1809, nanoserver-1809
 Architectures: windows-amd64
-windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+windows-amd64-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 windows-amd64-Directory: windows/nanoserver-1809
 Constraints: nanoserver-1809
 
-Tags: 2.0.4-windowsservercore, windowsservercore
+Tags: 2.1.0-windowsservercore, windowsservercore
 Architectures: windows-amd64
-windows-amd64-GitCommit: 9abb1b4d926fdcaea5a55e0451cd7725d3238de1
+windows-amd64-GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
 windows-amd64-Directory: windows/windowsservercore
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.1.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>