### PR TITLE
Update Clear Linux OS to 31070

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@289a7fa2e6c2b4d0658456229e0601e505e4db91
-base: git://github.com/clearlinux/docker-brew-clearlinux@289a7fa2e6c2b4d0658456229e0601e505e4db91
+latest: git://github.com/clearlinux/docker-brew-clearlinux@50971c45153318e83fc038fa841a7a04cc368785
+base: git://github.com/clearlinux/docker-brew-clearlinux@50971c45153318e83fc038fa841a7a04cc368785


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31070

@bryteise @gtkramer