### PR TITLE
Add Java 11 images for WebSphere Liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -11,59 +11,135 @@ Directory: beta
 Tags: kernel
 Directory: ga/latest/kernel
 
+Tags: kernel-java11
+Directory: ga/latest/kernel
+Architectures: amd64, ppc64le, s390x
+
 Tags: javaee8, latest
 Directory: ga/latest/javaee8
+
+Tags: javaee8-java11
+Directory: ga/latest/javaee8
+Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8
 Directory: ga/latest/webProfile8
 
+Tags: webProfile8-java11
+Directory: ga/latest/webProfile8
+Architectures: amd64, ppc64le, s390x
+
 Tags: microProfile1
 Directory: ga/latest/microProfile1
+
+Tags: microProfile1-java11
+Directory: ga/latest/microProfile1
+Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2
 Directory: ga/latest/microProfile2
 
+Tags: microProfile2-java11
+Directory: ga/latest/microProfile2
+Architectures: amd64, ppc64le, s390x
+
 Tags: microProfile3
 Directory: ga/latest/microProfile3
+
+Tags: microProfile3-java11
+Directory: ga/latest/microProfile3
+Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2
 Directory: ga/latest/springBoot2
 
+Tags: springBoot2-java11
+Directory: ga/latest/springBoot2
+Architectures: amd64, ppc64le, s390x
+
 Tags: springBoot1
 Directory: ga/latest/springBoot1
+
+Tags: springBoot1-java11
+Directory: ga/latest/springBoot1
+Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile7
 Directory: ga/latest/webProfile7
 
+Tags: webProfile7-java11
+Directory: ga/latest/webProfile7
+Architectures: amd64, ppc64le, s390x
+
 Tags: javaee7
 Directory: ga/latest/javaee7
+
+Tags: javaee7-java11
+Directory: ga/latest/javaee7
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel
 Directory: ga/19.0.0.9/kernel
 
+Tags: 19.0.0.9-kernel-java11
+Directory: ga/19.0.0.9/kernel
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.9-javaee8
 Directory: ga/19.0.0.9/javaee8
+
+Tags: 19.0.0.9-javaee8-java11
+Directory: ga/19.0.0.9/javaee8
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-webProfile8
 Directory: ga/19.0.0.9/webProfile8
 
+Tags: 19.0.0.9-webProfile8-java11
+Directory: ga/19.0.0.9/webProfile8
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.9-microProfile1
 Directory: ga/19.0.0.9/microProfile1
+
+Tags: 19.0.0.9-microProfile1-java11
+Directory: ga/19.0.0.9/microProfile1
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-microProfile2
 Directory: ga/19.0.0.9/microProfile2
 
+Tags: 19.0.0.9-microProfile2-java11
+Directory: ga/19.0.0.9/microProfile2
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.9-microProfile3
 Directory: ga/19.0.0.9/microProfile3
+
+Tags: 19.0.0.9-microProfile3-java11
+Directory: ga/19.0.0.9/microProfile3
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-springBoot2
 Directory: ga/19.0.0.9/springBoot2
 
+Tags: 19.0.0.9-springBoot2-java11
+Directory: ga/19.0.0.9/springBoot2
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.9-springBoot1
 Directory: ga/19.0.0.9/springBoot1
 
+Tags: 19.0.0.9-springBoot1-java11
+Directory: ga/19.0.0.9/springBoot1
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.9-javaee7
 Directory: ga/19.0.0.9/javaee7
+
+Tags: 19.0.0.9-javaee7-java11
+Directory: ga/19.0.0.9/javaee7
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.6-kernel
 Directory: ga/19.0.0.6/kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -13,6 +13,7 @@ Directory: ga/latest/kernel
 
 Tags: kernel-java11
 Directory: ga/latest/kernel
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee8, latest
@@ -20,6 +21,7 @@ Directory: ga/latest/javaee8
 
 Tags: javaee8-java11
 Directory: ga/latest/javaee8
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile8
@@ -27,6 +29,7 @@ Directory: ga/latest/webProfile8
 
 Tags: webProfile8-java11
 Directory: ga/latest/webProfile8
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile1
@@ -34,6 +37,7 @@ Directory: ga/latest/microProfile1
 
 Tags: microProfile1-java11
 Directory: ga/latest/microProfile1
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile2
@@ -41,6 +45,7 @@ Directory: ga/latest/microProfile2
 
 Tags: microProfile2-java11
 Directory: ga/latest/microProfile2
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: microProfile3
@@ -48,6 +53,7 @@ Directory: ga/latest/microProfile3
 
 Tags: microProfile3-java11
 Directory: ga/latest/microProfile3
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot2
@@ -55,6 +61,7 @@ Directory: ga/latest/springBoot2
 
 Tags: springBoot2-java11
 Directory: ga/latest/springBoot2
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: springBoot1
@@ -62,6 +69,7 @@ Directory: ga/latest/springBoot1
 
 Tags: springBoot1-java11
 Directory: ga/latest/springBoot1
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: webProfile7
@@ -69,6 +77,7 @@ Directory: ga/latest/webProfile7
 
 Tags: webProfile7-java11
 Directory: ga/latest/webProfile7
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: javaee7
@@ -76,6 +85,7 @@ Directory: ga/latest/javaee7
 
 Tags: javaee7-java11
 Directory: ga/latest/javaee7
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel
@@ -83,6 +93,7 @@ Directory: ga/19.0.0.9/kernel
 
 Tags: 19.0.0.9-kernel-java11
 Directory: ga/19.0.0.9/kernel
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-javaee8
@@ -90,6 +101,7 @@ Directory: ga/19.0.0.9/javaee8
 
 Tags: 19.0.0.9-javaee8-java11
 Directory: ga/19.0.0.9/javaee8
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-webProfile8
@@ -97,6 +109,7 @@ Directory: ga/19.0.0.9/webProfile8
 
 Tags: 19.0.0.9-webProfile8-java11
 Directory: ga/19.0.0.9/webProfile8
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-microProfile1
@@ -104,6 +117,7 @@ Directory: ga/19.0.0.9/microProfile1
 
 Tags: 19.0.0.9-microProfile1-java11
 Directory: ga/19.0.0.9/microProfile1
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-microProfile2
@@ -111,6 +125,7 @@ Directory: ga/19.0.0.9/microProfile2
 
 Tags: 19.0.0.9-microProfile2-java11
 Directory: ga/19.0.0.9/microProfile2
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-microProfile3
@@ -118,6 +133,7 @@ Directory: ga/19.0.0.9/microProfile3
 
 Tags: 19.0.0.9-microProfile3-java11
 Directory: ga/19.0.0.9/microProfile3
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-springBoot2
@@ -125,6 +141,7 @@ Directory: ga/19.0.0.9/springBoot2
 
 Tags: 19.0.0.9-springBoot2-java11
 Directory: ga/19.0.0.9/springBoot2
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-springBoot1
@@ -132,6 +149,15 @@ Directory: ga/19.0.0.9/springBoot1
 
 Tags: 19.0.0.9-springBoot1-java11
 Directory: ga/19.0.0.9/springBoot1
+File: Dockerfile.java11
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile7
+Directory: ga/19.0.0.9/webProfile7
+
+Tags: 19.0.0.9-webProfile7-java11
+Directory: ga/19.0.0.9/webProfile7
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-javaee7
@@ -139,6 +165,7 @@ Directory: ga/19.0.0.9/javaee7
 
 Tags: 19.0.0.9-javaee7-java11
 Directory: ga/19.0.0.9/javaee7
+File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.6-kernel


### PR DESCRIPTION
Adds WebSphere Liberty images for all recent tags (19.0.0.9 and latest) that are based on top of a Java 11 image from AdoptOpenJDK, similar to how we have the official OpenLiberty images set up.

Also adds two new `webProfile7` tags (one for Java 8 and one for Java 11) which I assume were excluded on accident, since there is a `19.0.0.6-webProfile7` tag and a `webProfile7` (latest) tag