### PR TITLE
Releasing Neo4j 3.5.11

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -8,15 +8,16 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
              Chris Gioran <chris@neo4j.com> (@digitalstain),
              Jenny Owen <jenny.owen@neo4j.com> (@jennyowen)           
 
-Tags: 3.5.9, 3.5, latest
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0aa6813bc76e0474adbc1d0cf6c325fcd5395e9a
-Directory: 3.5.9/community
 
-Tags: 3.5.9-enterprise, 3.5-enterprise, enterprise
+Tags: 3.5.11, 3.5, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0aa6813bc76e0474adbc1d0cf6c325fcd5395e9a
-Directory: 3.5.9/enterprise
+GitCommit: 2dca793274bd6adc45ba07e1ff6cb02dd6c8d714
+Directory: 3.5.11/community
+
+Tags: 3.5.11-enterprise, 3.5-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 2dca793274bd6adc45ba07e1ff6cb02dd6c8d714
+Directory: 3.5.11/enterprise
 
 Tags: 3.5.8
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git

--- a/library/neo4j
+++ b/library/neo4j
@@ -11,12 +11,12 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 
 Tags: 3.5.11, 3.5, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 2dca793274bd6adc45ba07e1ff6cb02dd6c8d714
+GitCommit: c559931b4b33062e1b4fcbcd2f2e8278ff7b3390
 Directory: 3.5.11/community
 
 Tags: 3.5.11-enterprise, 3.5-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 2dca793274bd6adc45ba07e1ff6cb02dd6c8d714
+GitCommit: c559931b4b33062e1b4fcbcd2f2e8278ff7b3390
 Directory: 3.5.11/enterprise
 
 Tags: 3.5.8


### PR DESCRIPTION
also there were problems with releases 3.5.9 and 3.5.10 so I'm removing them from this list.