### PR TITLE
Bump for Mono 6.4 stable release

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -4,15 +4,25 @@ Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
 GitRepo: https://github.com/mono/docker.git
 
-Tags: 6.0.0.313, latest, 6.0.0, 6.0, 6
+Tags: 6.4.0.198, latest, 6.4.0, 6.4, 6
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
-Directory: 6.0.0.313
+GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
+Directory: 6.4.0.198
 
-Tags: 6.0.0.313-slim, slim, 6.0.0-slim, 6.0-slim, 6-slim
+Tags: 6.4.0.198-slim, slim, 6.4.0-slim, 6.4-slim, 6-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
-Directory: 6.0.0.313/slim
+GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
+Directory: 6.4.0.198/slim
+
+Tags: 6.0.0.334, 6.0.0, 6.0
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
+Directory: 6.0.0.334
+
+Tags: 6.0.0.334-slim, 6.0.0-slim, 6.0-slim
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
+Directory: 6.0.0.334/slim
 
 Tags: 5.20.1.34, 5.20.1, 5.20, 5
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
@@ -23,13 +33,3 @@ Tags: 5.20.1.34-slim, 5.20.1-slim, 5.20-slim, 5-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
 Directory: 5.20.1.34/slim
-
-Tags: 5.18.1.28, 5.18.1, 5.18
-Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
-Directory: 5.18.1.28
-
-Tags: 5.18.1.28-slim, 5.18.1-slim, 5.18-slim
-Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: c47c852008be6934ac650f282c18c70f2cfec72f
-Directory: 5.18.1.28/slim


### PR DESCRIPTION
Hooray hooray, it's Mono release day

* Ship 6.4 stable, matching Visual Studio for Mac 8.3
* Bump 6.0 to latest point release
* Drop oldest 5.x