### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.0-rc.1, 3.8-rc
+Tags: 3.8.0-rc.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a66e87e730aca0a82c1547511546799944bca0b
+GitCommit: fb3a168bf8efaf644cc8dbfc10f12e74f050f02d
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.0-rc.1-management, 3.8-rc-management
+Tags: 3.8.0-rc.2-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.0-rc.1-alpine, 3.8-rc-alpine
+Tags: 3.8.0-rc.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a66e87e730aca0a82c1547511546799944bca0b
+GitCommit: fb3a168bf8efaf644cc8dbfc10f12e74f050f02d
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.0-rc.1-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.0-rc.2-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/fb3a168: Update to 3.8.0-rc.2, Erlang/OTP 22.1, OpenSSL 1.1.1d