### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,109 +5,109 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.13.0-buster, 1.13-buster, 1-buster, buster
-SharedTags: 1.13.0, 1.13, 1, latest
+Tags: 1.13.1-buster, 1.13-buster, 1-buster, buster
+SharedTags: 1.13.1, 1.13, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2909cfd3ecb769671eb8222eaf9a782a6aed024d
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/buster
 
-Tags: 1.13.0-stretch, 1.13-stretch, 1-stretch, stretch
+Tags: 1.13.1-stretch, 1.13-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e7c5f6049153f4f754eff210413b1d7ea882ad72
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/stretch
 
-Tags: 1.13.0-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.0-alpine, 1.13-alpine, 1-alpine, alpine
+Tags: 1.13.1-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.1-alpine, 1.13-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2909cfd3ecb769671eb8222eaf9a782a6aed024d
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/alpine3.10
 
-Tags: 1.13.0-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.13.0-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.0, 1.13, 1, latest
+Tags: 1.13.1-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13.0-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.13.0-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.0, 1.13, 1, latest
+Tags: 1.13.1-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.13.0-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.13.0-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.0, 1.13, 1, latest
+Tags: 1.13.1-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.13.0-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
-SharedTags: 1.13.0-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.1-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
+SharedTags: 1.13.1-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 2909cfd3ecb769671eb8222eaf9a782a6aed024d
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.13.0-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.13.0-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.1-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.13.1-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 2909cfd3ecb769671eb8222eaf9a782a6aed024d
+GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
 Directory: 1.13/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.12.9-buster, 1.12-buster
-SharedTags: 1.12.9, 1.12
+Tags: 1.12.10-buster, 1.12-buster
+SharedTags: 1.12.10, 1.12
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/buster
 
-Tags: 1.12.9-stretch, 1.12-stretch
+Tags: 1.12.10-stretch, 1.12-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/stretch
 
-Tags: 1.12.9-alpine3.10, 1.12-alpine3.10, 1.12.9-alpine, 1.12-alpine
+Tags: 1.12.10-alpine3.10, 1.12-alpine3.10, 1.12.10-alpine, 1.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/alpine3.10
 
-Tags: 1.12.9-alpine3.9, 1.12-alpine3.9
+Tags: 1.12.10-alpine3.9, 1.12-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/alpine3.9
 
-Tags: 1.12.9-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
-SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1.12.9, 1.12
+Tags: 1.12.10-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
+SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12.9-windowsservercore-1803, 1.12-windowsservercore-1803
-SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1.12.9, 1.12
+Tags: 1.12.10-windowsservercore-1803, 1.12-windowsservercore-1803
+SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12.9-windowsservercore-1809, 1.12-windowsservercore-1809
-SharedTags: 1.12.9-windowsservercore, 1.12-windowsservercore, 1.12.9, 1.12
+Tags: 1.12.10-windowsservercore-1809, 1.12-windowsservercore-1809
+SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
 Architectures: windows-amd64
-GitCommit: 963918ca305e07a1570c065eaa7ee58fc4c9c6ce
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12.9-nanoserver-1803, 1.12-nanoserver-1803
-SharedTags: 1.12.9-nanoserver, 1.12-nanoserver
+Tags: 1.12.10-nanoserver-1803, 1.12-nanoserver-1803
+SharedTags: 1.12.10-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.12.9-nanoserver-1809, 1.12-nanoserver-1809
-SharedTags: 1.12.9-nanoserver, 1.12-nanoserver
+Tags: 1.12.10-nanoserver-1809, 1.12-nanoserver-1809
+SharedTags: 1.12.10-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f6469ffe955721dd25e4cbb3013506659998aad
+GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
 Directory: 1.12/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/8ca16c6: Update to 1.12.10
- https://github.com/docker-library/golang/commit/4fa4888: Update to 1.13.1