### PR TITLE
Bump Traefik to v2.0.1 and v1.7.18

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.0-windowsservercore-1809, 2.0.0-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.1-windowsservercore-1809, 2.0.1-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 9954ed014366d9def23b3d695e38cad339ff14bc
+GitCommit: e158b458340bad5e6c039ba84a4768e0d7e2195f
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.0, 2.0.0, v2.0, 2.0, montdor, latest
+Tags: v2.0.1, 2.0.1, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 9954ed014366d9def23b3d695e38cad339ff14bc
+GitCommit: e158b458340bad5e6c039ba84a4768e0d7e2195f
 Directory: alpine
 
 Tags: v1.7.17-windowsservercore-1809, 1.7.17-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -12,18 +12,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: e158b458340bad5e6c039ba84a4768e0d7e2195f
 Directory: alpine
 
-Tags: v1.7.17-windowsservercore-1809, 1.7.17-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.18-windowsservercore-1809, 1.7.18-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 3ddcd457753890311afbd4209996e07caf84c1be
+GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.17-alpine, 1.7.17-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.18-alpine, 1.7.18-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 3ddcd457753890311afbd4209996e07caf84c1be
+GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
 Directory: alpine
 
-Tags: v1.7.17, 1.7.17, v1.7, 1.7, maroilles
+Tags: v1.7.18, 1.7.18, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 3ddcd457753890311afbd4209996e07caf84c1be
+GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
 Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.0.1](https://github.com/containous/traefik/releases/tag/v2.0.1) and [v1.7.18](https://github.com/containous/traefik/releases/tag/v1.7.18).

/cc @mmatur @emilevauge @ldez

Cheers
