### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.6, 2.0, latest
+Tags: 2.0.7, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c15abf52542d1e8765cc675cbba05fc3eeb9d04
+GitCommit: 2663a97d654b3d46e930ab98fc136443f93bfe82
 Directory: 2.0
 
-Tags: 2.0.6-alpine, 2.0-alpine, alpine
+Tags: 2.0.7-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c15abf52542d1e8765cc675cbba05fc3eeb9d04
+GitCommit: 2663a97d654b3d46e930ab98fc136443f93bfe82
 Directory: 2.0/alpine
 
-Tags: 1.9.10, 1.9, 1
+Tags: 1.9.11, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9efd6eb655c9ce87ccf6b84a68f2b4e647fff706
+GitCommit: 9dddade0c1bddeb2346ffef36b97d037c39bd5cf
 Directory: 1.9
 
-Tags: 1.9.10-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.11-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
+GitCommit: 9dddade0c1bddeb2346ffef36b97d037c39bd5cf
 Directory: 1.9/alpine
 
 Tags: 1.8.21, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9dddade: Update to 1.9.11
- https://github.com/docker-library/haproxy/commit/2663a97: Update to 2.0.7