### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-15-jdk-oraclelinux7, 14-ea-15-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-15-jdk-oracle, 14-ea-15-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-15-jdk, 14-ea-15, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-16-jdk-oraclelinux7, 14-ea-16-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-16-jdk-oracle, 14-ea-16-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-16-jdk, 14-ea-16, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-15-jdk-buster, 14-ea-15-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-16-jdk-buster, 14-ea-16-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk
 
-Tags: 14-ea-15-jdk-slim-buster, 14-ea-15-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-15-jdk-slim, 14-ea-15-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-16-jdk-slim-buster, 14-ea-16-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-16-jdk-slim, 14-ea-16-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: bde1e9a0f36e12e3df58b81acddd695fd140cf6a
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-15-jdk-windowsservercore-1809, 14-ea-15-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-15-jdk-windowsservercore, 14-ea-15-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-15-jdk, 14-ea-15, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-16-jdk-windowsservercore-1809, 14-ea-16-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-16-jdk-windowsservercore, 14-ea-16-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-16-jdk, 14-ea-16, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-15-jdk-windowsservercore-1803, 14-ea-15-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-15-jdk-windowsservercore, 14-ea-15-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-15-jdk, 14-ea-15, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-16-jdk-windowsservercore-1803, 14-ea-16-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-16-jdk-windowsservercore, 14-ea-16-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-16-jdk, 14-ea-16, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-15-jdk-windowsservercore-ltsc2016, 14-ea-15-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-15-jdk-windowsservercore, 14-ea-15-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-15-jdk, 14-ea-15, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-16-jdk-windowsservercore-ltsc2016, 14-ea-16-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-16-jdk-windowsservercore, 14-ea-16-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-16-jdk, 14-ea-16, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: e85b3b3882c0fdba3f9fce40b9fe9f62afb7cb70
+GitCommit: 60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/60d76cf: Update to 14-ea+16