### PR TITLE
Update Clear Linux OS to 31110

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@50971c45153318e83fc038fa841a7a04cc368785
-base: git://github.com/clearlinux/docker-brew-clearlinux@50971c45153318e83fc038fa841a7a04cc368785
+latest: git://github.com/clearlinux/docker-brew-clearlinux@77e256c00d19d8ce690e29bd564988624f233392
+base: git://github.com/clearlinux/docker-brew-clearlinux@77e256c00d19d8ce690e29bd564988624f233392


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31110

@bryteise @gtkramer