### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -19,92 +19,92 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e90a92eb25fd7527f8eb5b6cede5f217f93ab57
 Directory: 2.7-rc/alpine3.10
 
-Tags: 2.6.4-buster, 2.6-buster, 2-buster, buster, 2.6.4, 2.6, 2, latest
+Tags: 2.6.5-buster, 2.6-buster, 2-buster, buster, 2.6.5, 2.6, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/buster
 
-Tags: 2.6.4-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.4-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.5-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.5-slim, 2.6-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
 Directory: 2.6/buster/slim
 
-Tags: 2.6.4-stretch, 2.6-stretch, 2-stretch, stretch
+Tags: 2.6.5-stretch, 2.6-stretch, 2-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/stretch
 
-Tags: 2.6.4-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
+Tags: 2.6.5-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.4-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.4-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.5-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.5-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/alpine3.10
 
-Tags: 2.6.4-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
+Tags: 2.6.5-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a7df7a72b4a3d1b3e06ead303841b3fdaca560e
+GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/alpine3.9
 
-Tags: 2.5.6-buster, 2.5-buster, 2.5.6, 2.5
+Tags: 2.5.7-buster, 2.5-buster, 2.5.7, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
 Directory: 2.5/buster
 
-Tags: 2.5.6-slim-buster, 2.5-slim-buster, 2.5.6-slim, 2.5-slim
+Tags: 2.5.7-slim-buster, 2.5-slim-buster, 2.5.7-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: 21c98da485e331cdc2518e80ff91e48335041dec
 Directory: 2.5/buster/slim
 
-Tags: 2.5.6-stretch, 2.5-stretch
+Tags: 2.5.7-stretch, 2.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
 Directory: 2.5/stretch
 
-Tags: 2.5.6-slim-stretch, 2.5-slim-stretch
+Tags: 2.5.7-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: 21c98da485e331cdc2518e80ff91e48335041dec
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.6-alpine3.10, 2.5-alpine3.10, 2.5.6-alpine, 2.5-alpine
+Tags: 2.5.7-alpine3.10, 2.5-alpine3.10, 2.5.7-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
 Directory: 2.5/alpine3.10
 
-Tags: 2.5.6-alpine3.9, 2.5-alpine3.9
+Tags: 2.5.7-alpine3.9, 2.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32f51b68da57933c7ed66fde184e29846345a445
+GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
 Directory: 2.5/alpine3.9
 
-Tags: 2.4.7-buster, 2.4-buster, 2.4.7, 2.4
+Tags: 2.4.8-buster, 2.4-buster, 2.4.8, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
 Directory: 2.4/buster
 
-Tags: 2.4.7-slim-buster, 2.4-slim-buster, 2.4.7-slim, 2.4-slim
+Tags: 2.4.8-slim-buster, 2.4-slim-buster, 2.4.8-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: d6c177822be0198eb410c210912dcd7e2c04fd3f
 Directory: 2.4/buster/slim
 
-Tags: 2.4.7-stretch, 2.4-stretch
+Tags: 2.4.8-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
 Directory: 2.4/stretch
 
-Tags: 2.4.7-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.8-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: d6c177822be0198eb410c210912dcd7e2c04fd3f
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.7-alpine3.10, 2.4-alpine3.10, 2.4.7-alpine, 2.4-alpine
+Tags: 2.4.8-alpine3.10, 2.4-alpine3.10, 2.4.8-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
 Directory: 2.4/alpine3.10
 
-Tags: 2.4.7-alpine3.9, 2.4-alpine3.9
+Tags: 2.4.8-alpine3.9, 2.4-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a54569998bc011d4f79c25e532f21200bbf64dbb
+GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
 Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/d6c1778: Update to 2.4.8, rubygems 3.0.3
- https://github.com/docker-library/ruby/commit/21c98da: Update to 2.5.7, rubygems 3.0.3
- https://github.com/docker-library/ruby/commit/8565a59: Update to 2.6.5
- https://github.com/docker-library/ruby/commit/1382674: Merge pull request https://github.com/docker-library/ruby/pull/296 from JanDintel/ruby-version-upgrades
- https://github.com/docker-library/ruby/commit/5a3b107: Update ruby 2.4.x to 2.4.8
- https://github.com/docker-library/ruby/commit/5c9e21c: Update ruby 2.6.x to 2.6.5
- https://github.com/docker-library/ruby/commit/bf0e16e: Update ruby 2.5.x to 2.5.7
- https://github.com/docker-library/ruby/commit/704b155: Update generated README