### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: b3207b755c5ded9ac105b9746632fcccb70e7abf
+GitCommit: 83f6b34cd354e5f914c07e11b0fe5a525fa9c4e2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibm
@@ -179,6 +179,180 @@ Tags: springBoot1-java11
 Directory: official/latest/springBoot1/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
+Tags: 19.0.0.9-kernel, 19.0.0.9-kernel-java8-ibm
+Directory: official/19.0.0.9/kernel/java8/ibmjava
+
+Tags: 19.0.0.9-kernel-java8-ibmsfj
+Directory: official/19.0.0.9/kernel/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-kernel-java8-openj9
+Directory: official/19.0.0.9/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-kernel-java11
+Directory: official/19.0.0.9/kernel/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-kernel-java12
+Directory: official/19.0.0.9/kernel/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile8, 19.0.0.9-webProfile8-java8-ibm
+Directory: official/19.0.0.9/webProfile8/java8/ibmjava
+
+Tags: 19.0.0.9-webProfile8-java8-ibmsfj
+Directory: official/19.0.0.9/webProfile8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-webProfile8-java8-openj9
+Directory: official/19.0.0.9/webProfile8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile8-java11
+Directory: official/19.0.0.9/webProfile8/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile8-java12
+Directory: official/19.0.0.9/webProfile8/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-javaee8, 19.0.0.9-javaee8-java8-ibm
+Directory: official/19.0.0.9/javaee8/java8/ibmjava
+
+Tags: 19.0.0.9-javaee8-java8-ibmsfj
+Directory: official/19.0.0.9/javaee8/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-javaee8-java8-openj9
+Directory: official/19.0.0.9/javaee8/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-javaee8-java11
+Directory: official/19.0.0.9/javaee8/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-javaee8-java12
+Directory: official/19.0.0.9/javaee8/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile1, 19.0.0.9-microProfile1-java8-ibm
+Directory: official/19.0.0.9/microProfile1/java8/ibmjava
+
+Tags: 19.0.0.9-microProfile1-java8-ibmsfj
+Directory: official/19.0.0.9/microProfile1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-microProfile1-java8-openj9
+Directory: official/19.0.0.9/microProfile1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile1-java11
+Directory: official/19.0.0.9/microProfile1/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile2, 19.0.0.9-microProfile2-java8-ibm
+Directory: official/19.0.0.9/microProfile2/java8/ibmjava
+
+Tags: 19.0.0.9-microProfile2-java8-ibmsfj
+Directory: official/19.0.0.9/microProfile2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-microProfile2-java8-openj9
+Directory: official/19.0.0.9/microProfile2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile2-java11
+Directory: official/19.0.0.9/microProfile2/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile2-java12
+Directory: official/19.0.0.9/microProfile2/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile3, 19.0.0.9-microProfile3-java8-ibm
+Directory: official/19.0.0.9/microProfile3/java8/ibmjava
+
+Tags: 19.0.0.9-microProfile3-java8-ibmsfj
+Directory: official/19.0.0.9/microProfile3/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-microProfile3-java8-openj9
+Directory: official/19.0.0.9/microProfile3/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile3-java11
+Directory: official/19.0.0.9/microProfile3/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-microProfile3-java12
+Directory: official/19.0.0.9/microProfile3/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-springBoot2, 19.0.0.9-springBoot2-java8-ibm
+Directory: official/19.0.0.9/springBoot2/java8/ibmjava
+
+Tags: 19.0.0.9-springBoot2-java8-ibmsfj
+Directory: official/19.0.0.9/springBoot2/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-springBoot2-java8-openj9
+Directory: official/19.0.0.9/springBoot2/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-springBoot2-java11
+Directory: official/19.0.0.9/springBoot2/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-springBoot2-java12
+Directory: official/19.0.0.9/springBoot2/java12/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile7, 19.0.0.9-webProfile7-java8-ibm
+Directory: official/19.0.0.9/webProfile7/java8/ibmjava
+
+Tags: 19.0.0.9-webProfile7-java8-ibmsfj
+Directory: official/19.0.0.9/webProfile7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-webProfile7-java8-openj9
+Directory: official/19.0.0.9/webProfile7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-webProfile7-java11
+Directory: official/19.0.0.9/webProfile7/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-javaee7, 19.0.0.9-javaee7-java8-ibm
+Directory: official/19.0.0.9/javaee7/java8/ibmjava
+
+Tags: 19.0.0.9-javaee7-java8-ibmsfj
+Directory: official/19.0.0.9/javaee7/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-javaee7-java8-openj9
+Directory: official/19.0.0.9/javaee7/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-javaee7-java11
+Directory: official/19.0.0.9/javaee7/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-springBoot1, 19.0.0.9-springBoot1-java8-ibm
+Directory: official/19.0.0.9/springBoot1/java8/ibmjava
+
+Tags: 19.0.0.9-springBoot1-java8-ibmsfj
+Directory: official/19.0.0.9/springBoot1/java8/ibmsfj
+Architectures: amd64
+
+Tags: 19.0.0.9-springBoot1-java8-openj9
+Directory: official/19.0.0.9/springBoot1/java8/openj9
+Architectures: amd64, ppc64le, s390x
+
+Tags: 19.0.0.9-springBoot1-java11
+Directory: official/19.0.0.9/springBoot1/java11/openj9
+Architectures: amd64, ppc64le, s390x
+
 Tags: 19.0.0.6-kernel, 19.0.0.6-kernel-java8-ibm
 Directory: official/19.0.0.6/kernel/java8/ibmjava
 
@@ -312,103 +486,4 @@ Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.6-springBoot1-java11
 Directory: official/19.0.0.6/springBoot1/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-kernel, 19.0.0.3-kernel-java8-ibm
-Directory: official/19.0.0.3/kernel/java8/ibmjava
-
-Tags: 19.0.0.3-kernel-java8-ibmsfj
-Directory: official/19.0.0.3/kernel/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-kernel-java8-openj9
-Directory: official/19.0.0.3/kernel/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-webProfile8, 19.0.0.3-webProfile8-java8-ibm
-Directory: official/19.0.0.3/webProfile8/java8/ibmjava
-
-Tags: 19.0.0.3-webProfile8-java8-ibmsfj
-Directory: official/19.0.0.3/webProfile8/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-webProfile8-java8-openj9
-Directory: official/19.0.0.3/webProfile8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-javaee8, 19.0.0.3-javaee8-java8-ibm
-Directory: official/19.0.0.3/javaee8/java8/ibmjava
-
-Tags: 19.0.0.3-javaee8-java8-ibmsfj
-Directory: official/19.0.0.3/javaee8/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-javaee8-java8-openj9
-Directory: official/19.0.0.3/javaee8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-microProfile1, 19.0.0.3-microProfile1-java8-ibm
-Directory: official/19.0.0.3/microProfile1/java8/ibmjava
-
-Tags: 19.0.0.3-microProfile1-java8-ibmsfj
-Directory: official/19.0.0.3/microProfile1/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-microProfile1-java8-openj9
-Directory: official/19.0.0.3/microProfile1/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-microProfile2, 19.0.0.3-microProfile2-java8-ibm
-Directory: official/19.0.0.3/microProfile2/java8/ibmjava
-
-Tags: 19.0.0.3-microProfile2-java8-ibmsfj
-Directory: official/19.0.0.3/microProfile2/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-microProfile2-java8-openj9
-Directory: official/19.0.0.3/microProfile2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-springBoot2, 19.0.0.3-springBoot2-java8-ibm
-Directory: official/19.0.0.3/springBoot2/java8/ibmjava
-
-Tags: 19.0.0.3-springBoot2-java8-ibmsfj
-Directory: official/19.0.0.3/springBoot2/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-springBoot2-java8-openj9
-Directory: official/19.0.0.3/springBoot2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-webProfile7, 19.0.0.3-webProfile7-java8-ibm
-Directory: official/19.0.0.3/webProfile7/java8/ibmjava
-
-Tags: 19.0.0.3-webProfile7-java8-ibmsfj
-Directory: official/19.0.0.3/webProfile7/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-webProfile7-java8-openj9
-Directory: official/19.0.0.3/webProfile7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-javaee7, 19.0.0.3-javaee7-java8-ibm
-Directory: official/19.0.0.3/javaee7/java8/ibmjava
-
-Tags: 19.0.0.3-javaee7-java8-ibmsfj
-Directory: official/19.0.0.3/javaee7/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-javaee7-java8-openj9
-Directory: official/19.0.0.3/javaee7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.3-springBoot1, 19.0.0.3-springBoot1-java8-ibm
-Directory: official/19.0.0.3/springBoot1/java8/ibmjava
-
-Tags: 19.0.0.3-springBoot1-java8-ibmsfj
-Directory: official/19.0.0.3/springBoot1/java8/ibmsfj
-Architectures: amd64
-
-Tags: 19.0.0.3-springBoot1-java8-openj9
-Directory: official/19.0.0.3/springBoot1/java8/openj9
 Architectures: amd64, ppc64le, s390x


### PR DESCRIPTION
Updating Open Liberty to `19.0.0.9`.  Replaces PR https://github.com/docker-library/official-images/pull/6647