### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -79,32 +79,32 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
 Directory: 2.5/alpine3.9
 
-Tags: 2.4.8-buster, 2.4-buster, 2.4.8, 2.4
+Tags: 2.4.9-buster, 2.4-buster, 2.4.9, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/buster
 
-Tags: 2.4.8-slim-buster, 2.4-slim-buster, 2.4.8-slim, 2.4-slim
+Tags: 2.4.9-slim-buster, 2.4-slim-buster, 2.4.9-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6c177822be0198eb410c210912dcd7e2c04fd3f
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/buster/slim
 
-Tags: 2.4.8-stretch, 2.4-stretch
+Tags: 2.4.9-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/stretch
 
-Tags: 2.4.8-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.9-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6c177822be0198eb410c210912dcd7e2c04fd3f
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.8-alpine3.10, 2.4-alpine3.10, 2.4.8-alpine, 2.4-alpine
+Tags: 2.4.9-alpine3.10, 2.4-alpine3.10, 2.4.9-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/alpine3.10
 
-Tags: 2.4.8-alpine3.9, 2.4-alpine3.9
+Tags: 2.4.9-alpine3.9, 2.4-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a3b107c520261d867811ac417ce28f3f89f8404
+GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
 Directory: 2.4/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/924602d: Update to 2.4.9, rubygems 3.0.3