### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/af5f6ff9a3916d89be6d190d562d247ae12ffa73/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/4dc7aebab7d3d92351f5f87a25cce6661536e5b9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,22 +24,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.18, 3.7
+Tags: 3.7.19, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95838592f42af01b475fdb26a71052af235094d6
+GitCommit: 7ee803d0359b5e5b0ae21b2447e4562be1182054
 Directory: 3.7/ubuntu
 
-Tags: 3.7.18-management, 3.7-management
+Tags: 3.7.19-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.18-alpine, 3.7-alpine
+Tags: 3.7.19-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95838592f42af01b475fdb26a71052af235094d6
+GitCommit: 7ee803d0359b5e5b0ae21b2447e4562be1182054
 Directory: 3.7/alpine
 
-Tags: 3.7.18-management-alpine, 3.7-management-alpine
+Tags: 3.7.19-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7ee803d: Update to 3.7.19, Erlang/OTP 22.1.1, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/4dc7aeb: Fix RC-skipping code for releases without RCs (like 3.7.19)