### PR TITLE
Node: Update node.js v12 from v12.10.0 to v12.11.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -43,29 +43,29 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
 Directory: 8/buster-slim
 
-Tags: 12.10.0-alpine, 12.10-alpine, 12-alpine, current-alpine, alpine
+Tags: 12.11.0-alpine, 12.11-alpine, 12-alpine, current-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a29572654fc378a7ebf0c962959f90a0d79b028
+GitCommit: 82f9946e28d575abf26933db47832ae2f561131a
 Directory: 12/alpine
 
-Tags: 12.10.0-stretch, 12.10-stretch, 12-stretch, current-stretch, stretch, 12.10.0, 12.10, 12, current, latest
+Tags: 12.11.0-stretch, 12.11-stretch, 12-stretch, current-stretch, stretch, 12.11.0, 12.11, 12, current, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4a29572654fc378a7ebf0c962959f90a0d79b028
+GitCommit: d7c86c0ae0d1129f2ddb226bf42cfebffa17d9c8
 Directory: 12/stretch
 
-Tags: 12.10.0-stretch-slim, 12.10-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.10.0-slim, 12.10-slim, 12-slim, current-slim, slim
+Tags: 12.11.0-stretch-slim, 12.11-stretch-slim, 12-stretch-slim, current-stretch-slim, stretch-slim, 12.11.0-slim, 12.11-slim, 12-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4a29572654fc378a7ebf0c962959f90a0d79b028
+GitCommit: d7c86c0ae0d1129f2ddb226bf42cfebffa17d9c8
 Directory: 12/stretch-slim
 
-Tags: 12.10.0-buster, 12.10-buster, 12-buster, current-buster, buster
+Tags: 12.11.0-buster, 12.11-buster, 12-buster, current-buster, buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4a29572654fc378a7ebf0c962959f90a0d79b028
+GitCommit: d7c86c0ae0d1129f2ddb226bf42cfebffa17d9c8
 Directory: 12/buster
 
-Tags: 12.10.0-buster-slim, 12.10-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
+Tags: 12.11.0-buster-slim, 12.11-buster-slim, 12-buster-slim, current-buster-slim, buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4a29572654fc378a7ebf0c962959f90a0d79b028
+GitCommit: d7c86c0ae0d1129f2ddb226bf42cfebffa17d9c8
 Directory: 12/buster-slim
 
 Tags: 10.16.3-jessie, 10.16-jessie, 10-jessie, dubnium-jessie, lts-jessie


### PR DESCRIPTION
Ref:
- https://github.com/nodejs/docker-node/pull/1113
- https://nodejs.org/en/blog/release/v12.11.0/
- https://github.com/nodejs/node/releases/tag/v12.11.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.11.0