### PR TITLE
Update Clear Linux OS to 31140

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@77e256c00d19d8ce690e29bd564988624f233392
-base: git://github.com/clearlinux/docker-brew-clearlinux@77e256c00d19d8ce690e29bd564988624f233392
+latest: git://github.com/clearlinux/docker-brew-clearlinux@8b161fb8368ed8dda11304fb0b2fc2e6954a3917
+base: git://github.com/clearlinux/docker-brew-clearlinux@8b161fb8368ed8dda11304fb0b2fc2e6954a3917


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31140

@bryteise @gtkramer