### PR TITLE
Odoo: Add Odoo 13.0

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,15 +1,15 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: b5f088de13927177263d6cbc5ebf7d39de4dcfa7
+GitCommit: ffe62bdd52f88ac85f54064e6eb02aa38f88f58d
 
-Tags: 12.0, 12, latest
-Architectures: amd64, arm64v8
+Tags: 13.0, 13, latest
+Architectures: amd64
+Directory: 13.0
+
+Tags: 12.0, 12
+Architectures: amd64
 Directory: 12.0
 
 Tags: 11.0, 11
-Architectures: amd64, arm64v8
-Directory: 11.0
-
-Tags: 10.0, 10
 Architectures: amd64
-Directory: 10.0
+Directory: 11.0


### PR DESCRIPTION
Hello here is the new Odoo version

* Add the new Odoo version 13.0
* Remove deprecated version 10.0
* Update supported versions to release 20191009
* Install phonenumbers in supported versions
* Upgrade pip before installing pip packages

Thanks 