### PR TITLE
Bump Traefik to v2.0.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.1-windowsservercore-1809, 2.0.1-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.2-windowsservercore-1809, 2.0.2-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: e158b458340bad5e6c039ba84a4768e0d7e2195f
+GitCommit: a232b9ebed96febf723daa43c6899ec86ba554eb
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.1, 2.0.1, v2.0, 2.0, montdor, latest
+Tags: v2.0.2, 2.0.2, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e158b458340bad5e6c039ba84a4768e0d7e2195f
+GitCommit: a232b9ebed96febf723daa43c6899ec86ba554eb
 Directory: alpine
 
 Tags: v1.7.18-windowsservercore-1809, 1.7.18-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -3,13 +3,13 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v2.0.2-windowsservercore-1809, 2.0.2-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: a232b9ebed96febf723daa43c6899ec86ba554eb
+GitCommit: 3d06252965f0028af9de0787b8caa4a1623a9e96
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.0.2, 2.0.2, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: a232b9ebed96febf723daa43c6899ec86ba554eb
+GitCommit: 3d06252965f0028af9de0787b8caa4a1623a9e96
 Directory: alpine
 
 Tags: v1.7.18-windowsservercore-1809, 1.7.18-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.0.2](https://github.com/containous/traefik/releases/tag/v2.0.2).

/cc @mmatur @emilevauge @dtomcej

Cheers
