### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.0, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
+GitCommit: f8ee3ed542e53192a2752572e841ec06e7a92d55
 Directory: 3.8/ubuntu
 
 Tags: 3.8.0-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
+GitCommit: f8ee3ed542e53192a2752572e841ec06e7a92d55
 Directory: 3.8/alpine
 
 Tags: 3.8.0-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.19, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ee803d0359b5e5b0ae21b2447e4562be1182054
+GitCommit: 543837bf4b14225456b60e240298eea53a629154
 Directory: 3.7/ubuntu
 
 Tags: 3.7.19-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.19-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ee803d0359b5e5b0ae21b2447e4562be1182054
+GitCommit: 543837bf4b14225456b60e240298eea53a629154
 Directory: 3.7/alpine
 
 Tags: 3.7.19-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/543837b: Update to 3.7.19, Erlang/OTP 22.1.2, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/f8ee3ed: Update to 3.8.0, Erlang/OTP 22.1.2, OpenSSL 1.1.1d