### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.31.1, 2.31, 2, latest
+Tags: 2.33.0, 2.33, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 74e1e1a5c6daa14102e66c7f4f4a5b533d9b6b49
+GitCommit: 81330547f79e45086f204cebd533e102c56cfbac
 Directory: 2/debian
 
-Tags: 2.31.1-alpine, 2.31-alpine, 2-alpine, alpine
+Tags: 2.33.0-alpine, 2.33-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74e1e1a5c6daa14102e66c7f4f4a5b533d9b6b49
+GitCommit: 81330547f79e45086f204cebd533e102c56cfbac
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/8133054: Update to 2.33.0, ghost-cli 1.11.0
- https://github.com/docker-library/ghost/commit/0c681a6: Update to 2.32.0, ghost-cli 1.11.0