### PR TITLE
Node: Update node.js v8 to v8.16.2

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,44 +3,44 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 8.16.1-jessie, 8.16-jessie, 8-jessie, carbon-jessie
+Tags: 8.16.2-jessie, 8.16-jessie, 8-jessie, carbon-jessie
 Architectures: amd64, arm32v7, i386
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/jessie
 
-Tags: 8.16.1-jessie-slim, 8.16-jessie-slim, 8-jessie-slim, carbon-jessie-slim
+Tags: 8.16.2-jessie-slim, 8.16-jessie-slim, 8-jessie-slim, carbon-jessie-slim
 Architectures: amd64, arm32v7, i386
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/jessie-slim
 
-Tags: 8.16.1-alpine, 8.16-alpine, 8-alpine, carbon-alpine
+Tags: 8.16.2-alpine, 8.16-alpine, 8-alpine, carbon-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/alpine
 
-Tags: 8.16.1-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
+Tags: 8.16.2-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/onbuild
 
-Tags: 8.16.1-stretch, 8.16-stretch, 8-stretch, carbon-stretch, 8.16.1, 8.16, 8, carbon
+Tags: 8.16.2-stretch, 8.16-stretch, 8-stretch, carbon-stretch, 8.16.2, 8.16, 8, carbon
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/stretch
 
-Tags: 8.16.1-stretch-slim, 8.16-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.16.1-slim, 8.16-slim, 8-slim, carbon-slim
+Tags: 8.16.2-stretch-slim, 8.16-stretch-slim, 8-stretch-slim, carbon-stretch-slim, 8.16.2-slim, 8.16-slim, 8-slim, carbon-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/stretch-slim
 
-Tags: 8.16.1-buster, 8.16-buster, 8-buster, carbon-buster
+Tags: 8.16.2-buster, 8.16-buster, 8-buster, carbon-buster
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/buster
 
-Tags: 8.16.1-buster-slim, 8.16-buster-slim, 8-buster-slim, carbon-buster-slim
+Tags: 8.16.2-buster-slim, 8.16-buster-slim, 8-buster-slim, carbon-buster-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9c583095d4cf08bbd68f570a1f9a99780820351
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/buster-slim
 
 Tags: 12.11.1-alpine, 12.11-alpine, 12-alpine, current-alpine, alpine
@@ -105,10 +105,10 @@ Directory: 10/buster-slim
 
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
-GitCommit: 3bf0d764ee0868d89f9d5a1d26b1d48a2d22abcb
+GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
 Architectures: amd64
-GitCommit: 3bf0d764ee0868d89f9d5a1d26b1d48a2d22abcb
+GitCommit: 69c8a5f448f46f9e34d7fb577eca79ba01f6864d
 Directory: chakracore/10


### PR DESCRIPTION
https://github.com/nodejs/docker-node/pull/1127
https://nodejs.org/en/blog/release/v8.16.2/