### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.17, 8.0, 8, latest
-GitCommit: 4af273a07854d7e4b68c5148b8e23b86aa8706e2
+Tags: 8.0.18, 8.0, 8, latest
+GitCommit: 367788b4c0eccf8bf6d10e8897262d22cf816284
 Directory: 8.0
 
-Tags: 5.7.27, 5.7, 5
-GitCommit: 51f9523ad07abacbce90c43eb27390c1c1f76266
+Tags: 5.7.28, 5.7, 5
+GitCommit: 5fa3526d23a846c6a2982901bc8190025af44336
 Directory: 5.7
 
-Tags: 5.6.45, 5.6
-GitCommit: ed0e47e48b8ca3dbc4d68d68f56384bdd1fb5cdb
+Tags: 5.6.46, 5.6
+GitCommit: 49bedb5f999c19d3b931ea8bfd926a5b0a1c1db4
 Directory: 5.6


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/305192d: Merge pull request https://github.com/docker-library/mysql/pull/599 from infosiftr/really_sourced
- https://github.com/docker-library/mysql/commit/2501cf3: Improve _is_sourced check
- https://github.com/docker-library/mysql/commit/ddf116f: Merge pull request https://github.com/docker-library/mysql/pull/479 from infosiftr/mysql.db-test
- https://github.com/docker-library/mysql/commit/0619155: Update "test" database deletion code with extra query from mysql_secure_installation
- https://github.com/docker-library/mysql/commit/b5a5d78: Merge pull request https://github.com/docker-library/mysql/pull/471 from ltangvald/refactoring
- https://github.com/docker-library/mysql/commit/206541a: Adjust printf to be more resilient; use exit code directly instead of a variable
- https://github.com/docker-library/mysql/commit/91785a5: Add --dont-use-mysql-root-password flag for docker_process_sql
- https://github.com/docker-library/mysql/commit/8d01eea: Fix source detection for centos, call check_config first, explicit global for DATADIR SOCKET
- https://github.com/docker-library/mysql/commit/8a58acb: Adjustments from tianon's comments
- https://github.com/docker-library/mysql/commit/169471f: Apply update.sh to update each entrypoint; drop 5.5 from update.sh
- https://github.com/docker-library/mysql/commit/06acf82: A few entrypoint updates to increase usability
- https://github.com/docker-library/mysql/commit/bbf5d01: Remove empty function docker_wait_for_server
- https://github.com/docker-library/mysql/commit/125ac54: Replace function docker_init_client_command with docker_process_sql
- https://github.com/docker-library/mysql/commit/964f6c2: Merge function docker_load_tzinfo into docker_setup_db
- https://github.com/docker-library/mysql/commit/ce4d14d: Merge function docker_generate_root_password into docker_setup_db
- https://github.com/docker-library/mysql/commit/71962c5: Rename function docker_init_database_dir to docker_create_db_directories
- https://github.com/docker-library/mysql/commit/04b03e0: Merge functions mysql_write_password_file, docker_init_root_user and docker_setup_db_users into docker_setup_db
- https://github.com/docker-library/mysql/commit/880bb34: Rename docker_init_database_user to docker_setup_db_users
- https://github.com/docker-library/mysql/commit/dfa4cb4: Rename docker_expire_root_user to mysql_expire_root_user
- https://github.com/docker-library/mysql/commit/9b90b1c: Move old-mysql-only logic for waiting for server startup into function
- https://github.com/docker-library/mysql/commit/915c792: Rename functions for starting and stopping server
- https://github.com/docker-library/mysql/commit/f1abc95: Rename docker_main to _main
- https://github.com/docker-library/mysql/commit/c9600d2: Rename log functions from docker to mysql
- https://github.com/docker-library/mysql/commit/34ae313: Rename docker_init_env to docker_setup_env
- https://github.com/docker-library/mysql/commit/ae7b623: Rename docker_get_config to mysql_get_config
- https://github.com/docker-library/mysql/commit/5e10737: Rename docker_write_password_file to mysql_write_password_file
- https://github.com/docker-library/mysql/commit/67f2bd3: Rename docker_process_init_file to docker_process_init_files
- https://github.com/docker-library/mysql/commit/1503220: Rename docker_verify_env to docker_verify_minimum_env
- https://github.com/docker-library/mysql/commit/2fcb086: Rename docker_file_env to file_env
- https://github.com/docker-library/mysql/commit/ef9caa9: Rename docker_check_config to mysql_check_config
- https://github.com/docker-library/mysql/commit/9f77ea5: entrypoint: Make value checks more consistent
- https://github.com/docker-library/mysql/commit/33ba3e5: entrypoint: Only execute main function if the script is not sourced
- https://github.com/docker-library/mysql/commit/db2319e: entrypoint: Move main script functionality to function
- https://github.com/docker-library/mysql/commit/f9c185f: entrypoint: Move more logic into functions
- https://github.com/docker-library/mysql/commit/db12713: entrypoint: Use mktemp instead of install
- https://github.com/docker-library/mysql/commit/4672559: Prefix function names in entrypoint with "docker"
- https://github.com/docker-library/mysql/commit/eb2821b: Fix typo templaing->templating
- https://github.com/docker-library/mysql/commit/2242976: Move flag for password file to when the client command is first defined
- https://github.com/docker-library/mysql/commit/03bdbad: Add 5.5 and 5.6 to entrypoint templating
- https://github.com/docker-library/mysql/commit/a9e8576: Template: Use --daemonize for temporary server startup.
- https://github.com/docker-library/mysql/commit/9e51c81: Template: Use mysqladmin to stop temporary server
- https://github.com/docker-library/mysql/commit/ea73775: Template: Store root password in file
- https://github.com/docker-library/mysql/commit/a8aa1cf: Template: Create logging functions
- https://github.com/docker-library/mysql/commit/34f3ef2: Template: Rename template directory to be hidden
- https://github.com/docker-library/mysql/commit/afceb7f: Template: Create functions for starting and stopping server during init
- https://github.com/docker-library/mysql/commit/5a727ad: Make template for 5.7+ entrypoint script
- https://github.com/docker-library/mysql/commit/f16150e: Unify entrypoint scripts for 5.7 and 8.0
- https://github.com/docker-library/mysql/commit/d56d41d: Update generated README
- https://github.com/docker-library/mysql/commit/68f5102: Merge pull request https://github.com/docker-library/mysql/pull/580 from J0WI/https-update
- https://github.com/docker-library/mysql/commit/0f33848: Use https in update.sh