### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.1-beta.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ffe636b312146540ff662b87968fe96aba80fc03
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.1-beta.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.1-beta.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ffe636b312146540ff662b87968fe96aba80fc03
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.1-beta.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.0, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8ee3ed542e53192a2752572e841ec06e7a92d55
+GitCommit: b8ca2ef2814cf35de476e763db94eb9706657f3c
 Directory: 3.8/ubuntu
 
 Tags: 3.8.0-management, 3.8-management, 3-management, management
@@ -16,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f8ee3ed542e53192a2752572e841ec06e7a92d55
+GitCommit: b8ca2ef2814cf35de476e763db94eb9706657f3c
 Directory: 3.8/alpine
 
 Tags: 3.8.0-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -24,9 +44,29 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
+Tags: 3.7.20-beta.1, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1e090d573910c57cc203c4f0b1327f524107ced5
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.20-beta.1-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.20-beta.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1e090d573910c57cc203c4f0b1327f524107ced5
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.20-beta.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.19, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 543837bf4b14225456b60e240298eea53a629154
+GitCommit: e1a86a588a2d2d8ef26ae6930ad3c8ec66b1c1c3
 Directory: 3.7/ubuntu
 
 Tags: 3.7.19-management, 3.7-management
@@ -36,7 +76,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.19-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 543837bf4b14225456b60e240298eea53a629154
+GitCommit: e1a86a588a2d2d8ef26ae6930ad3c8ec66b1c1c3
 Directory: 3.7/alpine
 
 Tags: 3.7.19-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ffe636b: Update to 3.8.1-beta.1, Erlang/OTP 22.1.3, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/1e090d5: Update to 3.7.20-beta.1, Erlang/OTP 22.1.3, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/b8ca2ef: Update to 3.8.0, Erlang/OTP 22.1.3, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/e1a86a5: Update to 3.7.19, Erlang/OTP 22.1.3, OpenSSL 1.1.1d