### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-17-jdk-oraclelinux7, 14-ea-17-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-17-jdk-oracle, 14-ea-17-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-17-jdk, 14-ea-17, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-18-jdk-oraclelinux7, 14-ea-18-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-18-jdk-oracle, 14-ea-18-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-17-jdk-buster, 14-ea-17-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-18-jdk-buster, 14-ea-18-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk
 
-Tags: 14-ea-17-jdk-slim-buster, 14-ea-17-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-17-jdk-slim, 14-ea-17-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-18-jdk-slim-buster, 14-ea-18-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-18-jdk-slim, 14-ea-18-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: bde1e9a0f36e12e3df58b81acddd695fd140cf6a
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-17-jdk-windowsservercore-1809, 14-ea-17-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-17-jdk-windowsservercore, 14-ea-17-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-17-jdk, 14-ea-17, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-18-jdk-windowsservercore-1809, 14-ea-18-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-17-jdk-windowsservercore-1803, 14-ea-17-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-17-jdk-windowsservercore, 14-ea-17-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-17-jdk, 14-ea-17, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-18-jdk-windowsservercore-1803, 14-ea-18-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-17-jdk-windowsservercore-ltsc2016, 14-ea-17-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-17-jdk-windowsservercore, 14-ea-17-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-17-jdk, 14-ea-17, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-18-jdk-windowsservercore-ltsc2016, 14-ea-18-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: ba1583c30a0d1883ee9b42cb5710009721409ef5
+GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/f34b3e5: Update to 14-ea+18