### PR TITLE
Update Clear Linux OS to 31290

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@8b161fb8368ed8dda11304fb0b2fc2e6954a3917
-base: git://github.com/clearlinux/docker-brew-clearlinux@8b161fb8368ed8dda11304fb0b2fc2e6954a3917
+latest: git://github.com/clearlinux/docker-brew-clearlinux@c52fcf11d5b25aebdb1d7fadf0ce243c1a3e3c81
+base: git://github.com/clearlinux/docker-brew-clearlinux@c52fcf11d5b25aebdb1d7fadf0ce243c1a3e3c81


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31290

@bryteise @gtkramer