### PR TITLE
Update Sonarqube to prepare 8.0 release

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,7 +4,16 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: c2ec0708e5c20c4bed02606c3b626dede5e3b8a7
+GitCommit: d11132e3b265330a85091ce8141446501e2ac233
 
 Tags: 7.9.1-community, 7.9-community, latest, lts
 Directory: 7/community
+
+Tags: 8.0-community-beta, 8-community-beta, community-beta
+Directory: 8/community
+
+Tags: 8.0-developer-beta, 8-developer-beta, developer-beta
+Directory: 8/developer
+
+Tags: 8.0-enterprise-beta, 8-enterprise-beta, enterprise-beta
+Directory: 8/enterprise

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,7 +4,8 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: d11132e3b265330a85091ce8141446501e2ac233
+GitFetch: refs/heads/branch-8
+GitCommit: 8ae0fadc72fef64334998e811f1b9cf68a458a2c
 
 Tags: 7.9.1-community, 7.9-community, latest, lts
 Directory: 7/community


### PR DESCRIPTION
Hello guys ! please do not merge yet, we are releasing SonarQube 8.0 version and the zip is not publicly available yet.

In the meantime, we are happy to get feedback on the Dockerfile & scripts, as we reworked them for this new version. The QA will become greener as the sonarqube zip become available, i will then switch the PR from `draft` to actual PR when it comes.

We opened a [PR on the doc side](https://github.com/docker-library/docs/pull/1587), please accept both PR in a close timebox :)