### PR TITLE
Update oraclelinux for python 2.7

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 573754fe56e7e8d570c554e8152fc9606c89561d
+amd64-GitCommit: a5399bf87cefa2ea601e2e0de6e579c92beb805e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 9ad8700fd37bd66518bea4dd4461ebf5b47b3cfc


### PR DESCRIPTION
	[amd64 8.0] 2019-10-08-2
        [amd64 8-slim] 2019-10-08-20

Signed-off-by: michthom <michael.a.thompson@oracle.com>