### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -47,41 +47,41 @@ GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
-SharedTags: 13-jdk, 13, jdk, latest
+Tags: 13.0.1-jdk-oraclelinux7, 13.0.1-oraclelinux7, 13.0-jdk-oraclelinux7, 13.0-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13.0.1-jdk-oracle, 13.0.1-oracle, 13.0-jdk-oracle, 13.0-oracle, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
+SharedTags: 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: amd64
-GitCommit: 7efc7a9956ea7f0f55fc752ca18a55e193d9c55a
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
-Tags: 13-jdk-buster, 13-buster, jdk-buster, buster
+Tags: 13.0.1-jdk-buster, 13.0.1-buster, 13.0-jdk-buster, 13.0-buster, 13-jdk-buster, 13-buster, jdk-buster, buster
 Architectures: amd64
-GitCommit: 3d26403f6d5d290f9bd23fb6a68fec1c5ac54656
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk
 
-Tags: 13-jdk-slim-buster, 13-slim-buster, jdk-slim-buster, slim-buster, 13-jdk-slim, 13-slim, jdk-slim, slim
+Tags: 13.0.1-jdk-slim-buster, 13.0.1-slim-buster, 13.0-jdk-slim-buster, 13.0-slim-buster, 13-jdk-slim-buster, 13-slim-buster, jdk-slim-buster, slim-buster, 13.0.1-jdk-slim, 13.0.1-slim, 13.0-jdk-slim, 13.0-slim, 13-jdk-slim, 13-slim, jdk-slim, slim
 Architectures: amd64
-GitCommit: 3d26403f6d5d290f9bd23fb6a68fec1c5ac54656
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/slim
 
-Tags: 13-jdk-windowsservercore-1809, 13-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13-jdk, 13, jdk, latest
+Tags: 13.0.1-jdk-windowsservercore-1809, 13.0.1-windowsservercore-1809, 13.0-jdk-windowsservercore-1809, 13.0-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: aeb02a53ca43da29d6e820e5fe485db7ba03b879
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13-jdk-windowsservercore-1803, 13-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13-jdk, 13, jdk, latest
+Tags: 13.0.1-jdk-windowsservercore-1803, 13.0.1-windowsservercore-1803, 13.0-jdk-windowsservercore-1803, 13.0-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
+SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: aeb02a53ca43da29d6e820e5fe485db7ba03b879
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13-jdk, 13, jdk, latest
+Tags: 13.0.1-jdk-windowsservercore-ltsc2016, 13.0.1-windowsservercore-ltsc2016, 13.0-jdk-windowsservercore-ltsc2016, 13.0-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: aeb02a53ca43da29d6e820e5fe485db7ba03b879
+GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0a1e59a: Update to 13.0.1