### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.2.3-php7.1-apache, 5.2-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.2.3-php7.1, 5.2-php7.1, 5-php7.1, php7.1
+Tags: 5.2.4-php7.1-apache, 5.2-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.2.4-php7.1, 5.2-php7.1, 5-php7.1, php7.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.1/apache
 
-Tags: 5.2.3-php7.1-fpm, 5.2-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
+Tags: 5.2.4-php7.1-fpm, 5.2-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.1/fpm
 
-Tags: 5.2.3-php7.1-fpm-alpine, 5.2-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
+Tags: 5.2.4-php7.1-fpm-alpine, 5.2-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.1/fpm-alpine
 
-Tags: 5.2.3-php7.2-apache, 5.2-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.2.3-php7.2, 5.2-php7.2, 5-php7.2, php7.2
+Tags: 5.2.4-php7.2-apache, 5.2-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.2.4-php7.2, 5.2-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.2/apache
 
-Tags: 5.2.3-php7.2-fpm, 5.2-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
+Tags: 5.2.4-php7.2-fpm, 5.2-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.2/fpm
 
-Tags: 5.2.3-php7.2-fpm-alpine, 5.2-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.2.4-php7.2-fpm-alpine, 5.2-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.2/fpm-alpine
 
-Tags: 5.2.3-apache, 5.2-apache, 5-apache, apache, 5.2.3, 5.2, 5, latest, 5.2.3-php7.3-apache, 5.2-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.2.3-php7.3, 5.2-php7.3, 5-php7.3, php7.3
+Tags: 5.2.4-apache, 5.2-apache, 5-apache, apache, 5.2.4, 5.2, 5, latest, 5.2.4-php7.3-apache, 5.2-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.2.4-php7.3, 5.2-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.3/apache
 
-Tags: 5.2.3-fpm, 5.2-fpm, 5-fpm, fpm, 5.2.3-php7.3-fpm, 5.2-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.2.4-fpm, 5.2-fpm, 5-fpm, fpm, 5.2.4-php7.3-fpm, 5.2-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.3/fpm
 
-Tags: 5.2.3-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.2.3-php7.3-fpm-alpine, 5.2-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.2.4-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.2.4-php7.3-fpm-alpine, 5.2-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 41af7e24571774b8016b930bfb767c39552d0a02
 Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/41af7e2: Update to 5.2.4