### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 2.36.0, 2.36, 2, latest
+Tags: 2.37.0, 2.37, 2, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 519b053afd7c47a0c0848e86ff626a87398516b8
+GitCommit: 9dfda796cc4d59238c25e0825855d3bc4922e17d
 Directory: 2/debian
 
-Tags: 2.36.0-alpine, 2.36-alpine, 2-alpine, alpine
+Tags: 2.37.0-alpine, 2.37-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 519b053afd7c47a0c0848e86ff626a87398516b8
+GitCommit: 9dfda796cc4d59238c25e0825855d3bc4922e17d
 Directory: 2/alpine
 
 Tags: 1.26.0, 1.26, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/9dfda79: Update to 2.37.0, ghost-cli 1.11.0