### PR TITLE
Update Hy

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,22 +1,22 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: a1a6af6ad95540f3d5d7de95a27bf2e8d0ddd569
+GitCommit: 3306ec49a8c629f4fc9e6287c39c01d2dea8bda9
 Directory: dockerfiles-generated
 
 Tags: 0.17.0-python3.7-buster, 0.17-python3.7-buster, 0-python3.7-buster, python3.7-buster, 0.17.0-buster, 0.17-buster, 0-buster, buster
+SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-buster
 
 Tags: 0.17.0-python3.7-stretch, 0.17-python3.7-stretch, 0-python3.7-stretch, python3.7-stretch, 0.17.0-stretch, 0.17-stretch, 0-stretch, stretch
-SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-stretch
 
-Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10
+Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.10
 
-Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
+Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.9
 
@@ -39,53 +39,53 @@ Constraints: windowsservercore-ltsc2016
 File: Dockerfile.python3.7-windowsservercore-ltsc2016
 
 Tags: 0.17.0-python3.6-buster, 0.17-python3.6-buster, 0-python3.6-buster, python3.6-buster
+SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-buster
 
 Tags: 0.17.0-python3.6-stretch, 0.17-python3.6-stretch, 0-python3.6-stretch, python3.6-stretch
-SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-stretch
 
-Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine3.10, python3.6-alpine3.10
+Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine3.10, python3.6-alpine3.10, 0.17.0-python3.6-alpine, 0.17-python3.6-alpine, 0-python3.6-alpine, python3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.10
 
-Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9, 0.17.0-python3.6-alpine, 0.17-python3.6-alpine, 0-python3.6-alpine, python3.6-alpine
+Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.9
 
 Tags: 0.17.0-python3.5-buster, 0.17-python3.5-buster, 0-python3.5-buster, python3.5-buster
+SharedTags: 0.17.0-python3.5, 0.17-python3.5, 0-python3.5, python3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-buster
 
 Tags: 0.17.0-python3.5-stretch, 0.17-python3.5-stretch, 0-python3.5-stretch, python3.5-stretch
-SharedTags: 0.17.0-python3.5, 0.17-python3.5, 0-python3.5, python3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-stretch
 
-Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine3.10, python3.5-alpine3.10
+Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine3.10, python3.5-alpine3.10, 0.17.0-python3.5-alpine, 0.17-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.10
 
-Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9, 0.17.0-python3.5-alpine, 0.17-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
+Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.9
 
 Tags: 0.17.0-python2.7-buster, 0.17-python2.7-buster, 0-python2.7-buster, python2.7-buster
+SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-buster
 
 Tags: 0.17.0-python2.7-stretch, 0.17-python2.7-stretch, 0-python2.7-stretch, python2.7-stretch
-SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-stretch
 
-Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10
+Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.10
 
-Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
+Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.9
 
@@ -108,14 +108,8 @@ Constraints: windowsservercore-ltsc2016
 File: Dockerfile.python2.7-windowsservercore-ltsc2016
 
 Tags: 0.17.0-pypy3.6-stretch, 0.17-pypy3.6-stretch, 0-pypy3.6-stretch, pypy3.6-stretch, 0.17.0-pypy-stretch, 0.17-pypy-stretch, 0-pypy-stretch, pypy-stretch
-SharedTags: 0.17.0-pypy3.6, 0.17-pypy3.6, 0-pypy3.6, pypy3.6, 0.17.0-pypy, 0.17-pypy, 0-pypy, pypy
-Architectures: amd64, i386, s390x
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.pypy3.6-stretch
-
-Tags: 0.17.0-pypy3.5-stretch, 0.17-pypy3.5-stretch, 0-pypy3.5-stretch, pypy3.5-stretch
-SharedTags: 0.17.0-pypy3.5, 0.17-pypy3.5, 0-pypy3.5, pypy3.5
-Architectures: amd64, i386, ppc64le, s390x
-File: Dockerfile.pypy3.5-stretch
 
 Tags: 0.17.0-pypy2.7-jessie, 0.17-pypy2.7-jessie, 0-pypy2.7-jessie, pypy2.7-jessie
 Architectures: amd64, i386


### PR DESCRIPTION
Mostly Python/PyPy upstream changes and some default tag shifting (Buster + Alpine 3.10); see https://github.com/hylang/docker-hylang/pull/2.