### PR TITLE
Update Amazon Corretto (8.232.09.1 and 11.0.5.10.1).

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -3,14 +3,14 @@ Maintainers: Amazon Corretto Team (@corretto),
              Ziyi Luo (@ziyiluo),
              David Alvarez (@alvdavi)
 
-Tags: 8, 8u222, 8-al2-full, latest
+Tags: 8, 8u232, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: cd7c7563f35cc12cf50a9a418e5ecaa73810a8e8
+GitCommit: 36e50e6fec65b3b12fa4e595e8b8fa1def0b39f5
 Architectures: amd64, arm64v8
 
-Tags: 11, 11.0.4, 11-al2-full
+Tags: 11, 11.0.5, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: ef101ef699ac861721faffa22247c32d845a217a
+GitCommit: 8a8fdf18ac8700a98bf8995cc85ec70616e5e130
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Quarterly update based on OpenJDK8u232 and OpenJDK11.0.5.