### PR TITLE
Update SapMachine from version 13 to 13.0.1.

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -6,7 +6,7 @@ Architectures: amd64
 GitCommit: 1c93a00d33e446e1feff9ea40eaa320e1093e309
 Directory: dockerfiles/official/lts
 
-Tags: 13, latest
+Tags: 13, 13.0.1, latest
 Architectures: amd64
-GitCommit: 613ec0132bdb274ed8d0cf1fdabefb3ead3b9d9d
+GitCommit: 9c0699a4b6a48335a9929cce5895dc6e6871b73d
 Directory: dockerfiles/official/stable


### PR DESCRIPTION
New SapMachine stable version 13.0.1