### PR TITLE
ZNC: re-enable IPv6, upgrade alpine

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,6 +1,6 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
-GitCommit: 90d901c4934ff7f9b215406f6bcc775135b8ec76
+GitCommit: 8549b62a7e44cb6c2d1fde3839461ceddebac15d
 Architectures: amd64, arm32v6, arm64v8
 
 Tags: 1.7.5, 1.7, latest


### PR DESCRIPTION
Ref https://github.com/znc/znc-docker/issues/19