### PR TITLE
[security] Update golang 1.13.3 and 1.12.12

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,109 +5,109 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.13.1-buster, 1.13-buster, 1-buster, buster
-SharedTags: 1.13.1, 1.13, 1, latest
+Tags: 1.13.3-buster, 1.13-buster, 1-buster, buster
+SharedTags: 1.13.3, 1.13, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/buster
 
-Tags: 1.13.1-stretch, 1.13-stretch, 1-stretch, stretch
+Tags: 1.13.3-stretch, 1.13-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/stretch
 
-Tags: 1.13.1-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.1-alpine, 1.13-alpine, 1-alpine, alpine
+Tags: 1.13.3-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.3-alpine, 1.13-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/alpine3.10
 
-Tags: 1.13.1-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
+Tags: 1.13.3-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13.1-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
+Tags: 1.13.3-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.13.1-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.13.1-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.1, 1.13, 1, latest
+Tags: 1.13.3-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.13.1-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
-SharedTags: 1.13.1-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.3-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
+SharedTags: 1.13.3-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.13.1-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.13.1-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.3-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.13.3-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 4fa4888b25307c734ed4bbda6ce68549b7d9dbdc
+GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
 Directory: 1.13/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.12.10-buster, 1.12-buster
-SharedTags: 1.12.10, 1.12
+Tags: 1.12.12-buster, 1.12-buster
+SharedTags: 1.12.12, 1.12
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/buster
 
-Tags: 1.12.10-stretch, 1.12-stretch
+Tags: 1.12.12-stretch, 1.12-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/stretch
 
-Tags: 1.12.10-alpine3.10, 1.12-alpine3.10, 1.12.10-alpine, 1.12-alpine
+Tags: 1.12.12-alpine3.10, 1.12-alpine3.10, 1.12.12-alpine, 1.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/alpine3.10
 
-Tags: 1.12.10-alpine3.9, 1.12-alpine3.9
+Tags: 1.12.12-alpine3.9, 1.12-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/alpine3.9
 
-Tags: 1.12.10-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
-SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
+Tags: 1.12.12-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
+SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
 Architectures: windows-amd64
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12.10-windowsservercore-1803, 1.12-windowsservercore-1803
-SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
+Tags: 1.12.12-windowsservercore-1803, 1.12-windowsservercore-1803
+SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
 Architectures: windows-amd64
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12.10-windowsservercore-1809, 1.12-windowsservercore-1809
-SharedTags: 1.12.10-windowsservercore, 1.12-windowsservercore, 1.12.10, 1.12
+Tags: 1.12.12-windowsservercore-1809, 1.12-windowsservercore-1809
+SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
 Architectures: windows-amd64
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12.10-nanoserver-1803, 1.12-nanoserver-1803
-SharedTags: 1.12.10-nanoserver, 1.12-nanoserver
+Tags: 1.12.12-nanoserver-1803, 1.12-nanoserver-1803
+SharedTags: 1.12.12-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.12.10-nanoserver-1809, 1.12-nanoserver-1809
-SharedTags: 1.12.10-nanoserver, 1.12-nanoserver
+Tags: 1.12.12-nanoserver-1809, 1.12-nanoserver-1809
+SharedTags: 1.12.12-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ca16c61ab1f47d169590457fdddff73162a63c8
+GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
 Directory: 1.12/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Update to 1.12.12: https://github.com/docker-library/golang/commit/0b996cdb43a0e0a16d8af23fd25f5eef7b51721b

Update to 1.13.3: https://github.com/docker-library/golang/commit/a4deea14ce3306822bb9352ccf124af8c0eea257