### PR TITLE
Release of GeoNetwork 3.8.1

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/fb2d94fca6965245e6e1c260f4ee574969227e2c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/b7bedb90f76fb630d7863665014adea427112a5c/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
@@ -12,14 +12,6 @@ Directory: 3.6.0
 Tags: 3.6.0-postgres, 3.6-postgres
 GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
 Directory: 3.6.0/postgres
-
-Tags: 3.8.0
-GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
-Directory: 3.8.0
-
-Tags: 3.8.0-postgres
-GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
-Directory: 3.8.0/postgres
 
 Tags: 3.8.1, 3.8, latest
 GitCommit: fb2d94fca6965245e6e1c260f4ee574969227e2c

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/27a30d076d7358917d9f0d06577ff856f2e8e2b6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/fb2d94fca6965245e6e1c260f4ee574969227e2c/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
@@ -13,10 +13,18 @@ Tags: 3.6.0-postgres, 3.6-postgres
 GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
 Directory: 3.6.0/postgres
 
-Tags: 3.8.0, 3.8, latest
+Tags: 3.8.0
 GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
 Directory: 3.8.0
 
-Tags: 3.8.0-postgres, 3.8-postgres, postgres
+Tags: 3.8.0-postgres
 GitCommit: e946f10156ed14097351c05cb79349dfda046c0d
 Directory: 3.8.0/postgres
+
+Tags: 3.8.1, 3.8, latest
+GitCommit: fb2d94fca6965245e6e1c260f4ee574969227e2c
+Directory: 3.8.1
+
+Tags: 3.8.1-postgres, 3.8-postgres, postgres
+GitCommit: fb2d94fca6965245e6e1c260f4ee574969227e2c
+Directory: 3.8.1/postgres


### PR DESCRIPTION
Updated official GN version to its latest release (3.8.1), to catch up with the [latest changes on the image code](https://github.com/geonetwork/docker-geonetwork).