### PR TITLE
Update NATS tags

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,36 +4,40 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitCommit: f71b553207305f7d725e3eed1329dcd8b00ca22f
 
-Tags: 2.1.0-linux, linux
-SharedTags: 2.1.0, latest
+Tags: 2.1.0-scratch, 2.1-scratch, 2-scratch, scratch, 2.1.0-linux, 2.1-linux, 2-linux, linux
+SharedTags: 2.1.0, 2.1, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 amd64-Directory: 2.1.0/scratch/amd64
 arm32v6-Directory: 2.1.0/scratch/arm32v6
 arm32v7-Directory: 2.1.0/scratch/arm32v7
 arm64v8-Directory: 2.1.0/scratch/arm64v8
 
-Tags: 2.1.0-windowsservercore-1809, windowsservercore-1809, windowsservercore
+Tags: 2.1.0-windowsservercore-1809, 2.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.1.0/windowsservercore1809
 Constraints: windowsservercore-1809
 
-Tags: 2.1.0-nanoserver-1809, nanoserver-1809
-SharedTags: 2.1.0, latest
+Tags: 2.1.0-nanoserver-1809, 2.1-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.1.0-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.0, 2.1, 2, latest
 Architectures: windows-amd64
 Directory: 2.1.0/nanoserver1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.1.0-windowsservercore-1803, windowsservercore-1803
+Tags: 2.1.0-windowsservercore-1803, 2.1-windowsservercore-1803, 2-windowsservercore-1803, windowsservercore-1803
+SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.1.0/windowsservercore1803
 Constraints: windowsservercore-1803
 
-Tags: 2.1.0-nanoserver-1803, nanoserver-1803
+Tags: 2.1.0-nanoserver-1803, 2.1-nanoserver-1803, 2-nanoserver-1803, nanoserver-1803
+SharedTags: 2.1.0-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.0, 2.1, 2, latest
 Architectures: windows-amd64
 Directory: 2.1.0/nanoserver1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 2.1.0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+Tags: 2.1.0-windowsservercore-ltsc2016, 2.1-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.1.0/windowsservercoreltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Add more tags so Windows can do automatic version detection. This also
adds more tags for scratch.

Based on feedback from @tianon on a previous PR https://github.com/docker-library/official-images/pull/6766.

cc @kozlovic 