### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-18-jdk-oraclelinux7, 14-ea-18-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-18-jdk-oracle, 14-ea-18-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-19-jdk-oraclelinux7, 14-ea-19-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-19-jdk-oracle, 14-ea-19-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-19-jdk, 14-ea-19, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-18-jdk-buster, 14-ea-18-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-19-jdk-buster, 14-ea-19-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk
 
-Tags: 14-ea-18-jdk-slim-buster, 14-ea-18-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-18-jdk-slim, 14-ea-18-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-19-jdk-slim-buster, 14-ea-19-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-19-jdk-slim, 14-ea-19-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: bde1e9a0f36e12e3df58b81acddd695fd140cf6a
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-18-jdk-windowsservercore-1809, 14-ea-18-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-19-jdk-windowsservercore-1809, 14-ea-19-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-19-jdk-windowsservercore, 14-ea-19-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-19-jdk, 14-ea-19, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-18-jdk-windowsservercore-1803, 14-ea-18-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-19-jdk-windowsservercore-1803, 14-ea-19-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-19-jdk-windowsservercore, 14-ea-19-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-19-jdk, 14-ea-19, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-18-jdk-windowsservercore-ltsc2016, 14-ea-18-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-18-jdk-windowsservercore, 14-ea-18-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-18-jdk, 14-ea-18, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-19-jdk-windowsservercore-ltsc2016, 14-ea-19-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-19-jdk-windowsservercore, 14-ea-19-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-19-jdk, 14-ea-19, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: f34b3e5fc57fe265e64592d46224e69d23cda443
+GitCommit: 64c974878212b45f5c2f6b4a3e3319f1d5a1f05d
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
@@ -85,130 +85,130 @@ GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.4-jdk-stretch, 11.0.4-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
-SharedTags: 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.5-jdk-stretch, 11.0.5-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
+SharedTags: 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jdk
 
-Tags: 11.0.4-jdk-slim-buster, 11.0.4-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.4-jdk-slim, 11.0.4-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.5-jdk-slim-buster, 11.0.5-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.5-jdk-slim, 11.0.5-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jdk/slim
 
-Tags: 11.0.4-jdk-windowsservercore-1809, 11.0.4-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.5-jdk-windowsservercore-1809, 11.0.5-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.4-jdk-windowsservercore-1803, 11.0.4-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.5-jdk-windowsservercore-1803, 11.0.5-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
+SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.4-jdk-windowsservercore-ltsc2016, 11.0.4-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.4-jdk-windowsservercore, 11.0.4-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.4-jdk, 11.0.4, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.5-jdk-windowsservercore-ltsc2016, 11.0.5-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e7c6ade3d9d636c39fbbfa30c144a93fbb038494
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.4-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
-SharedTags: 11.0.4-jre, 11.0-jre, 11-jre
+Tags: 11.0.5-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
+SharedTags: 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jre
 
-Tags: 11.0.4-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.4-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.5-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.5-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jre/slim
 
-Tags: 11.0.4-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Tags: 11.0.5-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.4-jre-windowsservercore-1803, 11.0-jre-windowsservercore-1803, 11-jre-windowsservercore-1803
-SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Tags: 11.0.5-jre-windowsservercore-1803, 11.0-jre-windowsservercore-1803, 11-jre-windowsservercore-1803
+SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 11.0.4-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.4-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.4-jre, 11.0-jre, 11-jre
+Tags: 11.0.5-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 572682ed1cb951ab8d978e8015e4a910093db920
+GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u222-jdk-stretch, 8u222-stretch, 8-jdk-stretch, 8-stretch
-SharedTags: 8u222-jdk, 8u222, 8-jdk, 8
+Tags: 8u232-jdk-stretch, 8u232-stretch, 8-jdk-stretch, 8-stretch
+SharedTags: 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: amd64
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jdk
 
-Tags: 8u222-jdk-slim-buster, 8u222-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u222-jdk-slim, 8u222-slim, 8-jdk-slim, 8-slim
+Tags: 8u232-jdk-slim-buster, 8u232-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u232-jdk-slim, 8u232-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jdk/slim
 
-Tags: 8u222-jdk-windowsservercore-1809, 8u222-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
+Tags: 8u232-jdk-windowsservercore-1809, 8u232-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u222-jdk-windowsservercore-1803, 8u222-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
-SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
+Tags: 8u232-jdk-windowsservercore-1803, 8u232-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
+SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u222-jdk-windowsservercore-ltsc2016, 8u222-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u222-jdk-windowsservercore, 8u222-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u222-jdk, 8u222, 8-jdk, 8
+Tags: 8u232-jdk-windowsservercore-ltsc2016, 8u232-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u222-jre-stretch, 8-jre-stretch
-SharedTags: 8u222-jre, 8-jre
+Tags: 8u232-jre-stretch, 8-jre-stretch
+SharedTags: 8u232-jre, 8-jre
 Architectures: amd64
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jre
 
-Tags: 8u222-jre-slim-buster, 8-jre-slim-buster, 8u222-jre-slim, 8-jre-slim
+Tags: 8u232-jre-slim-buster, 8-jre-slim-buster, 8u232-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: 451e66427f3c53fada288aaff950617c5864745f
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jre/slim
 
-Tags: 8u222-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
+Tags: 8u232-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u222-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
-SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
+Tags: 8u232-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
+SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 8u222-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u222-jre-windowsservercore, 8-jre-windowsservercore, 8u222-jre, 8-jre
+Tags: 8u232-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
+SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: d938a100d9f43bab60a1d5f655b61cbac97c74ae
+GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/64c9748: Update to 14-ea+19
- https://github.com/docker-library/openjdk/commit/fb20f30: Update to 11.0.5
- https://github.com/docker-library/openjdk/commit/403960e: Update to 8u232