### PR TITLE
Update Clear Linux OS to 31350

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@c52fcf11d5b25aebdb1d7fadf0ce243c1a3e3c81
-base: git://github.com/clearlinux/docker-brew-clearlinux@c52fcf11d5b25aebdb1d7fadf0ce243c1a3e3c81
+latest: git://github.com/clearlinux/docker-brew-clearlinux@7a06a5bf8dff19d5da6f53043ea739cc1c6e9ea5
+base: git://github.com/clearlinux/docker-brew-clearlinux@7a06a5bf8dff19d5da6f53043ea739cc1c6e9ea5


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31350

@bryteise @gtkramer