### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -49,21 +49,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: buster
 
-Tags: cosmic-curl, 18.10-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
-Directory: cosmic/curl
-
-Tags: cosmic-scm, 18.10-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3bdba8b3675c0f820f2ce7bd88e79e4aac2fb8c
-Directory: cosmic/scm
-
-Tags: cosmic, 18.10
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
-Directory: cosmic
-
 Tags: disco-curl, 19.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/05d1698: Remove cosmic (EOL)