### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,30 +1,29 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              iliana destroyer of worlds (@iliana),
-             Praveen K Paladugu (@praveen-pk),
              Eric Warehime (@Eric-Warehime)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 6621cd66614eaa1ab425e4144b95884c6efb0b8b
+GitCommit: 6ab69daed0190d3b76a7462930901796f36df56b
 
-Tags: 2.0.20190823.1, 2, latest
+Tags: 2.0.20191016.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 5cad81cf824efef29c3c9a0d0a995dd8b73abf22
+amd64-GitCommit: 915e49b7f8172c134623ea7181b511fddec9a819
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 23d169161c6a8484d4da6fc0c9b6ecf0995c5dab
+arm64v8-GitCommit: 2b5fc06101d0497b6794c6c2fee7e535d86a6bf4
 
-Tags: 2.0.20190823.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20191016.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: ea2f4afccbbaa445448ba66ad29efec075226e63
+amd64-GitCommit: f09f12331dc25c7e1e3669585db74e477a0b762e
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: e14aa5a0e296d1cd03619e49927392c0eb157dc0
+arm64v8-GitCommit: b12bb09d2a04bf451403e99e0b95975d75907980
 
-Tags: 2018.03.0.20190826, 2018.03, 1
+Tags: 2018.03.0.20191014.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: a30a06ba6226455e027f63585deb4d3803ba90fc
+amd64-GitCommit: 566b99a65831000e6ae8856d98e8d8e68741871f
 
-Tags: 2018.03.0.20190826-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20191014.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 30593e836dad758b8f236426bc709adb7c3f4d87
+amd64-GitCommit: bd732e6748bed4ef08ca1dcf759b676659e0ff44


### PR DESCRIPTION
<details><summary>New amazonlinux:2 package versions</summary>

```
amazon-linux-extras-1.6.9-2.amzn2.noarch
glib2-2.56.1-4.amzn2.x86_64
libgcc-7.3.1-6.amzn2.0.4.x86_64
libnghttp2-1.39.2-1.amzn2.x86_64
libssh2-1.4.3-12.amzn2.2.2.x86_64
libstdc++-7.3.1-6.amzn2.0.4.x86_64
libxml2-2.9.1-6.amzn2.3.3.x86_64
ncurses-6.0-8.20170212.amzn2.1.3.x86_64
ncurses-base-6.0-8.20170212.amzn2.1.3.noarch
ncurses-libs-6.0-8.20170212.amzn2.1.3.x86_64
nspr-4.21.0-1.amzn2.0.2.x86_64
nss-3.44.0-4.amzn2.0.2.x86_64
nss-softokn-3.44.0-5.amzn2.0.2.x86_64
nss-softokn-freebl-3.44.0-5.amzn2.0.2.x86_64
nss-sysinit-3.44.0-4.amzn2.0.2.x86_64
nss-tools-3.44.0-4.amzn2.0.2.x86_64
nss-util-3.44.0-3.amzn2.0.2.x86_64
python-2.7.16-3.amzn2.0.1.x86_64
python-libs-2.7.16-3.amzn2.0.1.x86_64
tzdata-2019b-1.amzn2.noarch
```
</details>
<details><summary>New amazonlinux:1 package versions</summary>

```
curl-7.61.1-12.93.amzn1.x86_64
libcurl-7.61.1-12.93.amzn1.x86_64
libnghttp2-1.31.1-2.5.amzn1.x86_64
tzdata-2019b-1.72.amzn1.noarch
```
</details>