### PR TITLE
Update ghost-basics tests for new versions

### DIFF
--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -30,8 +30,8 @@ _request() {
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
 case "$ghostVersion" in
 	0.*) _request GET '/ghost/' -I |tac|tac| grep -q '^Location: .*setup' ;;
-	1.*)   _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
-	2.*)   _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
-	3.*)   _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	1.*) _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	2.*) _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	3.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	*) echo "no tests for version ${ghostVersion}" && exit 1 ;;
 esac
-

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -30,6 +30,8 @@ _request() {
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
 case "$ghostVersion" in
 	0.*) _request GET '/ghost/' -I |tac|tac| grep -q '^Location: .*setup' ;;
-	*)   _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	1.*)   _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	2.*)   _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	3.*)   _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 esac
 


### PR DESCRIPTION
refs https://github.com/docker-library/ghost/pull/194
- use correct api endpoints for different versions of Ghost