### PR TITLE
Add alpine image

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,7 +2,8 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 93c2dfeadcc2247f5f670c32a7fb11c06a0a6c63
+GitCommit: 4854982e40f364582d2459be021425b4f7d7ba69
+GitFetch: refs/heads/docker-feedback
 
 Tags: 2.1.0-alpine3.10, 2.1-alpine3.10, 2-alpine3.10, alpine3.10, 2.1.0-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8

--- a/library/nats
+++ b/library/nats
@@ -2,42 +2,43 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: f71b553207305f7d725e3eed1329dcd8b00ca22f
+GitCommit: 93c2dfeadcc2247f5f670c32a7fb11c06a0a6c63
+
+Tags: 2.1.0-alpine3.10, 2.1-alpine3.10, 2-alpine3.10, alpine3.10, 2.1.0-alpine, 2.1-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+Directory: 2.1.0/alpine3.10
 
 Tags: 2.1.0-scratch, 2.1-scratch, 2-scratch, scratch, 2.1.0-linux, 2.1-linux, 2-linux, linux
 SharedTags: 2.1.0, 2.1, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-amd64-Directory: 2.1.0/scratch/amd64
-arm32v6-Directory: 2.1.0/scratch/arm32v6
-arm32v7-Directory: 2.1.0/scratch/arm32v7
-arm64v8-Directory: 2.1.0/scratch/arm64v8
+Directory: 2.1.0/scratch
 
 Tags: 2.1.0-windowsservercore-1809, 2.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
 SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.0/windowsservercore1809
+Directory: 2.1.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 2.1.0-nanoserver-1809, 2.1-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
 SharedTags: 2.1.0-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.0, 2.1, 2, latest
 Architectures: windows-amd64
-Directory: 2.1.0/nanoserver1809
+Directory: 2.1.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 2.1.0-windowsservercore-1803, 2.1-windowsservercore-1803, 2-windowsservercore-1803, windowsservercore-1803
 SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.0/windowsservercore1803
+Directory: 2.1.0/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 2.1.0-nanoserver-1803, 2.1-nanoserver-1803, 2-nanoserver-1803, nanoserver-1803
 SharedTags: 2.1.0-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.0, 2.1, 2, latest
 Architectures: windows-amd64
-Directory: 2.1.0/nanoserver1803
+Directory: 2.1.0/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 2.1.0-windowsservercore-ltsc2016, 2.1-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 2.1.0-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.0/windowsservercoreltsc2016
+Directory: 2.1.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
This change pulls in our latest repo commit, which brings 3 new changes.
* We're adding an Alpine image
* We've removed Go binaries from our repos and just download a release
* We've renamed our windows directories to match the image names