### PR TITLE
Add Official Newrelic PHP Daemon Image

### DIFF
--- a/library/newrelic-php-daemon
+++ b/library/newrelic-php-daemon
@@ -5,7 +5,7 @@ Maintainers: Amanda Murphy <amurphy@newrelic.com> (@murphpdx),
              Kyle Kneitinger <kkneitenger@newrelic.com> (@kneitinger)
 GitRepo: https://github.com/newrelic/newrelic-php-daemon-docker.git
 
-Tags: latest, 9.2.0.247 9.2.0, 9.2
+Tags: latest, 9.2.0.247, 9.2.0, 9.2
 Architectures: amd64
 GitCommit: 8acf95eae363e3dcc75ffd8b803e08bed75ee2b9
 Directory: 9.2.0

--- a/library/newrelic-php-daemon
+++ b/library/newrelic-php-daemon
@@ -1,7 +1,7 @@
-Maintainers: Amanda Murphy <amurphy@newrelic.com> (@murphpdx)
-             Adam Harvey <aharvey@newrelic.com> (@LawnGnome)
-             Johannes Tax <jtax@newrelic.com> (@pyohannes)
-             Fahmy Mohammed <fmohammed@newrelic.com> (@Fahmy-Mohammed)
+Maintainers: Amanda Murphy <amurphy@newrelic.com> (@murphpdx),
+             Adam Harvey <aharvey@newrelic.com> (@LawnGnome),
+             Johannes Tax <jtax@newrelic.com> (@pyohannes),
+             Fahmy Mohammed <fmohammed@newrelic.com> (@Fahmy-Mohammed),
              Kyle Kneitinger <kkneitenger@newrelic.com> (@kneitinger)
 GitRepo: https://github.com/newrelic/newrelic-php-daemon-docker.git
 

--- a/library/newrelic-php-daemon
+++ b/library/newrelic-php-daemon
@@ -1,0 +1,11 @@
+Maintainers: Amanda Murphy <amurphy@newrelic.com> (@murphpdx)
+             Adam Harvey <aharvey@newrelic.com> (@LawnGnome)
+             Johannes Tax <jtax@newrelic.com> (@pyohannes)
+             Fahmy Mohammed <fmohammed@newrelic.com> (@Fahmy-Mohammed)
+             Kyle Kneitinger <kkneitenger@newrelic.com> (@kneitinger)
+GitRepo: https://github.com/newrelic/newrelic-php-daemon-docker.git
+
+Tags: latest, 9.2.0.247 9.2.0, 9.2
+Architectures: amd64
+GitCommit: 8acf95eae363e3dcc75ffd8b803e08bed75ee2b9
+Directory: 9.2.0


### PR DESCRIPTION
Hello, 
We, the New Relic PHP Agent team, would like to add an official image for our New Relic PHP Agent daemon. 

-	[ ] associated with or contacted upstream? Yes https://github.com/newrelic/newrelic-php-daemon-docker
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long) https://github.com/docker-library/docs/pull/1591
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
