### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.7, 2.0, latest
+Tags: 2.0.8, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2663a97d654b3d46e930ab98fc136443f93bfe82
+GitCommit: 3700abeba4834a27c43b16330cbaf1b8bae565cd
 Directory: 2.0
 
-Tags: 2.0.7-alpine, 2.0-alpine, alpine
+Tags: 2.0.8-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2663a97d654b3d46e930ab98fc136443f93bfe82
+GitCommit: 3700abeba4834a27c43b16330cbaf1b8bae565cd
 Directory: 2.0/alpine
 
 Tags: 1.9.11, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3700abe: Update to 2.0.8