### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.1-beta.1, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe636b312146540ff662b87968fe96aba80fc03
+GitCommit: 78996bc1c3ffdf298c6151f1ff15935afcc66841
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.1-beta.1-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.1-beta.1-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe636b312146540ff662b87968fe96aba80fc03
+GitCommit: 78996bc1c3ffdf298c6151f1ff15935afcc66841
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.1-beta.1-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.0, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8ca2ef2814cf35de476e763db94eb9706657f3c
+GitCommit: 4a563bd82fe53b46b144d5ee17af6627ff34af65
 Directory: 3.8/ubuntu
 
 Tags: 3.8.0-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8ca2ef2814cf35de476e763db94eb9706657f3c
+GitCommit: 4a563bd82fe53b46b144d5ee17af6627ff34af65
 Directory: 3.8/alpine
 
 Tags: 3.8.0-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -46,7 +46,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.20-rc.1, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 75fc0deff117e3cd15a60c98d7d1d030a971b5ce
+GitCommit: dd228054dee7f7ff343fd31e410c0f451d910ac9
 Directory: 3.7-rc/ubuntu
 
 Tags: 3.7.20-rc.1-management, 3.7-rc-management
@@ -56,7 +56,7 @@ Directory: 3.7-rc/ubuntu/management
 
 Tags: 3.7.20-rc.1-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 75fc0deff117e3cd15a60c98d7d1d030a971b5ce
+GitCommit: dd228054dee7f7ff343fd31e410c0f451d910ac9
 Directory: 3.7-rc/alpine
 
 Tags: 3.7.20-rc.1-management-alpine, 3.7-rc-management-alpine
@@ -66,7 +66,7 @@ Directory: 3.7-rc/alpine/management
 
 Tags: 3.7.19, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1a86a588a2d2d8ef26ae6930ad3c8ec66b1c1c3
+GitCommit: d76928ec3b631df325366ee322e516bb94379016
 Directory: 3.7/ubuntu
 
 Tags: 3.7.19-management, 3.7-management
@@ -76,7 +76,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.19-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1a86a588a2d2d8ef26ae6930ad3c8ec66b1c1c3
+GitCommit: d76928ec3b631df325366ee322e516bb94379016
 Directory: 3.7/alpine
 
 Tags: 3.7.19-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/4a563bd: Update to 3.8.0, Erlang/OTP 22.1.4, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/dd22805: Update to 3.7.20-rc.1, Erlang/OTP 22.1.4, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/d76928e: Update to 3.7.19, Erlang/OTP 22.1.4, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/78996bc: Update to 3.8.1-beta.1, Erlang/OTP 22.1.4, OpenSSL 1.1.1d