### PR TITLE
Update NATS

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -2,8 +2,7 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Waldemar Salinas <wally@synadia.com> (@wallyqs)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4854982e40f364582d2459be021425b4f7d7ba69
-GitFetch: refs/heads/docker-feedback
+GitCommit: 5b1a290bd1b553e43186003f5130ba1b805e505d
 
 Tags: 2.1.0-alpine3.10, 2.1-alpine3.10, 2-alpine3.10, alpine3.10, 2.1.0-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8


### PR DESCRIPTION
The changes from nats-io/nats-docker docker-feedback have been merged to master. This removes the reference to the non-master branch.