### PR TITLE
kong: move plain tags to 1.4 images

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,38 +2,38 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 1.4.0-alpine, 1.4.0, 1.4
+Tags: 1.4.0-alpine, 1.4.0, 1.4, alpine, latest
 GitCommit: 3064639825d8f33fa84220993de49c5cfee5a3a9
 GitFetch: refs/tags/1.4.0
 Directory: alpine
 Architectures: amd64
 
-Tags: 1.4.0-ubuntu, 1.4-ubuntu
+Tags: 1.4.0-ubuntu, 1.4-ubuntu, ubuntu
 GitCommit: 3064639825d8f33fa84220993de49c5cfee5a3a9
 GitFetch: refs/tags/1.4.0
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 1.4.0-centos, 1.4-centos
+Tags: 1.4.0-centos, 1.4-centos, centos
 GitCommit: 3064639825d8f33fa84220993de49c5cfee5a3a9
 GitFetch: refs/tags/1.4.0
 Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
-Tags: 1.3.0-alpine, 1.3.0, 1.3, alpine, latest
+Tags: 1.3.0-alpine, 1.3.0, 1.3
 GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
 GitFetch: refs/tags/1.3.0
 Directory: alpine
 Architectures: amd64
 
-Tags: 1.3.0-ubuntu, 1.3-ubuntu, ubuntu
+Tags: 1.3.0-ubuntu, 1.3-ubuntu
 GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
 GitFetch: refs/tags/1.3.0
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 1.3.0-centos, 1.3-centos, centos
+Tags: 1.3.0-centos, 1.3-centos
 GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0
 GitFetch: refs/tags/1.3.0
 Constraints: !aufs


### PR DESCRIPTION
Move tags alpine, latest, ubuntu, and centos tags up from the 1.3 images to the 1.4 images.

Related with #6846