### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3700abeba4834a27c43b16330cbaf1b8bae565cd
 Directory: 2.0/alpine
 
-Tags: 1.9.11, 1.9, 1
+Tags: 1.9.12, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9dddade0c1bddeb2346ffef36b97d037c39bd5cf
+GitCommit: bd6b8fd614e9359ebd1f4b27cfa38ae44d63c174
 Directory: 1.9
 
-Tags: 1.9.11-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.12-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9dddade0c1bddeb2346ffef36b97d037c39bd5cf
+GitCommit: bd6b8fd614e9359ebd1f4b27cfa38ae44d63c174
 Directory: 1.9/alpine
 
-Tags: 1.8.21, 1.8
+Tags: 1.8.22, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dbb06aa772a093dab4b88660f8470a4f28de310
+GitCommit: 9054c7c7dcc271f7bda910e240af66f00d6d43a0
 Directory: 1.8
 
-Tags: 1.8.21-alpine, 1.8-alpine
+Tags: 1.8.22-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
+GitCommit: 9054c7c7dcc271f7bda910e240af66f00d6d43a0
 Directory: 1.8/alpine
 
-Tags: 1.7.11, 1.7
+Tags: 1.7.12, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3ff4cd3d32d9eceda4b33183a91d8d276bc08d5
+GitCommit: 14431e31ab981456585021f7dca35626c5e060c1
 Directory: 1.7
 
-Tags: 1.7.11-alpine, 1.7-alpine
+Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
+GitCommit: 14431e31ab981456585021f7dca35626c5e060c1
 Directory: 1.7/alpine
 
-Tags: 1.6.14, 1.6
+Tags: 1.6.15, 1.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
+GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
 Directory: 1.6
 
-Tags: 1.6.14-alpine, 1.6-alpine
+Tags: 1.6.15-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
+GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
 Directory: 1.6/alpine
 
 Tags: 1.5.19, 1.5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bd6b8fd: Update to 1.9.12