### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.1-beta.1, 3.8-rc
+Tags: 3.8.1-beta.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78996bc1c3ffdf298c6151f1ff15935afcc66841
+GitCommit: 8bbb3c698d3a16883f8000e82e6b76fa3aaddf91
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.1-beta.1-management, 3.8-rc-management
+Tags: 3.8.1-beta.2-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.1-beta.1-alpine, 3.8-rc-alpine
+Tags: 3.8.1-beta.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78996bc1c3ffdf298c6151f1ff15935afcc66841
+GitCommit: 8bbb3c698d3a16883f8000e82e6b76fa3aaddf91
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.1-beta.1-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.1-beta.2-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.0, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a563bd82fe53b46b144d5ee17af6627ff34af65
+GitCommit: a0bf95f11c0b2e757847f19e4ce4943fdd63e327
 Directory: 3.8/ubuntu
 
 Tags: 3.8.0-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a563bd82fe53b46b144d5ee17af6627ff34af65
+GitCommit: a0bf95f11c0b2e757847f19e4ce4943fdd63e327
 Directory: 3.8/alpine
 
 Tags: 3.8.0-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -44,42 +44,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.20-rc.1, 3.7-rc
+Tags: 3.7.20, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd228054dee7f7ff343fd31e410c0f451d910ac9
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.20-rc.1-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.20-rc.1-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd228054dee7f7ff343fd31e410c0f451d910ac9
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.20-rc.1-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.19, 3.7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d76928ec3b631df325366ee322e516bb94379016
+GitCommit: 16e8c4e3e29c3e316ea2caa94572b6b476004c88
 Directory: 3.7/ubuntu
 
-Tags: 3.7.19-management, 3.7-management
+Tags: 3.7.20-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.19-alpine, 3.7-alpine
+Tags: 3.7.20-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d76928ec3b631df325366ee322e516bb94379016
+GitCommit: 16e8c4e3e29c3e316ea2caa94572b6b476004c88
 Directory: 3.7/alpine
 
-Tags: 3.7.19-management-alpine, 3.7-management-alpine
+Tags: 3.7.20-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/c413e93: Update to 3.8.1-beta.2, Erlang/OTP 22.1.4, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/d90754f: Update to 3.7.20-rc.2, Erlang/OTP 22.1.4, OpenSSL 1.1.1d