### PR TITLE
Update Clear Linux OS to 31380

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@7a06a5bf8dff19d5da6f53043ea739cc1c6e9ea5
-base: git://github.com/clearlinux/docker-brew-clearlinux@7a06a5bf8dff19d5da6f53043ea739cc1c6e9ea5
+latest: git://github.com/clearlinux/docker-brew-clearlinux@da2a75c1f3788870210c7560343d5277cb80c2a1
+base: git://github.com/clearlinux/docker-brew-clearlinux@da2a75c1f3788870210c7560343d5277cb80c2a1


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 31380

@bryteise @gtkramer