### PR TITLE
Plone: Release 4.3.19 and 5.1.6

### DIFF
--- a/library/plone
+++ b/library/plone
@@ -5,35 +5,35 @@ GitRepo: https://github.com/plone/plone.docker.git
 
 Tags: 5.2.0, 5.2, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f52edd954d2530f453f6fe30f55284940e85c94
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 5.2/5.2.0/debian
 
 Tags: 5.2.0-alpine, 5.2-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f52edd954d2530f453f6fe30f55284940e85c94
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 5.2/5.2.0/alpine
 
 Tags: 5.2.0-python2, 5.2-python2, 5-python2, python2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f52edd954d2530f453f6fe30f55284940e85c94
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 5.2/5.2.0/python2
 
 Tags: 5.1.6, 5.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 5.1/5.1.6/debian
 
 Tags: 5.1.6-alpine, 5.1-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 5.1/5.1.6/alpine
 
 Tags: 4.3.19, 4.3, 4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 4.3/4.3.19/debian
 
 Tags: 4.3.19-alpine, 4.3-alpine, 4-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+GitCommit: 163708ce4228e162647a3666937a86b72c8c0fc6
 Directory: 4.3/4.3.19/alpine

--- a/library/plone
+++ b/library/plone
@@ -17,3 +17,13 @@ Tags: 5.2.0-python2, 5.2-python2, 5-python2, python2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5f52edd954d2530f453f6fe30f55284940e85c94
 Directory: 5.2/5.2.0/python2
+
+Tags: 4.3.19, 4.3, 4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+Directory: 4.3/4.3.19/debian
+
+Tags: 4.3.19-alpine, 4.3-alpine, 4-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+Directory: 4.3/4.3.19/alpine

--- a/library/plone
+++ b/library/plone
@@ -18,6 +18,16 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5f52edd954d2530f453f6fe30f55284940e85c94
 Directory: 5.2/5.2.0/python2
 
+Tags: 5.1.6, 5.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+Directory: 5.1/5.1.6/debian
+
+Tags: 5.1.6-alpine, 5.1-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333
+Directory: 5.1/5.1.6/alpine
+
 Tags: 4.3.19, 4.3, 4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ef2e9d345e80d96d816d8a738b39cd49f353b333


### PR DESCRIPTION
New releases for Plone branches:
- 4.3.x
- 5.1.x
