### PR TITLE
Fedora Update 20191028.

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -40,19 +40,19 @@ ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
-Tags: latest, 30
+Tags: 30
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/30-updates-candidate
-GitCommit: 786cc461af4f2e5dd23be791333bc6e1cbbddfdf
+GitCommit: 14e0023deca67bb8b1be7803949f804f490b7d1a
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 
-Tags: 31
+Tags: latest, 31
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/31-updates-candidate
-GitCommit: 8a81f67271e959dfc8f8a888b161bbd540b7a83b
+GitCommit: a531762a988cc17d88aa823350ba64596aadf721
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/


### PR DESCRIPTION
Fedora 31 is now the latest release

Signed-off-by: Clement Verna <cverna@tutanota.com>