### PR TITLE
Bump Traefik to v2.0.4 and v1.7.19

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,18 +12,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: a9b658f7321a0a76f4cf3c4636d01c90a65a982b
 Directory: alpine
 
-Tags: v1.7.18-windowsservercore-1809, 1.7.18-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.19-windowsservercore-1809, 1.7.19-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
+GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.18-alpine, 1.7.18-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.19-alpine, 1.7.19-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
+GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
 Directory: alpine
 
-Tags: v1.7.18, 1.7.18, v1.7, 1.7, maroilles
+Tags: v1.7.19, 1.7.19, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: ade7d8e54cb823e51101a64e5a6ba78fb4de7f49
+GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
 Directory: scratch

--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.2-windowsservercore-1809, 2.0.2-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.4-windowsservercore-1809, 2.0.4-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 3d06252965f0028af9de0787b8caa4a1623a9e96
+GitCommit: a9b658f7321a0a76f4cf3c4636d01c90a65a982b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.2, 2.0.2, v2.0, 2.0, montdor, latest
+Tags: v2.0.4, 2.0.4, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 3d06252965f0028af9de0787b8caa4a1623a9e96
+GitCommit: a9b658f7321a0a76f4cf3c4636d01c90a65a982b
 Directory: alpine
 
 Tags: v1.7.18-windowsservercore-1809, 1.7.18-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.0.4](https://github.com/containous/traefik/releases/tag/v2.0.4) and [v1.7.19](https://github.com/containous/traefik/releases/tag/v1.7.19).

/cc @mmatur @emilevauge @dtomcej

Cheers
