### PR TITLE
update Bonita maintainers

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -1,7 +1,10 @@
 Maintainers: Jérémy Jacquier-Roux <jeremy.jacquier-roux@bonitasoft.org> (@JeremJR),
-             Guillaume Rosinosky <guillaume.rosinosky@bonitasoft.org> (@guillaumerosinosky),
              Truc Nguyen <truc.nguyen@bonitasoft.org> (@tnguyen1),
-             Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur)
+             Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur),
+             Baptiste Mesta <baptiste.mesta@bonitasoft.org> (@baptistemesta),
+             Danila Mazour <danila.mazour@bonitasoft.org> (@danila-m),
+             Emmanuel Duchastenier <emmanuel.duchastenier@bonitasoft.org> (@educhastenier),
+             Pascal Garcia <pascal.garcia@bonitasoft.org> (@passga)
 GitRepo: https://github.com/Bonitasoft-Community/docker_bonita.git
 
 Tags: 7.8.4, 7.8


### PR DESCRIPTION
Update list of maintainers in order to facilitate review https://github.com/docker-library/official-images/pull/6801#issuecomment-543853924
- remove @guillaumerosinosky as he has new responsabilities
- add @baptistemesta, @danila-m, @educhastenier, @passga who should me more present into the future PRs related to the Bonita docker image