### PR TITLE
Add debian based Amazon Corretto 8 image

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -9,6 +9,13 @@ GitFetch: refs/heads/8-al2-full
 GitCommit: 36e50e6fec65b3b12fa4e595e8b8fa1def0b39f5
 Architectures: amd64, arm64v8
 
+Tags: 8-debian, 8u232-debian
+GitRepo: https://github.com/corretto/corretto-8-docker.git
+GitFetch: refs/heads/8-al2-full
+GitCommit: 59d4b477aa3f17336181771ed9394be3642a53ad
+Architectures: amd64, arm64v8
+Directory: contrib/debian
+
 Tags: 11, 11.0.5, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full


### PR DESCRIPTION
This includes the following changes:

- Add debian based image to Amazon Corretto repository: https://github.com/corretto/corretto-8-docker/pull/35