### PR TITLE
Update ruby-gems open-uri usage for 2.5+ to use "URI.open"

### DIFF
--- a/test/tests/ruby-gems/container.sh
+++ b/test/tests/ruby-gems/container.sh
@@ -20,11 +20,22 @@ gems="$(ruby -e '
 	require "json"
 	require "open-uri"
 
+	# https://github.com/ruby/ruby/commit/05aac90a1bcfeb180f5e78ea8b00a4d1b04d5eed
+	# https://bugs.ruby-lang.org/issues/15893
+	# for Ruby 2.5+, we should use "URI.open", but for Ruby 2.4 we still need to use "open(...)" directly
+	def openURI(uri)
+		if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("2.5")
+			URI.open(uri)
+		else
+			open(uri)
+		end
+	end
+
 	for gem in gems
 		# ruby 2.2.2+: rack activesupport
 		# ruby 2.0+: mime-types
 		# (jruby 1.7 is ruby 1.9)
-		gemRubyVersion = JSON.load(open("https://rubygems.org/api/v1/versions/#{ gem }.json"))[0]["ruby_version"]
+		gemRubyVersion = JSON.load(openURI("https://rubygems.org/api/v1/versions/#{ gem }.json"))[0]["ruby_version"]
 		if Gem::Dependency.new("", gemRubyVersion).match?("", RUBY_VERSION)
 			puts gem
 		else


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/15893 and https://github.com/ruby/ruby/commit/05aac90a1bcfeb180f5e78ea8b00a4d1b04d5eed for more details.

Specifically, in 2.7.0-preview2, this changed from silently working to throwing: "warning: calling URI.open via Kernel#open is deprecated, call URI.open directly"