### PR TITLE
Update Ubuntu

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -3,33 +3,33 @@
 
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
 GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 2a658dc75f44c6b3a9bbae6526c1825cad12b03c
+GitCommit: dd8ba1772fa26d16fa747360eedac203a9974f69
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8f4b095575c0e00752e10e60765c1bd65625ae95
+amd64-GitCommit: 7f7bea7f1fb44b7394681f5a0dabb7acab96f875
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 3c1630469ff60341105f34768fbcad4850395c2d
+arm32v7-GitCommit: ea7eaf5170b05a83455228bb6bccdcdb1860baac
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 800d645e11148350b265fbe6c1dabf1067bdfc95
+arm64v8-GitCommit: 0637fb27a9308891998ce0494041224de044543d
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 9c5fc5f361080f35e9f2133700eece703d1fc792
+i386-GitCommit: 9377a8eb37483f2021f9e1a965ca43a6b6cca9f0
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 69126d091f6b56d786667ba55ac33cbe651d900d
+ppc64le-GitCommit: 4b8cb367bc81b5ad02e560f124c2b2de6884254f
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 1cfbe45ebfeabe2fddd231be59a53b1ce1550fd1
+s390x-GitCommit: 5efb8c39031361f296cf97fe83a714af03927a47
 
-# 20191010 (bionic)
-Tags: 18.04, bionic-20191010, bionic, latest
+# 20191029 (bionic)
+Tags: 18.04, bionic-20191029, bionic, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20191011 (disco)
-Tags: 19.04, disco-20191011, disco
+# 20191030 (disco)
+Tags: 19.04, disco-20191030, disco
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: disco
 
@@ -38,7 +38,12 @@ Tags: 19.10, eoan-20191017, eoan, rolling
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: eoan
 
-# 20191010 (xenial)
-Tags: 16.04, xenial-20191010, xenial
+# 20191030 (focal)
+Tags: 20.04, focal-20191030, focal, devel
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: focal
+
+# 20191024 (xenial)
+Tags: 16.04, xenial-20191024, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: xenial


### PR DESCRIPTION
First image for Focal Fossa, to become 20.04 LTS.

20191029 (bionic)
20191030 (disco)
20191030 (focal)
20191024 (xenial)