### PR TITLE
Update golang 1.13.4 and 1.12.13

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,109 +5,109 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.13.3-buster, 1.13-buster, 1-buster, buster
-SharedTags: 1.13.3, 1.13, 1, latest
+Tags: 1.13.4-buster, 1.13-buster, 1-buster, buster
+SharedTags: 1.13.4, 1.13, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/buster
 
-Tags: 1.13.3-stretch, 1.13-stretch, 1-stretch, stretch
+Tags: 1.13.4-stretch, 1.13-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/stretch
 
-Tags: 1.13.3-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.3-alpine, 1.13-alpine, 1-alpine, alpine
+Tags: 1.13.4-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10, 1.13.4-alpine, 1.13-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/alpine3.10
 
-Tags: 1.13.3-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
+Tags: 1.13.4-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.13.4-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.4, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13.3-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
+Tags: 1.13.4-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+SharedTags: 1.13.4-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.4, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.13.3-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.13.3-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.3, 1.13, 1, latest
+Tags: 1.13.4-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.13.4-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.4, 1.13, 1, latest
 Architectures: windows-amd64
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.13.3-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
-SharedTags: 1.13.3-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.4-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
+SharedTags: 1.13.4-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.13.3-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.13.3-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.4-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.13.4-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a4deea14ce3306822bb9352ccf124af8c0eea257
+GitCommit: f30f0428221b94c7dcb414ebdcea83106df20897
 Directory: 1.13/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.12.12-buster, 1.12-buster
-SharedTags: 1.12.12, 1.12
+Tags: 1.12.13-buster, 1.12-buster
+SharedTags: 1.12.13, 1.12
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/buster
 
-Tags: 1.12.12-stretch, 1.12-stretch
+Tags: 1.12.13-stretch, 1.12-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/stretch
 
-Tags: 1.12.12-alpine3.10, 1.12-alpine3.10, 1.12.12-alpine, 1.12-alpine
+Tags: 1.12.13-alpine3.10, 1.12-alpine3.10, 1.12.13-alpine, 1.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/alpine3.10
 
-Tags: 1.12.12-alpine3.9, 1.12-alpine3.9
+Tags: 1.12.13-alpine3.9, 1.12-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/alpine3.9
 
-Tags: 1.12.12-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
-SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
+Tags: 1.12.13-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
+SharedTags: 1.12.13-windowsservercore, 1.12-windowsservercore, 1.12.13, 1.12
 Architectures: windows-amd64
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12.12-windowsservercore-1803, 1.12-windowsservercore-1803
-SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
+Tags: 1.12.13-windowsservercore-1803, 1.12-windowsservercore-1803
+SharedTags: 1.12.13-windowsservercore, 1.12-windowsservercore, 1.12.13, 1.12
 Architectures: windows-amd64
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 1.12.12-windowsservercore-1809, 1.12-windowsservercore-1809
-SharedTags: 1.12.12-windowsservercore, 1.12-windowsservercore, 1.12.12, 1.12
+Tags: 1.12.13-windowsservercore-1809, 1.12-windowsservercore-1809
+SharedTags: 1.12.13-windowsservercore, 1.12-windowsservercore, 1.12.13, 1.12
 Architectures: windows-amd64
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.12.12-nanoserver-1803, 1.12-nanoserver-1803
-SharedTags: 1.12.12-nanoserver, 1.12-nanoserver
+Tags: 1.12.13-nanoserver-1803, 1.12-nanoserver-1803
+SharedTags: 1.12.13-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
-Tags: 1.12.12-nanoserver-1809, 1.12-nanoserver-1809
-SharedTags: 1.12.12-nanoserver, 1.12-nanoserver
+Tags: 1.12.13-nanoserver-1809, 1.12-nanoserver-1809
+SharedTags: 1.12.13-nanoserver, 1.12-nanoserver
 Architectures: windows-amd64
-GitCommit: 0b996cdb43a0e0a16d8af23fd25f5eef7b51721b
+GitCommit: 4cd30a13eca195db17474df090d84d2901ddf3d6
 Directory: 1.12/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Update to 1.13.4 https://github.com/docker-library/golang/commit/f30f0428221b94c7dcb414ebdcea83106df20897

Update to 1.12.13 https://github.com/docker-library/golang/commit/4cd30a13eca195db17474df090d84d2901ddf3d6


