### PR TITLE
Updating tags

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -7,9 +7,11 @@ Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
 Directory: official/latest/kernel/java8/openj9
+Architectures: amd64, ppc64le, s390x
 
 Tags: full, full-java8-openj9, latest
 Directory: official/latest/full/java8/openj9
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel, 19.0.0.9-kernel-java8-ibm
 Directory: official/19.0.0.9/kernel/java8/ibmjava

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -7,15 +7,12 @@ Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
 Directory: official/latest/kernel/java8/openj9
-Architectures: amd64, ppc64le, s390x
 
 Tags: full, full-java8-openj9, latest
 Directory: official/latest/full/java8/openj9
-Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel, 19.0.0.9-kernel-java8-ibm
 Directory: official/19.0.0.9/kernel/java8/ibmjava
-Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel-java8-ibmsfj
 Directory: official/19.0.0.9/kernel/java8/ibmsfj

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,185 +2,20 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 9605fe165029887c1e7211455049b3b161d1ed31
+GitCommit: 8be7cc066f746fd76c51fdeb890823b376ba26dc
 Architectures: amd64, i386, ppc64le, s390x
 
-Tags: kernel, kernel-java8-ibm
-Directory: official/latest/kernel/java8/ibmjava
-
-Tags: kernel-java8-ibmsfj
-Directory: official/latest/kernel/java8/ibmsfj
-Architectures: amd64
-
-Tags: kernel-java8-openj9
+Tags: kernel, kernel-java8-openj9
 Directory: official/latest/kernel/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
-Tags: kernel-java11
-Directory: official/latest/kernel/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: kernel-java12
-Directory: official/latest/kernel/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile8, webProfile8-java8-ibm
-Directory: official/latest/webProfile8/java8/ibmjava
-
-Tags: webProfile8-java8-ibmsfj
-Directory: official/latest/webProfile8/java8/ibmsfj
-Architectures: amd64
-
-Tags: webProfile8-java8-openj9
-Directory: official/latest/webProfile8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile8-java11
-Directory: official/latest/webProfile8/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile8-java12
-Directory: official/latest/webProfile8/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee8, javaee8-java8-ibm, latest
-Directory: official/latest/javaee8/java8/ibmjava
-
-Tags: javaee8-java8-ibmsfj
-Directory: official/latest/javaee8/java8/ibmsfj
-Architectures: amd64
-
-Tags: javaee8-java8-openj9
-Directory: official/latest/javaee8/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee8-java11
-Directory: official/latest/javaee8/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee8-java12
-Directory: official/latest/javaee8/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile1, microProfile1-java8-ibm
-Directory: official/latest/microProfile1/java8/ibmjava
-
-Tags: microProfile1-java8-ibmsfj
-Directory: official/latest/microProfile1/java8/ibmsfj
-Architectures: amd64
-
-Tags: microProfile1-java8-openj9
-Directory: official/latest/microProfile1/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile1-java11
-Directory: official/latest/microProfile1/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile2, microProfile2-java8-ibm
-Directory: official/latest/microProfile2/java8/ibmjava
-
-Tags: microProfile2-java8-ibmsfj
-Directory: official/latest/microProfile2/java8/ibmsfj
-Architectures: amd64
-
-Tags: microProfile2-java8-openj9
-Directory: official/latest/microProfile2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile2-java11
-Directory: official/latest/microProfile2/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile2-java12
-Directory: official/latest/microProfile2/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile3, microProfile3-java8-ibm
-Directory: official/latest/microProfile3/java8/ibmjava
-
-Tags: microProfile3-java8-ibmsfj
-Directory: official/latest/microProfile3/java8/ibmsfj
-Architectures: amd64
-
-Tags: microProfile3-java8-openj9
-Directory: official/latest/microProfile3/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile3-java11
-Directory: official/latest/microProfile3/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile3-java12
-Directory: official/latest/microProfile3/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot2, springBoot2-java8-ibm
-Directory: official/latest/springBoot2/java8/ibmjava
-
-Tags: springBoot2-java8-ibmsfj
-Directory: official/latest/springBoot2/java8/ibmsfj
-Architectures: amd64
-
-Tags: springBoot2-java8-openj9
-Directory: official/latest/springBoot2/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot2-java11
-Directory: official/latest/springBoot2/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot2-java12
-Directory: official/latest/springBoot2/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile7, webProfile7-java8-ibm
-Directory: official/latest/webProfile7/java8/ibmjava
-
-Tags: webProfile7-java8-ibmsfj
-Directory: official/latest/webProfile7/java8/ibmsfj
-Architectures: amd64
-
-Tags: webProfile7-java8-openj9
-Directory: official/latest/webProfile7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile7-java11
-Directory: official/latest/webProfile7/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee7, javaee7-java8-ibm
-Directory: official/latest/javaee7/java8/ibmjava
-
-Tags: javaee7-java8-ibmsfj
-Directory: official/latest/javaee7/java8/ibmsfj
-Architectures: amd64
-
-Tags: javaee7-java8-openj9
-Directory: official/latest/javaee7/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee7-java11
-Directory: official/latest/javaee7/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot1, springBoot1-java8-ibm
-Directory: official/latest/springBoot1/java8/ibmjava
-
-Tags: springBoot1-java8-ibmsfj
-Directory: official/latest/springBoot1/java8/ibmsfj
-Architectures: amd64
-
-Tags: springBoot1-java8-openj9
-Directory: official/latest/springBoot1/java8/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot1-java11
-Directory: official/latest/springBoot1/java11/openj9
+Tags: full, full-java8-openj9, latest
+Directory: official/latest/full/java8/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel, 19.0.0.9-kernel-java8-ibm
 Directory: official/19.0.0.9/kernel/java8/ibmjava
+Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-kernel-java8-ibmsfj
 Directory: official/19.0.0.9/kernel/java8/ibmsfj


### PR DESCRIPTION
We are reducing our 10 variations of tags (kernel, microProfile1-3, webProfile7-8, javaee7-8, springBoot1-2) to just two:  `kernel`, and `full`.  

We are also reducing the OS + Java stack to be just Ubuntu + IBM JRE.  

In order to give customers time to adopt this new strategy we are leaving the versioned tags (`19.0.0.9` and `19.0.0.6`) as-is until they run out of support. 