### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-20-jdk-oraclelinux7, 14-ea-20-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-20-jdk-oracle, 14-ea-20-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-20-jdk, 14-ea-20, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-21-jdk-oraclelinux7, 14-ea-21-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-21-jdk-oracle, 14-ea-21-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-21-jdk, 14-ea-21, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-20-jdk-buster, 14-ea-20-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-21-jdk-buster, 14-ea-21-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk
 
-Tags: 14-ea-20-jdk-slim-buster, 14-ea-20-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-20-jdk-slim, 14-ea-20-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-21-jdk-slim-buster, 14-ea-21-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-21-jdk-slim, 14-ea-21-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -26,38 +26,38 @@ Architectures: amd64
 GitCommit: bde1e9a0f36e12e3df58b81acddd695fd140cf6a
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-20-jdk-windowsservercore-1809, 14-ea-20-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-20-jdk-windowsservercore, 14-ea-20-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-20-jdk, 14-ea-20, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-21-jdk-windowsservercore-1809, 14-ea-21-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-21-jdk-windowsservercore, 14-ea-21-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-21-jdk, 14-ea-21, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-20-jdk-windowsservercore-1803, 14-ea-20-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-20-jdk-windowsservercore, 14-ea-20-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-20-jdk, 14-ea-20, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-21-jdk-windowsservercore-1803, 14-ea-21-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
+SharedTags: 14-ea-21-jdk-windowsservercore, 14-ea-21-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-21-jdk, 14-ea-21, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
-Tags: 14-ea-20-jdk-windowsservercore-ltsc2016, 14-ea-20-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-20-jdk-windowsservercore, 14-ea-20-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-20-jdk, 14-ea-20, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-21-jdk-windowsservercore-ltsc2016, 14-ea-21-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-21-jdk-windowsservercore, 14-ea-21-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-21-jdk, 14-ea-21, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14-ea-20-jdk-nanoserver-1809, 14-ea-20-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
-SharedTags: 14-ea-20-jdk-nanoserver, 14-ea-20-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-ea-21-jdk-nanoserver-1809, 14-ea-21-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14-ea-21-jdk-nanoserver, 14-ea-21-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14-ea-20-jdk-nanoserver-1803, 14-ea-20-nanoserver-1803, 14-ea-jdk-nanoserver-1803, 14-ea-nanoserver-1803, 14-jdk-nanoserver-1803, 14-nanoserver-1803
-SharedTags: 14-ea-20-jdk-nanoserver, 14-ea-20-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-ea-21-jdk-nanoserver-1803, 14-ea-21-nanoserver-1803, 14-ea-jdk-nanoserver-1803, 14-ea-nanoserver-1803, 14-jdk-nanoserver-1803, 14-nanoserver-1803
+SharedTags: 14-ea-21-jdk-nanoserver, 14-ea-21-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: 25c3b44ab83e14a4692bd54a85be026956710341
+GitCommit: 9d0fd4e53df969368f9ad9eac9399f075a2565df
 Directory: 14/jdk/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9d0fd4e: Update to 14-ea+21