### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,62 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.1-rc.1, 3.8-rc
+Tags: 3.8.1, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b23250aeabba626efc06cb1d1e3a3871bf319baf
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.1-rc.1-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.1-rc.1-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b23250aeabba626efc06cb1d1e3a3871bf319baf
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.1-rc.1-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.0, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a0bf95f11c0b2e757847f19e4ce4943fdd63e327
+GitCommit: 7cab67f4d886688ce77d1e89f38ac5dbc53b8e47
 Directory: 3.8/ubuntu
 
-Tags: 3.8.0-management, 3.8-management, 3-management, management
+Tags: 3.8.1-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.1-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a0bf95f11c0b2e757847f19e4ce4943fdd63e327
+GitCommit: 7cab67f4d886688ce77d1e89f38ac5dbc53b8e47
 Directory: 3.8/alpine
 
-Tags: 3.8.0-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.1-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.20, 3.7
+Tags: 3.7.21, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e8c4e3e29c3e316ea2caa94572b6b476004c88
+GitCommit: 16013aeafd9d37625fccb560ed2cfd86e30f9c28
 Directory: 3.7/ubuntu
 
-Tags: 3.7.20-management, 3.7-management
+Tags: 3.7.21-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.20-alpine, 3.7-alpine
+Tags: 3.7.21-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e8c4e3e29c3e316ea2caa94572b6b476004c88
+GitCommit: 16013aeafd9d37625fccb560ed2cfd86e30f9c28
 Directory: 3.7/alpine
 
-Tags: 3.7.20-management-alpine, 3.7-management-alpine
+Tags: 3.7.21-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7cab67f: Update to 3.8.1, Erlang/OTP 22.1.5, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/16013ae: Update to 3.7.21, Erlang/OTP 22.1.5, OpenSSL 1.1.1d