### PR TITLE
Release of GeoNetwork 3.8.2

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,22 +1,25 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/b7bedb90f76fb630d7863665014adea427112a5c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7fa2e3de056490ef677313333d2320629309e360/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
-Architectures: amd64
 
 Tags: 3.6.0, 3.6
+Architectures: amd64
 GitCommit: e249c6031a55559392204a2c3ef8e8f8d11545a5
 Directory: 3.6.0
 
 Tags: 3.6.0-postgres, 3.6-postgres
-GitCommit: 9a28f0a61a8b043b1562f79caed9fdec3c009452
+Architectures: amd64
+GitCommit: 29aa73c582e074010412628d45ea22074b8e7e74
 Directory: 3.6.0/postgres
 
-Tags: 3.8.1, 3.8, latest
-GitCommit: fb2d94fca6965245e6e1c260f4ee574969227e2c
-Directory: 3.8.1
+Tags: 3.8.2, 3.8, latest
+Architectures: amd64
+GitCommit: 35a9e428fc697b1fd898bd20c3303ee734c317e6
+Directory: 3.8.2
 
-Tags: 3.8.1-postgres, 3.8-postgres, postgres
-GitCommit: fb2d94fca6965245e6e1c260f4ee574969227e2c
-Directory: 3.8.1/postgres
+Tags: 3.8.2-postgres, 3.8-postgres, postgres
+Architectures: amd64
+GitCommit: 35a9e428fc697b1fd898bd20c3303ee734c317e6
+Directory: 3.8.2/postgres


### PR DESCRIPTION
* Release of GeoNetwork 3.8.2.
* Add a new environmet variable `POSTGRES_DB_NAME` to `postgres` image flavour [1].
* Modify `generate-stackbrew-library.sh` to get the architectures from the parent
image like is done in official Tomcat image.

[1] https://github.com/geonetwork/docker-geonetwork/pull/34