### PR TITLE
Update websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: e1c2db08788fd71f30f56c22e4914e893bd553ff
+GitCommit: 937848c385599a42c074254de992583f3929dfc5
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -10,83 +10,11 @@ Directory: beta
 
 Tags: kernel
 Directory: ga/latest/kernel
+File: Dockerfile.ubuntu.ibmjava8
 
-Tags: kernel-java11
-Directory: ga/latest/kernel
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee8, latest
-Directory: ga/latest/javaee8
-
-Tags: javaee8-java11
-Directory: ga/latest/javaee8
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile8
-Directory: ga/latest/webProfile8
-
-Tags: webProfile8-java11
-Directory: ga/latest/webProfile8
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile1
-Directory: ga/latest/microProfile1
-
-Tags: microProfile1-java11
-Directory: ga/latest/microProfile1
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile2
-Directory: ga/latest/microProfile2
-
-Tags: microProfile2-java11
-Directory: ga/latest/microProfile2
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: microProfile3
-Directory: ga/latest/microProfile3
-
-Tags: microProfile3-java11
-Directory: ga/latest/microProfile3
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot2
-Directory: ga/latest/springBoot2
-
-Tags: springBoot2-java11
-Directory: ga/latest/springBoot2
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: springBoot1
-Directory: ga/latest/springBoot1
-
-Tags: springBoot1-java11
-Directory: ga/latest/springBoot1
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: webProfile7
-Directory: ga/latest/webProfile7
-
-Tags: webProfile7-java11
-Directory: ga/latest/webProfile7
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
-
-Tags: javaee7
-Directory: ga/latest/javaee7
-
-Tags: javaee7-java11
-Directory: ga/latest/javaee7
-File: Dockerfile.java11
-Architectures: amd64, ppc64le, s390x
+Tags: full, latest
+Directory: ga/latest/full
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-kernel
 Directory: ga/19.0.0.9/kernel


### PR DESCRIPTION
We're also reducing the tags from WebSphere Liberty ([PR](https://github.com/WASdev/ci.docker/pull/296)) to be consistent with the upstream project Open Liberty to be just `kernel` and `full`.  

We're leaving the current versioned-tags (19.0.0.9 and 19.0.0.6) intact until they run out of support.