### PR TITLE
Odoo: update 11.0-13.0 to release 20191106

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: ffe62bdd52f88ac85f54064e6eb02aa38f88f58d
+GitCommit: 596a7cabc07dd3b1d18b6c2832cace7328e36969
 
 Tags: 13.0, 13, latest
 Architectures: amd64


### PR DESCRIPTION
Hi,

Here are the latest releases of the supported Odoo versions.
It also brings this fix odoo/docker#279 for this issue odoo/docker#278

Thanks