### PR TITLE
Update open-liberty to 19.0.0.11

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 8be7cc066f746fd76c51fdeb890823b376ba26dc
+GitCommit: bb2013d92924be2a05a8e91756f28f4eb4772282
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
@@ -28,10 +28,6 @@ Tags: 19.0.0.9-kernel-java11
 Directory: official/19.0.0.9/kernel/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
-Tags: 19.0.0.9-kernel-java12
-Directory: official/19.0.0.9/kernel/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
 Tags: 19.0.0.9-webProfile8, 19.0.0.9-webProfile8-java8-ibm
 Directory: official/19.0.0.9/webProfile8/java8/ibmjava
 
@@ -47,10 +43,6 @@ Tags: 19.0.0.9-webProfile8-java11
 Directory: official/19.0.0.9/webProfile8/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
-Tags: 19.0.0.9-webProfile8-java12
-Directory: official/19.0.0.9/webProfile8/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
 Tags: 19.0.0.9-javaee8, 19.0.0.9-javaee8-java8-ibm
 Directory: official/19.0.0.9/javaee8/java8/ibmjava
 
@@ -64,10 +56,6 @@ Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-javaee8-java11
 Directory: official/19.0.0.9/javaee8/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.9-javaee8-java12
-Directory: official/19.0.0.9/javaee8/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-microProfile1, 19.0.0.9-microProfile1-java8-ibm
@@ -100,10 +88,6 @@ Tags: 19.0.0.9-microProfile2-java11
 Directory: official/19.0.0.9/microProfile2/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
-Tags: 19.0.0.9-microProfile2-java12
-Directory: official/19.0.0.9/microProfile2/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
 Tags: 19.0.0.9-microProfile3, 19.0.0.9-microProfile3-java8-ibm
 Directory: official/19.0.0.9/microProfile3/java8/ibmjava
 
@@ -119,10 +103,6 @@ Tags: 19.0.0.9-microProfile3-java11
 Directory: official/19.0.0.9/microProfile3/java11/openj9
 Architectures: amd64, ppc64le, s390x
 
-Tags: 19.0.0.9-microProfile3-java12
-Directory: official/19.0.0.9/microProfile3/java12/openj9
-Architectures: amd64, ppc64le, s390x
-
 Tags: 19.0.0.9-springBoot2, 19.0.0.9-springBoot2-java8-ibm
 Directory: official/19.0.0.9/springBoot2/java8/ibmjava
 
@@ -136,10 +116,6 @@ Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-springBoot2-java11
 Directory: official/19.0.0.9/springBoot2/java11/openj9
-Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.9-springBoot2-java12
-Directory: official/19.0.0.9/springBoot2/java12/openj9
 Architectures: amd64, ppc64le, s390x
 
 Tags: 19.0.0.9-webProfile7, 19.0.0.9-webProfile7-java8-ibm


### PR DESCRIPTION
Updating to `19.0.0.11` and removing unsupported Java 12 images.