### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.2-rc.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3d8ea96e0a1a54c995eedbc325df34e163224365
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.2-rc.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.2-rc.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3d8ea96e0a1a54c995eedbc325df34e163224365
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.2-rc.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.1, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7cab67f4d886688ce77d1e89f38ac5dbc53b8e47
+GitCommit: 2c905c89ec12342a3ed4141bcf3f81dcffbf6d33
 Directory: 3.8/ubuntu
 
 Tags: 3.8.1-management, 3.8-management, 3-management, management
@@ -16,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.1-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7cab67f4d886688ce77d1e89f38ac5dbc53b8e47
+GitCommit: 2c905c89ec12342a3ed4141bcf3f81dcffbf6d33
 Directory: 3.8/alpine
 
 Tags: 3.8.1-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -24,9 +44,29 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
+Tags: 3.7.22-rc.1, 3.7-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: af309d9a07c92cb07da5df0ed209be480a38c9a8
+Directory: 3.7-rc/ubuntu
+
+Tags: 3.7.22-rc.1-management, 3.7-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
+Directory: 3.7-rc/ubuntu/management
+
+Tags: 3.7.22-rc.1-alpine, 3.7-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: af309d9a07c92cb07da5df0ed209be480a38c9a8
+Directory: 3.7-rc/alpine
+
+Tags: 3.7.22-rc.1-management-alpine, 3.7-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
+Directory: 3.7-rc/alpine/management
+
 Tags: 3.7.21, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16013aeafd9d37625fccb560ed2cfd86e30f9c28
+GitCommit: 5d05d58893a6f955a620893a3e0b06e531e7c78d
 Directory: 3.7/ubuntu
 
 Tags: 3.7.21-management, 3.7-management
@@ -36,7 +76,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.21-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16013aeafd9d37625fccb560ed2cfd86e30f9c28
+GitCommit: 5d05d58893a6f955a620893a3e0b06e531e7c78d
 Directory: 3.7/alpine
 
 Tags: 3.7.21-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/20f102e: Update to 3.8.1, Erlang/OTP 22.1.6, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/c967db9: Update to 3.7.21, Erlang/OTP 22.1.6, OpenSSL 1.1.1d