### PR TITLE
Update fsharp to 10.6.0 with .NET Core 3.0.100 SDK

### DIFF
--- a/library/fsharp
+++ b/library/fsharp
@@ -1,7 +1,7 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
-GitCommit: 0b35104dc02b1698240ba95923e937398959825c
+GitCommit: a5ba1bc5bda83fda4f0f995315ec003cc2dac587
 
 Tags: latest, 10, 10.6, 10.6.0
 Architectures: amd64, arm64v8

--- a/library/fsharp
+++ b/library/fsharp
@@ -1,7 +1,7 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
-GitCommit: a5ba1bc5bda83fda4f0f995315ec003cc2dac587
+GitCommit: 2ffa0ffb79c1607617c28130f981e83f55e6cbc5
 
 Tags: latest, 10, 10.6, 10.6.0
 Architectures: amd64, arm64v8
@@ -10,5 +10,5 @@ Directory: 10.6.0/mono
 Tags: 4, 4.1, 4.1.34
 Directory: 4.1.34/mono
 
-Tags: netcore, 10-netcore, 10.2-netcore, 10.2.3-netcore
-Directory: 10.2.3/netcore
+Tags: netcore, 10-netcore, 10.6-netcore, 10.6.0-netcore
+Directory: 10.6.0/netcore

--- a/library/fsharp
+++ b/library/fsharp
@@ -1,14 +1,14 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot),
              Steve Desmond <steve@stevedesmond.ca> (@stevedesmond-ca)
 GitRepo: https://github.com/fsprojects/docker-fsharp.git
-GitCommit: 06220dff2a08b409db3b0ef78e99c041cf05290c
+GitCommit: 0b35104dc02b1698240ba95923e937398959825c
 
-Tags: latest, 10, 10.2, 10.2.3
+Tags: latest, 10, 10.6, 10.6.0
 Architectures: amd64, arm64v8
-Directory: 10.2.3/mono
+Directory: 10.6.0/mono
 
 Tags: 4, 4.1, 4.1.34
 Directory: 4.1.34/mono
 
-Tags: netcore, 10-netcore, 10.2-netcore, 10.2.3-netcore
-Directory: 10.2.3/netcore
+Tags: netcore, 10-netcore, 10.6-netcore, 10.6.0-netcore
+Directory: 10.6.0/netcore

--- a/library/fsharp
+++ b/library/fsharp
@@ -10,5 +10,5 @@ Directory: 10.6.0/mono
 Tags: 4, 4.1, 4.1.34
 Directory: 4.1.34/mono
 
-Tags: netcore, 10-netcore, 10.6-netcore, 10.6.0-netcore
-Directory: 10.6.0/netcore
+Tags: netcore, 10-netcore, 10.2-netcore, 10.2.3-netcore
+Directory: 10.2.3/netcore


### PR DESCRIPTION
* Adds `dotnet fsi` support
* Built on latest stable mono 6.4.0.198