### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -10,16 +10,6 @@ GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
 Directory: 9.0/jdk13/openjdk-oracle
 Constraints: !aufs
 
-Tags: 9.0.27-jdk12-adoptopenjdk-hotspot, 9.0-jdk12-adoptopenjdk-hotspot, 9-jdk12-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
-Directory: 9.0/jdk12/adoptopenjdk-hotspot
-
-Tags: 9.0.27-jdk12-adoptopenjdk-openj9, 9.0-jdk12-adoptopenjdk-openj9, 9-jdk12-adoptopenjdk-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
-Directory: 9.0/jdk12/adoptopenjdk-openj9
-
 Tags: 9.0.27-jdk11-openjdk, 9.0-jdk11-openjdk, 9-jdk11-openjdk, 9.0.27-jdk11, 9.0-jdk11, 9-jdk11, 9.0.27, 9.0, 9
 Architectures: amd64, arm64v8
 GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
@@ -31,7 +21,7 @@ GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
 Directory: 9.0/jdk11/openjdk-slim
 
 Tags: 9.0.27-jdk11-adoptopenjdk-hotspot, 9.0-jdk11-adoptopenjdk-hotspot, 9-jdk11-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, ppc64le
 GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
 Directory: 9.0/jdk11/adoptopenjdk-hotspot
 
@@ -56,7 +46,7 @@ GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
 Directory: 9.0/jdk8/openjdk-slim
 
 Tags: 9.0.27-jdk8-adoptopenjdk-hotspot, 9.0-jdk8-adoptopenjdk-hotspot, 9-jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: 8348a86101660e76224afcc57c4c9fae4dc76de8
 Directory: 9.0/jdk8/adoptopenjdk-hotspot
 
@@ -76,16 +66,6 @@ GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
 Directory: 8.5/jdk13/openjdk-oracle
 Constraints: !aufs
 
-Tags: 8.5.47-jdk12-adoptopenjdk-hotspot, 8.5-jdk12-adoptopenjdk-hotspot, 8-jdk12-adoptopenjdk-hotspot, jdk12-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
-Directory: 8.5/jdk12/adoptopenjdk-hotspot
-
-Tags: 8.5.47-jdk12-adoptopenjdk-openj9, 8.5-jdk12-adoptopenjdk-openj9, 8-jdk12-adoptopenjdk-openj9, jdk12-adoptopenjdk-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
-Directory: 8.5/jdk12/adoptopenjdk-openj9
-
 Tags: 8.5.47-jdk11-openjdk, 8.5-jdk11-openjdk, 8-jdk11-openjdk, jdk11-openjdk, 8.5.47-jdk11, 8.5-jdk11, 8-jdk11, jdk11
 Architectures: amd64, arm64v8
 GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
@@ -97,7 +77,7 @@ GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
 Directory: 8.5/jdk11/openjdk-slim
 
 Tags: 8.5.47-jdk11-adoptopenjdk-hotspot, 8.5-jdk11-adoptopenjdk-hotspot, 8-jdk11-adoptopenjdk-hotspot, jdk11-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, ppc64le
 GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
 Directory: 8.5/jdk11/adoptopenjdk-hotspot
 
@@ -122,7 +102,7 @@ GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
 Directory: 8.5/jdk8/openjdk-slim
 
 Tags: 8.5.47-jdk8-adoptopenjdk-hotspot, 8.5-jdk8-adoptopenjdk-hotspot, 8-jdk8-adoptopenjdk-hotspot, jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: 8438be7c4c8434b617903ea5a478441ae04572c1
 Directory: 8.5/jdk8/adoptopenjdk-hotspot
 
@@ -147,7 +127,7 @@ GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
 Directory: 7/jdk8/openjdk-slim
 
 Tags: 7.0.96-jdk8-adoptopenjdk-hotspot, 7.0-jdk8-adoptopenjdk-hotspot, 7-jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: 7cdbab2ce07c1593fc657fd6fac7821a5472dfd2
 Directory: 7/jdk8/adoptopenjdk-hotspot
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/tomcat/commit/2aeb637: Merge pull request https://github.com/docker-library/tomcat/pull/177 from infosiftr/drop-12
- https://github.com/docker-library/tomcat/commit/7945643: adoptopenjdk 12 images are no longer supported