### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,17 +51,17 @@ Directory: php7.3/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-2.3.0-php7.1, cli-2.3-php7.1, cli-2-php7.1, cli-php7.1
+Tags: cli-2.4.0-php7.1, cli-2.4-php7.1, cli-2-php7.1, cli-php7.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
 Directory: php7.1/cli
 
-Tags: cli-2.3.0-php7.2, cli-2.3-php7.2, cli-2-php7.2, cli-php7.2
+Tags: cli-2.4.0-php7.2, cli-2.4-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
 Directory: php7.2/cli
 
-Tags: cli-2.3.0, cli-2.3, cli-2, cli, cli-2.3.0-php7.3, cli-2.3-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: f4cc67fc2a0479f292f2ccbcdb9f58113374d258
+GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
 Directory: php7.3/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/9df8730: Update to cli 2.4.0