### PR TITLE
Bump Traefik to v2.0.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.0.4-windowsservercore-1809, 2.0.4-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.5-windowsservercore-1809, 2.0.5-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: a9b658f7321a0a76f4cf3c4636d01c90a65a982b
+GitCommit: 2275def60d8cf0d0d85cd2097661bf60ca089338
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.4, 2.0.4, v2.0, 2.0, montdor, latest
+Tags: v2.0.5, 2.0.5, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: a9b658f7321a0a76f4cf3c4636d01c90a65a982b
+GitCommit: 2275def60d8cf0d0d85cd2097661bf60ca089338
 Directory: alpine
 
 Tags: v1.7.19-windowsservercore-1809, 1.7.19-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.0.5](https://github.com/containous/traefik/releases/tag/v2.0.5).

/cc @ldez @mmatur @emilevauge @dtomcej

Cheers
