### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -79,6 +79,21 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: eoan
 
+Tags: focal-curl, 20.04-curl
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
+Directory: focal/curl
+
+Tags: focal-scm, 20.04-scm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
+Directory: focal/scm
+
+Tags: focal, 20.04
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
+Directory: focal
+
 Tags: jessie-curl, oldoldstable-curl
 Architectures: amd64, arm32v5, arm32v7, i386
 GitCommit: b0fc01aa5e3aed6820d8fed6f3301e0542fbeb36


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/2583ce5: Merge pull request https://github.com/docker-library/buildpack-deps/pull/102 from vicamo/for-upstream/add-ubuntu-focal
- https://github.com/docker-library/buildpack-deps/commit/1bf287b: Add Ubuntu Focal Fossa
- https://github.com/docker-library/buildpack-deps/commit/05d1698: Remove cosmic (EOL)