### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.8, 2.0, latest
+Tags: 2.0.9, 2.0, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3700abeba4834a27c43b16330cbaf1b8bae565cd
+GitCommit: 48f3107226322100e210875bc6756739779aace2
 Directory: 2.0
 
-Tags: 2.0.8-alpine, 2.0-alpine, alpine
+Tags: 2.0.9-alpine, 2.0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3700abeba4834a27c43b16330cbaf1b8bae565cd
+GitCommit: 48f3107226322100e210875bc6756739779aace2
 Directory: 2.0/alpine
 
 Tags: 1.9.12, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/48f3107: Update to 2.0.9