### PR TITLE
Bump Perl to 5.30.1

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,32 +1,32 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 01044791941b91f99e970c3f1256d9dc0daee5e4
+GitCommit: bad811d7db8abc4f7b612f6a7b4c7890ff44f399
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.30, 5.30.0, 5-buster, 5.30-buster, 5.30.0-buster
-Directory: 5.030.000-main-buster
+Tags: latest, 5, 5.30, 5.30.0, 5-buster, 5.30-buster, 5.30.1-buster
+Directory: 5.030.001-main-buster
 
-Tags: 5-stretch, 5.30-stretch, 5.30.0-stretch
-Directory: 5.030.000-main-stretch
+Tags: 5-stretch, 5.30-stretch, 5.30.1-stretch
+Directory: 5.030.001-main-stretch
 
-Tags: slim, 5-slim, 5.30-slim, 5.30.0-slim, slim-buster, 5-slim-buster, 5.30-slim-buster, 5.30.0-slim-buster
-Directory: 5.030.000-slim-buster
+Tags: slim, 5-slim, 5.30-slim, 5.30.1-slim, slim-buster, 5-slim-buster, 5.30-slim-buster, 5.30.1-slim-buster
+Directory: 5.030.001-slim-buster
 
-Tags: slim-stretch, 5-slim-stretch, 5.30-slim-stretch, 5.30.0-slim-stretch
-Directory: 5.030.000-slim-stretch
+Tags: slim-stretch, 5-slim-stretch, 5.30-slim-stretch, 5.30.1-slim-stretch
+Directory: 5.030.001-slim-stretch
 
-Tags: threaded, 5-threaded, 5.30-threaded, 5.30.0-threaded, threaded-buster, 5-threaded-buster, 5.30-threaded-buster, 5.30.0-threaded-buster
-Directory: 5.030.000-main,threaded-buster
+Tags: threaded, 5-threaded, 5.30-threaded, 5.30.1-threaded, threaded-buster, 5-threaded-buster, 5.30-threaded-buster, 5.30.1-threaded-buster
+Directory: 5.030.001-main,threaded-buster
 
-Tags: threaded-stretch, 5-threaded-stretch, 5.30-threaded-stretch, 5.30.0-threaded-stretch
-Directory: 5.030.000-main,threaded-stretch
+Tags: threaded-stretch, 5-threaded-stretch, 5.30-threaded-stretch, 5.30.1-threaded-stretch
+Directory: 5.030.001-main,threaded-stretch
 
-Tags: slim-threaded, 5-slim-threaded, 5.30-slim-threaded, 5.30.0-slim-threaded, slim-threaded-buster, 5-slim-threaded-buster, 5.30-slim-threaded-buster, 5.30.0-slim-threaded-buster
-Directory: 5.030.000-slim,threaded-buster
+Tags: slim-threaded, 5-slim-threaded, 5.30-slim-threaded, 5.30.1-slim-threaded, slim-threaded-buster, 5-slim-threaded-buster, 5.30-slim-threaded-buster, 5.30.1-slim-threaded-buster
+Directory: 5.030.001-slim,threaded-buster
 
-Tags: slim-threaded-stretch, 5-slim-threaded-stretch, 5.30-slim-threaded-stretch, 5.30.0-slim-threaded-stretch
-Directory: 5.030.000-slim,threaded-stretch
+Tags: slim-threaded-stretch, 5-slim-threaded-stretch, 5.30-slim-threaded-stretch, 5.30.1-slim-threaded-stretch
+Directory: 5.030.001-slim,threaded-stretch
 
 Tags: 5.28, 5.28.2, 5.28-buster, 5.28.2-buster
 Directory: 5.028.002-main-buster


### PR DESCRIPTION
Update for https://metacpan.org/release/SHAY/perl-5.30.1