### PR TITLE
Additions and updates for Oracle Linux images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a5399bf87cefa2ea601e2e0de6e579c92beb805e
+amd64-GitCommit: 6d08f03f9a8075d3a2a42a1b59e3fea6a513849c
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9ad8700fd37bd66518bea4dd4461ebf5b47b3cfc
+arm64v8-GitCommit: 1f220b00ca1a1da9cf186e461863a8e91454ff0b
 Constraints: !aufs
 
 Tags: 8.0, 8
@@ -18,9 +18,9 @@ Tags: 8-slim
 Architectures: amd64, arm64v8
 Directory: 8-slim
 
-Tags: 7.6, 7, latest
+Tags: 7.7, 7, latest
 Architectures: amd64, arm64v8
-Directory: 7.6
+Directory: 7.7
 
 Tags: 7-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
* Update `dist-amd64/8-slim` image to use `microdnf` to reduce the image size
* Update `dist-arm64v8/8-slim` image to use `microdnf` to reduce the image size
* Update `dist-amd64/7-slim` image for `sudo-1.8.23-4.0.1.el7.src.rpm`
* Update `dist-arm64v8/7-slim` image for `sudo-1.8.23-4.0.1.el7.src.rpm`
* Added `dist-amd64/7.7` image and assigned it the `7, latest` tags
* Added `dist-arm64v8/7.7` image and assigned it the `7, latest` tags

Signed-off-by: Avi Miller <avi.miller@oracle.com>