### PR TITLE
add libc6-compat for ARM builds

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -3,7 +3,7 @@ Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 Tags: 1.6.2, 1.6, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 8b6089210878e21f356261081e8aebf324236b56
+GitCommit: d0bf79e2d24101649713f0d1b276901921bb3999
 Directory: 0.X
 
 Tags: 1.5.3, 1.5


### PR DESCRIPTION
This fixes a bug where the ARM build wasn't running successfully in ARM due to missing shared libraries. 