### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,298 +2,376 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: bb2013d92924be2a05a8e91756f28f4eb4772282
+GitCommit: 504fdf26e680b1f71de82ac4099044cb55e8e2d8
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
-Directory: official/latest/kernel/java8/openj9
+Directory: releases/latest/kernel
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: full, full-java8-openj9, latest
-Directory: official/latest/full/java8/openj9
+Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-kernel, 19.0.0.9-kernel-java8-ibm
-Directory: official/19.0.0.9/kernel/java8/ibmjava
+Directory: releases/19.0.0.9/kernel
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-kernel-java8-ibmsfj
-Directory: official/19.0.0.9/kernel/java8/ibmsfj
+Directory: releases/19.0.0.9/kernel
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-kernel-java8-openj9
-Directory: official/19.0.0.9/kernel/java8/openj9
+Directory: releases/19.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-kernel-java11
-Directory: official/19.0.0.9/kernel/java11/openj9
+Directory: releases/19.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-webProfile8, 19.0.0.9-webProfile8-java8-ibm
-Directory: official/19.0.0.9/webProfile8/java8/ibmjava
+Directory: releases/19.0.0.9/webProfile8
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-webProfile8-java8-ibmsfj
-Directory: official/19.0.0.9/webProfile8/java8/ibmsfj
+Directory: releases/19.0.0.9/webProfile8
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-webProfile8-java8-openj9
-Directory: official/19.0.0.9/webProfile8/java8/openj9
+Directory: releases/19.0.0.9/webProfile8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-webProfile8-java11
-Directory: official/19.0.0.9/webProfile8/java11/openj9
+Directory: releases/19.0.0.9/webProfile8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-javaee8, 19.0.0.9-javaee8-java8-ibm
-Directory: official/19.0.0.9/javaee8/java8/ibmjava
+Directory: releases/19.0.0.9/javaee8
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-javaee8-java8-ibmsfj
-Directory: official/19.0.0.9/javaee8/java8/ibmsfj
+Directory: releases/19.0.0.9/javaee8
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-javaee8-java8-openj9
-Directory: official/19.0.0.9/javaee8/java8/openj9
+Directory: releases/19.0.0.9/javaee8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-javaee8-java11
-Directory: official/19.0.0.9/javaee8/java11/openj9
+Directory: releases/19.0.0.9/javaee8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-microProfile1, 19.0.0.9-microProfile1-java8-ibm
-Directory: official/19.0.0.9/microProfile1/java8/ibmjava
+Directory: releases/19.0.0.9/microProfile1
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-microProfile1-java8-ibmsfj
-Directory: official/19.0.0.9/microProfile1/java8/ibmsfj
+Directory: releases/19.0.0.9/microProfile1
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-microProfile1-java8-openj9
-Directory: official/19.0.0.9/microProfile1/java8/openj9
+Directory: releases/19.0.0.9/microProfile1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-microProfile1-java11
-Directory: official/19.0.0.9/microProfile1/java11/openj9
+Directory: releases/19.0.0.9/microProfile1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-microProfile2, 19.0.0.9-microProfile2-java8-ibm
-Directory: official/19.0.0.9/microProfile2/java8/ibmjava
+Directory: releases/19.0.0.9/microProfile2
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-microProfile2-java8-ibmsfj
-Directory: official/19.0.0.9/microProfile2/java8/ibmsfj
+Directory: releases/19.0.0.9/microProfile2
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-microProfile2-java8-openj9
-Directory: official/19.0.0.9/microProfile2/java8/openj9
+Directory: releases/19.0.0.9/microProfile2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-microProfile2-java11
-Directory: official/19.0.0.9/microProfile2/java11/openj9
+Directory: releases/19.0.0.9/microProfile2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-microProfile3, 19.0.0.9-microProfile3-java8-ibm
-Directory: official/19.0.0.9/microProfile3/java8/ibmjava
+Directory: releases/19.0.0.9/microProfile3
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-microProfile3-java8-ibmsfj
-Directory: official/19.0.0.9/microProfile3/java8/ibmsfj
+Directory: releases/19.0.0.9/microProfile3
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-microProfile3-java8-openj9
-Directory: official/19.0.0.9/microProfile3/java8/openj9
+Directory: releases/19.0.0.9/microProfile3
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-microProfile3-java11
-Directory: official/19.0.0.9/microProfile3/java11/openj9
+Directory: releases/19.0.0.9/microProfile3
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-springBoot2, 19.0.0.9-springBoot2-java8-ibm
-Directory: official/19.0.0.9/springBoot2/java8/ibmjava
+Directory: releases/19.0.0.9/springBoot2
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-springBoot2-java8-ibmsfj
-Directory: official/19.0.0.9/springBoot2/java8/ibmsfj
+Directory: releases/19.0.0.9/springBoot2
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-springBoot2-java8-openj9
-Directory: official/19.0.0.9/springBoot2/java8/openj9
+Directory: releases/19.0.0.9/springBoot2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-springBoot2-java11
-Directory: official/19.0.0.9/springBoot2/java11/openj9
+Directory: releases/19.0.0.9/springBoot2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-webProfile7, 19.0.0.9-webProfile7-java8-ibm
-Directory: official/19.0.0.9/webProfile7/java8/ibmjava
+Directory: releases/19.0.0.9/webProfile7
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-webProfile7-java8-ibmsfj
-Directory: official/19.0.0.9/webProfile7/java8/ibmsfj
+Directory: releases/19.0.0.9/webProfile7
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-webProfile7-java8-openj9
-Directory: official/19.0.0.9/webProfile7/java8/openj9
+Directory: releases/19.0.0.9/webProfile7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-webProfile7-java11
-Directory: official/19.0.0.9/webProfile7/java11/openj9
+Directory: releases/19.0.0.9/webProfile7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-javaee7, 19.0.0.9-javaee7-java8-ibm
-Directory: official/19.0.0.9/javaee7/java8/ibmjava
+Directory: releases/19.0.0.9/javaee7
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-javaee7-java8-ibmsfj
-Directory: official/19.0.0.9/javaee7/java8/ibmsfj
+Directory: releases/19.0.0.9/javaee7
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-javaee7-java8-openj9
-Directory: official/19.0.0.9/javaee7/java8/openj9
+Directory: releases/19.0.0.9/javaee7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-javaee7-java11
-Directory: official/19.0.0.9/javaee7/java11/openj9
+Directory: releases/19.0.0.9/javaee7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.9-springBoot1, 19.0.0.9-springBoot1-java8-ibm
-Directory: official/19.0.0.9/springBoot1/java8/ibmjava
+Directory: releases/19.0.0.9/springBoot1
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-springBoot1-java8-ibmsfj
-Directory: official/19.0.0.9/springBoot1/java8/ibmsfj
+Directory: releases/19.0.0.9/springBoot1
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.9-springBoot1-java8-openj9
-Directory: official/19.0.0.9/springBoot1/java8/openj9
+Directory: releases/19.0.0.9/springBoot1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.9-springBoot1-java11
-Directory: official/19.0.0.9/springBoot1/java11/openj9
+Directory: releases/19.0.0.9/springBoot1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-kernel, 19.0.0.6-kernel-java8-ibm
-Directory: official/19.0.0.6/kernel/java8/ibmjava
+Directory: releases/19.0.0.6/kernel
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-kernel-java8-ibmsfj
-Directory: official/19.0.0.6/kernel/java8/ibmsfj
+Directory: releases/19.0.0.6/kernel
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-kernel-java8-openj9
-Directory: official/19.0.0.6/kernel/java8/openj9
+Directory: releases/19.0.0.6/kernel
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-kernel-java11
-Directory: official/19.0.0.6/kernel/java11/openj9
+Directory: releases/19.0.0.6/kernel
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-webProfile8, 19.0.0.6-webProfile8-java8-ibm
-Directory: official/19.0.0.6/webProfile8/java8/ibmjava
+Directory: releases/19.0.0.6/webProfile8
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-webProfile8-java8-ibmsfj
-Directory: official/19.0.0.6/webProfile8/java8/ibmsfj
+Directory: releases/19.0.0.6/webProfile8
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-webProfile8-java8-openj9
-Directory: official/19.0.0.6/webProfile8/java8/openj9
+Directory: releases/19.0.0.6/webProfile8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-webProfile8-java11
-Directory: official/19.0.0.6/webProfile8/java11/openj9
+Directory: releases/19.0.0.6/webProfile8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-javaee8, 19.0.0.6-javaee8-java8-ibm
-Directory: official/19.0.0.6/javaee8/java8/ibmjava
+Directory: releases/19.0.0.6/javaee8
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-javaee8-java8-ibmsfj
-Directory: official/19.0.0.6/javaee8/java8/ibmsfj
+Directory: releases/19.0.0.6/javaee8
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-javaee8-java8-openj9
-Directory: official/19.0.0.6/javaee8/java8/openj9
+Directory: releases/19.0.0.6/javaee8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-javaee8-java11
-Directory: official/19.0.0.6/javaee8/java11/openj9
+Directory: releases/19.0.0.6/javaee8
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-microProfile1, 19.0.0.6-microProfile1-java8-ibm
-Directory: official/19.0.0.6/microProfile1/java8/ibmjava
+Directory: releases/19.0.0.6/microProfile1
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-microProfile1-java8-ibmsfj
-Directory: official/19.0.0.6/microProfile1/java8/ibmsfj
+Directory: releases/19.0.0.6/microProfile1
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-microProfile1-java8-openj9
-Directory: official/19.0.0.6/microProfile1/java8/openj9
+Directory: releases/19.0.0.6/microProfile1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-microProfile1-java11
-Directory: official/19.0.0.6/microProfile1/java11/openj9
+Directory: releases/19.0.0.6/microProfile1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-microProfile2, 19.0.0.6-microProfile2-java8-ibm
-Directory: official/19.0.0.6/microProfile2/java8/ibmjava
+Directory: releases/19.0.0.6/microProfile2
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-microProfile2-java8-ibmsfj
-Directory: official/19.0.0.6/microProfile2/java8/ibmsfj
+Directory: releases/19.0.0.6/microProfile2
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-microProfile2-java8-openj9
-Directory: official/19.0.0.6/microProfile2/java8/openj9
+Directory: releases/19.0.0.6/microProfile2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-microProfile2-java11
-Directory: official/19.0.0.6/microProfile2/java11/openj9
+Directory: releases/19.0.0.6/microProfile2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-springBoot2, 19.0.0.6-springBoot2-java8-ibm
-Directory: official/19.0.0.6/springBoot2/java8/ibmjava
+Directory: releases/19.0.0.6/springBoot2
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-springBoot2-java8-ibmsfj
-Directory: official/19.0.0.6/springBoot2/java8/ibmsfj
+Directory: releases/19.0.0.6/springBoot2
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-springBoot2-java8-openj9
-Directory: official/19.0.0.6/springBoot2/java8/openj9
+Directory: releases/19.0.0.6/springBoot2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-springBoot2-java11
-Directory: official/19.0.0.6/springBoot2/java11/openj9
+Directory: releases/19.0.0.6/springBoot2
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-webProfile7, 19.0.0.6-webProfile7-java8-ibm
-Directory: official/19.0.0.6/webProfile7/java8/ibmjava
+Directory: releases/19.0.0.6/webProfile7
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-webProfile7-java8-ibmsfj
-Directory: official/19.0.0.6/webProfile7/java8/ibmsfj
+Directory: releases/19.0.0.6/webProfile7
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-webProfile7-java8-openj9
-Directory: official/19.0.0.6/webProfile7/java8/openj9
+Directory: releases/19.0.0.6/webProfile7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-webProfile7-java11
-Directory: official/19.0.0.6/webProfile7/java11/openj9
+Directory: releases/19.0.0.6/webProfile7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-javaee7, 19.0.0.6-javaee7-java8-ibm
-Directory: official/19.0.0.6/javaee7/java8/ibmjava
+Directory: releases/19.0.0.6/javaee7
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-javaee7-java8-ibmsfj
-Directory: official/19.0.0.6/javaee7/java8/ibmsfj
+Directory: releases/19.0.0.6/javaee7
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-javaee7-java8-openj9
-Directory: official/19.0.0.6/javaee7/java8/openj9
+Directory: releases/19.0.0.6/javaee7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-javaee7-java11
-Directory: official/19.0.0.6/javaee7/java11/openj9
+Directory: releases/19.0.0.6/javaee7
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 19.0.0.6-springBoot1, 19.0.0.6-springBoot1-java8-ibm
-Directory: official/19.0.0.6/springBoot1/java8/ibmjava
+Directory: releases/19.0.0.6/springBoot1
+File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.6-springBoot1-java8-ibmsfj
-Directory: official/19.0.0.6/springBoot1/java8/ibmsfj
+Directory: releases/19.0.0.6/springBoot1
 Architectures: amd64
+File: Dockerfile.alpine.ibmsfj8
 
 Tags: 19.0.0.6-springBoot1-java8-openj9
-Directory: official/19.0.0.6/springBoot1/java8/openj9
+Directory: releases/19.0.0.6/springBoot1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 19.0.0.6-springBoot1-java11
-Directory: official/19.0.0.6/springBoot1/java11/openj9
+Directory: releases/19.0.0.6/springBoot1
 Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11


### PR DESCRIPTION
* Packaging the Dockerfiles into a `releases` folder
* Collapsing the different folders into a single one, with just different Dockerfile names.  This allows us to avoid duplicating folders that our images were using