### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,19 +4,19 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 5.0.6, 5.0, 5, latest, 5.0.6-buster, 5.0-buster, 5-buster, buster
+Tags: 5.0.7, 5.0, 5, latest, 5.0.7-buster, 5.0-buster, 5-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ec0ad5628df2404509f776e9c70fbecf5364c10
+GitCommit: d42494ab2d96070c8d83f37a7542fbbffd999988
 Directory: 5.0
 
-Tags: 5.0.6-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.6-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
+Tags: 5.0.7-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.7-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
 Architectures: amd64
-GitCommit: 6ec0ad5628df2404509f776e9c70fbecf5364c10
+GitCommit: d42494ab2d96070c8d83f37a7542fbbffd999988
 Directory: 5.0/32bit
 
-Tags: 5.0.6-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.6-alpine3.10, 5.0-alpine3.10, 5-alpine3.10, alpine3.10
+Tags: 5.0.7-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.7-alpine3.10, 5.0-alpine3.10, 5-alpine3.10, alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ec0ad5628df2404509f776e9c70fbecf5364c10
+GitCommit: d42494ab2d96070c8d83f37a7542fbbffd999988
 Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-buster, 4.0-buster, 4-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/d42494a: Update to 5.0.7