### PR TITLE
library/perl: Set an always-accessible WORKDIR

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,7 +1,7 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: bad811d7db8abc4f7b612f6a7b4c7890ff44f399
+GitCommit: 61f3aae15f583754767f4d5a969d609f1facdeb4
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
 Tags: latest, 5, 5.30, 5.30.0, 5-buster, 5.30-buster, 5.30.1-buster

--- a/library/perl
+++ b/library/perl
@@ -4,7 +4,7 @@ GitRepo: https://github.com/perl/docker-perl.git
 GitCommit: 61f3aae15f583754767f4d5a969d609f1facdeb4
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.30, 5.30.0, 5-buster, 5.30-buster, 5.30.1-buster
+Tags: latest, 5, 5.30, 5.30.1, 5-buster, 5.30-buster, 5.30.1-buster
 Directory: 5.030.001-main-buster
 
 Tags: 5-stretch, 5.30-stretch, 5.30.1-stretch


### PR DESCRIPTION
Ensure that running this image with a non-root user will work, even when
not customizing `WORKDIR`.

https://github.com/Perl/docker-perl/issues/72