### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,37 +1,47 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/f3bcdac877d725fb3abcabe3b0319b95dcceead8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/9024f3f2012caaf06774bdddc6c9ff485205c6ca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.0.9, 2.0, latest
+Tags: 2.1.0, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48f3107226322100e210875bc6756739779aace2
+GitCommit: 5993cb3c56edd07b4ad902f3d4ac0eaada8db9a0
+Directory: 2.1
+
+Tags: 2.1.0-alpine, 2.1-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5993cb3c56edd07b4ad902f3d4ac0eaada8db9a0
+Directory: 2.1/alpine
+
+Tags: 2.0.10, 2.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 53a929dbf37c77816aed9af7864a3b6e7568937f
 Directory: 2.0
 
-Tags: 2.0.9-alpine, 2.0-alpine, alpine
+Tags: 2.0.10-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48f3107226322100e210875bc6756739779aace2
+GitCommit: 53a929dbf37c77816aed9af7864a3b6e7568937f
 Directory: 2.0/alpine
 
-Tags: 1.9.12, 1.9, 1
+Tags: 1.9.13, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd6b8fd614e9359ebd1f4b27cfa38ae44d63c174
+GitCommit: bbd9a3d20e2bda908eec696df9e6731bae448095
 Directory: 1.9
 
-Tags: 1.9.12-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.13-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd6b8fd614e9359ebd1f4b27cfa38ae44d63c174
+GitCommit: bbd9a3d20e2bda908eec696df9e6731bae448095
 Directory: 1.9/alpine
 
-Tags: 1.8.22, 1.8
+Tags: 1.8.23, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9054c7c7dcc271f7bda910e240af66f00d6d43a0
+GitCommit: 3dde4821a9d74cd1ea60bb2943e3513bfd1165a7
 Directory: 1.8
 
-Tags: 1.8.22-alpine, 1.8-alpine
+Tags: 1.8.23-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9054c7c7dcc271f7bda910e240af66f00d6d43a0
+GitCommit: 3dde4821a9d74cd1ea60bb2943e3513bfd1165a7
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9024f3f: Update "latest" to 2.1
- https://github.com/docker-library/haproxy/commit/6625a71: Merge pull request https://github.com/docker-library/haproxy/pull/104 from TimWolla/haproxy-2.1
- https://github.com/docker-library/haproxy/commit/5993cb3: Add HAProxy 2.1
- https://github.com/docker-library/haproxy/commit/bbd9a3d: Update to 1.9.13
- https://github.com/docker-library/haproxy/commit/3dde482: Update to 1.8.23
- https://github.com/docker-library/haproxy/commit/53a929d: Update to 2.0.10