### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -7,292 +7,292 @@ GitRepo: https://github.com/docker-library/openjdk.git
 Tags: 14-ea-24-jdk-oraclelinux7, 14-ea-24-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-24-jdk-oracle, 14-ea-24-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
 SharedTags: 14-ea-24-jdk, 14-ea-24, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
 Tags: 14-ea-24-jdk-buster, 14-ea-24-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk
 
 Tags: 14-ea-24-jdk-slim-buster, 14-ea-24-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-24-jdk-slim, 14-ea-24-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
 Architectures: amd64
-GitCommit: bde1e9a0f36e12e3df58b81acddd695fd140cf6a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/alpine
 
 Tags: 14-ea-24-jdk-windowsservercore-1809, 14-ea-24-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
 SharedTags: 14-ea-24-jdk-windowsservercore, 14-ea-24-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-24-jdk, 14-ea-24, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 14-ea-24-jdk-windowsservercore-1803, 14-ea-24-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
 SharedTags: 14-ea-24-jdk-windowsservercore, 14-ea-24-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-24-jdk, 14-ea-24, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 14-ea-24-jdk-windowsservercore-ltsc2016, 14-ea-24-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
 SharedTags: 14-ea-24-jdk-windowsservercore, 14-ea-24-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-24-jdk, 14-ea-24, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 14-ea-24-jdk-nanoserver-1809, 14-ea-24-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
 SharedTags: 14-ea-24-jdk-nanoserver, 14-ea-24-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 14-ea-24-jdk-nanoserver-1803, 14-ea-24-nanoserver-1803, 14-ea-jdk-nanoserver-1803, 14-ea-nanoserver-1803, 14-jdk-nanoserver-1803, 14-nanoserver-1803
 SharedTags: 14-ea-24-jdk-nanoserver, 14-ea-24-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: db840bef290a52e33a58d513270ec4e41a076d67
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 13.0.1-jdk-oraclelinux7, 13.0.1-oraclelinux7, 13.0-jdk-oraclelinux7, 13.0-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13.0.1-jdk-oracle, 13.0.1-oracle, 13.0-jdk-oracle, 13.0-oracle, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
 SharedTags: 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: amd64
-GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
 Tags: 13.0.1-jdk-buster, 13.0.1-buster, 13.0-jdk-buster, 13.0-buster, 13-jdk-buster, 13-buster, jdk-buster, buster
 Architectures: amd64
-GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk
 
 Tags: 13.0.1-jdk-slim-buster, 13.0.1-slim-buster, 13.0-jdk-slim-buster, 13.0-slim-buster, 13-jdk-slim-buster, 13-slim-buster, jdk-slim-buster, slim-buster, 13.0.1-jdk-slim, 13.0.1-slim, 13.0-jdk-slim, 13.0-slim, 13-jdk-slim, 13-slim, jdk-slim, slim
 Architectures: amd64
-GitCommit: 0a1e59a9fbc4f2cabaef69d9fede0ffe283dc431
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/slim
 
 Tags: 13.0.1-jdk-windowsservercore-1809, 13.0.1-windowsservercore-1809, 13.0-jdk-windowsservercore-1809, 13.0-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
 SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 13.0.1-jdk-windowsservercore-1803, 13.0.1-windowsservercore-1803, 13.0-jdk-windowsservercore-1803, 13.0-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
 SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 13.0.1-jdk-windowsservercore-ltsc2016, 13.0.1-windowsservercore-ltsc2016, 13.0-jdk-windowsservercore-ltsc2016, 13.0-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 13.0.1-jdk-nanoserver-1809, 13.0.1-nanoserver-1809, 13.0-jdk-nanoserver-1809, 13.0-nanoserver-1809, 13-jdk-nanoserver-1809, 13-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
 SharedTags: 13.0.1-jdk-nanoserver, 13.0.1-nanoserver, 13.0-jdk-nanoserver, 13.0-nanoserver, 13-jdk-nanoserver, 13-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 13.0.1-jdk-nanoserver-1803, 13.0.1-nanoserver-1803, 13.0-jdk-nanoserver-1803, 13.0-nanoserver-1803, 13-jdk-nanoserver-1803, 13-nanoserver-1803, jdk-nanoserver-1803, nanoserver-1803
 SharedTags: 13.0.1-jdk-nanoserver, 13.0.1-nanoserver, 13.0-jdk-nanoserver, 13.0-nanoserver, 13-jdk-nanoserver, 13-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 11.0.5-jdk-stretch, 11.0.5-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
 SharedTags: 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk
 
 Tags: 11.0.5-jdk-slim-buster, 11.0.5-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.5-jdk-slim, 11.0.5-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/slim
 
 Tags: 11.0.5-jdk-windowsservercore-1809, 11.0.5-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.5-jdk-windowsservercore-1803, 11.0.5-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
 SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 11.0.5-jdk-windowsservercore-ltsc2016, 11.0.5-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.5-jdk-nanoserver-1809, 11.0.5-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.5-jdk-nanoserver, 11.0.5-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.5-jdk-nanoserver-1803, 11.0.5-nanoserver-1803, 11.0-jdk-nanoserver-1803, 11.0-nanoserver-1803, 11-jdk-nanoserver-1803, 11-nanoserver-1803
 SharedTags: 11.0.5-jdk-nanoserver, 11.0.5-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 11.0.5-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
 SharedTags: 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre
 
 Tags: 11.0.5-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.5-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/slim
 
 Tags: 11.0.5-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.5-jre-windowsservercore-1803, 11.0-jre-windowsservercore-1803, 11-jre-windowsservercore-1803
 SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 11.0.5-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
 SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: fb20f308cef5db398462495afd2f7bc60f51590a
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.5-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.5-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.5-jre-nanoserver-1803, 11.0-jre-nanoserver-1803, 11-jre-nanoserver-1803
 SharedTags: 11.0.5-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 8u232-jdk-stretch, 8u232-stretch, 8-jdk-stretch, 8-stretch
 SharedTags: 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk
 
 Tags: 8u232-jdk-slim-buster, 8u232-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u232-jdk-slim, 8u232-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/slim
 
 Tags: 8u232-jdk-windowsservercore-1809, 8u232-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u232-jdk-windowsservercore-1803, 8u232-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
 SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 8u232-jdk-windowsservercore-ltsc2016, 8u232-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u232-jdk-nanoserver-1809, 8u232-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u232-jdk-nanoserver, 8u232-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u232-jdk-nanoserver-1803, 8u232-nanoserver-1803, 8-jdk-nanoserver-1803, 8-nanoserver-1803
 SharedTags: 8u232-jdk-nanoserver, 8u232-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 8u232-jre-stretch, 8-jre-stretch
 SharedTags: 8u232-jre, 8-jre
 Architectures: amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre
 
 Tags: 8u232-jre-slim-buster, 8-jre-slim-buster, 8u232-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/slim
 
 Tags: 8u232-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u232-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
 SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/windowsservercore-1803
 Constraints: windowsservercore-1803
 
 Tags: 8u232-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
 SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 403960ed0b1f6dcb2f3194f7f3139bb954e28b77
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u232-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u232-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u232-jre-nanoserver-1803, 8-jre-nanoserver-1803
 SharedTags: 8u232-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 15835397954c9ec123e42e685035ecd239e0a1db
+GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/nanoserver-1803
 Constraints: nanoserver-1803, windowsservercore-1803


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/e101ce4: Merge pull request https://github.com/docker-library/openjdk/pull/377 from infosiftr/provenance-clarification
- https://github.com/docker-library/openjdk/commit/53e199b: Merge pull request https://github.com/docker-library/openjdk/pull/376 from infosiftr/jshell
- https://github.com/docker-library/openjdk/commit/61a91d5: Further clarify build provenance by inlining relevant quotes
- https://github.com/docker-library/openjdk/commit/32aebc4: Remove "jshell" default command from all JRE images