### PR TITLE
Roll back Ubuntu 14.04 Trusty 20191107

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -46,7 +46,20 @@ Directory: focal
 # 20190515 (trusty)
 Tags: 14.04, trusty-20190515, trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 7a1a4f883de2d81351a82c86c24a0033dcae03db
 Directory: trusty
+amd64-GitCommit: 010bf9649b1d10e2c34b159a9a9b338d0fdd4939
+amd64-GitFetch: refs/heads/dist-amd64
+arm32v7-GitCommit: b9a951ace1f2e2e418828a197f62678c337f903e
+arm32v7-GitFetch: refs/heads/dist-arm32v7
+arm64v8-GitCommit: dffe0ea71413c9ca297a0935bade25c3ad3348a3
+arm64v8-GitFetch: refs/heads/dist-arm64v8
+i386-GitCommit: 2f8e166f4a725c5bcf3e96e2986d312f39a14098
+i386-GitFetch: refs/heads/dist-i386
+ppc64le-GitCommit: bbbf38c2900bd6aea408e3690be45e74bf2de1a5
+ppc64le-GitFetch: refs/heads/dist-ppc64le
+s390x-GitCommit: 4f55bf693232c85b18f9e6084c8f6780a24c3ba4
+s390x-GitFetch: refs/heads/dist-s390x
 
 # 20191108 (xenial)
 Tags: 16.04, xenial-20191108, xenial

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -43,11 +43,6 @@ Tags: 20.04, focal-20191030, focal, devel
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: focal
 
-# 20191107 (trusty)
-Tags: 14.04, trusty-20191107, trusty
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-Directory: trusty
-
 # 20191108 (xenial)
 Tags: 16.04, xenial-20191108, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -43,6 +43,11 @@ Tags: 20.04, focal-20191030, focal, devel
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: focal
 
+# 20190515 (trusty)
+Tags: 14.04, trusty-20190515, trusty
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+Directory: trusty
+
 # 20191108 (xenial)
 Tags: 16.04, xenial-20191108, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
Due to issues updating and installing packages when ESM repo is added
we are rolling back recent update to Trusty.

For more context see discussions in https://github.com/docker-library/official-images/pull/7029