### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -44,42 +44,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.22-rc.1, 3.7-rc
+Tags: 3.7.22, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7129682dc04e080e20ec7a963e3a6f777b95218f
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.22-rc.1-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.22-rc.1-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7129682dc04e080e20ec7a963e3a6f777b95218f
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.22-rc.1-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.21, 3.7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb3256136809408f58be851338316b6d2ee83946
+GitCommit: 1f8ab85549615647c535da2a8ca2a0d22136ad35
 Directory: 3.7/ubuntu
 
-Tags: 3.7.21-management, 3.7-management
+Tags: 3.7.22-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.21-alpine, 3.7-alpine
+Tags: 3.7.22-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb3256136809408f58be851338316b6d2ee83946
+GitCommit: 1f8ab85549615647c535da2a8ca2a0d22136ad35
 Directory: 3.7/alpine
 
-Tags: 3.7.21-management-alpine, 3.7-management-alpine
+Tags: 3.7.22-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/1f8ab85: Update to 3.7.22, Erlang/OTP 22.1.8, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/c074869: Update to 3.7.22-rc.2, Erlang/OTP 22.1.8, OpenSSL 1.1.1d