### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.41, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8da3138c7ad5973fbaae0e464a190d377d2b4219
+GitCommit: 4faace97468d7bced1ac4a072f89f151359ee9fa
 Directory: 2.4
 
 Tags: 2.4.41-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82fd968fb7cfe496a0f87888777e834530dd9154
+GitCommit: 3616f04657a48b960d842956c4a6b1581e7cecdb
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/3616f04: Merge pull request https://github.com/docker-library/httpd/pull/151 from infosiftr/SIGWINCH
- https://github.com/docker-library/httpd/commit/452478b: Add a small comment to remind us why we don't have extra PIE flags for Alpine
- https://github.com/docker-library/httpd/commit/4faace9: Swap "WINCH" for "SIGWINCH" (which fixes containerd's ability to use this value)