### PR TITLE
Use more Apache mirrors for improved Storm build resiliency

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -3,13 +3,13 @@ GitRepo: https://github.com/31z4/storm-docker.git
 Architectures: amd64
 
 Tags: 1.1.3, 1.1
-GitCommit: f98a59dfc28739e8aa0b9ede44f069ef21e077a4
+GitCommit: 664a7f4730f58be00fd7fe0526d2c13180107c6f
 Directory: 1.1.3
 
 Tags: 1.2.3, 1.2
-GitCommit: f98a59dfc28739e8aa0b9ede44f069ef21e077a4
+GitCommit: 664a7f4730f58be00fd7fe0526d2c13180107c6f
 Directory: 1.2.3
 
 Tags: 2.1.0, 2.1, latest
-GitCommit: 0d8a6404d602feb6afd379d3816b9a6549b463a1
+GitCommit: 664a7f4730f58be00fd7fe0526d2c13180107c6f
 Directory: 2.1.0


### PR DESCRIPTION
This should address https://github.com/docker-library/official-images/issues/7024.