### PR TITLE
Bump Traefik to v2.1.0-rc3 and v2.0.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.1.0-rc2-windowsservercore-1809, 2.1.0-rc2-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809
+Tags: v2.1.0-rc3-windowsservercore-1809, 2.1.0-rc3-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 91673baa8542cd4217988bb57f88482c544aa25b
+GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.0-rc2, 2.1.0-rc2, v2.1, 2.1, cantal
+Tags: v2.1.0-rc3, 2.1.0-rc3, v2.1, 2.1, cantal
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 91673baa8542cd4217988bb57f88482c544aa25b
+GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
 Directory: alpine
 
 Tags: v2.0.5-windowsservercore-1809, 2.0.5-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
 Directory: alpine
 
-Tags: v2.0.5-windowsservercore-1809, 2.0.5-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.6-windowsservercore-1809, 2.0.6-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 2275def60d8cf0d0d85cd2097661bf60ca089338
+GitCommit: b72d1f755636b068394ce476bffc4317ad59fa90
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.5, 2.0.5, v2.0, 2.0, montdor, latest
+Tags: v2.0.6, 2.0.6, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 2275def60d8cf0d0d85cd2097661bf60ca089338
+GitCommit: b72d1f755636b068394ce476bffc4317ad59fa90
 Directory: alpine
 
 Tags: v1.7.19-windowsservercore-1809, 1.7.19-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.1.0-rc3](https://github.com/containous/traefik/releases/tag/v2.1.0-rc3).

/cc @mmatur @emilevauge @dtomcej

Cheers
