### PR TITLE
Update RethinkDB image

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,6 +1,6 @@
 Maintainers: Gábor Boros <gabor.brs@gmail.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
-GitCommit: c49237920aa96f28ad4da38201b42c7783de0d4a
+GitCommit: 6efa057f145112f259949ce5b37a3bd6384eb5c5
 
 Tags: 2.3.7, 2.3, 2, latest
 Directory: bionic/2.3.7

--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,6 +1,6 @@
-Maintainers: Daniel Alan Miller <dalanmiller@rethinkdb.com> (@dalanmiller)
+Maintainers: Gábor Boros <gabor.brs@gmail.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
-GitCommit: 05946c0dbe3c7fa9338d3827428b2c32074a1447
+GitCommit: c49237920aa96f28ad4da38201b42c7783de0d4a
 
-Tags: 2.3.6, 2.3, 2, latest
-Directory: jessie/2.3.6
+Tags: 2.3.7, 2.3, 2, latest
+Directory: bionic/2.3.7


### PR DESCRIPTION
Hereby we would like to update the official docker image for rethinkdb from 2.3.6 to 2.3.7.  Since RethinkDB is back, we will open more PRs in the future.