### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/fdf59597a0835d1f15162b41f30879279931f8db/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/d017f89a4f01b72e8b2f71ee6384b5009386a586/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: fdf59597a0835d1f15162b41f30879279931f8db
+GitCommit: d017f89a4f01b72e8b2f71ee6384b5009386a586
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: df521b5fcacf7164e3e33d6560d2a7da665ade9c
+amd64-GitCommit: f2f720428163ea8376ba295d417ca40dcb899fc0
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 07b2319b5396700339df5ad362c4cf130d999e36
+arm32v5-GitCommit: 5fe27e6f5ba12c8ead34ed2e5b55bcdd2d86297b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: e8975dafa55b46a7f86d803437cce95ccbd8664b
+arm32v6-GitCommit: bfddfd488069edcfb8181527b507ee2bf250f3dd
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: b0c8277ed23870f23e80b80fc7fc99c78697c5a6
+arm32v7-GitCommit: 98675453f03556d39be5f4ad80ff5b42b0c2138e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f58635aa0afb06fb5473b9a149137bea9390f399
+arm64v8-GitCommit: d15bbfe00b1d02c0ce7afcda866bd4acbb778eb8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 1f74114df645e9ef75cb194069c0f550c9e3a319
+i386-GitCommit: d37a965329403e3378a58d4ae2379f932f878fb5
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: f289d32ea0fa6d7ac83e9235c1bd9911d780fb14
+ppc64le-GitCommit: 05997c03a306c396865e6e91072eaa8741c414aa
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 01bfc00b278b6a55c789b7e0011acf6d92b0c48e
+s390x-GitCommit: 1ae12fee1e085fa9912abdccbec50d80f0a18172
 
 Tags: 1.31.1-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/d017f89: Update buildroot to 2019.11
- https://github.com/docker-library/busybox/commit/93d36a8: Update Buildroot to 2019.08.2
- https://github.com/docker-library/busybox/commit/fdf5959: Update to 1.31.1 (and Buildroot 2019.08.1)