### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.3.0-php7.1-apache, 5.3-php7.1-apache, 5-php7.1-apache, php7.1-apache, 5.3.0-php7.1, 5.3-php7.1, 5-php7.1, php7.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
-Directory: php7.1/apache
-
-Tags: 5.3.0-php7.1-fpm, 5.3-php7.1-fpm, 5-php7.1-fpm, php7.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
-Directory: php7.1/fpm
-
-Tags: 5.3.0-php7.1-fpm-alpine, 5.3-php7.1-fpm-alpine, 5-php7.1-fpm-alpine, php7.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
-Directory: php7.1/fpm-alpine
-
 Tags: 5.3.0-php7.2-apache, 5.3-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.3.0-php7.2, 5.3-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.2/apache
 
 Tags: 5.3.0-php7.2-fpm, 5.3-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.2/fpm
 
 Tags: 5.3.0-php7.2-fpm-alpine, 5.3-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.2/fpm-alpine
 
 Tags: 5.3.0-apache, 5.3-apache, 5-apache, apache, 5.3.0, 5.3, 5, latest, 5.3.0-php7.3-apache, 5.3-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.3.0-php7.3, 5.3-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.3/apache
 
 Tags: 5.3.0-fpm, 5.3-fpm, 5-fpm, fpm, 5.3.0-php7.3-fpm, 5.3-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.3/fpm
 
 Tags: 5.3.0-fpm-alpine, 5.3-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.3.0-php7.3-fpm-alpine, 5.3-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 17f48a156dac1308a07796ed41ac6bca007308e9
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.3/fpm-alpine
+
+Tags: 5.3.0-php7.4-apache, 5.3-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.3.0-php7.4, 5.3-php7.4, 5-php7.4, php7.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
+Directory: php7.4/apache
+
+Tags: 5.3.0-php7.4-fpm, 5.3-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
+Directory: php7.4/fpm
+
+Tags: 5.3.0-php7.4-fpm-alpine, 5.3-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
+Directory: php7.4/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
 
-Tags: cli-2.4.0-php7.1, cli-2.4-php7.1, cli-2-php7.1, cli-php7.1
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
-Directory: php7.1/cli
-
 Tags: cli-2.4.0-php7.2, cli-2.4-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.2/cli
 
 Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 9df87306ae4794479dbc9eaf570aca33fc4f41aa
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
 Directory: php7.3/cli
+
+Tags: cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+GitCommit: c63f536e5d24b474c93e6c4b8deeacf95a89eb64
+Directory: php7.4/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/532bb60: Merge pull request https://github.com/docker-library/wordpress/pull/454 from J0WI/php74
- https://github.com/docker-library/wordpress/commit/c63f536: Fix gd extension in 7.4
- https://github.com/docker-library/wordpress/commit/996d18e: Add PHP 7.4
- https://github.com/docker-library/wordpress/commit/93e9445: Remove PHP 7.1