### PR TITLE
Update Solr to 8.3.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,92 +4,92 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.3.0, 8.3, 8, latest
+Tags: 8.3.1, 8.3, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 389e7844c8405605a930fc30cc8029eb6027798e
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.3
 
-Tags: 8.3.0-slim, 8.3-slim, 8-slim, slim
+Tags: 8.3.1-slim, 8.3-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 389e7844c8405605a930fc30cc8029eb6027798e
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: e1f14cc65ae720d0db958bc2905e97b776b4f74d
+GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 5.5/slim


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/www-announce/201912.mbox/%3cCAHPRk5GoOknvSWUJkojSoVqqB4wLZdwHgEX_jpCMZ73ZL8v1LA@mail.gmail.com%3e

In docker-solr scripts we fixed the oom_solr.sh script