### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.4.10-bionic, 10.4-bionic, 10-bionic, bionic, 10.4.10, 10.4, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3b2e52a6a0a525d879053a33886f35d3a5c38603
+GitCommit: ad6b97a27e6c09b81fb8d1e091b276b8ca5fff76
 Directory: 10.4
 
 Tags: 10.3.20-bionic, 10.3-bionic, 10.3.20, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3b2e52a6a0a525d879053a33886f35d3a5c38603
+GitCommit: ad6b97a27e6c09b81fb8d1e091b276b8ca5fff76
 Directory: 10.3
 
 Tags: 10.2.29-bionic, 10.2-bionic, 10.2.29, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3b2e52a6a0a525d879053a33886f35d3a5c38603
+GitCommit: ad6b97a27e6c09b81fb8d1e091b276b8ca5fff76
 Directory: 10.2
 
 Tags: 10.1.43-bionic, 10.1-bionic, 10.1.43, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3b2e52a6a0a525d879053a33886f35d3a5c38603
+GitCommit: ad6b97a27e6c09b81fb8d1e091b276b8ca5fff76
 Directory: 10.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mariadb/commit/ad6b97a: Fix note to use MARIADB_VERSION instead of MYSQL_VERSION