### PR TITLE
Bump Traefik to v2.0.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
 Directory: alpine
 
-Tags: v2.0.6-windowsservercore-1809, 2.0.6-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
+Tags: v2.0.7-windowsservercore-1809, 2.0.7-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: b72d1f755636b068394ce476bffc4317ad59fa90
+GitCommit: 5617af7977d3933e07a9bbe170b7262607151cdf
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.0.6, 2.0.6, v2.0, 2.0, montdor, latest
+Tags: v2.0.7, 2.0.7, v2.0, 2.0, montdor, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: b72d1f755636b068394ce476bffc4317ad59fa90
+GitCommit: 5617af7977d3933e07a9bbe170b7262607151cdf
 Directory: alpine
 
 Tags: v1.7.19-windowsservercore-1809, 1.7.19-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.0.7](https://github.com/containous/traefik/releases/tag/v2.0.7).

/cc @mmatur @emilevauge @dtomcej

Cheers
