### PR TITLE
Update hello-world

### DIFF
--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/88475d7d4cfb43feda2b74a5bfdaf5ff8f964fb1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/837f63a4a9cc1e06320f47abb98965b6c5672b30/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 88475d7d4cfb43feda2b74a5bfdaf5ff8f964fb1
+GitCommit: 837f63a4a9cc1e06320f47abb98965b6c5672b30
 
 Tags: linux
 SharedTags: latest
@@ -22,13 +22,6 @@ ppc64le-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 ppc64le-Directory: ppc64le/hello-world
 s390x-GitCommit: b715c35271f1d18832480bde75fe17b93db26414
 s390x-Directory: s390x/hello-world
-
-Tags: nanoserver-1803
-SharedTags: nanoserver, latest
-Architectures: windows-amd64
-windows-amd64-GitCommit: 9c93e37114a7fe99b5fc0d776e0b8dff99cbbb75
-windows-amd64-Directory: amd64/hello-world/nanoserver-1803
-Constraints: nanoserver-1803
 
 Tags: nanoserver-1809
 SharedTags: nanoserver, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/hello-world/commit/837f63a: Remove EOL Windows 1803-based (SAC) images
- https://github.com/docker-library/hello-world/commit/e0560ca: Merge pull request https://github.com/docker-library/hello-world/pull/61 from infosiftr/adiós
- https://github.com/docker-library/hello-world/commit/c6800ec: Remove (now unused) hola-mundo and hello-seattle bits
- https://github.com/docker-library/hello-world/commit/c617f52: Update generated README
- https://github.com/docker-library/hello-world/commit/e9c7f46: Update generated README