### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/1743b5266c186071b3005311d1d2cb61f6e539b0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/e2fbda03b975d10f70c32858cff764f0c8606ac9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -33,13 +33,6 @@ GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-26-jdk-windowsservercore-1803, 14-ea-26-windowsservercore-1803, 14-ea-jdk-windowsservercore-1803, 14-ea-windowsservercore-1803, 14-jdk-windowsservercore-1803, 14-windowsservercore-1803
-SharedTags: 14-ea-26-jdk-windowsservercore, 14-ea-26-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-26-jdk, 14-ea-26, 14-ea-jdk, 14-ea, 14-jdk, 14
-Architectures: windows-amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
-Directory: 14/jdk/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 14-ea-26-jdk-windowsservercore-ltsc2016, 14-ea-26-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
 SharedTags: 14-ea-26-jdk-windowsservercore, 14-ea-26-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-26-jdk, 14-ea-26, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
@@ -53,13 +46,6 @@ Architectures: windows-amd64
 GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 14-ea-26-jdk-nanoserver-1803, 14-ea-26-nanoserver-1803, 14-ea-jdk-nanoserver-1803, 14-ea-nanoserver-1803, 14-jdk-nanoserver-1803, 14-nanoserver-1803
-SharedTags: 14-ea-26-jdk-nanoserver, 14-ea-26-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
-Architectures: windows-amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
-Directory: 14/jdk/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 13.0.1-jdk-oraclelinux7, 13.0.1-oraclelinux7, 13.0-jdk-oraclelinux7, 13.0-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13.0.1-jdk-oracle, 13.0.1-oracle, 13.0-jdk-oracle, 13.0-oracle, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
 SharedTags: 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
@@ -85,13 +71,6 @@ GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13.0.1-jdk-windowsservercore-1803, 13.0.1-windowsservercore-1803, 13.0-jdk-windowsservercore-1803, 13.0-windowsservercore-1803, 13-jdk-windowsservercore-1803, 13-windowsservercore-1803, jdk-windowsservercore-1803, windowsservercore-1803
-SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 13/jdk/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 13.0.1-jdk-windowsservercore-ltsc2016, 13.0.1-windowsservercore-ltsc2016, 13.0-jdk-windowsservercore-ltsc2016, 13.0-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
@@ -105,13 +84,6 @@ Architectures: windows-amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 13/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 13.0.1-jdk-nanoserver-1803, 13.0.1-nanoserver-1803, 13.0-jdk-nanoserver-1803, 13.0-nanoserver-1803, 13-jdk-nanoserver-1803, 13-nanoserver-1803, jdk-nanoserver-1803, nanoserver-1803
-SharedTags: 13.0.1-jdk-nanoserver, 13.0.1-nanoserver, 13.0-jdk-nanoserver, 13.0-nanoserver, 13-jdk-nanoserver, 13-nanoserver, jdk-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 13/jdk/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 11.0.5-jdk-stretch, 11.0.5-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
 SharedTags: 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
@@ -131,13 +103,6 @@ GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.5-jdk-windowsservercore-1803, 11.0.5-windowsservercore-1803, 11.0-jdk-windowsservercore-1803, 11.0-windowsservercore-1803, 11-jdk-windowsservercore-1803, 11-windowsservercore-1803
-SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 11/jdk/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 11.0.5-jdk-windowsservercore-ltsc2016, 11.0.5-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
@@ -151,13 +116,6 @@ Architectures: windows-amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 11.0.5-jdk-nanoserver-1803, 11.0.5-nanoserver-1803, 11.0-jdk-nanoserver-1803, 11.0-nanoserver-1803, 11-jdk-nanoserver-1803, 11-nanoserver-1803
-SharedTags: 11.0.5-jdk-nanoserver, 11.0.5-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 11/jdk/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 11.0.5-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
 SharedTags: 11.0.5-jre, 11.0-jre, 11-jre
@@ -177,13 +135,6 @@ GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.5-jre-windowsservercore-1803, 11.0-jre-windowsservercore-1803, 11-jre-windowsservercore-1803
-SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
-Architectures: windows-amd64
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
-Directory: 11/jre/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 11.0.5-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
 SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
@@ -197,13 +148,6 @@ Architectures: windows-amd64
 GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 11.0.5-jre-nanoserver-1803, 11.0-jre-nanoserver-1803, 11-jre-nanoserver-1803
-SharedTags: 11.0.5-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
-Architectures: windows-amd64
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
-Directory: 11/jre/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 8u232-jdk-stretch, 8u232-stretch, 8-jdk-stretch, 8-stretch
 SharedTags: 8u232-jdk, 8u232, 8-jdk, 8
@@ -223,13 +167,6 @@ GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u232-jdk-windowsservercore-1803, 8u232-windowsservercore-1803, 8-jdk-windowsservercore-1803, 8-windowsservercore-1803
-SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 8/jdk/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 8u232-jdk-windowsservercore-ltsc2016, 8u232-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u232-jdk-windowsservercore, 8u232-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u232-jdk, 8u232, 8-jdk, 8
 Architectures: windows-amd64
@@ -243,13 +180,6 @@ Architectures: windows-amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 8u232-jdk-nanoserver-1803, 8u232-nanoserver-1803, 8-jdk-nanoserver-1803, 8-nanoserver-1803
-SharedTags: 8u232-jdk-nanoserver, 8u232-nanoserver, 8-jdk-nanoserver, 8-nanoserver
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 8/jdk/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 8u232-jre-stretch, 8-jre-stretch
 SharedTags: 8u232-jre, 8-jre
@@ -269,13 +199,6 @@ GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u232-jre-windowsservercore-1803, 8-jre-windowsservercore-1803
-SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 8/jre/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 8u232-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
 SharedTags: 8u232-jre-windowsservercore, 8-jre-windowsservercore, 8u232-jre, 8-jre
 Architectures: windows-amd64
@@ -289,10 +212,3 @@ Architectures: windows-amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 8u232-jre-nanoserver-1803, 8-jre-nanoserver-1803
-SharedTags: 8u232-jre-nanoserver, 8-jre-nanoserver
-Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
-Directory: 8/jre/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/e2fbda0: Remove EOL Windows 1803-based (SAC) images