### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/9ba0d6f19538d7922f62a41cea6589e366b100d3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/6ac52e6a15acd1315a1a891c9e4eb3aa0a99700f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -46,13 +46,6 @@ GitCommit: 6d7dddef73dba24e57f1eabff64346950d46157c
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.13-windowsservercore-1803, 4.0-windowsservercore-1803
-SharedTags: 4.0.13-windowsservercore, 4.0-windowsservercore, 4.0.13, 4.0
-Architectures: windows-amd64
-GitCommit: 6d7dddef73dba24e57f1eabff64346950d46157c
-Directory: 4.0/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 4.0.13-windowsservercore-1809, 4.0-windowsservercore-1809
 SharedTags: 4.0.13-windowsservercore, 4.0-windowsservercore, 4.0.13, 4.0
 Architectures: windows-amd64
@@ -60,30 +53,23 @@ GitCommit: 9ba0d6f19538d7922f62a41cea6589e366b100d3
 Directory: 4.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.2.1-bionic, 4.2-bionic, 4-bionic, bionic
-SharedTags: 4.2.1, 4.2, 4, latest
+Tags: 4.2.2-bionic, 4.2-bionic, 4-bionic, bionic
+SharedTags: 4.2.2, 4.2, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/
-Architectures: amd64, arm64v8, s390x
-GitCommit: c23e9e1f59a59eaa3980b02b3cd51e885a0c55a9
+Architectures: amd64, s390x
+GitCommit: 20c833d9ceb873c52469cdf7de1e533412ebfe0a
 Directory: 4.2
 
-Tags: 4.2.1-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 4.2.1-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.1, 4.2, 4, latest
+Tags: 4.2.2-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 4.2.2-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.2, 4.2, 4, latest
 Architectures: windows-amd64
-GitCommit: 62bea45864a0d356c346266b94b0fad1413ca033
+GitCommit: a1078156e52dc6952f3f787a67fa7b473ed18c0b
 Directory: 4.2/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.2.1-windowsservercore-1803, 4.2-windowsservercore-1803, 4-windowsservercore-1803, windowsservercore-1803
-SharedTags: 4.2.1-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.1, 4.2, 4, latest
+Tags: 4.2.2-windowsservercore-1809, 4.2-windowsservercore-1809, 4-windowsservercore-1809, windowsservercore-1809
+SharedTags: 4.2.2-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.2, 4.2, 4, latest
 Architectures: windows-amd64
-GitCommit: 62bea45864a0d356c346266b94b0fad1413ca033
-Directory: 4.2/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
-Tags: 4.2.1-windowsservercore-1809, 4.2-windowsservercore-1809, 4-windowsservercore-1809, windowsservercore-1809
-SharedTags: 4.2.1-windowsservercore, 4.2-windowsservercore, 4-windowsservercore, windowsservercore, 4.2.1, 4.2, 4, latest
-Architectures: windows-amd64
-GitCommit: 9ba0d6f19538d7922f62a41cea6589e366b100d3
+GitCommit: a1078156e52dc6952f3f787a67fa7b473ed18c0b
 Directory: 4.2/windows/windowsservercore-1809
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/6ac52e6: Remove EOL Windows 1803-based (SAC) images
- https://github.com/docker-library/mongo/commit/a107815: Update to 4.2.2