### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/julia/blob/efa44508a65752e70bc49732820c0c2df79740c7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/21f95e9cc42605de2b9bbf59960168cbdefdd7e6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -22,12 +22,12 @@ GitCommit: efa44508a65752e70bc49732820c0c2df79740c7
 Directory: 1.3/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.3.0-windowsservercore-1803, 1.3-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
+Tags: 1.3.0-windowsservercore-1809, 1.3-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
 SharedTags: 1.3.0, 1.3, 1, latest
 Architectures: windows-amd64
-GitCommit: efa44508a65752e70bc49732820c0c2df79740c7
-Directory: 1.3/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
+GitCommit: 21f95e9cc42605de2b9bbf59960168cbdefdd7e6
+Directory: 1.3/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
 
 Tags: 1.0.5-buster, 1.0-buster
 SharedTags: 1.0.5, 1.0
@@ -47,9 +47,9 @@ GitCommit: 4c770401df0b946da5cf61150bedb05280b218a6
 Directory: 1.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.0.5-windowsservercore-1803, 1.0-windowsservercore-1803
+Tags: 1.0.5-windowsservercore-1809, 1.0-windowsservercore-1809
 SharedTags: 1.0.5, 1.0
 Architectures: windows-amd64
-GitCommit: 4c770401df0b946da5cf61150bedb05280b218a6
-Directory: 1.0/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
+GitCommit: 21f95e9cc42605de2b9bbf59960168cbdefdd7e6
+Directory: 1.0/windows/windowsservercore-1809
+Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/21f95e9: Replace EOL Windows 1803-based (SAC) images with 1809-based (LTSC) images