### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/1ea0c7233e5c56ac59f7e0719df33f3a2bade7fc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/147f9b46c8934979f1afd77b048b510c6f29ee69/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -26,13 +26,6 @@ Architectures: windows-amd64
 GitCommit: 0ecd42b0e0b519259224959b8f9dc64e76d5a73e
 Directory: 3.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
-
-Tags: 3.8.0-windowsservercore-1803, 3.8-windowsservercore-1803, 3-windowsservercore-1803, windowsservercore-1803
-SharedTags: 3.8.0-windowsservercore, 3.8-windowsservercore, 3-windowsservercore, windowsservercore, 3.8.0, 3.8, 3, latest
-Architectures: windows-amd64
-GitCommit: 0ecd42b0e0b519259224959b8f9dc64e76d5a73e
-Directory: 3.8/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
 
 Tags: 3.8.0-windowsservercore-1809, 3.8-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.8.0-windowsservercore, 3.8-windowsservercore, 3-windowsservercore, windowsservercore, 3.8.0, 3.8, 3, latest
@@ -78,13 +71,6 @@ Architectures: windows-amd64
 GitCommit: 78ae92d7a478ecb98dc0db9ac3acf2d23bfd1bdb
 Directory: 3.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
-
-Tags: 3.7.5-windowsservercore-1803, 3.7-windowsservercore-1803
-SharedTags: 3.7.5-windowsservercore, 3.7-windowsservercore, 3.7.5, 3.7
-Architectures: windows-amd64
-GitCommit: 78ae92d7a478ecb98dc0db9ac3acf2d23bfd1bdb
-Directory: 3.7/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
 
 Tags: 3.7.5-windowsservercore-1809, 3.7-windowsservercore-1809
 SharedTags: 3.7.5-windowsservercore, 3.7-windowsservercore, 3.7.5, 3.7
@@ -192,13 +178,6 @@ Architectures: windows-amd64
 GitCommit: c4414a2fdbb7fa1e752f27565e41c7032b673a03
 Directory: 2.7/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
-
-Tags: 2.7.17-windowsservercore-1803, 2.7-windowsservercore-1803, 2-windowsservercore-1803
-SharedTags: 2.7.17-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.17, 2.7, 2
-Architectures: windows-amd64
-GitCommit: c4414a2fdbb7fa1e752f27565e41c7032b673a03
-Directory: 2.7/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
 
 Tags: 2.7.17-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
 SharedTags: 2.7.17-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.17, 2.7, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/147f9b4: Remove EOL Windows 1803-based (SAC) images