### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/ba5eb71bcc5a3f539dc0142dbc0d8dca0a4a30e0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/c4e34da5896ac4901bf14ff8f377d3d2a102eb4a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -28,26 +28,12 @@ GitCommit: c4125e0e6e3529f5524bd5e49b02767dd20532c8
 Directory: 1.13/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13.5-windowsservercore-1803, 1.13-windowsservercore-1803, 1-windowsservercore-1803, windowsservercore-1803
-SharedTags: 1.13.5-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.5, 1.13, 1, latest
-Architectures: windows-amd64
-GitCommit: c4125e0e6e3529f5524bd5e49b02767dd20532c8
-Directory: 1.13/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 1.13.5-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
 SharedTags: 1.13.5-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.5, 1.13, 1, latest
 Architectures: windows-amd64
 GitCommit: c4125e0e6e3529f5524bd5e49b02767dd20532c8
 Directory: 1.13/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 1.13.5-nanoserver-1803, 1.13-nanoserver-1803, 1-nanoserver-1803, nanoserver-1803
-SharedTags: 1.13.5-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: c4125e0e6e3529f5524bd5e49b02767dd20532c8
-Directory: 1.13/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 1.13.5-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
 SharedTags: 1.13.5-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
@@ -84,26 +70,12 @@ GitCommit: 3d800bdb5817168f16f4b8fca8bf19c4a967a488
 Directory: 1.12/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.12.14-windowsservercore-1803, 1.12-windowsservercore-1803
-SharedTags: 1.12.14-windowsservercore, 1.12-windowsservercore, 1.12.14, 1.12
-Architectures: windows-amd64
-GitCommit: 3d800bdb5817168f16f4b8fca8bf19c4a967a488
-Directory: 1.12/windows/windowsservercore-1803
-Constraints: windowsservercore-1803
-
 Tags: 1.12.14-windowsservercore-1809, 1.12-windowsservercore-1809
 SharedTags: 1.12.14-windowsservercore, 1.12-windowsservercore, 1.12.14, 1.12
 Architectures: windows-amd64
 GitCommit: 3d800bdb5817168f16f4b8fca8bf19c4a967a488
 Directory: 1.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 1.12.14-nanoserver-1803, 1.12-nanoserver-1803
-SharedTags: 1.12.14-nanoserver, 1.12-nanoserver
-Architectures: windows-amd64
-GitCommit: 3d800bdb5817168f16f4b8fca8bf19c4a967a488
-Directory: 1.12/windows/nanoserver-1803
-Constraints: nanoserver-1803, windowsservercore-1803
 
 Tags: 1.12.14-nanoserver-1809, 1.12-nanoserver-1809
 SharedTags: 1.12.14-nanoserver, 1.12-nanoserver


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/c4e34da: Remove EOL Windows 1803-based (SAC) images