### PR TITLE
Release Mono 6.6 as stable

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -4,25 +4,25 @@ Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
 GitRepo: https://github.com/mono/docker.git
 
-Tags: 6.4.0.198, latest, 6.4.0, 6.4, 6
+Tags: 6.6.0.161, latest, 6.6.0, 6.6, 6
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: 4374af564e9ffd69f526135fb78c148d0a03012a
+Directory: 6.6.0.161
+
+Tags: 6.6.0.161-slim, slim, 6.6.0-slim, 6.6-slim, 6-slim
+Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitCommit: 4374af564e9ffd69f526135fb78c148d0a03012a
+Directory: 6.6.0.161/slim
+
+Tags: 6.4.0.198, 6.4.0, 6.4
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
 Directory: 6.4.0.198
 
-Tags: 6.4.0.198-slim, slim, 6.4.0-slim, 6.4-slim, 6-slim
+Tags: 6.4.0.198-slim, 6.4.0-slim, 6.4-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
 Directory: 6.4.0.198/slim
-
-Tags: 6.0.0.334, 6.0.0, 6.0
-Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
-Directory: 6.0.0.334
-
-Tags: 6.0.0.334-slim, 6.0.0-slim, 6.0-slim
-Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: 1d31220a290b2b4d19654a8cdb4ba13888e29717
-Directory: 6.0.0.334/slim
 
 Tags: 5.20.1.34, 5.20.1, 5.20, 5
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le


### PR DESCRIPTION
I'm told 6.6 is stable now