### PR TITLE
Bump Traefik to v1.7.20

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -23,18 +23,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5617af7977d3933e07a9bbe170b7262607151cdf
 Directory: alpine
 
-Tags: v1.7.19-windowsservercore-1809, 1.7.19-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.20-windowsservercore-1809, 1.7.20-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
+GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.19-alpine, 1.7.19-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.20-alpine, 1.7.20-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
+GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
 Directory: alpine
 
-Tags: v1.7.19, 1.7.19, v1.7, 1.7, maroilles
+Tags: v1.7.20, 1.7.20, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: fffbc9254282cdd9496d6978aab070b798c6959d
+GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v1.7.20](https://github.com/containous/traefik/releases/tag/v1.7.20).

/cc @mmatur @emilevauge @dtomcej

Cheers
