### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.2, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9b5cc284abec6f7ed1483168a548e76cda59c3b
+GitCommit: 853ba639f40baeb1f6ae021730fe8b71386b0999
 Directory: 3.8/ubuntu
 
 Tags: 3.8.2-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.2-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9b5cc284abec6f7ed1483168a548e76cda59c3b
+GitCommit: 853ba639f40baeb1f6ae021730fe8b71386b0999
 Directory: 3.8/alpine
 
 Tags: 3.8.2-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.23, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 028ac5ad25254f2833ade6e864ac9ec4b4f0bcf4
+GitCommit: 5e85a579dd4b26be602ed1552f746ac5c56648d8
 Directory: 3.7/ubuntu
 
 Tags: 3.7.23-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.23-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 028ac5ad25254f2833ade6e864ac9ec4b4f0bcf4
+GitCommit: 5e85a579dd4b26be602ed1552f746ac5c56648d8
 Directory: 3.7/alpine
 
 Tags: 3.7.23-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/853ba63: Update to 3.8.2, Erlang/OTP 22.2, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/5e85a57: Update to 3.7.23, Erlang/OTP 22.2, OpenSSL 1.1.1d