### PR TITLE
Bump Traefik to v2.1.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.1.0-rc3-windowsservercore-1809, 2.1.0-rc3-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809
+Tags: v2.1.0-windowsservercore-1809, 2.1.0-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
+GitCommit: 29e15e35329937ca87fe38a28155e172faca769d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.0-rc3, 2.1.0-rc3, v2.1, 2.1, cantal
+Tags: v2.1.0, 2.1.0, v2.1, 2.1, cantal, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 3c4a65fb18c4a2102d4e018e05880e8c356a7d1b
-Directory: alpine
-
-Tags: v2.0.7-windowsservercore-1809, 2.0.7-windowsservercore-1809, v2.0-windowsservercore-1809, 2.0-windowsservercore-1809, montdor-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitCommit: 5617af7977d3933e07a9bbe170b7262607151cdf
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.0.7, 2.0.7, v2.0, 2.0, montdor, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 5617af7977d3933e07a9bbe170b7262607151cdf
+GitCommit: 29e15e35329937ca87fe38a28155e172faca769d
 Directory: alpine
 
 Tags: v1.7.20-windowsservercore-1809, 1.7.20-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.1.0](https://github.com/containous/traefik/releases/tag/v2.1.0).

/cc @mmatur @emilevauge @dtomcej

Cheers
