### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.1.0, 2.1, latest
+Tags: 2.1.1, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5993cb3c56edd07b4ad902f3d4ac0eaada8db9a0
+GitCommit: e74fecb9de2e2789ea647cfeba894d3bdfef8a27
 Directory: 2.1
 
-Tags: 2.1.0-alpine, 2.1-alpine, alpine
+Tags: 2.1.1-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5993cb3c56edd07b4ad902f3d4ac0eaada8db9a0
+GitCommit: e74fecb9de2e2789ea647cfeba894d3bdfef8a27
 Directory: 2.1/alpine
 
-Tags: 2.0.10, 2.0
+Tags: 2.0.11, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53a929dbf37c77816aed9af7864a3b6e7568937f
+GitCommit: 6c4c153089f23ac61de99cb6edc1ad21453125bb
 Directory: 2.0
 
-Tags: 2.0.10-alpine, 2.0-alpine
+Tags: 2.0.11-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53a929dbf37c77816aed9af7864a3b6e7568937f
+GitCommit: 6c4c153089f23ac61de99cb6edc1ad21453125bb
 Directory: 2.0/alpine
 
 Tags: 1.9.13, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e74fecb: Update to 2.1.1
- https://github.com/docker-library/haproxy/commit/6c4c153: Update to 2.0.11