### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 3306ec49a8c629f4fc9e6287c39c01d2dea8bda9
+GitCommit: 7637a2ea0c4b00734c1979613529be060fad5120
 Directory: dockerfiles-generated
 
 Tags: 0.17.0-python3.7-buster, 0.17-python3.7-buster, 0-python3.7-buster, python3.7-buster, 0.17.0-buster, 0.17-buster, 0-buster, buster
@@ -25,12 +25,6 @@ SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.python3.7-windowsservercore-1809
-
-Tags: 0.17.0-python3.7-windowsservercore-1803, 0.17-python3.7-windowsservercore-1803, 0-python3.7-windowsservercore-1803, python3.7-windowsservercore-1803, 0.17.0-windowsservercore-1803, 0.17-windowsservercore-1803, 0-windowsservercore-1803, windowsservercore-1803
-SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
-Architectures: windows-amd64
-Constraints: windowsservercore-1803
-File: Dockerfile.python3.7-windowsservercore-1803
 
 Tags: 0.17.0-python3.7-windowsservercore-ltsc2016, 0.17-python3.7-windowsservercore-ltsc2016, 0-python3.7-windowsservercore-ltsc2016, python3.7-windowsservercore-ltsc2016, 0.17.0-windowsservercore-ltsc2016, 0.17-windowsservercore-ltsc2016, 0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
@@ -94,12 +88,6 @@ SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.python2.7-windowsservercore-1809
-
-Tags: 0.17.0-python2.7-windowsservercore-1803, 0.17-python2.7-windowsservercore-1803, 0-python2.7-windowsservercore-1803, python2.7-windowsservercore-1803
-SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
-Architectures: windows-amd64
-Constraints: windowsservercore-1803
-File: Dockerfile.python2.7-windowsservercore-1803
 
 Tags: 0.17.0-python2.7-windowsservercore-ltsc2016, 0.17-python2.7-windowsservercore-ltsc2016, 0-python2.7-windowsservercore-ltsc2016, python2.7-windowsservercore-ltsc2016
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7


### PR DESCRIPTION
Remove EOL Windows 1803-based (SAC) images

See https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle (EOL 11/12/2019)