### PR TITLE
upgrade r-base to R 3.6.2 released yesterday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 3.6.1, latest
+Tags: 3.6.2, latest
 Architectures: amd64, arm64v8
-GitCommit: 919df9809c677916100cf837be687f6704d6b1b1
+GitCommit: df56b98e4a2a4611fa9aacae99c4a304531c2640
 Directory: r-base


### PR DESCRIPTION
standard R update based on the updated Debian package from yesterday's upstream release