### PR TITLE
Update jetty to include jdk13 and slim images

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -2,38 +2,38 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.4.24-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
-Architectures: amd64
+Tags: 9.4.26-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
+GitCommit: 4d8c5831719bd7dc409e990250e6c9ff95856b10
 
-Tags: 9.4.24-jre11, 9.4-jre11, 9-jre11
-Architectures: amd64
+Tags: 9.4.26-jre11, 9.4-jre11, 9-jre11
+Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
+GitCommit: 4d8c5831719bd7dc409e990250e6c9ff95856b10
 
-Tags: 9.4.24-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.26-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
+GitCommit: 4d8c5831719bd7dc409e990250e6c9ff95856b10
 
-Tags: 9.4.24-jdk13-slim, 9.4-jdk13-slim, 9-jdk13-slim
+Tags: 9.4.26-jdk13-slim, 9.4-jdk13-slim, 9-jdk13-slim
 Architectures: amd64
 Directory: 9.4-jdk13-slim
-GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
+GitCommit: 4d8c5831719bd7dc409e990250e6c9ff95856b10
 
-Tags: 9.4.24, 9.4, 9, 9.4.24-jdk13, 9.4-jdk13, 9-jdk13, latest, jdk13
+Tags: 9.4.26, 9.4, 9, 9.4.26-jdk13, 9.4-jdk13, 9-jdk13, latest, jdk13
 Architectures: amd64
 Directory: 9.4-jdk13
-GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
+GitCommit: 4d8c5831719bd7dc409e990250e6c9ff95856b10
 
 Tags: 9.3.28-jre8, 9.3-jre8
 Architectures: amd64
 Directory: 9.3-jre8
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 28562cbee783f1ccb94c375b7e9165c6cfe6d2e2
 
 Tags: 9.2.29-jre8, 9.2-jre8
 Architectures: amd64
 Directory: 9.2-jre8
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 28562cbee783f1ccb94c375b7e9165c6cfe6d2e2
 

--- a/library/jetty
+++ b/library/jetty
@@ -3,7 +3,7 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
 Tags: 9.4.24-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: 9.4-jre11-slim
 GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 

--- a/library/jetty
+++ b/library/jetty
@@ -2,37 +2,38 @@ Maintainers: Mike Dillon <mike@appropriate.io> (@md5),
              Greg Wilkins <gregw@webtide.com> (@gregw)
 GitRepo: https://github.com/appropriate/docker-jetty.git
 
-Tags: 9.4.18-jre11, 9.4-jre11, 9-jre11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 9.4.24-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Architectures: amd64, arm64v8
+Directory: 9.4-jre11-slim
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+
+Tags: 9.4.24-jre11, 9.4-jre11, 9-jre11
+Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 997e9496cc30fbc9afee70d7924e6f6a4a93e116
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
-Tags: 9.4.18, 9.4, 9, 9.4.18-jre8, 9.4-jre8, 9-jre8, latest, jre8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 9.4.24-jre8, 9.4-jre8, 9-jre8
+Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: 997e9496cc30fbc9afee70d7924e6f6a4a93e116
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
-Tags: 9.4.18-alpine, 9.4-alpine, 9-alpine, 9.4.18-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, alpine, jre8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-Directory: 9.4-jre8/alpine
-GitCommit: 997e9496cc30fbc9afee70d7924e6f6a4a93e116
+Tags: 9.4.24-jdk13-slim, 9.4-jdk13-slim, 9-jdk13-slim
+Architectures: amd64, arm64v8
+Directory: 9.4-jdk13-slim
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
-Tags: 9.3.27, 9.3, 9.3.27-jre8, 9.3-jre8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 9.4.24, 9.4, 9, 9.4.24-jdk13, 9.4-jdk13, 9-jdk13, latest, jdk13
+Architectures: amd64, arm64v8
+Directory: 9.4-jdk13
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+
+Tags: 9.3.28-jre8, 9.3-jre8
+Architectures: amd64
 Directory: 9.3-jre8
-GitCommit: 5643739bf5adead920f061a4f055cc7bbbc37888
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
-Tags: 9.3.27-alpine, 9.3-alpine, 9.3.27-jre8-alpine, 9.3-jre8-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-Directory: 9.3-jre8/alpine
-GitCommit: 5643739bf5adead920f061a4f055cc7bbbc37888
-
-Tags: 9.2.28, 9.2, 9.2.28-jre8, 9.2-jre8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 9.2.29-jre8, 9.2-jre8
+Architectures: amd64
 Directory: 9.2-jre8
-GitCommit: 5643739bf5adead920f061a4f055cc7bbbc37888
+GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
-Tags: 9.2.28-jre7, 9.2-jre7, 9-jre7, jre7
-Architectures: amd64, arm32v5, arm32v7, i386
-Directory: 9.2-jre7
-GitCommit: 5643739bf5adead920f061a4f055cc7bbbc37888

--- a/library/jetty
+++ b/library/jetty
@@ -8,7 +8,7 @@ Directory: 9.4-jre11-slim
 GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
 Tags: 9.4.24-jre11, 9.4-jre11, 9-jre11
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: 9.4-jre11
 GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 

--- a/library/jetty
+++ b/library/jetty
@@ -5,27 +5,27 @@ GitRepo: https://github.com/appropriate/docker-jetty.git
 Tags: 9.4.24-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64
 Directory: 9.4-jre11-slim
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
 
 Tags: 9.4.24-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64
 Directory: 9.4-jre11
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
 
 Tags: 9.4.24-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
 
 Tags: 9.4.24-jdk13-slim, 9.4-jdk13-slim, 9-jdk13-slim
 Architectures: amd64
 Directory: 9.4-jdk13-slim
-GitCommit: 823933aa1dcf95789ee1939cf26d5f4450099d25
+GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
 
 Tags: 9.4.24, 9.4, 9, 9.4.24-jdk13, 9.4-jdk13, 9-jdk13, latest, jdk13
 Architectures: amd64
 Directory: 9.4-jdk13
-GitCommit: 823933aa1dcf95789ee1939cf26d5f4450099d25
+GitCommit: 52ae70e1fb5a5e2a01639642d4cfd7092bd290d6
 
 Tags: 9.3.28-jre8, 9.3-jre8
 Architectures: amd64

--- a/library/jetty
+++ b/library/jetty
@@ -18,14 +18,14 @@ Directory: 9.4-jre8
 GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
 
 Tags: 9.4.24-jdk13-slim, 9.4-jdk13-slim, 9-jdk13-slim
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: 9.4-jdk13-slim
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 823933aa1dcf95789ee1939cf26d5f4450099d25
 
 Tags: 9.4.24, 9.4, 9, 9.4.24-jdk13, 9.4-jdk13, 9-jdk13, latest, jdk13
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: 9.4-jdk13
-GitCommit: bca7ee7ba90b432551df2de24dac36b782e2e2f4
+GitCommit: 823933aa1dcf95789ee1939cf26d5f4450099d25
 
 Tags: 9.3.28-jre8, 9.3-jre8
 Architectures: amd64


### PR DESCRIPTION
These images are based of a new staged Dockerfile and support JDK11, 13 and slim varients. The alpine varients are dropped.

Signed-off-by: Greg Wilkins <gregw@webtide.com>