### PR TITLE
update ROS2 Crystal Dashing and Eloquent

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -86,12 +86,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 1eb48f1275f0a9153d0b0ed088bed338f1a79ead
+GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: 1eb48f1275f0a9153d0b0ed088bed338f1a79ead
+GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
 Directory: ros/crystal/ubuntu/bionic/ros-base
 
 
@@ -103,12 +103,12 @@ Directory: ros/crystal/ubuntu/bionic/ros-base
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1eb48f1275f0a9153d0b0ed088bed338f1a79ead
+GitCommit: d188a5a15dba3d3fa266e4578c1ed2e1b4421c72
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1eb48f1275f0a9153d0b0ed088bed338f1a79ead
+GitCommit: d188a5a15dba3d3fa266e4578c1ed2e1b4421c72
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 
@@ -120,10 +120,10 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d3983aa82e927de86d777f1b42beb89dbdddb9ec
+GitCommit: 9b63c2f2a11ef18c93f7c8f35770625fc48181d8
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d3983aa82e927de86d777f1b42beb89dbdddb9ec
+GitCommit: 9b63c2f2a11ef18c93f7c8f35770625fc48181d8
 Directory: ros/eloquent/ubuntu/bionic/ros-base


### PR DESCRIPTION
Crystal: use snapshots repository before retiring
Dashing: 0.7.2 -> 0.7.3
Eloquent: 0.8.3 -> 0.8.4