### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 14-ea-26-jdk-oraclelinux7, 14-ea-26-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-26-jdk-oracle, 14-ea-26-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-26-jdk, 14-ea-26, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-27-jdk-oraclelinux7, 14-ea-27-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-27-jdk-oracle, 14-ea-27-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-27-jdk, 14-ea-27, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-26-jdk-buster, 14-ea-26-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-27-jdk-buster, 14-ea-27-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk
 
-Tags: 14-ea-26-jdk-slim-buster, 14-ea-26-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-26-jdk-slim, 14-ea-26-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-27-jdk-slim-buster, 14-ea-27-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-27-jdk-slim, 14-ea-27-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-26-jdk-windowsservercore-1809, 14-ea-26-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-26-jdk-windowsservercore, 14-ea-26-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-26-jdk, 14-ea-26, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-27-jdk-windowsservercore-1809, 14-ea-27-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-27-jdk-windowsservercore, 14-ea-27-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-27-jdk, 14-ea-27, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-26-jdk-windowsservercore-ltsc2016, 14-ea-26-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-26-jdk-windowsservercore, 14-ea-26-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-26-jdk, 14-ea-26, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-27-jdk-windowsservercore-ltsc2016, 14-ea-27-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-27-jdk-windowsservercore, 14-ea-27-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-27-jdk, 14-ea-27, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14-ea-26-jdk-nanoserver-1809, 14-ea-26-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
-SharedTags: 14-ea-26-jdk-nanoserver, 14-ea-26-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-ea-27-jdk-nanoserver-1809, 14-ea-27-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14-ea-27-jdk-nanoserver, 14-ea-27-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: 4cb67d65ec173de716bdc99b09be0bcb187f0850
+GitCommit: 8b49adae07cd3b86b3f52334434d00645889ff18
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8b49ada: Update to 14-ea+27