### PR TITLE
Update websphere-liberty to 19.0.0.12

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 0e11b18ce900797e50c8d7e7da55870fb94472c4
+GitCommit: 5d7f86fbf1e41f1992ad9641f06cb114bc20cec4
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -14,6 +14,14 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: full, latest
 Directory: ga/latest/full
+File: Dockerfile.ubuntu.ibmjava8
+
+Tags: 19.0.0.12-kernel-java8-ibmjava
+Directory: ga/19.0.0.12/kernel
+File: Dockerfile.ubuntu.ibmjava8
+
+Tags: 19.0.0.12-full-java8-ibmjava
+Directory: ga/19.0.0.12/full
 File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 19.0.0.9-kernel
@@ -95,30 +103,3 @@ Tags: 19.0.0.9-javaee7-java11
 Directory: ga/19.0.0.9/javaee7
 File: Dockerfile.java11
 Architectures: amd64, ppc64le, s390x
-
-Tags: 19.0.0.6-kernel
-Directory: ga/19.0.0.6/kernel
-
-Tags: 19.0.0.6-javaee8
-Directory: ga/19.0.0.6/javaee8
-
-Tags: 19.0.0.6-webProfile8
-Directory: ga/19.0.0.6/webProfile8
-
-Tags: 19.0.0.6-microProfile1
-Directory: ga/19.0.0.6/microProfile1
-
-Tags: 19.0.0.6-microProfile2
-Directory: ga/19.0.0.6/microProfile2
-
-Tags: 19.0.0.6-springBoot2
-Directory: ga/19.0.0.6/springBoot2
-
-Tags: 19.0.0.6-springBoot1
-Directory: ga/19.0.0.6/springBoot1
-
-Tags: 19.0.0.6-webProfile7
-Directory: ga/19.0.0.6/webProfile7
-
-Tags: 19.0.0.6-javaee7
-Directory: ga/19.0.0.6/javaee7


### PR DESCRIPTION
Replaces https://github.com/docker-library/official-images/pull/7118

Updates WebSphere Liberty to version 19.0.0.12