### PR TITLE
Fix full tag for WebSphere Liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 5d7f86fbf1e41f1992ad9641f06cb114bc20cec4
+GitCommit: 3c8a6c6ca9af05c504fb26788030e4f8ff5125b6
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
We have a tag called `full` that is supposed to contain all of the WebSphere Liberty features, for convenience and air-gapped scenarios.  We found out that we had missing features, so this new commit corrects that. 