### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.5.0
-GitCommit: cc94e7445ece47fe876e7ff70a2997d4ae2c5022
+Tags: 7.5.1
+GitCommit: c2f5a0165f9a3b6e071dfd413ea16fcca8522ff1
 Directory: 7
 
-Tags: 6.8.5
-GitCommit: fb24d2b5bdbc212787c066480d818851f4da8f86
+Tags: 6.8.6
+GitCommit: 4c04ee848e9183d70c6109e9325d6a40520d334d
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.5.0
-GitCommit: 36faeebe8ec7636c02ee060700eb9ec6cd5ed36c
+Tags: 7.5.1
+GitCommit: f6ea089ffdd329921f5aaf97d49288c9e1e411c7
 Directory: 7
 
-Tags: 6.8.5
-GitCommit: 090ae9080dd0bf75597a8f27a314854d06b50cb1
+Tags: 6.8.6
+GitCommit: 581e38e19e48fcae9ef2bf58afb20ffebe9da082
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.5.0
-GitCommit: 7ff29206aebd60c602ef05db0f316c26ad100502
+Tags: 7.5.1
+GitCommit: 8285a96df428bbc132e4650c6c4037617eeded12
 Directory: 7
 
-Tags: 6.8.5
-GitCommit: cbebabecdab7144b15e520000ca9a4a9b1a5e169
+Tags: 6.8.6
+GitCommit: befe697aacab90fc508ae0db4e292dae66a1820c
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/c2f5a01: Update to 7.5.1
- https://github.com/docker-library/elasticsearch/commit/4c04ee8: Update to 6.8.6

logstash:
- https://github.com/docker-library/logstash/commit/8285a96: Update to 7.5.1
- https://github.com/docker-library/logstash/commit/befe697: Update to 6.8.6

kibana:
- https://github.com/docker-library/kibana/commit/f6ea089: Update to 7.5.1
- https://github.com/docker-library/kibana/commit/581e38e: Update to 6.8.6