### PR TITLE
Add some tests for bundler finding binstubs

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -225,6 +225,7 @@ imageTests+=(
 		ruby-gems
 		ruby-bundler
 		ruby-nonroot
+		ruby-binstubs
 	'
 	[rust]='
 		rust-hello-world

--- a/test/tests/ruby-binstubs/Gemfile
+++ b/test/tests/ruby-binstubs/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'bundler-audit'
+gem 'brakeman'

--- a/test/tests/ruby-binstubs/container.sh
+++ b/test/tests/ruby-binstubs/container.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+dir="$(mktemp -d)"
+trap "rm -rf '$dir'" EXIT
+
+cp Gemfile "$dir"
+
+cd "$dir"
+
+gem install bundler -v "$1"
+bundle install
+bundle audit version

--- a/test/tests/ruby-binstubs/run.sh
+++ b/test/tests/ruby-binstubs/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eo pipefail
+
+testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
+runDir="$(dirname "$testDir")"
+
+"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.0.2
+"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.1.1


### PR DESCRIPTION
Hello! :wave:

We released bundler 2.1 a few days ago, and unfortunately we broke some stuff regarding official docker ruby images :disappointed:. See https://github.com/bundler/bundler/issues/7494.

Since I want to make sure this doesn't happen again, I'd like to add some tests to make sure it's all good with our releases :)

These tests currently fail against bundler 2.1.1, but I'm planning to fix this, of course.

Currently I'm slightly leaning towards fixing this inside the official images, but I'm open to discussing more, of course. There's a discussion about this in the linked bundler issue, with a proposed fix of setting `$GEM_PATH` and modifying `$PATH`.