### PR TITLE
Bump RethinkDB to 2.4.0

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,6 +1,6 @@
 Maintainers: Gábor Boros <gabor.brs@gmail.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
-GitCommit: 6efa057f145112f259949ce5b37a3bd6384eb5c5
+GitCommit: 54d3eebf6409b196264c193e0cbad027061739b3
 
-Tags: 2.3.7, 2.3, 2, latest
-Directory: bionic/2.3.7
+Tags: 2.4.0, 2.4, 2, latest
+Directory: bionic/2.4.0


### PR DESCRIPTION
Bump RethinkDB to 2.4.0 as the new release came out.