### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -80,17 +80,17 @@ GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: eoan
 
 Tags: focal-curl, 20.04-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
 Directory: focal/curl
 
 Tags: focal-scm, 20.04-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
 Directory: focal/scm
 
 Tags: focal, 20.04
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 1bf287b61b2c02d8890f4806a9bfb2c7042b308d
 Directory: focal
 


### PR DESCRIPTION
Following removal of i386 for `ubuntu:focal` (aka `20.04`) in https://github.com/docker-library/official-images/pull/7147.