### PR TITLE
Upgrade MediaWiki to 1.34.0

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,14 +2,14 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: f623859e09da4c3af9cb95a9464a43cad3177cd3
+GitCommit: a297d7afadf2c8f6038c85f15864ca6870b7df5a
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.33.1, 1.33, stable, latest
+Tags: 1.34.0, 1.34, stable, latest
+Directory: 1.34
+
+Tags: 1.33.2, 1.33.2, legacy
 Directory: 1.33
 
-Tags: 1.32.5, 1.32, legacy
-Directory: 1.32
-
-Tags: 1.31.5, 1.31, lts, legacylts
+Tags: 1.31.6, 1.31, lts, legacylts
 Directory: 1.31

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -8,7 +8,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 Tags: 1.34.0, 1.34, stable, latest
 Directory: 1.34
 
-Tags: 1.33.2, 1.33.2, legacy
+Tags: 1.33.2, 1.33, legacy
 Directory: 1.33
 
 Tags: 1.31.6, 1.31, lts, legacylts


### PR DESCRIPTION
Upgrade MediaWiki to the latest versions per:
https://tools.wmflabs.org/mwversion/