### PR TITLE
[security] Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,28 +4,28 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.0.5, 4.0, 4, latest
+Tags: 4.0.6, 4.0, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4064a505db909322bda24823c200f4c97985d638
+GitCommit: aabfc05b4b38b647dd94d452627829d399cf1cbf
 Directory: 4.0
 
-Tags: 4.0.5-passenger, 4.0-passenger, 4-passenger, passenger
+Tags: 4.0.6-passenger, 4.0-passenger, 4-passenger, passenger
 GitCommit: fd5541e76d7f2230484c19a784b8f9ee884559ce
 Directory: 4.0/passenger
 
-Tags: 4.0.5-alpine, 4.0-alpine, 4-alpine, alpine
-GitCommit: 4064a505db909322bda24823c200f4c97985d638
+Tags: 4.0.6-alpine, 4.0-alpine, 4-alpine, alpine
+GitCommit: aabfc05b4b38b647dd94d452627829d399cf1cbf
 Directory: 4.0/alpine
 
-Tags: 3.4.12, 3.4, 3
+Tags: 3.4.13, 3.4, 3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba9880cc3a224c7e5e15c1f9bf1757aa7c4c5b92
+GitCommit: 9a68b75d11b9113b9344571de14bf2ef00c327ba
 Directory: 3.4
 
-Tags: 3.4.12-passenger, 3.4-passenger, 3-passenger
+Tags: 3.4.13-passenger, 3.4-passenger, 3-passenger
 GitCommit: fd5541e76d7f2230484c19a784b8f9ee884559ce
 Directory: 3.4/passenger
 
-Tags: 3.4.12-alpine, 3.4-alpine, 3-alpine
-GitCommit: ba9880cc3a224c7e5e15c1f9bf1757aa7c4c5b92
+Tags: 3.4.13-alpine, 3.4-alpine, 3-alpine
+GitCommit: 9a68b75d11b9113b9344571de14bf2ef00c327ba
 Directory: 3.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/9a68b75: Update to 3.4.13
- https://github.com/docker-library/redmine/commit/aabfc05: Update to 4.0.6

See https://www.redmine.org/news/126