### PR TITLE
fix kong 1.4.0 tag

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -8,7 +8,7 @@ GitFetch: refs/tags/1.4.2
 Directory: alpine
 Architectures: amd64
 
-Tags: 1.4.0-ubuntu, 1.4-ubuntu, ubuntu
+Tags: 1.4.2-ubuntu, 1.4-ubuntu, ubuntu
 GitCommit: 3d81dc228e60ba75f1fc39b6d4808fd4ba95cd9e
 GitFetch: refs/tags/1.4.2
 Directory: ubuntu
@@ -20,6 +20,14 @@ GitFetch: refs/tags/1.4.2
 Constraints: !aufs
 Directory: centos
 Architectures: amd64
+
+# TODO(gszr) - to be removed once the 1.4.0-ubuntu tag
+# is rebuilt with the correct Kong version
+Tags: 1.4.0-ubuntu
+GitCommit: 3064639825d8f33fa84220993de49c5cfee5a3a9
+GitFetch: refs/tags/1.4.0
+Directory: ubuntu
+Architectures: amd64, arm64v8
 
 Tags: 1.3.0-alpine, 1.3.0, 1.3
 GitCommit: c99d107b7c82d1f58e913d2d2c8ac4fad1ee62f0


### PR DESCRIPTION
It was accidentally retagged as Kong 1.4.2.