### PR TITLE
Add `--deployment` flag check to ruby-bundler test

### DIFF
--- a/test/tests/ruby-bundler/container.sh
+++ b/test/tests/ruby-bundler/container.sh
@@ -12,5 +12,10 @@ BUNDLE_FROZEN=0 bundle install
 cp Gemfile.lock Gemfile.lock.orig
 BUNDLE_FROZEN=1 bundle install
 diff -u Gemfile.lock.orig Gemfile.lock >&2
-bundle install --deployment
+
+if ruby -rbundler -e 'exit Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2.1") ? 0 : 1'; then
+	BUNDLE_DEPLOYMENT=1 bundle install
+else
+	bundle install --deployment
+fi
 diff -u Gemfile.lock.orig Gemfile.lock >&2

--- a/test/tests/ruby-bundler/container.sh
+++ b/test/tests/ruby-bundler/container.sh
@@ -12,3 +12,5 @@ BUNDLE_FROZEN=0 bundle install
 cp Gemfile.lock Gemfile.lock.orig
 BUNDLE_FROZEN=1 bundle install
 diff -u Gemfile.lock.orig Gemfile.lock >&2
+bundle install --deployment
+diff -u Gemfile.lock.orig Gemfile.lock >&2


### PR DESCRIPTION
This PR adds a regression test for a recent issue that was introduced by `bundler` into the ruby docker images, as I mentioned I would do in https://github.com/docker-library/ruby/pull/289#issuecomment-510906568.