### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.1.1, 2.1, latest
+Tags: 2.1.2, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e74fecb9de2e2789ea647cfeba894d3bdfef8a27
+GitCommit: cc149313474c6d9f3b9b50a70656747ba7e50872
 Directory: 2.1
 
-Tags: 2.1.1-alpine, 2.1-alpine, alpine
+Tags: 2.1.2-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e74fecb9de2e2789ea647cfeba894d3bdfef8a27
+GitCommit: cc149313474c6d9f3b9b50a70656747ba7e50872
 Directory: 2.1/alpine
 
-Tags: 2.0.11, 2.0
+Tags: 2.0.12, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c4c153089f23ac61de99cb6edc1ad21453125bb
+GitCommit: 891e27621cf25e445bacdc3724b802aa70a8878c
 Directory: 2.0
 
-Tags: 2.0.11-alpine, 2.0-alpine
+Tags: 2.0.12-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c4c153089f23ac61de99cb6edc1ad21453125bb
+GitCommit: 891e27621cf25e445bacdc3724b802aa70a8878c
 Directory: 2.0/alpine
 
 Tags: 1.9.13, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/cc14931: Update to 2.1.2
- https://github.com/docker-library/haproxy/commit/891e276: Update to 2.0.12