### PR TITLE
Updating aarch64 tags for 7.7 and 7-slim.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -7,7 +7,7 @@ amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 9ae07ac03db04dd185594675256e03c215aba251
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 55c68d6966742243d955ee6c8b2c36d30b0689a1
+arm64v8-GitCommit: f9043d411c4ecbbe4dbff6f68be535ab33d65888
 Constraints: !aufs
 
 Tags: 8.0, 8

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -7,7 +7,7 @@ amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 9ae07ac03db04dd185594675256e03c215aba251
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1f220b00ca1a1da9cf186e461863a8e91454ff0b
+arm64v8-GitCommit: 55c68d6966742243d955ee6c8b2c36d30b0689a1
 Constraints: !aufs
 
 Tags: 8.0, 8


### PR DESCRIPTION
To match the `amd64` image updates pushed a few days ago.

Signed-off-by: Avi Miller <avi.miller@oracle.com>