### PR TITLE
alpine: bump 3.11.2

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.0, 3.11, 3, latest
+Tags: 3.11.2, 3.11, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: 1527654153837aabbc881783be404be36997689b
+GitCommit: f4269f46ab2be03d6367a6fe9c26c6fc4c0d6928
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
note that 3.11.1 was skipped due to a bad git tag :-/