### PR TITLE
Update irssi

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -6,10 +6,10 @@ GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.2.2, 1.2, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5de274fe7940e89aed8879daf12f36f117899994
+GitCommit: 773216139cd3685fd710b77dc7d4ee26ec9fb187
 Directory: debian
 
 Tags: 1.2.2-alpine, 1.2-alpine, 1-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 5de274fe7940e89aed8879daf12f36f117899994
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4eb15e5f0583e58b326282ce0b1454aa5df1cf31
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/jessfraz/irssi/commit/7732161: Switch to Debian Buster and use "set -e" instead of "&&" (https://github.com/jessfraz/irssi/pull/23)
- https://github.com/jessfraz/irssi/commit/4eb15e5: Update to Alpine 3.11 and use "set -e" instead of "&&" (https://github.com/jessfraz/irssi/pull/24)
- https://github.com/jessfraz/irssi/commit/2ff754f: Update generated README