### PR TITLE
Update run.sh to use the latest version of bundler (2.1.2)

### DIFF
--- a/test/tests/ruby-binstubs/run.sh
+++ b/test/tests/ruby-binstubs/run.sh
@@ -4,5 +4,4 @@ set -eo pipefail
 testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
 runDir="$(dirname "$testDir")"
 
-"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.0.2
-"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.1.1
+"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.1.2


### PR DESCRIPTION
This is causing test/failures in other repositories such as https://github.com/docker-library/ruby/pull/301