### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,50 +1,50 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/3b767347867328b98aefa48e60de95b2190f631e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/e0f00b9a0841c8b0f78faecd07afb4c5754b3c27/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.7.0-rc1-buster, 2.7-rc-buster, rc-buster, 2.7.0-rc1, 2.7-rc, rc
+Tags: 2.7.0-buster, 2.7-buster, 2-buster, buster, 2.7.0, 2.7, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 158d90b04f0dfeac68001c54dde423100d2aad33
-Directory: 2.7-rc/buster
+GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+Directory: 2.7/buster
 
-Tags: 2.7.0-rc1-slim-buster, 2.7-rc-slim-buster, rc-slim-buster, 2.7.0-rc1-slim, 2.7-rc-slim, rc-slim
+Tags: 2.7.0-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.0-slim, 2.7-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 158d90b04f0dfeac68001c54dde423100d2aad33
-Directory: 2.7-rc/buster/slim
+GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+Directory: 2.7/buster/slim
 
-Tags: 2.7.0-rc1-alpine3.10, 2.7-rc-alpine3.10, rc-alpine3.10, 2.7.0-rc1-alpine, 2.7-rc-alpine, rc-alpine
+Tags: 2.7.0-alpine3.10, 2.7-alpine3.10, 2-alpine3.10, alpine3.10, 2.7.0-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 158d90b04f0dfeac68001c54dde423100d2aad33
-Directory: 2.7-rc/alpine3.10
+GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+Directory: 2.7/alpine3.10
 
-Tags: 2.6.5-buster, 2.6-buster, 2-buster, buster, 2.6.5, 2.6, 2, latest
+Tags: 2.6.5-buster, 2.6-buster, 2.6.5, 2.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/buster
 
-Tags: 2.6.5-slim-buster, 2.6-slim-buster, 2-slim-buster, slim-buster, 2.6.5-slim, 2.6-slim, 2-slim, slim
+Tags: 2.6.5-slim-buster, 2.6-slim-buster, 2.6.5-slim, 2.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
 Directory: 2.6/buster/slim
 
-Tags: 2.6.5-stretch, 2.6-stretch, 2-stretch, stretch
+Tags: 2.6.5-stretch, 2.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/stretch
 
-Tags: 2.6.5-slim-stretch, 2.6-slim-stretch, 2-slim-stretch, slim-stretch
+Tags: 2.6.5-slim-stretch, 2.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.5-alpine3.10, 2.6-alpine3.10, 2-alpine3.10, alpine3.10, 2.6.5-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.5-alpine3.10, 2.6-alpine3.10, 2.6.5-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/alpine3.10
 
-Tags: 2.6.5-alpine3.9, 2.6-alpine3.9, 2-alpine3.9, alpine3.9
+Tags: 2.6.5-alpine3.9, 2.6-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
 Directory: 2.6/alpine3.9


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/e0f00b9: Upgrade to Ruby 2.7.0 GA (https://github.com/docker-library/ruby/pull/301)
- https://github.com/docker-library/ruby/commit/16829e9: Update to 2.7.0-rc2