### PR TITLE
Add Solr 8.4

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,12 +4,22 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.3.1, 8.3, 8, latest
+Tags: 8.4.0, 8.4, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: ebaee644db50346594bc36eeb602358edb7a2dd8
+Directory: 8.4
+
+Tags: 8.4.0-slim, 8.4-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: ebaee644db50346594bc36eeb602358edb7a2dd8
+Directory: 8.4/slim
+
+Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
 GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.3
 
-Tags: 8.3.1-slim, 8.3-slim, 8-slim, slim
+Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
 GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
 Directory: 8.3/slim


### PR DESCRIPTION
See [Announcement](http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201912.mbox/%3cCAPsWd+NPnY-0=H4-otoy4soSWvCwMckuWpaCOFM83J=DuhjjUw@mail.gmail.com%3e)

Make sure to read the [upgrade notes](https://lucene.apache.org/solr/guide/8_4/solr-upgrade-notes.html); there have been changes to the default config that may require you to take action.

One the docker-solr side, there was a fix to the `oom.sh` script, and some house-keeping changes.