### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 7637a2ea0c4b00734c1979613529be060fad5120
+GitCommit: 8c8dece8ba1c8528be0dac3a72f6a448186c6bc2
 Directory: dockerfiles-generated
 
 Tags: 0.17.0-python3.7-buster, 0.17-python3.7-buster, 0-python3.7-buster, python3.7-buster, 0.17.0-buster, 0.17-buster, 0-buster, buster
@@ -15,10 +15,6 @@ File: Dockerfile.python3.7-stretch
 Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.10
-
-Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.7-alpine3.9
 
 Tags: 0.17.0-python3.7-windowsservercore-1809, 0.17-python3.7-windowsservercore-1809, 0-python3.7-windowsservercore-1809, python3.7-windowsservercore-1809, 0.17.0-windowsservercore-1809, 0.17-windowsservercore-1809, 0-windowsservercore-1809, windowsservercore-1809
 SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
@@ -45,10 +41,6 @@ Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.10
 
-Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.6-alpine3.9
-
 Tags: 0.17.0-python3.5-buster, 0.17-python3.5-buster, 0-python3.5-buster, python3.5-buster
 SharedTags: 0.17.0-python3.5, 0.17-python3.5, 0-python3.5, python3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -62,10 +54,6 @@ Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.10
 
-Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.5-alpine3.9
-
 Tags: 0.17.0-python2.7-buster, 0.17-python2.7-buster, 0-python2.7-buster, python2.7-buster
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -78,10 +66,6 @@ File: Dockerfile.python2.7-stretch
 Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.10
-
-Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python2.7-alpine3.9
 
 Tags: 0.17.0-python2.7-windowsservercore-1809, 0.17-python2.7-windowsservercore-1809, 0-python2.7-windowsservercore-1809, python2.7-windowsservercore-1809
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/8c8dece: Remove EOL python image variants
- https://github.com/hylang/docker-hylang/commit/c0170cd: Ignore Python 3.8 explicitly for now