### PR TITLE
Improve Tomcat test to actually load some JSP

### DIFF
--- a/test/tests/tomcat-hello-world/index.jsp
+++ b/test/tests/tomcat-hello-world/index.jsp
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Sample JSP Page</title>
+	</head>
+	<body>
+		<%= new String("Hello") %> <%= new String("Docker") %> <%= new String("World!") %>
+	</body>
+</html>

--- a/test/tests/tomcat-hello-world/run.sh
+++ b/test/tests/tomcat-hello-world/run.sh
@@ -8,7 +8,11 @@ image="$1"
 # since the "slim" tomcat variants don't have wget, we'll use buildpack-deps
 clientImage='buildpack-deps:stretch-curl'
 
-serverImage="$1"
+serverImage="$("$dir/../image-name.sh" librarytest/tomcat-hello-world "$image")"
+"$dir/../docker-build.sh" "$dir" "$serverImage" <<EOD
+FROM $image
+COPY dir/index.jsp \$CATALINA_HOME/webapps/ROOT/
+EOD
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$serverImage")"
@@ -25,9 +29,6 @@ _request() {
 # Make sure that Tomcat is listening
 . "$dir/../../retry.sh" '_request / &> /dev/null'
 
-# Check that we can request /
-[ -n "$(_request '/')" ]
-
-# Check that the example "Hello World" servlet works
-helloWorld="$(_request '/examples/servlets/servlet/HelloWorldExample')"
-[[ "$helloWorld" == *'Hello World!'* ]]
+# Check that our simple servlet works
+helloWorld="$(_request '/')"
+[[ "$helloWorld" == *'Hello Docker World!'* ]]


### PR DESCRIPTION
Instead of relying on existing example applets (https://github.com/docker-library/tomcat/pull/181), this loads a very simple `index.jsp` file into the Tomcat webapps and verifies that it gets executed correctly.