### PR TITLE
Add TLS variant of "redis-basics" test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -208,6 +208,7 @@ imageTests+=(
 	'
 	[redis]='
 		redis-basics
+		redis-basics-tls
 		redis-basics-config
 		redis-basics-persistent
 	'

--- a/test/tests/redis-basics-tls/run.sh
+++ b/test/tests/redis-basics-tls/run.sh
@@ -1,0 +1,1 @@
+../redis-basics/run.sh

--- a/test/tests/redis-basics/run.sh
+++ b/test/tests/redis-basics/run.sh
@@ -5,6 +5,56 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 image="$1"
 
+cliFlags=( -h redis )
+
+testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
+testName="$(basename "$testDir")"
+if [[ "$testName" == *tls* ]]; then
+	redisCliHelp="$(docker run --rm --entrypoint redis-cli "$image" --help 2>&1 || :)"
+	if ! grep -q -- '--tls' <<<"$redisCliHelp"; then
+		echo >&2 "skipping; not built with TLS support (possibly version < 6.0 or 32bit variant)"
+		exit 0
+	fi
+
+	tlsImage="$("$testDir/../image-name.sh" librarytest/redis-tls "$image")"
+	"$testDir/../docker-build.sh" "$testDir" "$tlsImage" <<-EOD
+		FROM alpine:3.11 AS certs
+		RUN apk add --no-cache openssl
+		RUN set -eux; \
+			mkdir /certs; \
+			openssl genrsa -out /certs/ca-private.key 8192; \
+			openssl req -new -x509 \
+				-key /certs/ca-private.key \
+				-out /certs/ca.crt \
+				-days $(( 365 * 30 )) \
+				-subj '/CN=lolca'; \
+			openssl genrsa -out /certs/private.key 4096; \
+			openssl req -new -key /certs/private.key \
+				-out /certs/cert.csr -subj '/CN=redis'; \
+			openssl x509 -req -in /certs/cert.csr \
+				-CA /certs/ca.crt -CAkey /certs/ca-private.key -CAcreateserial \
+				-out /certs/cert.crt -days $(( 365 * 30 )); \
+			openssl verify -CAfile /certs/ca.crt /certs/cert.crt
+
+		FROM $image
+		COPY --from=certs --chown=redis:redis /certs /certs
+		CMD [ \
+			"--tls-port", "6379", "--port", "0", \
+			"--tls-cert-file", "/certs/cert.crt", \
+			"--tls-key-file", "/certs/private.key", \
+			"--tls-ca-cert-file", "/certs/ca.crt" \
+		]
+	EOD
+	image="$tlsImage"
+
+	cliFlags+=(
+		--tls
+		--cert /certs/cert.crt
+		--key /certs/private.key
+		--cacert /certs/ca.crt
+	)
+fi
+
 cname="redis-container-$RANDOM-$RANDOM"
 cid="$(docker run -d --name "$cname" "$image")"
 trap "docker rm -vf $cid > /dev/null" EXIT
@@ -14,12 +64,11 @@ redis-cli() {
 		--link "$cname":redis \
 		--entrypoint redis-cli \
 		"$image" \
-		-h redis \
+		"${cliFlags[@]}" \
 		"$@"
 }
 
 # http://redis.io/topics/quickstart#check-if-redis-is-working
-
 . "$dir/../../retry.sh" --tries 20 '[ "$(redis-cli ping)" = "PONG" ]'
 
 [ "$(redis-cli set mykey somevalue)" = 'OK' ]


### PR DESCRIPTION
This only applies on 6.0+ and even then only after https://github.com/docker-library/redis/pull/218 merges.