### PR TITLE
Only test whatever bundler version comes with ruby by default

### DIFF
--- a/test/tests/ruby-binstubs/container.sh
+++ b/test/tests/ruby-binstubs/container.sh
@@ -8,6 +8,5 @@ cp Gemfile "$dir"
 
 cd "$dir"
 
-gem install bundler -v "$1"
 bundle install
 bundle audit version

--- a/test/tests/ruby-binstubs/run.sh
+++ b/test/tests/ruby-binstubs/run.sh
@@ -1,8 +1,1 @@
-#!/bin/bash
-set -eo pipefail
-
-testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
-runDir="$(dirname "$testDir")"
-
-"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.0.2
-"$runDir/run-in-container.sh" "$testDir" "$1" sh ./container.sh 2.1.1
+../run-sh-in-container.sh


### PR DESCRIPTION
This is a follow up to #7166.

I think the docker images tests should only care about the software they include by default, not about potential software that might get installed on them.

So, I think it's better that for each ruby version, we test against whatever bundler version comes with it by default.

This PR supersedes #7208.