### PR TITLE
Update Clear Linux OS to 32020

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -1,4 +1,4 @@
 # maintainer: William Douglas <william.douglas@intel.com> (@bryteise)
 
-latest: git://github.com/clearlinux/docker-brew-clearlinux@705a696de76155c812a7086a6e2b09ec6dcd46fa
-base: git://github.com/clearlinux/docker-brew-clearlinux@705a696de76155c812a7086a6e2b09ec6dcd46fa
+latest: git://github.com/clearlinux/docker-brew-clearlinux@0243c89dac41db8d4b486bed1e19015647b9abfc
+base: git://github.com/clearlinux/docker-brew-clearlinux@0243c89dac41db8d4b486bed1e19015647b9abfc


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 32020

@bryteise @gtkramer