### PR TITLE
XWiki 11.10.2 is now the LTS

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -4,22 +4,22 @@
 Maintainers: XWiki Core Dev Team <committers@xwiki.org> (@xwiki)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
-Tags: 10, 10.11, 10.11.10, 10-mysql-tomcat, mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 10, 10.11, 10.11.10, 10-mysql-tomcat
 Architectures: amd64
 GitCommit: 633cc1bbd533a45b6dafe205f817b8afb45d5a9a
 Directory: 10/mysql-tomcat
 
-Tags: 10-postgres-tomcat, 10.11-postgres-tomcat, 10.11.10-postgres-tomcat, postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 10-postgres-tomcat, 10.11-postgres-tomcat, 10.11.10-postgres-tomcat
 Architectures: amd64
 GitCommit: 633cc1bbd533a45b6dafe205f817b8afb45d5a9a
 Directory: 10/postgres-tomcat
 
-Tags: 11, 11.10, 11.10.2, 11-mysql-tomcat, 11.10-mysql-tomcat, 11.10.2-mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest
+Tags: 11, 11.10, 11.10.2, 11-mysql-tomcat, 11.10-mysql-tomcat, 11.10.2-mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest, mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64
 GitCommit: ab4e20f0ae8562b801f7f4901b931b8d9405b697
 Directory: 11/mysql-tomcat
 
-Tags: 11-postgres-tomcat, 11.10-postgres-tomcat, 11.10.2-postgres-tomcat, stable-postgres-tomcat, stable-postgres
+Tags: 11-postgres-tomcat, 11.10-postgres-tomcat, 11.10.2-postgres-tomcat, stable-postgres-tomcat, stable-postgres, postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 GitCommit: ab4e20f0ae8562b801f7f4901b931b8d9405b697
 Directory: 11/postgres-tomcat


### PR DESCRIPTION
Keep the 10.x tags till we release the last version of that previous LTS, so that we have a last docker image for it.