### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,110 +6,110 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.7.0-buster, 2.7-buster, 2-buster, buster, 2.7.0, 2.7, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.7/buster
 
 Tags: 2.7.0-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.0-slim, 2.7-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.7/buster/slim
 
 Tags: 2.7.0-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11, 2.7.0-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: defb10adcd6dd2178be3cd9c884fd035b52d42fb
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.7/alpine3.11
 
 Tags: 2.7.0-alpine3.10, 2.7-alpine3.10, 2-alpine3.10, alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0f00b9a0841c8b0f78faecd07afb4c5754b3c27
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.7/alpine3.10
 
 Tags: 2.6.5-buster, 2.6-buster, 2.6.5, 2.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/buster
 
 Tags: 2.6.5-slim-buster, 2.6-slim-buster, 2.6.5-slim, 2.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/buster/slim
 
 Tags: 2.6.5-stretch, 2.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/stretch
 
 Tags: 2.6.5-slim-stretch, 2.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8565a59602d3a95f5e858eb758aba0dcd6fce007
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/stretch/slim
 
 Tags: 2.6.5-alpine3.11, 2.6-alpine3.11, 2.6.5-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: defb10adcd6dd2178be3cd9c884fd035b52d42fb
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/alpine3.11
 
 Tags: 2.6.5-alpine3.10, 2.6-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c9e21cbf79b7f36d505555c9ecd62cf0f7e07f8
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.6/alpine3.10
 
 Tags: 2.5.7-buster, 2.5-buster, 2.5.7, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/buster
 
 Tags: 2.5.7-slim-buster, 2.5-slim-buster, 2.5.7-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 21c98da485e331cdc2518e80ff91e48335041dec
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/buster/slim
 
 Tags: 2.5.7-stretch, 2.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/stretch
 
 Tags: 2.5.7-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 21c98da485e331cdc2518e80ff91e48335041dec
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/stretch/slim
 
 Tags: 2.5.7-alpine3.11, 2.5-alpine3.11, 2.5.7-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: defb10adcd6dd2178be3cd9c884fd035b52d42fb
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/alpine3.11
 
 Tags: 2.5.7-alpine3.10, 2.5-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf0e16e7511c97fdf351fdfc2e7e17478a4eaf16
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.5/alpine3.10
 
 Tags: 2.4.9-buster, 2.4-buster, 2.4.9, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/buster
 
 Tags: 2.4.9-slim-buster, 2.4-slim-buster, 2.4.9-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/buster/slim
 
 Tags: 2.4.9-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/stretch
 
 Tags: 2.4.9-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/stretch/slim
 
 Tags: 2.4.9-alpine3.11, 2.4-alpine3.11, 2.4.9-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: defb10adcd6dd2178be3cd9c884fd035b52d42fb
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/alpine3.11
 
 Tags: 2.4.9-alpine3.10, 2.4-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 924602dc917e27f8af6b35f838d11e7f3f39b2dc
+GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
 Directory: 2.4/alpine3.10


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/e30082f: Merge pull request https://github.com/docker-library/ruby/pull/306 from deivid-rodriguez/add_path_scoped_to_ruby_version_to_path_and_gem_path
- https://github.com/docker-library/ruby/commit/82eecb7: Alternative fix
- https://github.com/docker-library/ruby/commit/7df74ad: Add paths scoped to ruby version to PATH and GEM_PATH
- https://github.com/docker-library/ruby/commit/8f3650c: Remove unnecessary PATH modification