### PR TITLE
Bump Traefik to v2.1.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.1.1-windowsservercore-1809, 2.1.1-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
+Tags: v2.1.2-windowsservercore-1809, 2.1.2-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: b8287957384e1f425f810ad05aaa87d0e77b3268
+GitCommit: 1dd2f83eeb4b5660ddc8a790cdd5ab24cf4cb67b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.1, 2.1.1, v2.1, 2.1, cantal, latest
+Tags: v2.1.2, 2.1.2, v2.1, 2.1, cantal, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: b8287957384e1f425f810ad05aaa87d0e77b3268
+GitCommit: 1dd2f83eeb4b5660ddc8a790cdd5ab24cf4cb67b
 Directory: alpine
 
 Tags: v1.7.20-windowsservercore-1809, 1.7.20-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.1.2](https://github.com/containous/traefik/releases/tag/v2.1.2).

/cc @mmatur @emilevauge @dtomcej

Cheers
