### PR TITLE
rebuild kong 1.4.2

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -23,19 +23,19 @@ Directory: centos
 Architectures: amd64
 
 Tags: 1.4.2-alpine, 1.4.2, 1.4, alpine, latest
-GitCommit: 3d81dc228e60ba75f1fc39b6d4808fd4ba95cd9e
+GitCommit: 77e38f9a35cc7824cab55443822764d2793ce91c
 GitFetch: refs/tags/1.4.2
 Directory: alpine
 Architectures: amd64
 
 Tags: 1.4.2-ubuntu, 1.4-ubuntu, ubuntu
-GitCommit: 3d81dc228e60ba75f1fc39b6d4808fd4ba95cd9e
+GitCommit: 77e38f9a35cc7824cab55443822764d2793ce91c
 GitFetch: refs/tags/1.4.2
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 1.4.2-centos, 1.4-centos, centos
-GitCommit: 3d81dc228e60ba75f1fc39b6d4808fd4ba95cd9e
+GitCommit: 77e38f9a35cc7824cab55443822764d2793ce91c
 GitFetch: refs/tags/1.4.2
 Constraints: !aufs
 Directory: centos


### PR DESCRIPTION
Per https://github.com/Kong/kong/issues/5388 the Ubuntu arm64 build was mistakenly an amd64 build.

The only image that needs to be updated is the Ubuntu Xenial arm64 but I believe that's not possible. The git diff of the previous 1.4.2 and this 1.4.2 is here https://github.com/Kong/docker-kong/commit/77e38f9a35cc7824cab55443822764d2793ce91c