### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -85,41 +85,41 @@ GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 13.0.1-jdk-oraclelinux7, 13.0.1-oraclelinux7, 13.0-jdk-oraclelinux7, 13.0-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13.0.1-jdk-oracle, 13.0.1-oracle, 13.0-jdk-oracle, 13.0-oracle, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
-SharedTags: 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
+Tags: 13.0.2-jdk-oraclelinux7, 13.0.2-oraclelinux7, 13.0-jdk-oraclelinux7, 13.0-oraclelinux7, 13-jdk-oraclelinux7, 13-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 13.0.2-jdk-oracle, 13.0.2-oracle, 13.0-jdk-oracle, 13.0-oracle, 13-jdk-oracle, 13-oracle, jdk-oracle, oracle
+SharedTags: 13.0.2-jdk, 13.0.2, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/oracle
 Constraints: !aufs
 
-Tags: 13.0.1-jdk-buster, 13.0.1-buster, 13.0-jdk-buster, 13.0-buster, 13-jdk-buster, 13-buster, jdk-buster, buster
+Tags: 13.0.2-jdk-buster, 13.0.2-buster, 13.0-jdk-buster, 13.0-buster, 13-jdk-buster, 13-buster, jdk-buster, buster
 Architectures: amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk
 
-Tags: 13.0.1-jdk-slim-buster, 13.0.1-slim-buster, 13.0-jdk-slim-buster, 13.0-slim-buster, 13-jdk-slim-buster, 13-slim-buster, jdk-slim-buster, slim-buster, 13.0.1-jdk-slim, 13.0.1-slim, 13.0-jdk-slim, 13.0-slim, 13-jdk-slim, 13-slim, jdk-slim, slim
+Tags: 13.0.2-jdk-slim-buster, 13.0.2-slim-buster, 13.0-jdk-slim-buster, 13.0-slim-buster, 13-jdk-slim-buster, 13-slim-buster, jdk-slim-buster, slim-buster, 13.0.2-jdk-slim, 13.0.2-slim, 13.0-jdk-slim, 13.0-slim, 13-jdk-slim, 13-slim, jdk-slim, slim
 Architectures: amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/slim
 
-Tags: 13.0.1-jdk-windowsservercore-1809, 13.0.1-windowsservercore-1809, 13.0-jdk-windowsservercore-1809, 13.0-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
+Tags: 13.0.2-jdk-windowsservercore-1809, 13.0.2-windowsservercore-1809, 13.0-jdk-windowsservercore-1809, 13.0-windowsservercore-1809, 13-jdk-windowsservercore-1809, 13-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 13.0.2-jdk-windowsservercore, 13.0.2-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.2-jdk, 13.0.2, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 13.0.1-jdk-windowsservercore-ltsc2016, 13.0.1-windowsservercore-ltsc2016, 13.0-jdk-windowsservercore-ltsc2016, 13.0-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 13.0.1-jdk-windowsservercore, 13.0.1-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.1-jdk, 13.0.1, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
+Tags: 13.0.2-jdk-windowsservercore-ltsc2016, 13.0.2-windowsservercore-ltsc2016, 13.0-jdk-windowsservercore-ltsc2016, 13.0-windowsservercore-ltsc2016, 13-jdk-windowsservercore-ltsc2016, 13-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 13.0.2-jdk-windowsservercore, 13.0.2-windowsservercore, 13.0-jdk-windowsservercore, 13.0-windowsservercore, 13-jdk-windowsservercore, 13-windowsservercore, jdk-windowsservercore, windowsservercore, 13.0.2-jdk, 13.0.2, 13.0-jdk, 13.0, 13-jdk, 13, jdk, latest
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 13.0.1-jdk-nanoserver-1809, 13.0.1-nanoserver-1809, 13.0-jdk-nanoserver-1809, 13.0-nanoserver-1809, 13-jdk-nanoserver-1809, 13-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 13.0.1-jdk-nanoserver, 13.0.1-nanoserver, 13.0-jdk-nanoserver, 13.0-nanoserver, 13-jdk-nanoserver, 13-nanoserver, jdk-nanoserver, nanoserver
+Tags: 13.0.2-jdk-nanoserver-1809, 13.0.2-nanoserver-1809, 13.0-jdk-nanoserver-1809, 13.0-nanoserver-1809, 13-jdk-nanoserver-1809, 13-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 13.0.2-jdk-nanoserver, 13.0.2-nanoserver, 13.0-jdk-nanoserver, 13.0-nanoserver, 13-jdk-nanoserver, 13-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/626e2f8: Update to 13.0.2