### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -63,13 +63,3 @@ Tags: 1.6.15-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
 Directory: 1.6/alpine
-
-Tags: 1.5.19, 1.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d21ad4557dd2ea46cba1f05a75dcd39ee42c5c56
-Directory: 1.5
-
-Tags: 1.5.19-alpine, 1.5-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: af7ea81960c11b73b8a328e65f97df62a389cd10
-Directory: 1.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c0760be: Merge pull request https://github.com/docker-library/haproxy/pull/108 from TimWolla/haproxy-1.5-eol
- https://github.com/docker-library/haproxy/commit/7789a9e: Drop 1.5 from travis.yml
- https://github.com/docker-library/haproxy/commit/94b9638: Remove HAProxy 1.5 (EOL)