### PR TITLE
Update Ghost to 3.3.0, 2.38.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.2.0, 3.2, 3, latest
+Tags: 3.3.0, 3.3, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6621b1ef3c1f6585dbb48ebfb6bd5827a59fdb2d
+GitCommit: 399fc7055104fea391d55b387f031b305ee4ad11
 Directory: 3/debian
 
-Tags: 3.2.0-alpine, 3.2-alpine, 3-alpine, alpine
+Tags: 3.3.0-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6621b1ef3c1f6585dbb48ebfb6bd5827a59fdb2d
+GitCommit: e5bb779011d30662e0c46d3bdf4aaf428f92e28f
 Directory: 3/alpine
 
-Tags: 2.37.2, 2.37, 2
+Tags: 2.38.0, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4a486f7f6ae1caa646c2b65f1c1a96c1614be879
+GitCommit: 399fc7055104fea391d55b387f031b305ee4ad11
 Directory: 2/debian
 
-Tags: 2.37.2-alpine, 2.37-alpine, 2-alpine
+Tags: 2.38.0-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4a486f7f6ae1caa646c2b65f1c1a96c1614be879
+GitCommit: e5bb779011d30662e0c46d3bdf4aaf428f92e28f
 Directory: 2/alpine
 
 Tags: 1.26.2, 1.26, 1


### PR DESCRIPTION
This intentionally does not touch the 1.x series -- there are deeper issues there being discussed in https://github.com/docker-library/ghost/issues/203.

This also includes fixes for `node:xxx-slim` removing `wget`. :+1: