### PR TITLE
Update Amazon Corretto (8.242.07.1 and 11.0.6.10.1).

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -3,14 +3,14 @@ Maintainers: Amazon Corretto Team (@corretto),
              Ziyi Luo (@ziyiluo),
              David Alvarez (@alvdavi)
 
-Tags: 8, 8u232, 8-al2-full, latest
+Tags: 8, 8u242, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: 36e50e6fec65b3b12fa4e595e8b8fa1def0b39f5
+GitCommit: e07146d6fa3b2a3a9ae401337c18318e7607be3a
 Architectures: amd64, arm64v8
 
-Tags: 11, 11.0.5, 11-al2-full
+Tags: 11, 11.0.6, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: 8a8fdf18ac8700a98bf8995cc85ec70616e5e130
+GitCommit: a797c24219a9262e581ee70fc928c57acacde331
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Quarterly update based on OpenJDK8u242 and OpenJDK11.0.6.