### PR TITLE
Convertigo official 7.7.0 release.

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -5,12 +5,3 @@ GitCommit: ff803d19e19d8be0712f16a39f07142c587e6a34
 Tags: 7.7.0, 7.7, latest
 Architectures: amd64
 Directory: docker/default
-
-Tags: 7.7.0-aks, 7.7-aks, aks
-Architectures: amd64
-Directory: docker/aks
-
-Tags: 7.6.6, 7.6
-GitCommit: cba10f7401396ca6249bad74ba041837077f9738
-Architectures: amd64
-Directory: docker/default

--- a/library/convertigo
+++ b/library/convertigo
@@ -1,15 +1,16 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/convertigo
-GitCommit: cba10f7401396ca6249bad74ba041837077f9738
+GitCommit: ff803d19e19d8be0712f16a39f07142c587e6a34
 
-Tags: 7.6.6, 7.6, latest
+Tags: 7.7.0, 7.7, latest
 Architectures: amd64
 Directory: docker/default
 
-Tags: 7.6.6-slim, 7.6-slim, slim
+Tags: 7.7.0-aks, 7.7-aks, aks
 Architectures: amd64
-Directory: docker/slim
+Directory: docker/aks
 
-Tags: 7.6.6-openj9, 7.6-openj9, openj9
+Tags: 7.6.6, 7.6
+GitCommit: cba10f7401396ca6249bad74ba041837077f9738
 Architectures: amd64
-Directory: docker/openj9
+Directory: docker/default


### PR DESCRIPTION
Adds a AKS version with specific Kubernetes tools installed.

Still maintains the 7.6.x versions.

Happy new year and thx !