### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,59 +4,59 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-4-jdk-oraclelinux7, 15-ea-4-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-4-jdk-oracle, 15-ea-4-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-4-jdk, 15-ea-4, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-5-jdk-oraclelinux7, 15-ea-5-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-5-jdk-oracle, 15-ea-5-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-5-jdk, 15-ea-5, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk/oracle
 Constraints: !aufs
 
-Tags: 15-ea-4-jdk-buster, 15-ea-4-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-5-jdk-buster, 15-ea-5-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk
 
-Tags: 15-ea-4-jdk-slim-buster, 15-ea-4-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-4-jdk-slim, 15-ea-4-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-5-jdk-slim-buster, 15-ea-5-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-5-jdk-slim, 15-ea-5-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk/slim
 
-Tags: 15-ea-4-jdk-windowsservercore-1809, 15-ea-4-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-4-jdk-windowsservercore, 15-ea-4-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-4-jdk, 15-ea-4, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-5-jdk-windowsservercore-1809, 15-ea-5-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-5-jdk-windowsservercore, 15-ea-5-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-5-jdk, 15-ea-5, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-4-jdk-windowsservercore-ltsc2016, 15-ea-4-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-4-jdk-windowsservercore, 15-ea-4-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-4-jdk, 15-ea-4, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-5-jdk-windowsservercore-ltsc2016, 15-ea-5-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-5-jdk-windowsservercore, 15-ea-5-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-5-jdk, 15-ea-5, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-4-jdk-nanoserver-1809, 15-ea-4-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-4-jdk-nanoserver, 15-ea-4-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-5-jdk-nanoserver-1809, 15-ea-5-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-5-jdk-nanoserver, 15-ea-5-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 80b2255fe8ec9b9374e3f77f426855b627f40114
+GitCommit: 61f394957893cfc3c00a66acdecffda579cc14ec
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14-ea-30-jdk-oraclelinux7, 14-ea-30-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-30-jdk-oracle, 14-ea-30-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-30-jdk, 14-ea-30, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-31-jdk-oraclelinux7, 14-ea-31-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-31-jdk-oracle, 14-ea-31-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-31-jdk, 14-ea-31, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-30-jdk-buster, 14-ea-30-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-31-jdk-buster, 14-ea-31-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk
 
-Tags: 14-ea-30-jdk-slim-buster, 14-ea-30-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-30-jdk-slim, 14-ea-30-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-31-jdk-slim-buster, 14-ea-31-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-31-jdk-slim, 14-ea-31-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk/slim
 
 Tags: 14-ea-15-jdk-alpine3.10, 14-ea-15-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-15-jdk-alpine, 14-ea-15-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -64,24 +64,24 @@ Architectures: amd64
 GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-30-jdk-windowsservercore-1809, 14-ea-30-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-30-jdk-windowsservercore, 14-ea-30-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-30-jdk, 14-ea-30, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-31-jdk-windowsservercore-1809, 14-ea-31-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-31-jdk-windowsservercore, 14-ea-31-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-31-jdk, 14-ea-31, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-30-jdk-windowsservercore-ltsc2016, 14-ea-30-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-30-jdk-windowsservercore, 14-ea-30-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-30-jdk, 14-ea-30, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-31-jdk-windowsservercore-ltsc2016, 14-ea-31-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-31-jdk-windowsservercore, 14-ea-31-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-31-jdk, 14-ea-31, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14-ea-30-jdk-nanoserver-1809, 14-ea-30-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
-SharedTags: 14-ea-30-jdk-nanoserver, 14-ea-30-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-ea-31-jdk-nanoserver-1809, 14-ea-31-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14-ea-31-jdk-nanoserver, 14-ea-31-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: 3e8bce63c989cdc8a2f121695d64a3717a9ad2dd
+GitCommit: bb3f1d5de6f9e2448b3c0ecb243029dbd2f2db20
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -123,67 +123,67 @@ GitCommit: 626e2f82bb753cb530feea7955698c29d346e738
 Directory: 13/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.5-jdk-stretch, 11.0.5-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
-SharedTags: 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.6-jdk-stretch, 11.0.6-stretch, 11.0-jdk-stretch, 11.0-stretch, 11-jdk-stretch, 11-stretch
+SharedTags: 11.0.6-jdk, 11.0.6, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jdk
 
-Tags: 11.0.5-jdk-slim-buster, 11.0.5-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.5-jdk-slim, 11.0.5-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.6-jdk-slim-buster, 11.0.6-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.6-jdk-slim, 11.0.6-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jdk/slim
 
-Tags: 11.0.5-jdk-windowsservercore-1809, 11.0.5-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.6-jdk-windowsservercore-1809, 11.0.6-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.6-jdk-windowsservercore, 11.0.6-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.6-jdk, 11.0.6, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.5-jdk-windowsservercore-ltsc2016, 11.0.5-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.5-jdk-windowsservercore, 11.0.5-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.5-jdk, 11.0.5, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.6-jdk-windowsservercore-ltsc2016, 11.0.6-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.6-jdk-windowsservercore, 11.0.6-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.6-jdk, 11.0.6, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.5-jdk-nanoserver-1809, 11.0.5-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.5-jdk-nanoserver, 11.0.5-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.6-jdk-nanoserver-1809, 11.0.6-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.6-jdk-nanoserver, 11.0.6-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 61a91d560d2637de14c5f7a96ded6d1b5b06ee0b
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.5-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
-SharedTags: 11.0.5-jre, 11.0-jre, 11-jre
+Tags: 11.0.6-jre-stretch, 11.0-jre-stretch, 11-jre-stretch
+SharedTags: 11.0.6-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jre
 
-Tags: 11.0.5-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.5-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.6-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.6-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jre/slim
 
-Tags: 11.0.5-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
+Tags: 11.0.6-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.6-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.6-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.5-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.5-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.5-jre, 11.0-jre, 11-jre
+Tags: 11.0.6-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.6-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.6-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.5-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.5-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.6-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.6-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e101ce4ea6dc4aae77905d501fd169e184f0bb00
+GitCommit: 1b6e2ef66a086f47315f5d05ecf7de3dae7413f2
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/61f3949: Update to 15-ea+5
- https://github.com/docker-library/openjdk/commit/bb3f1d5: Update to 14-ea+31
- https://github.com/docker-library/openjdk/commit/1b6e2ef: Update to 11.0.6