### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 3.3.0, 3.3, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 399fc7055104fea391d55b387f031b305ee4ad11
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 3/debian
 
 Tags: 3.3.0-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5bb779011d30662e0c46d3bdf4aaf428f92e28f
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 399fc7055104fea391d55b387f031b305ee4ad11
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 2/debian
 
 Tags: 2.38.0-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5bb779011d30662e0c46d3bdf4aaf428f92e28f
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 2/alpine
 
 Tags: 1.26.2, 1.26, 1
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e28a0e3482e710ed353fc2eecd8a4cf435fea045
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 1/debian
 
 Tags: 1.26.2-alpine, 1.26-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e28a0e3482e710ed353fc2eecd8a4cf435fea045
+GitCommit: aeed5c9122e22c71f321c36f11f8794b3915dce5
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/152b74f: Merge pull request https://github.com/docker-library/ghost/pull/206 from infosiftr/versions
- https://github.com/docker-library/ghost/commit/aeed5c9: Fix Ghost 1, sqlite3 version scraping, and update Ghost 3 to Node 12
- https://github.com/docker-library/ghost/commit/e5bb779: Also pin Alpine version to 3.11 explicitly