### PR TITLE
[ros] retiring EOL ROS crystal

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -79,23 +79,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: crystal
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: crystal-ros-core, crystal-ros-core-bionic
-Architectures: amd64, arm64v8
-GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
-Directory: ros/crystal/ubuntu/bionic/ros-core
-
-Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
-Architectures: amd64, arm64v8
-GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
-Directory: ros/crystal/ubuntu/bionic/ros-base
-
-
-################################################################################
 # Release: dashing
 
 ########################################


### PR DESCRIPTION
ROS Crystal is now EOL: https://github.com/ros/rosdistro/pull/23486