### PR TITLE
Update Amazon Corretto to 8.242.08.1

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -6,7 +6,7 @@ Maintainers: Amazon Corretto Team (@corretto),
 Tags: 8, 8u242, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: e07146d6fa3b2a3a9ae401337c18318e7607be3a
+GitCommit: ae31a3e5106d3d16e0a3154bca567c10879522af
 Architectures: amd64, arm64v8
 
 Tags: 11, 11.0.6, 11-al2-full


### PR DESCRIPTION
Update to https://github.com/corretto/corretto-8/releases/tag/8.242.08.1

This is based on the jdk8u242-b08 recently tagged.