### PR TITLE
Update Solr to 8.4.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,105 +1,105 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/426f7e3ead0c7671556ed8998fb0d345d1616ea5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/32c24945a2cb785c32d5974b18e9ad35ebe429f5/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.4.0, 8.4, 8, latest
+Tags: 8.4.1, 8.4, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: ebaee644db50346594bc36eeb602358edb7a2dd8
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.4
 
-Tags: 8.4.0-slim, 8.4-slim, 8-slim, slim
+Tags: 8.4.1-slim, 8.4-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: ebaee644db50346594bc36eeb602358edb7a2dd8
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.4/slim
 
 Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.3
 
 Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.7/slim
 
 Tags: 7.6.0, 7.6
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.6
 
 Tags: 7.6.0-slim, 7.6-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.6/slim
 
 Tags: 7.5.0, 7.5
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.5
 
 Tags: 7.5.0-slim, 7.5-slim
 Architectures: amd64, arm64v8
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: f698870cd4dfa5727d06b68e76f7de2b8a081480
+GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
 Directory: 5.5/slim


### PR DESCRIPTION
Announcement: http://mail-archives.apache.org/mod_mbox/lucene-general/202001.mbox/%3cCAHPRk5HAM+bi4CESxbr516MG=4nzisMab-1n915xM2ujC7e8Pw@mail.gmail.com%3e

It's a bug-fix release.

In docker-solr we made no real changes to the produced images.  We did make changes to the build to support releases on MacOS and via Vagrant.  The SOLR_DOWNLOAD_URL is now customizable.