### PR TITLE
Updating Oracle Linux 8 images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fb73215445f20c7c85d418b834c10eb2c5fef6a0 
+amd64-GitCommit: f62a89a8ace482d99a297e23817a74b026cd4e1a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: fb546d57fd3f8ac3fd3ab76510718783d5cd0e71 

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,13 +4,17 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9ae07ac03db04dd185594675256e03c215aba251
+amd64-GitCommit: fb73215445f20c7c85d418b834c10eb2c5fef6a0 
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f9043d411c4ecbbe4dbff6f68be535ab33d65888
+arm64v8-GitCommit: fb546d57fd3f8ac3fd3ab76510718783d5cd0e71 
 Constraints: !aufs
 
-Tags: 8.0, 8
+Tags: 8.1, 8
+Architectures: amd64, arm64v8
+Directory: 8.1
+
+Tags: 8.0
 Architectures: amd64, arm64v8
 Directory: 8.0
 


### PR DESCRIPTION
* Adding 8.1 images for both amd64 and arm64v8
* Updating 8-slim image
* Retain tzdata database across all images
* Fix older 8.0 weirdness with naming mismatch between Dockerfile and rootfs tarball

Signed-off-by: Avi Miller <avi.miller@oracle.com>