### PR TITLE
Add buster and centos images

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,6 +1,10 @@
-Maintainers: Gábor Boros <gabor.brs@gmail.com> (@gabor-boros)
+Maintainers: RethinkDB <services@rethinkdb.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
-GitCommit: 54d3eebf6409b196264c193e0cbad027061739b3
 
-Tags: 2.4.0, 2.4, 2, latest
-Directory: bionic/2.4.0
+Tags: 2.4.0-buster-slim, 2.4-buster-slim, 2-buster-slim, buster-slim, 2.4.0, 2.4, 2, latest
+Directory: buster/2.4.0
+GitCommit: 444f7754822cb3e96cb2b66042d8e87d2227be0b
+
+Tags: 2.4.0-centos, 2.4-centos, 2-centos, centos
+Directory: centos8/2.4.0
+GitCommit: 444f7754822cb3e96cb2b66042d8e87d2227be0b


### PR DESCRIPTION
Extend the list of available tags with Debian and Centos8. This request was initiated by our community in issue https://github.com/rethinkdb/rethinkdb-dockerfiles/issues/47.