### PR TITLE
Reverting an accidental regression of the 7-slim and 7 images 

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f62a89a8ace482d99a297e23817a74b026cd4e1a
+amd64-GitCommit: 550fefbaaceb2d46e9af820214e803b81ea60bde
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fb546d57fd3f8ac3fd3ab76510718783d5cd0e71 
+arm64v8-GitCommit: 46d9640c2525eb1daa807922d56affef75681a71
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
In my haste to update the Oracle Linux 8 and 8-slim images, it appears I accidentally reverted the 7 and 7-slim images back to an older version. This fixes that regression.

Signed-off-by: Avi Miller <avi.miller@oracle.com>