### PR TITLE
Triggering Oracle Linux 7 rebuild.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 550fefbaaceb2d46e9af820214e803b81ea60bde
+amd64-GitCommit: ef45135c78b4f9441c67fb10b41e992ec4c37c59
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 46d9640c2525eb1daa807922d56affef75681a71
+arm64v8-GitCommit: 72006700393eb7b7a8ac5bc9bb1abfb5b7893d88
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
After the merge this morning, Docker's build systems didn't rebuild the `oraclelinux:7-slim` tag for `amd64` but did rebuild the tag 7.7 tag as well as both the 7-slim and 7.7 tags for `arm64v8`.

Checking the image build times shows that the image wasn't updated at all, so this is essentially a no-op PR to trigger that build.

Signed-off-by: Avi Miller <avi.miller@oracle.com>