### PR TITLE
Update clojure:tools-deps to 1.10.1.502

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: be736864bf3e6d35c1bc6b13fd2add4a319fb92b
+GitCommit: e96f6249cac065855a40a9f36ba88949e0a52d7d
 
 Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.1, openjdk-8-stretch, openjdk-8-lein-stretch, openjdk-8-lein-2.9.1-stretch
 Directory: target/openjdk-8-stretch/lein
@@ -16,10 +16,10 @@ Directory: target/openjdk-8-stretch/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.483, openjdk-8-tools-deps-stretch, openjdk-8-tools-deps-1.10.1.483-stretch
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.502, openjdk-8-tools-deps-stretch, openjdk-8-tools-deps-1.10.1.502-stretch
 Directory: target/openjdk-8-stretch/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.483-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.502-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.1, lein, lein-2.9.1, openjdk-11-stretch, openjdk-11-lein-stretch, openjdk-11-lein-2.9.1-stretch, lein-stretch, lein-2.9.1-stretch
@@ -38,11 +38,11 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.483, tools-deps, tools-deps-1.10.1.483, openjdk-11-tools-deps-stretch, openjdk-11-tools-deps-1.10.1.483-stretch, tools-deps-stretch, tools-deps-1.10.1.483-stretch
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.502, tools-deps, tools-deps-1.10.1.502, openjdk-11-tools-deps-stretch, openjdk-11-tools-deps-1.10.1.502-stretch, tools-deps-stretch, tools-deps-1.10.1.502-stretch
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-stretch/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.483-slim-buster, tools-deps-1.10.1.483-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.502-slim-buster, tools-deps-1.10.1.502-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
@@ -58,10 +58,10 @@ Directory: target/openjdk-13-slim-buster/boot
 Tags: openjdk-13-boot-buster, openjdk-13-boot-2.8.3-buster
 Directory: target/openjdk-13-buster/boot
 
-Tags: openjdk-13-tools-deps, openjdk-13-tools-deps-1.10.1.483, openjdk-13-tools-deps-slim-buster, openjdk-13-tools-deps-1.10.1.483-slim-buster
+Tags: openjdk-13-tools-deps, openjdk-13-tools-deps-1.10.1.502, openjdk-13-tools-deps-slim-buster, openjdk-13-tools-deps-1.10.1.502-slim-buster
 Directory: target/openjdk-13-slim-buster/tools-deps
 
-Tags: openjdk-13-tools-deps-buster, openjdk-13-tools-deps-1.10.1.483-buster
+Tags: openjdk-13-tools-deps-buster, openjdk-13-tools-deps-1.10.1.502-buster
 Directory: target/openjdk-13-buster/tools-deps
 
 Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.1, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.1-slim-buster
@@ -76,10 +76,10 @@ Directory: target/openjdk-14-slim-buster/boot
 Tags: openjdk-14-boot-buster, openjdk-14-boot-2.8.3-buster
 Directory: target/openjdk-14-buster/boot
 
-Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.483, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.483-slim-buster
+Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.502, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.502-slim-buster
 Directory: target/openjdk-14-slim-buster/tools-deps
 
-Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.483-buster
+Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.502-buster
 Directory: target/openjdk-14-buster/tools-deps
 
 Tags: openjdk-14-alpine, openjdk-14-lein-alpine, openjdk-14-lein-2.9.1-alpine
@@ -88,5 +88,5 @@ Directory: target/openjdk-14-alpine/lein
 Tags: openjdk-14-boot-alpine, openjdk-14-boot-2.8.3-alpine
 Directory: target/openjdk-14-alpine/boot
 
-Tags: openjdk-14-tools-deps-alpine, openjdk-14-tools-deps-1.10.1.483-alpine
+Tags: openjdk-14-tools-deps-alpine, openjdk-14-tools-deps-1.10.1.502-alpine
 Directory: target/openjdk-14-alpine/tools-deps


### PR DESCRIPTION
New upstream release as well as [a bugfix](https://github.com/Quantisan/docker-clojure/issues/77) and [an enhancement](https://github.com/Quantisan/docker-clojure/issues/76).