### PR TITLE
Odoo: update 11.0-13.0 to release 20200121

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 596a7cabc07dd3b1d18b6c2832cace7328e36969
+GitCommit: 6d92142da193f60c161f97eea1079f437dd51d7e
 
 Tags: 13.0, 13, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,
here is the latest release of the supported Odoo version.

It includes those fixes. 

    * Fix absolute path for psql source list
    * Add xlrd library
    * merge two RUN layer into one
    * install python-slugify

Thanks