### PR TITLE
alpine: security bump 3.10.4, 3.9.5, 3.8.5

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -25,10 +25,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.3, 3.10
+Tags: 3.10.4, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: 410e490d5b140378624dc7c1c740c94462d8d6d3
+GitCommit: b05a5ce079ec947e76322ea7cf5900efd7ecae43
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -37,10 +37,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.9.4, 3.9
+Tags: 3.9.5, 3.9
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.9
-GitCommit: 29db8d88a0387f56cc77b270f72d33b9d48fd021
+GitCommit: 9becb5e9835cd628110545a4475ff66615a5683e
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -49,10 +49,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.8.4, 3.8
+Tags: 3.8.5, 3.8
 Architectures: arm64v8, arm32v6, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.8
-GitCommit: dc10be162e9d2c3f799fde73e25ad30f78ff479b
+GitCommit: c0919567e0350f0128fcad803d8e79c4ecfdf258
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 ppc64le-Directory: ppc64le/


### PR DESCRIPTION
3.10.4 fixes:
 - CVE-2019-1551 (openssl)

3.9.5 fixes:
 - CVE-2019-1551 (openssl)
 - CVE-2019-1547 (openssl)
 - CVE-2019-1549 (openssl)
 - CVE-2019-1563 (openssl)
 - CVE-2019-14697 (musl/i386)

3.8.5 fixes:
 - CVE-2019-14697 (musl/i386)