### PR TITLE
Ubuntu 19.04 Disco EOL

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -3,7 +3,7 @@
 
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
 GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 049685086825d4fddac171b13b0f31dd07e71c97
+GitCommit: fa37cb7218d69c82e29ddc44d22acd206a615a5c
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: bcdd3818e932eda677301ae5d81c80e010793c91
@@ -27,11 +27,6 @@ s390x-GitCommit: 26304346ad68640b70fa7ae2100ea89ea922bea8
 Tags: 18.04, bionic-20200112, bionic, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
-
-# 20200114 (disco)
-Tags: 19.04, disco-20200114, disco
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-Directory: disco
 
 # 20200114 (eoan)
 Tags: 19.10, eoan-20200114, eoan, rolling


### PR DESCRIPTION
As announced [1], Ubuntu Disco has reached the end of it's life.

[1] https://lists.ubuntu.com/archives/ubuntu-announce/2020-January/000252.html