### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.5.20, 1.5, 1, latest
+Tags: 1.5.21, 1.5, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 206a6c4dcbed0652885e716717653fc87de53bd0
+GitCommit: d72f50c74cb0a57b2b66111dc9b825f31a492594
 Directory: debian
 
-Tags: 1.5.20-alpine, 1.5-alpine, 1-alpine, alpine
+Tags: 1.5.21-alpine, 1.5-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3939abc659b8c72e10484d3771b4b15234b840ca
+GitCommit: c65207f9773870398bbdedd25a24b1224e2c849b
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/92fbb55: Merge pull request https://github.com/docker-library/memcached/pull/55 from J0WI/alpine11
- https://github.com/docker-library/memcached/commit/c65207f: Upgrade to Alpine 3.11
- https://github.com/docker-library/memcached/commit/7562888: Merge pull request https://github.com/docker-library/memcached/pull/56 from infosiftr/alpine-tls
- https://github.com/docker-library/memcached/commit/802d97f: Add TLS support to Alpine builds
- https://github.com/docker-library/memcached/commit/d72f50c: Update to 1.5.21