### PR TITLE
Release of GeoNetwork v3.8.3 and v3.10.0

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7fa2e3de056490ef677313333d2320629309e360/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/9fcf08514e1cbcd6b4f48a1d6acfac9fd23afa2d/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
-Tags: 3.6.0, 3.6
+Tags: 3.10.0, 3.10, latest
 Architectures: amd64
-GitCommit: e249c6031a55559392204a2c3ef8e8f8d11545a5
-Directory: 3.6.0
+GitCommit: 2e46c3594c3d47db12d6bd3344d474f4a408027a
+Directory: 3.10.0
 
-Tags: 3.6.0-postgres, 3.6-postgres
+Tags: 3.10.0-postgres, 3.10-postgres, postgres
 Architectures: amd64
-GitCommit: 29aa73c582e074010412628d45ea22074b8e7e74
-Directory: 3.6.0/postgres
+GitCommit: 2e46c3594c3d47db12d6bd3344d474f4a408027a
+Directory: 3.10.0/postgres
 
-Tags: 3.8.2, 3.8, latest
+Tags: 3.8.3, 3.8
 Architectures: amd64
-GitCommit: 35a9e428fc697b1fd898bd20c3303ee734c317e6
-Directory: 3.8.2
+GitCommit: af81a4ff8f592d27b4911ad20d569379864ee85f
+Directory: 3.8.3
 
-Tags: 3.8.2-postgres, 3.8-postgres, postgres
+Tags: 3.8.3-postgres, 3.8-postgres
 Architectures: amd64
-GitCommit: 35a9e428fc697b1fd898bd20c3303ee734c317e6
-Directory: 3.8.2/postgres
+GitCommit: af81a4ff8f592d27b4911ad20d569379864ee85f
+Directory: 3.8.3/postgres


### PR DESCRIPTION
* Release of GeoNetwork v3.8.3.
* Release of GeoNetwork v3.10.0.
* Remove tag 3.6.0 no longer maintained by the community.