### PR TITLE
Updating Oracle Linux images.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1125b2ee54ef029d2c96a2a221827bc232bb1d66
+amd64-GitCommit: f07e8fbbd636592fcdc76e46505d4d18ad79d4a3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 46d9640c2525eb1daa807922d56affef75681a71
+arm64v8-GitCommit: 12c83a2245b6399f7e5fc67eca6856d05caf0b39
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
* Updated Oracle Linux `7` and `7-slim` images for `arm64v8`
  * https://linux.oracle.com/cve/CVE-2019-13734.html
  * https://linux.oracle.com/errata/ELSA-2020-0227.html
* Updated Oracle Linux `6` and `6-slim` images for `amd64`
  * Updated `ca-certificates` to latest version

Signed-off-by: Avi Miller <avi.miller@oracle.com>