### PR TITLE
Updating Oracle Linux 8/8-slim images for amd64 and arm64v8 

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f07e8fbbd636592fcdc76e46505d4d18ad79d4a3
+amd64-GitCommit: 0ad982df90064219ac28d27947fcb9017071fa69
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 12c83a2245b6399f7e5fc67eca6856d05caf0b39
+arm64v8-GitCommit: f708650ac3b3ba37726e476b89f56ca07440c9c7
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
As per:

* https://linux.oracle.com/cve/CVE-2019-13734.html
* https://linux.oracle.com/errata/ELSA-2020-0273.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>