### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 315d33b3575cf1dade0c97f1d8c3dadffca8d198
+GitCommit: f375f042689f8ac1a87cee8c81b61e7e41fd55ea
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9


### PR DESCRIPTION
We put in 2 improvements to the shared class caching code:
- a boolean to turn it off (for development phase where  class caching optimization is not needed)
- updated the algorithm to re-size the cache according to how much memory the app uses