### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,59 +4,59 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-7-jdk-oraclelinux7, 15-ea-7-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-7-jdk-oracle, 15-ea-7-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-7-jdk, 15-ea-7, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-8-jdk-oraclelinux7, 15-ea-8-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-8-jdk-oracle, 15-ea-8-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk/oracle
 Constraints: !aufs
 
-Tags: 15-ea-7-jdk-buster, 15-ea-7-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-8-jdk-buster, 15-ea-8-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk
 
-Tags: 15-ea-7-jdk-slim-buster, 15-ea-7-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-7-jdk-slim, 15-ea-7-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-8-jdk-slim-buster, 15-ea-8-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-8-jdk-slim, 15-ea-8-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk/slim
 
-Tags: 15-ea-7-jdk-windowsservercore-1809, 15-ea-7-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-7-jdk-windowsservercore, 15-ea-7-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-7-jdk, 15-ea-7, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-8-jdk-windowsservercore-1809, 15-ea-8-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-8-jdk-windowsservercore, 15-ea-8-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-7-jdk-windowsservercore-ltsc2016, 15-ea-7-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-7-jdk-windowsservercore, 15-ea-7-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-7-jdk, 15-ea-7, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-8-jdk-windowsservercore-ltsc2016, 15-ea-8-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-8-jdk-windowsservercore, 15-ea-8-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-7-jdk-nanoserver-1809, 15-ea-7-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-7-jdk-nanoserver, 15-ea-7-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-8-jdk-nanoserver-1809, 15-ea-8-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-8-jdk-nanoserver, 15-ea-8-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 74f668327d3137e3666cff20610c400c15d2ed2c
+GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14-ea-33-jdk-oraclelinux7, 14-ea-33-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-33-jdk-oracle, 14-ea-33-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-33-jdk, 14-ea-33, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-34-jdk-oraclelinux7, 14-ea-34-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-34-jdk-oracle, 14-ea-34-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-33-jdk-buster, 14-ea-33-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-ea-34-jdk-buster, 14-ea-34-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk
 
-Tags: 14-ea-33-jdk-slim-buster, 14-ea-33-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-33-jdk-slim, 14-ea-33-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-ea-34-jdk-slim-buster, 14-ea-34-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-34-jdk-slim, 14-ea-34-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk/slim
 
 Tags: 14-ea-33-jdk-alpine3.10, 14-ea-33-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-33-jdk-alpine, 14-ea-33-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
@@ -64,24 +64,24 @@ Architectures: amd64
 GitCommit: 4e8fbef2ba9c8280d8c5243736d8a20ee784acc0
 Directory: 14/jdk/alpine
 
-Tags: 14-ea-33-jdk-windowsservercore-1809, 14-ea-33-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-33-jdk-windowsservercore, 14-ea-33-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-33-jdk, 14-ea-33, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-34-jdk-windowsservercore-1809, 14-ea-34-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-ea-34-jdk-windowsservercore, 14-ea-34-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-33-jdk-windowsservercore-ltsc2016, 14-ea-33-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-33-jdk-windowsservercore, 14-ea-33-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-33-jdk, 14-ea-33, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-ea-34-jdk-windowsservercore-ltsc2016, 14-ea-34-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-ea-34-jdk-windowsservercore, 14-ea-34-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14-ea-33-jdk-nanoserver-1809, 14-ea-33-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
-SharedTags: 14-ea-33-jdk-nanoserver, 14-ea-33-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-ea-34-jdk-nanoserver-1809, 14-ea-34-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14-ea-34-jdk-nanoserver, 14-ea-34-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: 7c087cd55d5c045fcc7239350da389e1741f63f0
+GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6470eb9: Update to 15-ea+8
- https://github.com/docker-library/openjdk/commit/d7bc1b1: Update to 14-ea+34
- https://github.com/docker-library/openjdk/commit/b2741f1: Add Windows 1809 images to AppVeyor configuration