### PR TITLE
[gazebo] update gazebo 9 and 10

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -26,12 +26,12 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: ad70e430c50dd3ee987ca2e7153f40c6071e87a4
+GitCommit: a992af9acb97e29e46a13af440202ba980fe18fc
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: ad70e430c50dd3ee987ca2e7153f40c6071e87a4
+GitCommit: a992af9acb97e29e46a13af440202ba980fe18fc
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -39,12 +39,12 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 30cfa33eacf61711114f8aca1cd38271fe14d61b
+GitCommit: 9a44043709478b7d67eb020ae16dc0584e831369
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 30cfa33eacf61711114f8aca1cd38271fe14d61b
+GitCommit: 9a44043709478b7d67eb020ae16dc0584e831369
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 ########################################
@@ -52,12 +52,12 @@ Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 Tags: gzserver9-stretch
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: e2c145e63a7b14d2ebd7928b4bdd0302195fe704
+GitCommit: e02819ea8bb6838c133d476a7f41f5079836eb4a
 Directory: gazebo/9/debian/stretch/gzserver9
 
 Tags: libgazebo9-stretch
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: e2c145e63a7b14d2ebd7928b4bdd0302195fe704
+GitCommit: e02819ea8bb6838c133d476a7f41f5079836eb4a
 Directory: gazebo/9/debian/stretch/libgazebo9
 
 
@@ -69,10 +69,10 @@ Directory: gazebo/9/debian/stretch/libgazebo9
 
 Tags: gzserver10, gzserver10-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 00d02282c2393ccde655fa0c333b4410a10b3985
+GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/gzserver10
 
 Tags: libgazebo10, libgazebo10-bionic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 00d02282c2393ccde655fa0c333b4410a10b3985
+GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/libgazebo10


### PR DESCRIPTION
Gazebo 9: 9.11.0 -> 9.12.0
Gazebo 10: 10.1.0 -> 10.2.0

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

Related to:
https://github.com/osrf/docker_images/pull/367
https://github.com/osrf/docker_images/pull/366
https://github.com/osrf/docker_images/pull/365
https://github.com/osrf/docker_images/pull/364