### PR TITLE
Update Flink images and source repo

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,8 +1,8 @@
-# this file is generated via https://github.com/docker-flink/docker-flink/blob/89abc4a50ec8810c558a8b24891f69f375a19f71/generate-stackbrew-library.sh
+# this file is generated via https://github.com/apache/flink-docker/blob/89abc4a50ec8810c558a8b24891f69f375a19f71/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
-GitRepo: https://github.com/docker-flink/docker-flink.git
+GitRepo: https://github.com/apache/flink-docker.git
 
 Tags: 1.8.3-scala_2.11, 1.8-scala_2.11
 Architectures: amd64
@@ -16,10 +16,10 @@ Directory: 1.8/scala_2.12-debian
 
 Tags: 1.9.2-scala_2.11, 1.9-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 9e0e37ff1bf72937ca72655d257778ed7ba4ebd0
+GitCommit: f26d84ce3c2c51ddb46fdf5cd8449256722d8459
 Directory: 1.9/scala_2.11-debian
 
 Tags: 1.9.2-scala_2.12, 1.9-scala_2.12, scala_2.12, 1.9.2, 1.9, latest
 Architectures: amd64
-GitCommit: 9e0e37ff1bf72937ca72655d257778ed7ba4ebd0
+GitCommit: f26d84ce3c2c51ddb46fdf5cd8449256722d8459
 Directory: 1.9/scala_2.12-debian


### PR DESCRIPTION
The source repo has moved from
https://github.com/docker-flink/docker-flink to
https://github.com/apache/flink-docker.

Refs docker-flink/docker-flink#94