### PR TITLE
kong: re-build 1.4.3-ubuntu and bump the distribution convenience tags

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,19 +2,19 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 2.0.0-alpine, 2.0.0, 2.0, latest
+Tags: 2.0.0-alpine, 2.0.0, 2.0, latest, alpine
 GitCommit: 8fdd912f9519b584a98ebe2d06d5ff0b12d55155
 GitFetch: refs/tags/2.0.0
 Directory: alpine
 Architectures: amd64
 
-Tags: 2.0.0-ubuntu, 2.0-ubuntu
+Tags: 2.0.0-ubuntu, 2.0-ubuntu, ubuntu
 GitCommit: 8fdd912f9519b584a98ebe2d06d5ff0b12d55155
 GitFetch: refs/tags/2.0.0
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 2.0.0-centos, 2.0-centos
+Tags: 2.0.0-centos, 2.0-centos, centos
 GitCommit: 8fdd912f9519b584a98ebe2d06d5ff0b12d55155
 GitFetch: refs/tags/2.0.0
 Constraints: !aufs
@@ -40,20 +40,20 @@ Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
-Tags: 1.4.3-alpine, 1.4.3, 1.4, alpine
-GitCommit: 3d9cd4bb1678aee6446b0c3f392ef37f34212c99
+Tags: 1.4.3-alpine, 1.4.3, 1.4
+GitCommit: d2884ee222e72c3edb9abd48d4062991e41ea7bc
 GitFetch: refs/tags/1.4.3
 Directory: alpine
 Architectures: amd64
 
-Tags: 1.4.3-ubuntu, 1.4-ubuntu, ubuntu
-GitCommit: 3d9cd4bb1678aee6446b0c3f392ef37f34212c99
+Tags: 1.4.3-ubuntu, 1.4-ubuntu
+GitCommit: d2884ee222e72c3edb9abd48d4062991e41ea7bc
 GitFetch: refs/tags/1.4.3
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 1.4.3-centos, 1.4-centos, centos
-GitCommit: 3d9cd4bb1678aee6446b0c3f392ef37f34212c99
+Tags: 1.4.3-centos, 1.4-centos
+GitCommit: d2884ee222e72c3edb9abd48d4062991e41ea7bc
 GitFetch: refs/tags/1.4.3
 Constraints: !aufs
 Directory: centos


### PR DESCRIPTION
- 1.4.3 arm asset was amd64 (included a naive test to catch this going forward)
- Looks like we missed bumping the distribution tags for a few releases so caught those up as well