### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -49,21 +49,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
 Directory: buster
 
-Tags: disco-curl, 19.04-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
-Directory: disco/curl
-
-Tags: disco-scm, 19.04-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dad73efaa10245757e58d28742cb7ed35fcd31f2
-Directory: disco/scm
-
-Tags: disco, 19.04
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd0058f0893008c7ffa8e9cb9d3d5208cf5f2f75
-Directory: disco
-
 Tags: eoan-curl, 19.10-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7f5fa2e64174be2821552587b23f7d84b1dae71c


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/51a2871: Remove EOL disco