### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.4.0, 3.4, 3, latest
+Tags: 3.5.0, 3.5, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: aed7ba7762d70d8bfe17d9250e7d06d93647d576
+GitCommit: eb3237cf781277f3cc4aa250444912bb04683aba
 Directory: 3/debian
 
-Tags: 3.4.0-alpine, 3.4-alpine, 3-alpine, alpine
+Tags: 3.5.0-alpine, 3.5-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aed7ba7762d70d8bfe17d9250e7d06d93647d576
+GitCommit: eb3237cf781277f3cc4aa250444912bb04683aba
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/eb3237c: Update to 3.5.0, ghost-cli 1.13.1