### PR TITLE
[gazebo] add gazebo11

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -38,12 +38,12 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 # Distro: ubuntu:bionic
 
 Tags: gzserver9, gzserver9-bionic
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64
 GitCommit: 9a44043709478b7d67eb020ae16dc0584e831369
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64
 GitCommit: 9a44043709478b7d67eb020ae16dc0584e831369
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
@@ -51,12 +51,12 @@ Directory: gazebo/9/ubuntu/bionic/libgazebo9
 # Distro: debian:stretch
 
 Tags: gzserver9-stretch
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64
 GitCommit: e02819ea8bb6838c133d476a7f41f5079836eb4a
 Directory: gazebo/9/debian/stretch/gzserver9
 
 Tags: libgazebo9-stretch
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64
 GitCommit: e02819ea8bb6838c133d476a7f41f5079836eb4a
 Directory: gazebo/9/debian/stretch/libgazebo9
 
@@ -68,11 +68,29 @@ Directory: gazebo/9/debian/stretch/libgazebo9
 # Distro: ubuntu:bionic
 
 Tags: gzserver10, gzserver10-bionic
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64
 GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/gzserver10
 
-Tags: libgazebo10, libgazebo10-bionic, latest
-Architectures: amd64, arm32v7, arm64v8
+Tags: libgazebo10, libgazebo10-bionic
+Architectures: amd64
 GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/libgazebo10
+
+
+################################################################################
+# Release: 11
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: gzserver11, gzserver11-bionic
+Architectures: amd64
+GitCommit: bd0ef992496452d93ea929ea5921b123acdab58c
+Directory: gazebo/11/ubuntu/bionic/gzserver11
+
+Tags: libgazebo11, libgazebo11-bionic, latest
+Architectures: amd64
+GitCommit: bd0ef992496452d93ea929ea5921b123acdab58c
+Directory: gazebo/11/ubuntu/bionic/libgazebo11
+


### PR DESCRIPTION
- Adds the new version of Gazebo: Gazebo11 and tag it as latest
- Remove arm builds for gazebo 9 and 10 and they've failed to build for a long time

Book-keeping:
https://github.com/osrf/docker_images/pull/371
https://github.com/osrf/docker_images/pull/374
