### PR TITLE
Add script to detect "naughty" commit histories

### DIFF
--- a/naughty-commits.sh
+++ b/naughty-commits.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fileSizeThresholdMB='2'
+
+: "${BASHBREW_CACHE:=$HOME/.cache/bashbrew}"
+export BASHBREW_CACHE BASHBREW_ARCH=
+
+if [ ! -d "$BASHBREW_CACHE/git" ]; then
+	# initialize the "bashbrew cache"
+	bashbrew --arch amd64 from --uniq --apply-constraints hello-world:linux > /dev/null
+fi
+
+_git() {
+	git -C "$BASHBREW_CACHE/git" "$@"
+}
+
+if [ "$#" -eq 0 ]; then
+	set -- '--all'
+fi
+
+imgs="$(bashbrew list --repos "$@" | sort -u)"
+for img in $imgs; do
+	IFS=$'\n'
+	commits=( $(
+		bashbrew cat --format '
+			{{- range $e := .Entries -}}
+				{{- range $a := .Architectures -}}
+					{{- /* force `git fetch` */ -}}
+					{{- $froms := $.ArchDockerFroms $a $e -}}
+
+					{{- $e.ArchGitCommit $a -}}
+					{{- "\n" -}}
+				{{- end -}}
+			{{- end -}}
+		' "$img" | sort -u
+	) )
+	unset IFS
+
+	declare -A naughtyCommits=() naughtyTopCommits=() seenCommits=()
+	for topCommit in "${commits[@]}"; do
+		IFS=$'\n'
+		potentiallyNaughtyGlobs=( '**.tar**' )
+		potentiallyNaughtyCommits=( $(_git log --diff-filter=DMT --format='format:%H' "$topCommit" -- "${potentiallyNaughtyGlobs[@]}") )
+		unset IFS
+
+		for commit in "${potentiallyNaughtyCommits[@]}"; do
+			[ -z "${seenCommits[$commit]:-}" ] || break
+			seenCommits[$commit]=1
+
+			IFS=$'\n'
+			binaryFiles=( $(
+				_git diff-tree --no-commit-id -r --numstat --diff-filter=DMT "$commit" -- "${potentiallyNaughtyGlobs[@]}" \
+					| grep '^-' \
+					| cut -d$'\t' -f3- \
+					|| :
+			) )
+			unset IFS
+
+			naughtyReasons=()
+			for file in "${binaryFiles[@]}"; do
+				fileSize="$(_git ls-tree -r --long "$commit" -- "$file" | awk '{ print $4 }')"
+				fileSizeMB="$(( fileSize / 1024 / 1024 ))"
+				if [ "$fileSizeMB" -gt "$fileSizeThresholdMB" ]; then
+					naughtyReasons+=( "modified binary file (larger than ${fileSizeThresholdMB}MB): $file (${fileSizeMB}MB)" )
+				fi
+			done
+
+			if [ "${#naughtyReasons[@]}" -gt 0 ]; then
+				IFS=$'\n'
+				naughtyCommits[$commit]="${naughtyReasons[*]}"
+				unset IFS
+				naughtyTopCommits[$commit]="$topCommit"
+			fi
+		done
+	done
+
+	if [ "${#naughtyCommits[@]}" -gt 0 ]; then
+		echo " - $img:"
+		for naughtyCommit in "${!naughtyCommits[@]}"; do
+			naughtyReasons="${naughtyCommits[$naughtyCommit]}"
+			naughtyTopCommit="${naughtyTopCommits[$naughtyCommit]}"
+			if [ "$naughtyTopCommit" != "$naughtyCommit" ]; then
+				#commitsBetween="$(_git rev-list --count "$naughtyCommit...$naughtyTopCommit")"
+				naughtyCommit+=" (in history of $naughtyTopCommit)"
+			fi
+			echo "   - commit $naughtyCommit:"
+			sed -e 's/^/     - /' <<<"$naughtyReasons"
+		done
+		echo
+	fi
+done


### PR DESCRIPTION
I originally wanted this script to be more generic and look for *any* modified binary files that are over a certain threshold, but it took ~88 minutes to run over the entire library, and almost all that time was spent in `git` itself generating commit diffs (since they're not stored on-disk in such a way that those commit diffs are inexpensive to calculate).

I also did a rough prototype in Go using https://github.com/src-d/go-git but it had essentially the same speed (as expected, since it's the underlying data that makes it expensive to calculate, not the language being used to request the data).

So, instead this looks for modified files which match `**.tar**`, which should match the ones we typically worry about anyhow (there are some other problematic cases, but they aren't going to be rebased anytime soon because they've been problematic for so long so aren't worth bending over backwards to detect).

To illustrate:

```console
$ time ./naughty-commits.sh --all
 - oraclelinux:
   - commit 0ad982df90064219ac28d27947fcb9017071fa69:
     - modified binary file (larger than 2MB): 6-slim/oraclelinux-6-slim-rootfs.tar.xz (23MB)
     - modified binary file (larger than 2MB): 6.10/oraclelinux-6.10-rootfs.tar.xz (41MB)
     - modified binary file (larger than 2MB): 7-slim/oraclelinux-7-slim-rootfs.tar.xz (22MB)
     - modified binary file (larger than 2MB): 7.7/oraclelinux-7.7-rootfs.tar.xz (47MB)
     - modified binary file (larger than 2MB): 8-slim/oraclelinux-8-slim-rootfs.tar.xz (19MB)
     - modified binary file (larger than 2MB): 8.1/oraclelinux-8.1-rootfs.tar.xz (46MB)
   - commit f708650ac3b3ba37726e476b89f56ca07440c9c7:
     - modified binary file (larger than 2MB): 7-slim/oraclelinux-7-slim_aarch64-rootfs.tar.xz (21MB)
     - modified binary file (larger than 2MB): 7.7/oraclelinux-7.7_aarch64-rootfs.tar.xz (44MB)
     - modified binary file (larger than 2MB): 8-slim/oraclelinux-8-slim-rootfs.tar.xz (18MB)
     - modified binary file (larger than 2MB): 8.1/oraclelinux-8.1-rootfs.tar.xz (43MB)

 - sl:
   - commit 5e22bab43db4ba8bd0f059dac5176515f7d720ad (in history of 07b4b6f00d097c4821ee976ec48000b1695e9eca):
     - modified binary file (larger than 2MB): sl6/sl-6-docker.tar.xz (27MB)
   - commit b875059814e34ceae1c53790e63318712e37aaa9 (in history of 2e463581894b46ae7c1cf09ac920f6dc2dc9c25d):
     - modified binary file (larger than 2MB): sl7/sl-7-docker.tar.xz (35MB)
   - commit 565b44ef66f3fe06ac95cd202efccc7993810bd4 (in history of 2e463581894b46ae7c1cf09ac920f6dc2dc9c25d):
     - modified binary file (larger than 2MB): sl7/sl-7-docker.tar.xz (35MB)
   - commit 07b4b6f00d097c4821ee976ec48000b1695e9eca:
     - modified binary file (larger than 2MB): sl6/sl-6-docker.tar.xz (27MB)
   - commit 2e463581894b46ae7c1cf09ac920f6dc2dc9c25d:
     - modified binary file (larger than 2MB): sl7/sl-7-docker.tar.xz (35MB)


real	0m35.875s
user	0m29.975s
sys	0m9.997s
```