### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,87 +1,87 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/50dcb999fcc9a922bd4a60769bcc514ca988a56f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/24ff831ddb5290f3be4cf3802a44d77ebdf634c2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-8-jdk-oraclelinux7, 15-ea-8-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-8-jdk-oracle, 15-ea-8-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-9-jdk-oraclelinux7, 15-ea-9-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-9-jdk-oracle, 15-ea-9-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-9-jdk, 15-ea-9, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk/oracle
 Constraints: !aufs
 
-Tags: 15-ea-8-jdk-buster, 15-ea-8-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-9-jdk-buster, 15-ea-9-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk
 
-Tags: 15-ea-8-jdk-slim-buster, 15-ea-8-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-8-jdk-slim, 15-ea-8-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-9-jdk-slim-buster, 15-ea-9-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-9-jdk-slim, 15-ea-9-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk/slim
 
-Tags: 15-ea-8-jdk-windowsservercore-1809, 15-ea-8-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-8-jdk-windowsservercore, 15-ea-8-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-7-jdk-alpine3.11, 15-ea-7-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-7-jdk-alpine, 15-ea-7-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
+Architectures: amd64
+GitCommit: ddfe4a29dd66d34375d6ebc4455c550524672e3e
+Directory: 15/jdk/alpine
+
+Tags: 15-ea-9-jdk-windowsservercore-1809, 15-ea-9-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-9-jdk-windowsservercore, 15-ea-9-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-9-jdk, 15-ea-9, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-8-jdk-windowsservercore-ltsc2016, 15-ea-8-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-8-jdk-windowsservercore, 15-ea-8-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-8-jdk, 15-ea-8, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-9-jdk-windowsservercore-ltsc2016, 15-ea-9-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-9-jdk-windowsservercore, 15-ea-9-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-9-jdk, 15-ea-9, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-8-jdk-nanoserver-1809, 15-ea-8-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-8-jdk-nanoserver, 15-ea-8-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-9-jdk-nanoserver-1809, 15-ea-9-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-9-jdk-nanoserver, 15-ea-9-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 6470eb9b90f020450b5d7a3e69708e2a902024ea
+GitCommit: 4bfbef917281809571510a2a53b297696a122e42
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14-ea-34-jdk-oraclelinux7, 14-ea-34-oraclelinux7, 14-ea-jdk-oraclelinux7, 14-ea-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, 14-ea-34-jdk-oracle, 14-ea-34-oracle, 14-ea-jdk-oracle, 14-ea-oracle, 14-jdk-oracle, 14-oracle
-SharedTags: 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-jdk-oraclelinux7, 14-oraclelinux7, 14-jdk-oracle, 14-oracle
+SharedTags: 14-jdk, 14
 Architectures: amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: 9be7dd0e7664b407d2fae82ebd7c7b03aaa415ee
 Directory: 14/jdk/oracle
 Constraints: !aufs
 
-Tags: 14-ea-34-jdk-buster, 14-ea-34-buster, 14-ea-jdk-buster, 14-ea-buster, 14-jdk-buster, 14-buster
+Tags: 14-jdk-buster, 14-buster
 Architectures: amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: 9be7dd0e7664b407d2fae82ebd7c7b03aaa415ee
 Directory: 14/jdk
 
-Tags: 14-ea-34-jdk-slim-buster, 14-ea-34-slim-buster, 14-ea-jdk-slim-buster, 14-ea-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14-ea-34-jdk-slim, 14-ea-34-slim, 14-ea-jdk-slim, 14-ea-slim, 14-jdk-slim, 14-slim
+Tags: 14-jdk-slim-buster, 14-slim-buster, 14-jdk-slim, 14-slim
 Architectures: amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: 9be7dd0e7664b407d2fae82ebd7c7b03aaa415ee
 Directory: 14/jdk/slim
 
-Tags: 14-ea-33-jdk-alpine3.10, 14-ea-33-alpine3.10, 14-ea-jdk-alpine3.10, 14-ea-alpine3.10, 14-jdk-alpine3.10, 14-alpine3.10, 14-ea-33-jdk-alpine, 14-ea-33-alpine, 14-ea-jdk-alpine, 14-ea-alpine, 14-jdk-alpine, 14-alpine
-Architectures: amd64
-GitCommit: 4e8fbef2ba9c8280d8c5243736d8a20ee784acc0
-Directory: 14/jdk/alpine
-
-Tags: 14-ea-34-jdk-windowsservercore-1809, 14-ea-34-windowsservercore-1809, 14-ea-jdk-windowsservercore-1809, 14-ea-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
-SharedTags: 14-ea-34-jdk-windowsservercore, 14-ea-34-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14-jdk-windowsservercore, 14-windowsservercore, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: 9be7dd0e7664b407d2fae82ebd7c7b03aaa415ee
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14-ea-34-jdk-windowsservercore-ltsc2016, 14-ea-34-windowsservercore-ltsc2016, 14-ea-jdk-windowsservercore-ltsc2016, 14-ea-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
-SharedTags: 14-ea-34-jdk-windowsservercore, 14-ea-34-windowsservercore, 14-ea-jdk-windowsservercore, 14-ea-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14-ea-34-jdk, 14-ea-34, 14-ea-jdk, 14-ea, 14-jdk, 14
+Tags: 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14-jdk-windowsservercore, 14-windowsservercore, 14-jdk, 14
 Architectures: windows-amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: 9be7dd0e7664b407d2fae82ebd7c7b03aaa415ee
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14-ea-34-jdk-nanoserver-1809, 14-ea-34-nanoserver-1809, 14-ea-jdk-nanoserver-1809, 14-ea-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
-SharedTags: 14-ea-34-jdk-nanoserver, 14-ea-34-nanoserver, 14-ea-jdk-nanoserver, 14-ea-nanoserver, 14-jdk-nanoserver, 14-nanoserver
+Tags: 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
-GitCommit: d7bc1b133e5c57f209f7ba8760d448fec2409780
+GitCommit: d676a9c8649a1f8b40b60fdbdf3a6475af030759
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/17f7f8d: Merge pull request https://github.com/docker-library/openjdk/pull/394 from infosiftr/alpine3.11
- https://github.com/docker-library/openjdk/commit/9be7dd0: Update to 14
- https://github.com/docker-library/openjdk/commit/ddfe4a2: Update to Alpine 3.11 (and add appropriate 15-alpine variant)
- https://github.com/docker-library/openjdk/commit/4bfbef9: Update to 15-ea+9
- https://github.com/docker-library/openjdk/commit/d676a9c: Update to 14
- https://github.com/docker-library/openjdk/commit/485e574: Remove 14/jdk/alpine -- builds no longer available
- https://github.com/docker-library/openjdk/commit/56d87fd: Merge pull request https://github.com/docker-library/openjdk/pull/393 from infosiftr/mawk
- https://github.com/docker-library/openjdk/commit/24ff831: Switch "generate-stackbrew-library.sh" from "switch" (gawk-ism) to if-else chain so it works in mawk