### PR TITLE
Update Consul to v1.7.0

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,12 +1,12 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.7.0-beta4, beta
+Tags: 1.7.0, 1.7, latest 
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 93f0bebbf361222b931f65e56224543a1614db34
+GitCommit: 20add33b31a54c8de514a72255618058727f0227 
 Directory: 0.X
 
-Tags: 1.6.3, 1.6, latest
+Tags: 1.6.3, 1.6
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: a6a7e327b27b148110e9bde6efbac6ea15bac7fa


### PR DESCRIPTION
This gets rid of the beta tag now that v1.7 is going GA. The latest tag has also moved to the v1.7 release.