### PR TITLE
Rocket.Chat 2.4.9

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,5 +1,5 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 2.4.1, 2.4, 2, latest
-GitCommit: 1af353ec8d8c0ae13dd6e1e1addba11c79f06d52
+Tags: 2.4.9, 2.4, 2, latest
+GitCommit: 022483549bdf709aef768fa26afa107b6f06cbb3


### PR DESCRIPTION
Changes:

https://github.com/RocketChat/Docker.Official.Image/commit/022483549bdf709aef768fa26afa107b6f06cbb3 Bump to Rocket.Chat 2.4.9