### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -44,22 +44,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.24-rc.1, 3.7-rc
+Tags: 3.7.24-rc.2, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bc714d731b5076d5fcf098aae818caa18a18266a
+GitCommit: 9859dc76960e21fefdcc79518e1b41867c428417
 Directory: 3.7-rc/ubuntu
 
-Tags: 3.7.24-rc.1-management, 3.7-rc-management
+Tags: 3.7.24-rc.2-management, 3.7-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7-rc/ubuntu/management
 
-Tags: 3.7.24-rc.1-alpine, 3.7-rc-alpine
+Tags: 3.7.24-rc.2-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bc714d731b5076d5fcf098aae818caa18a18266a
+GitCommit: 9859dc76960e21fefdcc79518e1b41867c428417
 Directory: 3.7-rc/alpine
 
-Tags: 3.7.24-rc.1-management-alpine, 3.7-rc-management-alpine
+Tags: 3.7.24-rc.2-management-alpine, 3.7-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
 Directory: 3.7-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/9859dc7: Update to 3.7.24-rc.2, Erlang/OTP 22.2.6, OpenSSL 1.1.1d