### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.5.1, 3.5, 3, latest
+Tags: 3.5.2, 3.5, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: db1b3dd3accfe8867a77a6597d8b2f023e512f9c
+GitCommit: 4681460fb73e0c11d43200b35c57c8a15dbc047f
 Directory: 3/debian
 
-Tags: 3.5.1-alpine, 3.5-alpine, 3-alpine, alpine
+Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: db1b3dd3accfe8867a77a6597d8b2f023e512f9c
+GitCommit: 4681460fb73e0c11d43200b35c57c8a15dbc047f
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4681460: Update to 3.5.2, ghost-cli 1.13.1