### PR TITLE
Make amazon corretto use corretto yum repositories.

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -6,11 +6,11 @@ Maintainers: Amazon Corretto Team (@corretto),
 Tags: 8, 8u242, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: ae31a3e5106d3d16e0a3154bca567c10879522af
+GitCommit: 222fba51be1858ab30f32ffff762a6909ef0e0e8
 Architectures: amd64, arm64v8
 
 Tags: 11, 11.0.6, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: a797c24219a9262e581ee70fc928c57acacde331
+GitCommit: e6b006191f79582abc672bde1ecddffa6417639a
 Architectures: amd64, arm64v8


### PR DESCRIPTION
We have updated our dockerfile images to make use of our new yum repos. This does not change the corretto version in the container, but it will allow people to update containers with yum update.