### PR TITLE
Fix Bash 4.3 issue and make scripts fail appropriately for similar issues in future

### DIFF
--- a/bashbrew/travis.sh
+++ b/bashbrew/travis.sh
@@ -51,33 +51,38 @@ if badTags="$(bashbrew list "${repos[@]}" | grep -E ':.+latest.*|:.*latest.+')" 
 	exit 1
 fi
 
-if [ -n "$extraCommands" ] && naughtyFrom="$(../naughty-from.sh "${repos[@]}")" && [ -n "$naughtyFrom" ]; then
-	echo >&2
-	echo >&2 "Invalid 'FROM' + 'Architectures' combinations detected:"
-	echo >&2
-	echo >&2 "$naughtyFrom"
-	echo >&2
-	echo >&2 'Read https://github.com/docker-library/official-images#multiple-architectures for more details.'
-	echo >&2
-	exit 1
-fi
+if [ -n "$extraCommands" ]; then
+	naughtyFrom="$(../naughty-from.sh "${repos[@]}")"
+	if [ -n "$naughtyFrom" ]; then
+		echo >&2
+		echo >&2 "Invalid 'FROM' + 'Architectures' combinations detected:"
+		echo >&2
+		echo >&2 "$naughtyFrom"
+		echo >&2
+		echo >&2 'Read https://github.com/docker-library/official-images#multiple-architectures for more details.'
+		echo >&2
+		exit 1
+	fi
 
-if [ -n "$extraCommands" ] && naughtyConstraints="$(../naughty-constraints.sh "${repos[@]}")" && [ -n "$naughtyConstraints" ]; then
-	echo >&2
-	echo >&2 "Invalid 'FROM' + 'Constraints' combinations detected:"
-	echo >&2
-	echo >&2 "$naughtyConstraints"
-	echo >&2
-	exit 1
-fi
+	naughtyConstraints="$(../naughty-constraints.sh "${repos[@]}")"
+	if [ -n "$naughtyConstraints" ]; then
+		echo >&2
+		echo >&2 "Invalid 'FROM' + 'Constraints' combinations detected:"
+		echo >&2
+		echo >&2 "$naughtyConstraints"
+		echo >&2
+		exit 1
+	fi
 
-if [ -n "$extraCommands" ] && naughtyCommits="$(../naughty-commits.sh "${repos[@]}")" && [ -n "$naughtyCommits" ]; then
-	echo >&2
-	echo >&2 "Unpleasant commits detected:"
-	echo >&2
-	echo >&2 "$naughtyCommits"
-	echo >&2
-	exit 1
+	naughtyCommits="$(../naughty-commits.sh "${repos[@]}")"
+	if [ -n "$naughtyCommits" ]; then
+		echo >&2
+		echo >&2 "Unpleasant commits detected:"
+		echo >&2
+		echo >&2 "$naughtyCommits"
+		echo >&2
+		exit 1
+	fi
 fi
 
 _bashbrew() {

--- a/naughty-commits.sh
+++ b/naughty-commits.sh
@@ -44,6 +44,9 @@ for img in $imgs; do
 		potentiallyNaughtyCommits=( $(_git log --diff-filter=DMT --format='format:%H' "$topCommit" -- "${potentiallyNaughtyGlobs[@]}") )
 		unset IFS
 
+		# bash 4.3 sucks (https://stackoverflow.com/a/7577209/433558)
+		[ "${#potentiallyNaughtyCommits[@]}" -gt 0 ] || continue
+
 		for commit in "${potentiallyNaughtyCommits[@]}"; do
 			[ -z "${seenCommits[$commit]:-}" ] || break
 			seenCommits[$commit]=1
@@ -56,6 +59,9 @@ for img in $imgs; do
 					|| :
 			) )
 			unset IFS
+
+			# bash 4.3 sucks (https://stackoverflow.com/a/7577209/433558)
+			[ "${#binaryFiles[@]}" -gt 0 ] || continue
 
 			naughtyReasons=()
 			for file in "${binaryFiles[@]}"; do


### PR DESCRIPTION
See https://travis-ci.org/docker-library/official-images/builds/649193952#L346-L348 for where I previously included the change from #7458 here to verify this. :+1:

See also https://travis-ci.org/docker-library/official-images/builds/649196121#L346-L362 for where I temporarily modified `library/sl` so that it would be included and show that the test does still verify the correct thing.

See also also https://travis-ci.org/docker-library/official-images/builds/649195724#L346-L364 where I did the same but with `library/oraclelinux` from current `master` to verify it also fails.