### PR TITLE
Update to Flink 1.10.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/apache/flink-docker/blob/89abc4a50ec8810c558a8b24891f69f375a19f71/generate-stackbrew-library.sh
+# this file is generated via https://github.com/apache/flink-docker/blob/dfe8ffece905785268d1d237b173d47d82ff20e6/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.8.3-scala_2.11, 1.8-scala_2.11
-Architectures: amd64
-GitCommit: 4d85b71b7cf9fa4a38f8682ed13aa0f55445e32e
-Directory: 1.8/scala_2.11-debian
-
-Tags: 1.8.3-scala_2.12, 1.8-scala_2.12, 1.8.3, 1.8
-Architectures: amd64
-GitCommit: 4d85b71b7cf9fa4a38f8682ed13aa0f55445e32e
-Directory: 1.8/scala_2.12-debian
-
-Tags: 1.9.2-scala_2.11, 1.9-scala_2.11, scala_2.11
+Tags: 1.9.2-scala_2.11, 1.9-scala_2.11
 Architectures: amd64
 GitCommit: f26d84ce3c2c51ddb46fdf5cd8449256722d8459
 Directory: 1.9/scala_2.11-debian
 
-Tags: 1.9.2-scala_2.12, 1.9-scala_2.12, scala_2.12, 1.9.2, 1.9, latest
+Tags: 1.9.2-scala_2.12, 1.9-scala_2.12, 1.9.2, 1.9
 Architectures: amd64
 GitCommit: f26d84ce3c2c51ddb46fdf5cd8449256722d8459
 Directory: 1.9/scala_2.12-debian
+
+Tags: 1.10.0-scala_2.11, 1.10-scala_2.11, scala_2.11
+Architectures: amd64
+GitCommit: 346809e6cab2ca0ac702fb4d2bf56afb6ee3c437
+Directory: 1.10/scala_2.11-debian
+
+Tags: 1.10.0-scala_2.12, 1.10-scala_2.12, scala_2.12, 1.10.0, 1.10, latest
+Architectures: amd64
+GitCommit: 346809e6cab2ca0ac702fb4d2bf56afb6ee3c437
+Directory: 1.10/scala_2.12-debian


### PR DESCRIPTION
Update to include the latest 1.10.0 release. The Dockerfiles have already been added into flink-docker repo through [this PR](https://github.com/apache/flink-docker/pull/6).