### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.1.2, 2.1, latest
+Tags: 2.1.3, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc149313474c6d9f3b9b50a70656747ba7e50872
+GitCommit: 52ce628f49cd7d355b7486e1c8dd9be51e492f4e
 Directory: 2.1
 
-Tags: 2.1.2-alpine, 2.1-alpine, alpine
+Tags: 2.1.3-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8c9c3e1783f9cf0ffd1d6aeabc8a1c2bca0bd80f
+GitCommit: 52ce628f49cd7d355b7486e1c8dd9be51e492f4e
 Directory: 2.1/alpine
 
-Tags: 2.0.12, 2.0
+Tags: 2.0.13, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 891e27621cf25e445bacdc3724b802aa70a8878c
+GitCommit: 73e364d5e78bf73c79cf3cbb36c0c888934dfb3f
 Directory: 2.0
 
-Tags: 2.0.12-alpine, 2.0-alpine
+Tags: 2.0.13-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8c9c3e1783f9cf0ffd1d6aeabc8a1c2bca0bd80f
+GitCommit: 73e364d5e78bf73c79cf3cbb36c0c888934dfb3f
 Directory: 2.0/alpine
 
-Tags: 1.9.13, 1.9, 1
+Tags: 1.9.14, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bbd9a3d20e2bda908eec696df9e6731bae448095
+GitCommit: 9c8c7a34289beee92e5d9648cd1f26cd89b1d1b3
 Directory: 1.9
 
-Tags: 1.9.13-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.14-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1260e9b17547577a6623e0857ade2803a1571dc7
+GitCommit: 9c8c7a34289beee92e5d9648cd1f26cd89b1d1b3
 Directory: 1.9/alpine
 
 Tags: 1.8.23, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/52ce628: Update to 2.1.3