### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -44,42 +44,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management
 
-Tags: 3.7.24-rc.2, 3.7-rc
+Tags: 3.7.24, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9859dc76960e21fefdcc79518e1b41867c428417
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.24-rc.2-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.24-rc.2-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9859dc76960e21fefdcc79518e1b41867c428417
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.24-rc.2-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: da06cbdbe9e89305b2650a782af06f96004a894e
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.23, 3.7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac035e224e3ddc7082cd8c8bea2a63417043d05
+GitCommit: 2ca391613d0c76bf0da98ca609b858f50e6140f4
 Directory: 3.7/ubuntu
 
-Tags: 3.7.23-management, 3.7-management
+Tags: 3.7.24-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f22c0b266cfeb8cb6d776f9e6a961908c2557ad3
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.23-alpine, 3.7-alpine
+Tags: 3.7.24-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ac035e224e3ddc7082cd8c8bea2a63417043d05
+GitCommit: 2ca391613d0c76bf0da98ca609b858f50e6140f4
 Directory: 3.7/alpine
 
-Tags: 3.7.23-management-alpine, 3.7-management-alpine
+Tags: 3.7.24-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4b2b11c59ee65c2a09616b163d4572559a86bb7b
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2ca3916: Update to 3.7.24, Erlang/OTP 22.2.6, OpenSSL 1.1.1d