### PR TITLE
[nats-streaming] Adding missing SharedTags for Windows image.

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -15,6 +15,7 @@ arm64v8-GitCommit: 9716618a61deba8a7e28b69d53d95d698bde5117
 arm64v8-Directory: arm64v8
 
 Tags: 0.17.0-nanoserver-1809, nanoserver-1809
+SharedTags: 0.17.0, latest
 Architectures: windows-amd64
 windows-amd64-GitCommit: 9716618a61deba8a7e28b69d53d95d698bde5117
 windows-amd64-Directory: windows/nanoserver-1809


### PR DESCRIPTION
The SharedTags was in the nanoserver-1803 section that has been
removed due to being EOL. Adding this tag to the nanoserver-1809.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>