### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.5.2, 3.5, 3, latest
+Tags: 3.6.0, 3.6, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4681460fb73e0c11d43200b35c57c8a15dbc047f
+GitCommit: 801174fc6c0812962e8ab9dbb988ac91dc2b3dcd
 Directory: 3/debian
 
-Tags: 3.5.2-alpine, 3.5-alpine, 3-alpine, alpine
+Tags: 3.6.0-alpine, 3.6-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4681460fb73e0c11d43200b35c57c8a15dbc047f
+GitCommit: 801174fc6c0812962e8ab9dbb988ac91dc2b3dcd
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/801174f: Update to 3.6.0, ghost-cli 1.13.1