### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9c8c7a34289beee92e5d9648cd1f26cd89b1d1b3
 Directory: 1.9/alpine
 
-Tags: 1.8.23, 1.8
+Tags: 1.8.24, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dde4821a9d74cd1ea60bb2943e3513bfd1165a7
+GitCommit: a55f971303062964269d0730d23e2ef1c78143f4
 Directory: 1.8
 
-Tags: 1.8.23-alpine, 1.8-alpine
+Tags: 1.8.24-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1260e9b17547577a6623e0857ade2803a1571dc7
+GitCommit: a55f971303062964269d0730d23e2ef1c78143f4
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a55f971: Update to 1.8.24