### PR TITLE
Bump Traefik to v1.7.21

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,18 +12,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: cca10154857dd0f4c71bf0973dbe9821f2e17a2d
 Directory: alpine
 
-Tags: v1.7.20-windowsservercore-1809, 1.7.20-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.21-windowsservercore-1809, 1.7.21-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
+GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.20-alpine, 1.7.20-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.21-alpine, 1.7.21-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
+GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
 Directory: alpine
 
-Tags: v1.7.20, 1.7.20, v1.7, 1.7, maroilles
+Tags: v1.7.21, 1.7.21, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 30e030d20c1da320d8817304e618f8d27157c79d
+GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v1.7.21](https://github.com/containous/traefik/releases/tag/v1.7.21).

/cc @mmatur @emilevauge @dtomcej

Cheers
