### PR TITLE
Fixing Oracle Linux 8.1 image for arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -7,7 +7,7 @@ amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: e1e3e2560fcfca32d0ac46bd01a4f9dcfcec8a9e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 448fa98ef8f70f9d5a1c00b630d274f0a20cb8ec
+arm64v8-GitCommit: e5700b5d5460542c506c27ee7f4d4cd9617bae7a
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
In the immortal words of Ms. B. Spears, "_Oops, I did it again._" 

@tianon Any chance you can add a check to `bashbrew` to make sure the package architecture inside the image matches the target architecture? So that if `rpm -qa` on the image returns `x86_64` for packages that are supposed to be `aarch64`, it returns an error? 

Signed-off-by: Avi Miller <avi.miller@oracle.com>