### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.7.0, 3.7, 3, latest
+Tags: 3.8.0, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04e671ab1d1f2edde35f93ce074de71937af43cf
+GitCommit: c429ec4db5fbd78d106166f897ecf01d843c532d
 Directory: 3/debian
 
-Tags: 3.7.0-alpine, 3.7-alpine, 3-alpine, alpine
+Tags: 3.8.0-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04e671ab1d1f2edde35f93ce074de71937af43cf
+GitCommit: c429ec4db5fbd78d106166f897ecf01d843c532d
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/c429ec4: Update to 3.8.0, ghost-cli 1.13.1