### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,127 +1,85 @@
-# this file is generated via https://github.com/docker-library/golang/blob/4bf3297b1dee4f81cac5a1e9ad6aaf9566236baf/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/69b2283d45ae89c84383d41a9b1aab4d84e5cbae/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.14rc1-buster, 1.14-rc-buster, rc-buster
-SharedTags: 1.14rc1, 1.14-rc, rc
+Tags: 1.14.0-buster, 1.14-buster, 1-buster, buster
+SharedTags: 1.14.0, 1.14, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06bc0446f48dfda05b3548bd1f64eb108471fc6b
-Directory: 1.14-rc/buster
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/buster
 
-Tags: 1.14rc1-stretch, 1.14-rc-stretch, rc-stretch
+Tags: 1.14.0-stretch, 1.14-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd09f367e097e0bd45467652072c3951c37280cb
-Directory: 1.14-rc/stretch
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/stretch
 
-Tags: 1.14rc1-alpine3.11, 1.14-rc-alpine3.11, rc-alpine3.11, 1.14rc1-alpine, 1.14-rc-alpine, rc-alpine
+Tags: 1.14.0-alpine3.11, 1.14-alpine3.11, 1-alpine3.11, alpine3.11, 1.14.0-alpine, 1.14-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06bc0446f48dfda05b3548bd1f64eb108471fc6b
-Directory: 1.14-rc/alpine3.11
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/alpine3.11
 
-Tags: 1.14rc1-windowsservercore-ltsc2016, 1.14-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.14rc1-windowsservercore, 1.14-rc-windowsservercore, rc-windowsservercore, 1.14rc1, 1.14-rc, rc
+Tags: 1.14.0-windowsservercore-ltsc2016, 1.14-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.14.0-windowsservercore, 1.14-windowsservercore, 1-windowsservercore, windowsservercore, 1.14.0, 1.14, 1, latest
 Architectures: windows-amd64
-GitCommit: 06bc0446f48dfda05b3548bd1f64eb108471fc6b
-Directory: 1.14-rc/windows/windowsservercore-ltsc2016
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.14rc1-windowsservercore-1809, 1.14-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.14rc1-windowsservercore, 1.14-rc-windowsservercore, rc-windowsservercore, 1.14rc1, 1.14-rc, rc
+Tags: 1.14.0-windowsservercore-1809, 1.14-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.14.0-windowsservercore, 1.14-windowsservercore, 1-windowsservercore, windowsservercore, 1.14.0, 1.14, 1, latest
 Architectures: windows-amd64
-GitCommit: 06bc0446f48dfda05b3548bd1f64eb108471fc6b
-Directory: 1.14-rc/windows/windowsservercore-1809
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.14rc1-nanoserver-1809, 1.14-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.14rc1-nanoserver, 1.14-rc-nanoserver, rc-nanoserver
+Tags: 1.14.0-nanoserver-1809, 1.14-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.14.0-nanoserver, 1.14-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 06bc0446f48dfda05b3548bd1f64eb108471fc6b
-Directory: 1.14-rc/windows/nanoserver-1809
+GitCommit: 69b2283d45ae89c84383d41a9b1aab4d84e5cbae
+Directory: 1.14/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.13.8-buster, 1.13-buster, 1-buster, buster
-SharedTags: 1.13.8, 1.13, 1, latest
+Tags: 1.13.8-buster, 1.13-buster
+SharedTags: 1.13.8, 1.13
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/buster
 
-Tags: 1.13.8-stretch, 1.13-stretch, 1-stretch, stretch
+Tags: 1.13.8-stretch, 1.13-stretch
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/stretch
 
-Tags: 1.13.8-alpine3.11, 1.13-alpine3.11, 1-alpine3.11, alpine3.11, 1.13.8-alpine, 1.13-alpine, 1-alpine, alpine
+Tags: 1.13.8-alpine3.11, 1.13-alpine3.11, 1.13.8-alpine, 1.13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/alpine3.11
 
-Tags: 1.13.8-alpine3.10, 1.13-alpine3.10, 1-alpine3.10, alpine3.10
+Tags: 1.13.8-alpine3.10, 1.13-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/alpine3.10
 
-Tags: 1.13.8-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.13.8-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.8, 1.13, 1, latest
+Tags: 1.13.8-windowsservercore-ltsc2016, 1.13-windowsservercore-ltsc2016
+SharedTags: 1.13.8-windowsservercore, 1.13-windowsservercore, 1.13.8, 1.13
 Architectures: windows-amd64
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.13.8-windowsservercore-1809, 1.13-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.13.8-windowsservercore, 1.13-windowsservercore, 1-windowsservercore, windowsservercore, 1.13.8, 1.13, 1, latest
+Tags: 1.13.8-windowsservercore-1809, 1.13-windowsservercore-1809
+SharedTags: 1.13.8-windowsservercore, 1.13-windowsservercore, 1.13.8, 1.13
 Architectures: windows-amd64
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.13.8-nanoserver-1809, 1.13-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.13.8-nanoserver, 1.13-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.13.8-nanoserver-1809, 1.13-nanoserver-1809
+SharedTags: 1.13.8-nanoserver, 1.13-nanoserver
 Architectures: windows-amd64
 GitCommit: 25aece9839b5abba963586e26e421dcd5ea00881
 Directory: 1.13/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 1.12.17-buster, 1.12-buster
-SharedTags: 1.12.17, 1.12
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/buster
-
-Tags: 1.12.17-stretch, 1.12-stretch
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/stretch
-
-Tags: 1.12.17-alpine3.11, 1.12-alpine3.11, 1.12.17-alpine, 1.12-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/alpine3.11
-
-Tags: 1.12.17-alpine3.10, 1.12-alpine3.10
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/alpine3.10
-
-Tags: 1.12.17-windowsservercore-ltsc2016, 1.12-windowsservercore-ltsc2016
-SharedTags: 1.12.17-windowsservercore, 1.12-windowsservercore, 1.12.17, 1.12
-Architectures: windows-amd64
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 1.12.17-windowsservercore-1809, 1.12-windowsservercore-1809
-SharedTags: 1.12.17-windowsservercore, 1.12-windowsservercore, 1.12.17, 1.12
-Architectures: windows-amd64
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 1.12.17-nanoserver-1809, 1.12-nanoserver-1809
-SharedTags: 1.12.17-nanoserver, 1.12-nanoserver
-Architectures: windows-amd64
-GitCommit: ffe8dcb44eb16cabd71b8b74cbf0d92f244afd53
-Directory: 1.12/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/69b2283: Update to 1.14 GA