### PR TITLE
Release Apache CouchDB 3.0.0

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,15 +3,15 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: 3bcc626d30623789b4750d076f059bcd010c2a04
+GitCommit: f56c425bb7d64918a57936376e0070e7742768cd
 
-Tags: latest, 2.3.1, 2.3, 2
-Architectures: amd64
+Tags: latest, 3.0.0, 3.0, 3
+Architectures: amd64, arm64v8, ppc64le
+Directory: 3.0.0
+
+Tags: 2.3.1, 2.3, 2
+Architectures: amd64, arm64v8, ppc64le
 Directory: 2.3.1
-
-Tags: 2.3.0
-Architectures: amd64
-Directory: 2.3.0
 
 # 1.x is no longer supported by the Apache CouchDB team.
 #


### PR DESCRIPTION
3.0.0 releases tomorrow. If acceptable, this PR may be merged anytime after 2020-02-26 12:00 UTC.