### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/deeb9b3ede9118ce4f642860d74c8513d39461b8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/de006e2143c7685102fcc790aec32ebdf1cf7789/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 2.1.21, 2.1
-Architectures: amd64, arm64v8, i386
-GitCommit: f98d3fc5282a99cdfe1ec8aa808d6313080137c0
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: de006e2143c7685102fcc790aec32ebdf1cf7789
 Directory: 2.1
 
-Tags: 2.2.15, 2.2, 2
-Architectures: amd64, i386
-GitCommit: 2852d6ace9623301bd831e38a6993a73f0a640a1
+Tags: 2.2.16, 2.2, 2
+Architectures: amd64, arm32v7, ppc64le
+GitCommit: de006e2143c7685102fcc790aec32ebdf1cf7789
 Directory: 2.2
 
-Tags: 3.0.19, 3.0
-Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 006818b41131828443e1e192a7ad94a84fe668b9
+Tags: 3.0.20, 3.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: de006e2143c7685102fcc790aec32ebdf1cf7789
 Directory: 3.0
 
-Tags: 3.11.5, 3.11, 3, latest
-Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: e5b7ed497ff74587560682dd4c6a2e9b01f818d9
+Tags: 3.11.6, 3.11, 3, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: de006e2143c7685102fcc790aec32ebdf1cf7789
 Directory: 3.11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/b778a26: Merge pull request https://github.com/docker-library/cassandra/pull/199 from infosiftr/buster
- https://github.com/docker-library/cassandra/commit/de006e2: Switch from using Debian packages to using binary releases
- https://github.com/docker-library/cassandra/commit/11a1ede: Update to 3.11.6
- https://github.com/docker-library/cassandra/commit/65f2c6a: Update to 3.0.20
- https://github.com/docker-library/cassandra/commit/e14dfcd: Update to 2.2.16
- https://github.com/docker-library/cassandra/commit/0d1a732: Update to Buster (and https repos, per upstream)