### PR TITLE
upgrade r-base to R 3.6.3 released yesterday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 3.6.2, latest
+Tags: 3.6.3, latest
 Architectures: amd64, arm64v8
-GitCommit: df56b98e4a2a4611fa9aacae99c4a304531c2640
+GitCommit: e76a46e4d082c0294437c34df1072f48c6fa3685
 Directory: r-base


### PR DESCRIPTION
Standard update to R 3.6.3 which was released upstream, and debianized, yesterday