### PR TITLE
Haskell GHC 8.8.3 (and 8.8.2).

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,10 +2,15 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
              Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 8.8.1, 8.8, 8, latest
-GitCommit: aa517c24c51bbd54da5805517acd12120a9340ab
+Tags: 8.8.3, 8.8, 8, latest
+GitCommit: c7675920a33d47aa30ff5456ee622cd61a2d62be
+Directory: 8.8
+
+Tags: 8.8.2
+GitCommit: 1eaf476bf1a9933898f8e96bb366308485d9353f
+GitFetch: refs/heads/temp-8.8.2
 Directory: 8.8
 
 Tags: 8.6.5, 8.6
-GitCommit: aa517c24c51bbd54da5805517acd12120a9340ab
+GitCommit: c7675920a33d47aa30ff5456ee622cd61a2d62be
 Directory: 8.6


### PR DESCRIPTION
The intention is to do a one-time publish of 8.8.2, with follow-up PR to remove it. The Dockerfiles were refactored a bit to split up one big layer into a few smaller layers to address build flakiness caused by GPG key fetching, and they are also finally parameterized! :+1: