### PR TITLE
Revert "Bump IBM Java version to 1.8.0_sr6fp6 (8.0.6.6)."

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,30 +5,30 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/jre/alpine
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sfj-alpine, sfj-alpine
 Architectures: amd64
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/sfj/alpine
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/sdk/ubuntu
 
 Tags: 8-sdk-alpine, sdk-alpine
 Architectures: amd64
-GitCommit: b009173a2b7d8a27a91b029c79d5616d962be582
+GitCommit: 1552ece33496b1871d8d999f7d2091cd9b2eb036
 Directory: ibmjava/8/sdk/alpine


### PR DESCRIPTION
The latest release is broken, need to revert back to the previous one :(
Reverts docker-library/official-images#7537