### PR TITLE
Updating Oracle Linux 8.1/8-slim for CVE-2020-1712

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e1e3e2560fcfca32d0ac46bd01a4f9dcfcec8a9e
+amd64-GitCommit: 090c41832c757a0ebe2d0bb59b2d39c0edc31ac8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e5700b5d5460542c506c27ee7f4d4cd9617bae7a
+arm64v8-GitCommit: 5aa9756ecf67386d96d15a3b8422d6c9fa7b948e
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
* Updated Oracle Linux `8` and `8-slim` images for `amd64` and `arm64v8`
  * Updated `systemd` to `systemd-239-18.0.2.el8_1.4`
  * https://linux.oracle.com/errata/ELSA-2020-0575.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>