### PR TITLE
Add new caddy image

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/60b6757193c05c9be5f4006d2ade2da9a3446ae5/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/42735f560d5ac8975c4a7d5feffe12dd590a229b/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: v2.0.0-beta.17, v2.0.0-beta.17-alpine, alpine, latest
+Tags: 2.0.0-beta.17, 2.0.0-beta.17-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 60b6757193c05c9be5f4006d2ade2da9a3446ae5
+GitCommit: 42735f560d5ac8975c4a7d5feffe12dd590a229b
 Architectures: amd64
 
-Tags: v2.0.0-beta.17-builder, builder
+Tags: 2.0.0-beta.17-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: b34f1304f6b6c29233827efa0270c89d9290d558
+GitCommit: 42735f560d5ac8975c4a7d5feffe12dd590a229b
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/d054226024be7b70f58e4e18904043a690c485bb/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-beta.20, 2.0.0-beta.20-alpine, alpine, latest
+Tags: 2.0.0-rc.1, 2.0.0-rc.1-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb
+GitCommit: d054226024be7b70f58e4e18904043a690c485bb
 Architectures: amd64
 
-Tags: 2.0.0-beta.20-builder, builder
+Tags: 2.0.0-rc.1-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: 4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb
+GitCommit: d054226024be7b70f58e4e18904043a690c485bb
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/843a13055fd2ffa1686f6070752d3d313a6bfbe0/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-beta.19, 2.0.0-beta.19-alpine, alpine, latest
+Tags: 2.0.0-beta.20, 2.0.0-beta.20-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 843a13055fd2ffa1686f6070752d3d313a6bfbe0
+GitCommit: 4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb
 Architectures: amd64
 
-Tags: 2.0.0-beta.19-builder, builder
+Tags: 2.0.0-beta.20-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: 843a13055fd2ffa1686f6070752d3d313a6bfbe0
+GitCommit: 4747ccb2c2f6d1a75a7590094be016f1a4ce3ddb
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/6c597e446dd027b0a11dbf733e407bb4191a0e8c/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/82359bcbcd3d43b8703605afc60370b6c5f87d1f/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-rc.2, 2.0.0-rc.2-alpine, alpine, latest
+Tags: 2.0.0-rc.3, 2.0.0-rc.3-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 6c597e446dd027b0a11dbf733e407bb4191a0e8c
+GitCommit: 82359bcbcd3d43b8703605afc60370b6c5f87d1f
 Architectures: amd64
 
-Tags: 2.0.0-rc.2-builder, builder
+Tags: 2.0.0-rc.3-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: 6c597e446dd027b0a11dbf733e407bb4191a0e8c
+GitCommit: 82359bcbcd3d43b8703605afc60370b6c5f87d1f
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/d054226024be7b70f58e4e18904043a690c485bb/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/6c597e446dd027b0a11dbf733e407bb4191a0e8c/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-rc.1, 2.0.0-rc.1-alpine, alpine, latest
+Tags: 2.0.0-rc.2, 2.0.0-rc.2-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: d054226024be7b70f58e4e18904043a690c485bb
+GitCommit: 6c597e446dd027b0a11dbf733e407bb4191a0e8c
 Architectures: amd64
 
-Tags: 2.0.0-rc.1-builder, builder
+Tags: 2.0.0-rc.2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: d054226024be7b70f58e4e18904043a690c485bb
+GitCommit: 6c597e446dd027b0a11dbf733e407bb4191a0e8c
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/dbdd5294d5172438253ed6b5793b26e26ef30eb5/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/60b6757193c05c9be5f4006d2ade2da9a3446ae5/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: v2.0.0-beta.15, v2.0.0-beta.15-alpine, alpine, latest
+Tags: v2.0.0-beta.17, v2.0.0-beta.17-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: dbdd5294d5172438253ed6b5793b26e26ef30eb5
+GitCommit: 60b6757193c05c9be5f4006d2ade2da9a3446ae5
 Architectures: amd64
 
-Tags: v2.0.0-beta.15-builder, builder
+Tags: v2.0.0-beta.17-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: f286081caf2bc97489ed1d539b52abb1bf0da123
+GitCommit: b34f1304f6b6c29233827efa0270c89d9290d558
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/42735f560d5ac8975c4a7d5feffe12dd590a229b/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/843a13055fd2ffa1686f6070752d3d313a6bfbe0/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-beta.17, 2.0.0-beta.17-alpine, alpine, latest
+Tags: 2.0.0-beta.19, 2.0.0-beta.19-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 42735f560d5ac8975c4a7d5feffe12dd590a229b
+GitCommit: 843a13055fd2ffa1686f6070752d3d313a6bfbe0
 Architectures: amd64
 
-Tags: 2.0.0-beta.17-builder, builder
+Tags: 2.0.0-beta.19-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
-GitCommit: 42735f560d5ac8975c4a7d5feffe12dd590a229b
+GitCommit: 843a13055fd2ffa1686f6070752d3d313a6bfbe0
 Architectures: amd64

--- a/library/caddy
+++ b/library/caddy
@@ -1,0 +1,16 @@
+# this file is generated with gomplate:
+# template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
+# config context: https://github.com/caddyserver/caddy-docker/blob/dbdd5294d5172438253ed6b5793b26e26ef30eb5/stackbrew-config.yaml
+Maintainers: Dave Henderson (@hairyhenderson)
+
+Tags: v2.0.0-beta.15, v2.0.0-beta.15-alpine, alpine, latest
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: alpine
+GitCommit: dbdd5294d5172438253ed6b5793b26e26ef30eb5
+Architectures: amd64
+
+Tags: v2.0.0-beta.15-builder, builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: builder
+GitCommit: f286081caf2bc97489ed1d539b52abb1bf0da123
+Architectures: amd64


### PR DESCRIPTION
Hi there! This proposes a new official image for [Caddy](https://caddyserver.com), _"a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go."_

This is for Caddy v2+, which is in RC (currently at v2.0.0-rc.3). It complements the (quite popular) Caddy v1 image https://hub.docker.com/r/abiosoft/caddy. I've been working with @mholt (Caddy's author) to create this one.

I've got a `bashbrew`-based build currently working for the [`caddy/caddy`](https://hub.docker.com/r/caddy/caddy) image, which I'm hoping to replace with an official `caddy` image.

For now I'm only building on `amd64`, but hope to add new architectures soon. I'm somewhat uncertain how to test multi-platforms myself (I'd use buildx, but I gather bashbrew doesn't support that?).

Docs PR is here: https://github.com/docker-library/docs/pull/1667

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/caddyserver
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1667
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>