### PR TITLE
Bump Traefik to v2.2.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,6 +1,17 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur), Damien Duportal <damien@containo.us> (@dduportal)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
+Tags: v2.2.0-rc1-windowsservercore-1809, 2.2.0-rc1-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
+Architectures: windows-amd64
+GitCommit: 92cfab77bf0b968b37b567d1816a57df74f7e69a
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.2.0-rc1, 2.2.0-rc1, v2.2, 2.2, chevrotin
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 92cfab77bf0b968b37b567d1816a57df74f7e69a
+Directory: alpine
+
 Tags: v2.1.6-windowsservercore-1809, 2.1.6-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitCommit: a1cd15373faf833121fbc5d6418d4f30c7738d88


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.0-rc1](https://github.com/containous/traefik/releases/tag/v2.2.0-rc1).

/cc @mmatur @emilevauge @dtomcej

Cheers
