### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0-rc1, 6.0-rc, rc, 6.0-rc1-buster, 6.0-rc-buster, rc-buster
+Tags: 6.0-rc2, 6.0-rc, rc, 6.0-rc2-buster, 6.0-rc-buster, rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
+GitCommit: 7678eb71afd668779635758a2e0005cd87cc6c16
 Directory: 6.0-rc
 
-Tags: 6.0-rc1-alpine, 6.0-rc-alpine, rc-alpine, 6.0-rc1-alpine3.11, 6.0-rc-alpine3.11, rc-alpine3.11
+Tags: 6.0-rc2-alpine, 6.0-rc-alpine, rc-alpine, 6.0-rc2-alpine3.11, 6.0-rc-alpine3.11, rc-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
+GitCommit: 7678eb71afd668779635758a2e0005cd87cc6c16
 Directory: 6.0-rc/alpine
 
 Tags: 5.0.7, 5.0, 5, latest, 5.0.7-buster, 5.0-buster, 5-buster, buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/7678eb7: Update to 6.0-rc2