### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.3-rc.1, 3.8-rc
+Tags: 3.8.3-rc.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 860c6229fdb04ab9e68b9b7e528b2afefab1efc3
+GitCommit: 365d8d47398e9b7cdfa9ba286ad2859cf83bc47b
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.3-rc.1-management, 3.8-rc-management
+Tags: 3.8.3-rc.2-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.3-rc.1-alpine, 3.8-rc-alpine
+Tags: 3.8.3-rc.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 860c6229fdb04ab9e68b9b7e528b2afefab1efc3
+GitCommit: 365d8d47398e9b7cdfa9ba286ad2859cf83bc47b
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.3-rc.1-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.3-rc.2-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
 Directory: 3.8-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/365d8d4: Update to 3.8.3-rc.2, Erlang/OTP 22.2.8, OpenSSL 1.1.1d