### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-12-jdk-oraclelinux7, 15-ea-12-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-12-jdk-oracle, 15-ea-12-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-12-jdk, 15-ea-12, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-13-jdk-oraclelinux7, 15-ea-13-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-13-jdk-oracle, 15-ea-13-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-13-jdk, 15-ea-13, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk/oracle
 Constraints: !aufs
 
-Tags: 15-ea-12-jdk-buster, 15-ea-12-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-13-jdk-buster, 15-ea-13-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk
 
-Tags: 15-ea-12-jdk-slim-buster, 15-ea-12-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-12-jdk-slim, 15-ea-12-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-13-jdk-slim-buster, 15-ea-13-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-13-jdk-slim, 15-ea-13-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: ee26e3735002dfb83551faf0f3b73822addc4799
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-12-jdk-windowsservercore-1809, 15-ea-12-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-12-jdk-windowsservercore, 15-ea-12-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-12-jdk, 15-ea-12, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-13-jdk-windowsservercore-1809, 15-ea-13-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-13-jdk-windowsservercore, 15-ea-13-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-13-jdk, 15-ea-13, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-12-jdk-windowsservercore-ltsc2016, 15-ea-12-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-12-jdk-windowsservercore, 15-ea-12-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-12-jdk, 15-ea-12, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-13-jdk-windowsservercore-ltsc2016, 15-ea-13-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-13-jdk-windowsservercore, 15-ea-13-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-13-jdk, 15-ea-13, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-12-jdk-nanoserver-1809, 15-ea-12-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-12-jdk-nanoserver, 15-ea-12-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-13-jdk-nanoserver-1809, 15-ea-13-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-13-jdk-nanoserver, 15-ea-13-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 9b88b83ce32c3e8ebd5bf1faae8524501f8c7afb
+GitCommit: 664f4953394f3459704e15f09aae014a22c57f33
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/664f495: Update to 15-ea+13