### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/49ea4fec27a234d7e9657dcced334f1bb8a9da04/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/9a912d0e83db821040cbe3a4d4f543b857e9c61c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 49ea4fec27a234d7e9657dcced334f1bb8a9da04
+GitCommit: 9a912d0e83db821040cbe3a4d4f543b857e9c61c
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9d1c74a415de8f8795dfe3cd42b97c9ae7ef770f
+amd64-GitCommit: 9bb427f4dcafc97cf3f8b523fc8ed147d8bba7d8
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e8ca1536f1638174e391ac62312f3d8d5b2d7041
+arm32v5-GitCommit: d3f085e1d42fe99d11bee29b556f386fafcae04d
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 696fd5847e5da6a05070304a5871502f423fb26b
+arm32v6-GitCommit: fc02c9f154d0b02ee0e4ca95161b0ca8ab726147
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 4d57293595c1502991e3ba35c6c30841cd5d6d5a
+arm32v7-GitCommit: 0504f1abd6d89443e2223b73159c7f3d77393710
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 874cdd06813463d856646a2af1beddd3b29e868a
+arm64v8-GitCommit: b87bf5287e8126d473c607a5669919784f2b66de
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: d9473a766bd604cee97e6966da192178d7300192
+i386-GitCommit: e05006df43b2dc008ce63e50109a138844434653
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 39457972d336a120f399d92c0da851da018e2adf
+ppc64le-GitCommit: 1a032fa4206559a7b5ab7ca671244e18ef1e829d
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 808ff0966658770c85dd5d4d430a14ae42c0655b
+s390x-GitCommit: 19381f29c950469136109dc48bfccc6f47c1ef31
 
 Tags: 1.31.1-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/9a912d0: Update buildroot to 2020.02