### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.3-rc.2, 3.8-rc
+Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 365d8d47398e9b7cdfa9ba286ad2859cf83bc47b
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.3-rc.2-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.3-rc.2-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 365d8d47398e9b7cdfa9ba286ad2859cf83bc47b
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.3-rc.2-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a5957b93e31661739a9018bc2ae5d20f1bfae59
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.2, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2c15b5b5a8bbe49f4c4752d0095417f4b304332
+GitCommit: f385008e7aeb1ed78975b1c3563904f157e3d91a
 Directory: 3.8/ubuntu
 
-Tags: 3.8.2-management, 3.8-management, 3-management, management
+Tags: 3.8.3-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.2-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2c15b5b5a8bbe49f4c4752d0095417f4b304332
+GitCommit: f385008e7aeb1ed78975b1c3563904f157e3d91a
 Directory: 3.8/alpine
 
-Tags: 3.8.2-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/f385008: Update to 3.8.3, Erlang/OTP 22.2.8, OpenSSL 1.1.1d