### PR TITLE
Updating Oracle Linux 7 images for CVE-2019-5482

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 090c41832c757a0ebe2d0bb59b2d39c0edc31ac8
+amd64-GitCommit: 833eb6d332617fe47a3b3f6e76e85a354e4d581f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5aa9756ecf67386d96d15a3b8422d6c9fa7b948e
+arm64v8-GitCommit: 7fb5fa359cb2d6a289690a5680b28d9ac3b9edc2
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
* Updated Oracle Linux `7` and `7-slim` images for `amd64` and `arm64v8`
  * Updated `curl` to `curl-7.29.0-54.0.5.el7_7.2`
  * https://linux.oracle.com/errata/ELSA-2020-5562.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>