### PR TITLE
Update clojure leiningen, tools-deps, and latest tag

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -5,67 +5,49 @@ GitRepo: https://github.com/Quantisan/docker-clojure.git
 GitCommit: 09a243f78bde5ce2f5304b4d10a5d6b8152dc803
 
 Tags: latest
-Directory: target/openjdk-11-stretch/latest
+Directory: target/openjdk-11-slim-buster/latest
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.2, openjdk-8-stretch, openjdk-8-lein-stretch, openjdk-8-lein-2.9.2-stretch
-Directory: target/openjdk-8-stretch/lein
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.2, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.2-buster
+Directory: target/openjdk-8-buster/lein
 
 Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.2-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
-Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-stretch, openjdk-8-boot-2.8.3-stretch
-Directory: target/openjdk-8-stretch/boot
+Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
+Directory: target/openjdk-8-buster/boot
 
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.536, openjdk-8-tools-deps-stretch, openjdk-8-tools-deps-1.10.1.536-stretch
-Directory: target/openjdk-8-stretch/tools-deps
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.536, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.536-buster
+Directory: target/openjdk-8-buster/tools-deps
 
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.536-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.2, lein, lein-2.9.2, openjdk-11-stretch, openjdk-11-lein-stretch, openjdk-11-lein-2.9.2-stretch, lein-stretch, lein-2.9.2-stretch
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.2, lein, lein-2.9.2, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.2-buster, lein-buster, lein-2.9.2-buster
 Architectures: amd64, arm64v8
-Directory: target/openjdk-11-stretch/lein
+Directory: target/openjdk-11-buster/lein
 
 Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.2-slim-buster, slim-buster, lein-slim-buster, lein-2.9.2-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/lein
 
-Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-stretch, openjdk-11-boot-2.8.3-stretch, boot-stretch, boot-2.8.3-stretch
+Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
 Architectures: amd64, arm64v8
-Directory: target/openjdk-11-stretch/boot
+Directory: target/openjdk-11-buster/boot
 
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.536, tools-deps, tools-deps-1.10.1.536, openjdk-11-tools-deps-stretch, openjdk-11-tools-deps-1.10.1.536-stretch, tools-deps-stretch, tools-deps-1.10.1.536-stretch
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.536, tools-deps, tools-deps-1.10.1.536, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.536-buster, tools-deps-buster, tools-deps-1.10.1.536-buster
 Architectures: amd64, arm64v8
-Directory: target/openjdk-11-stretch/tools-deps
+Directory: target/openjdk-11-buster/tools-deps
 
 Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.536-slim-buster, tools-deps-1.10.1.536-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
-
-Tags: openjdk-13, openjdk-13-lein, openjdk-13-lein-2.9.2, openjdk-13-slim-buster, openjdk-13-lein-slim-buster, openjdk-13-lein-2.9.2-slim-buster
-Directory: target/openjdk-13-slim-buster/lein
-
-Tags: openjdk-13-buster, openjdk-13-lein-buster, openjdk-13-lein-2.9.2-buster
-Directory: target/openjdk-13-buster/lein
-
-Tags: openjdk-13-boot, openjdk-13-boot-2.8.3, openjdk-13-boot-slim-buster, openjdk-13-boot-2.8.3-slim-buster
-Directory: target/openjdk-13-slim-buster/boot
-
-Tags: openjdk-13-boot-buster, openjdk-13-boot-2.8.3-buster
-Directory: target/openjdk-13-buster/boot
-
-Tags: openjdk-13-tools-deps, openjdk-13-tools-deps-1.10.1.536, openjdk-13-tools-deps-slim-buster, openjdk-13-tools-deps-1.10.1.536-slim-buster
-Directory: target/openjdk-13-slim-buster/tools-deps
-
-Tags: openjdk-13-tools-deps-buster, openjdk-13-tools-deps-1.10.1.536-buster
-Directory: target/openjdk-13-buster/tools-deps
 
 Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.2, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.2-slim-buster
 Directory: target/openjdk-14-slim-buster/lein
@@ -85,11 +67,29 @@ Directory: target/openjdk-14-slim-buster/tools-deps
 Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.536-buster
 Directory: target/openjdk-14-buster/tools-deps
 
-Tags: openjdk-14-alpine, openjdk-14-lein-alpine, openjdk-14-lein-2.9.2-alpine
-Directory: target/openjdk-14-alpine/lein
+Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.2, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.2-slim-buster
+Directory: target/openjdk-15-slim-buster/lein
 
-Tags: openjdk-14-boot-alpine, openjdk-14-boot-2.8.3-alpine
-Directory: target/openjdk-14-alpine/boot
+Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.2-buster
+Directory: target/openjdk-15-buster/lein
 
-Tags: openjdk-14-tools-deps-alpine, openjdk-14-tools-deps-1.10.1.536-alpine
-Directory: target/openjdk-14-alpine/tools-deps
+Tags: openjdk-15-boot, openjdk-15-boot-2.8.3, openjdk-15-boot-slim-buster, openjdk-15-boot-2.8.3-slim-buster
+Directory: target/openjdk-15-slim-buster/boot
+
+Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
+Directory: target/openjdk-15-buster/boot
+
+Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.536, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.536-slim-buster
+Directory: target/openjdk-15-slim-buster/tools-deps
+
+Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.536-buster
+Directory: target/openjdk-15-buster/tools-deps
+
+Tags: openjdk-15-alpine, openjdk-15-lein-alpine, openjdk-15-lein-2.9.2-alpine
+Directory: target/openjdk-15-alpine/lein
+
+Tags: openjdk-15-boot-alpine, openjdk-15-boot-2.8.3-alpine
+Directory: target/openjdk-15-alpine/boot
+
+Tags: openjdk-15-tools-deps-alpine, openjdk-15-tools-deps-1.10.1.536-alpine
+Directory: target/openjdk-15-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -7,10 +7,10 @@ GitCommit: 09a243f78bde5ce2f5304b4d10a5d6b8152dc803
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.2, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.2-buster
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.3, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.3-buster
 Directory: target/openjdk-8-buster/lein
 
-Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.2-slim-buster
+Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.3-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
@@ -25,11 +25,11 @@ Directory: target/openjdk-8-buster/tools-deps
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.536-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.2, lein, lein-2.9.2, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.2-buster, lein-buster, lein-2.9.2-buster
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.3, lein, lein-2.9.3, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.3-buster, lein-buster, lein-2.9.3-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.2-slim-buster, slim-buster, lein-slim-buster, lein-2.9.2-slim-buster
+Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.3-slim-buster, slim-buster, lein-slim-buster, lein-2.9.3-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/lein
 
@@ -49,10 +49,10 @@ Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.536-slim-b
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.2, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.2-slim-buster
+Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.3, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.3-slim-buster
 Directory: target/openjdk-14-slim-buster/lein
 
-Tags: openjdk-14-buster, openjdk-14-lein-buster, openjdk-14-lein-2.9.2-buster
+Tags: openjdk-14-buster, openjdk-14-lein-buster, openjdk-14-lein-2.9.3-buster
 Directory: target/openjdk-14-buster/lein
 
 Tags: openjdk-14-boot, openjdk-14-boot-2.8.3, openjdk-14-boot-slim-buster, openjdk-14-boot-2.8.3-slim-buster
@@ -67,10 +67,10 @@ Directory: target/openjdk-14-slim-buster/tools-deps
 Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.536-buster
 Directory: target/openjdk-14-buster/tools-deps
 
-Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.2, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.2-slim-buster
+Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.3, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.3-slim-buster
 Directory: target/openjdk-15-slim-buster/lein
 
-Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.2-buster
+Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.3-buster
 Directory: target/openjdk-15-buster/lein
 
 Tags: openjdk-15-boot, openjdk-15-boot-2.8.3, openjdk-15-boot-slim-buster, openjdk-15-boot-2.8.3-slim-buster
@@ -85,7 +85,7 @@ Directory: target/openjdk-15-slim-buster/tools-deps
 Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.536-buster
 Directory: target/openjdk-15-buster/tools-deps
 
-Tags: openjdk-15-alpine, openjdk-15-lein-alpine, openjdk-15-lein-2.9.2-alpine
+Tags: openjdk-15-alpine, openjdk-15-lein-alpine, openjdk-15-lein-2.9.3-alpine
 Directory: target/openjdk-15-alpine/lein
 
 Tags: openjdk-15-boot-alpine, openjdk-15-boot-2.8.3-alpine

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: c9fb61e5a9a1a520d447de64ea210f53b5732f01
+GitCommit: 09a243f78bde5ce2f5304b4d10a5d6b8152dc803
 
 Tags: latest
 Directory: target/openjdk-11-stretch/latest

--- a/library/clojure
+++ b/library/clojure
@@ -2,12 +2,15 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: e96f6249cac065855a40a9f36ba88949e0a52d7d
+GitCommit: c9fb61e5a9a1a520d447de64ea210f53b5732f01
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.1, openjdk-8-stretch, openjdk-8-lein-stretch, openjdk-8-lein-2.9.1-stretch
+Tags: latest
+Directory: target/openjdk-11-stretch/latest
+
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.2, openjdk-8-stretch, openjdk-8-lein-stretch, openjdk-8-lein-2.9.2-stretch
 Directory: target/openjdk-8-stretch/lein
 
-Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.1-slim-buster
+Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.2-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-stretch, openjdk-8-boot-2.8.3-stretch
@@ -16,17 +19,17 @@ Directory: target/openjdk-8-stretch/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.502, openjdk-8-tools-deps-stretch, openjdk-8-tools-deps-1.10.1.502-stretch
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.536, openjdk-8-tools-deps-stretch, openjdk-8-tools-deps-1.10.1.536-stretch
 Directory: target/openjdk-8-stretch/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.502-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.536-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.1, lein, lein-2.9.1, openjdk-11-stretch, openjdk-11-lein-stretch, openjdk-11-lein-2.9.1-stretch, lein-stretch, lein-2.9.1-stretch
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.2, lein, lein-2.9.2, openjdk-11-stretch, openjdk-11-lein-stretch, openjdk-11-lein-2.9.2-stretch, lein-stretch, lein-2.9.2-stretch
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-stretch/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.1-slim-buster, slim-buster, lein-slim-buster, lein-2.9.1-slim-buster, latest
+Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.2-slim-buster, slim-buster, lein-slim-buster, lein-2.9.2-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/lein
 
@@ -38,18 +41,18 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.502, tools-deps, tools-deps-1.10.1.502, openjdk-11-tools-deps-stretch, openjdk-11-tools-deps-1.10.1.502-stretch, tools-deps-stretch, tools-deps-1.10.1.502-stretch
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.536, tools-deps, tools-deps-1.10.1.536, openjdk-11-tools-deps-stretch, openjdk-11-tools-deps-1.10.1.536-stretch, tools-deps-stretch, tools-deps-1.10.1.536-stretch
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-stretch/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.502-slim-buster, tools-deps-1.10.1.502-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.536-slim-buster, tools-deps-1.10.1.536-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-13, openjdk-13-lein, openjdk-13-lein-2.9.1, openjdk-13-slim-buster, openjdk-13-lein-slim-buster, openjdk-13-lein-2.9.1-slim-buster
+Tags: openjdk-13, openjdk-13-lein, openjdk-13-lein-2.9.2, openjdk-13-slim-buster, openjdk-13-lein-slim-buster, openjdk-13-lein-2.9.2-slim-buster
 Directory: target/openjdk-13-slim-buster/lein
 
-Tags: openjdk-13-buster, openjdk-13-lein-buster, openjdk-13-lein-2.9.1-buster
+Tags: openjdk-13-buster, openjdk-13-lein-buster, openjdk-13-lein-2.9.2-buster
 Directory: target/openjdk-13-buster/lein
 
 Tags: openjdk-13-boot, openjdk-13-boot-2.8.3, openjdk-13-boot-slim-buster, openjdk-13-boot-2.8.3-slim-buster
@@ -58,16 +61,16 @@ Directory: target/openjdk-13-slim-buster/boot
 Tags: openjdk-13-boot-buster, openjdk-13-boot-2.8.3-buster
 Directory: target/openjdk-13-buster/boot
 
-Tags: openjdk-13-tools-deps, openjdk-13-tools-deps-1.10.1.502, openjdk-13-tools-deps-slim-buster, openjdk-13-tools-deps-1.10.1.502-slim-buster
+Tags: openjdk-13-tools-deps, openjdk-13-tools-deps-1.10.1.536, openjdk-13-tools-deps-slim-buster, openjdk-13-tools-deps-1.10.1.536-slim-buster
 Directory: target/openjdk-13-slim-buster/tools-deps
 
-Tags: openjdk-13-tools-deps-buster, openjdk-13-tools-deps-1.10.1.502-buster
+Tags: openjdk-13-tools-deps-buster, openjdk-13-tools-deps-1.10.1.536-buster
 Directory: target/openjdk-13-buster/tools-deps
 
-Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.1, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.1-slim-buster
+Tags: openjdk-14, openjdk-14-lein, openjdk-14-lein-2.9.2, openjdk-14-slim-buster, openjdk-14-lein-slim-buster, openjdk-14-lein-2.9.2-slim-buster
 Directory: target/openjdk-14-slim-buster/lein
 
-Tags: openjdk-14-buster, openjdk-14-lein-buster, openjdk-14-lein-2.9.1-buster
+Tags: openjdk-14-buster, openjdk-14-lein-buster, openjdk-14-lein-2.9.2-buster
 Directory: target/openjdk-14-buster/lein
 
 Tags: openjdk-14-boot, openjdk-14-boot-2.8.3, openjdk-14-boot-slim-buster, openjdk-14-boot-2.8.3-slim-buster
@@ -76,17 +79,17 @@ Directory: target/openjdk-14-slim-buster/boot
 Tags: openjdk-14-boot-buster, openjdk-14-boot-2.8.3-buster
 Directory: target/openjdk-14-buster/boot
 
-Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.502, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.502-slim-buster
+Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.536, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.536-slim-buster
 Directory: target/openjdk-14-slim-buster/tools-deps
 
-Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.502-buster
+Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.536-buster
 Directory: target/openjdk-14-buster/tools-deps
 
-Tags: openjdk-14-alpine, openjdk-14-lein-alpine, openjdk-14-lein-2.9.1-alpine
+Tags: openjdk-14-alpine, openjdk-14-lein-alpine, openjdk-14-lein-2.9.2-alpine
 Directory: target/openjdk-14-alpine/lein
 
 Tags: openjdk-14-boot-alpine, openjdk-14-boot-2.8.3-alpine
 Directory: target/openjdk-14-alpine/boot
 
-Tags: openjdk-14-tools-deps-alpine, openjdk-14-tools-deps-1.10.1.502-alpine
+Tags: openjdk-14-tools-deps-alpine, openjdk-14-tools-deps-1.10.1.536-alpine
 Directory: target/openjdk-14-alpine/tools-deps


### PR DESCRIPTION
This update contains 3 changes:

1. Leiningen 2.9.2 was released (and then 2.9.3 was released)
1. tools-deps 1.10.1.536 was released
1. We decided to bake lein, boot, and tools-deps into the `latest` image to minimize confusion for the "quick start" image.