### PR TITLE
Add EspoCRM official image

### DIFF
--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/12856eaa14480e6adec6420e9a294ff1a6ab41ea/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/1029b7a4cbc7bce1494c97383e04fc96d9c29ae0/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.1-apache, 8.3-apache, 8-apache, latest, 8.3.1, 8.3, 8
+Tags: apache, 8.3.2-apache, 8.3-apache, 8-apache, latest, 8.3.2, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
+GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
 Directory: apache
 
-Tags: fpm, 8.3.1-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.2-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
+GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.1-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.2-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
+GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/c75f6deaef3e685f6767a83014aba433b58e07a4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/7b933d4fc7036f1a037e5c20b5e88fd2537c669f/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.4.0-apache, 8.4-apache, 8-apache, latest, 8.4.0, 8.4, 8
+Tags: apache, 8.4.1-apache, 8.4-apache, 8-apache, latest, 8.4.1, 8.4, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
+GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
 Directory: apache
 
-Tags: fpm, 8.4.0-fpm, 8.4-fpm, 8-fpm
+Tags: fpm, 8.4.1-fpm, 8.4-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
+GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
 Directory: fpm
 
-Tags: fpm-alpine, 8.4.0-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.4.1-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
+GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/541e2ead27a98bffa809f9302bf4e78262c902c6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/062527a437bbabb8d5712970938d5defdc937a04/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.2.5-apache, 8.2-apache, 8-apache, latest, 8.2.5, 8.2, 8
+Tags: apache, 8.3.0-apache, 8.3-apache, 8-apache, latest, 8.3.0, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
+GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
 Directory: apache
 
-Tags: fpm, 8.2.5-fpm, 8.2-fpm, 8-fpm
+Tags: fpm, 8.3.0-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
+GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
 Directory: fpm
 
-Tags: fpm-alpine, 8.2.5-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.0-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
+GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,0 +1,19 @@
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b0b555425c5aa0b4e357a8fe431e06249f1489f5/generate-stackbrew-library.sh
+
+Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
+GitRepo: https://github.com/espocrm/espocrm-docker.git
+
+Tags: apache, 8.2.4-apache, 8.2-apache, 8-apache, latest, 8.2.4, 8.2, 8
+Architectures: amd64, i386, arm32v7, arm64v8, s390x
+GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+Directory: apache
+
+Tags: fpm, 8.2.4-fpm, 8.2-fpm, 8-fpm
+Architectures: amd64, i386, arm32v7, arm64v8, s390x
+GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+Directory: fpm
+
+Tags: fpm-alpine, 8.2.4-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine
+Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/33718c149de426626382a54bd4b4ae9911df72f2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9345bf125c1b7f0ced021c89ec12e3deecc79ac1/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.3-apache, 8.3-apache, 8-apache, latest, 8.3.3, 8.3, 8
+Tags: apache, 8.3.4-apache, 8.3-apache, 8-apache, latest, 8.3.4, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
+GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
 Directory: apache
 
-Tags: fpm, 8.3.3-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.4-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
+GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.3-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.4-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
+GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9184c12c27b05014826bdae389691841b234fa15/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/ffa773c6600a24e4025220c741da159e4f79518f/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.3-apache, 9.0-apache, 9-apache, latest, 9.0.3, 9.0, 9
+Tags: apache, 9.0.4-apache, 9.0-apache, 9-apache, latest, 9.0.4, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 9184c12c27b05014826bdae389691841b234fa15
+GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
 Directory: apache
 
-Tags: fpm, 9.0.3-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.4-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 9184c12c27b05014826bdae389691841b234fa15
+GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.3-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.4-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 9184c12c27b05014826bdae389691841b234fa15
+GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9184c12c27b05014826bdae389691841b234fa15/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.2-apache, 9.0-apache, 9-apache, latest, 9.0.2, 9.0, 9
+Tags: apache, 9.0.3-apache, 9.0-apache, 9-apache, latest, 9.0.3, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
+GitCommit: 9184c12c27b05014826bdae389691841b234fa15
 Directory: apache
 
-Tags: fpm, 9.0.2-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.3-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
+GitCommit: 9184c12c27b05014826bdae389691841b234fa15
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.2-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.3-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
+GitCommit: 9184c12c27b05014826bdae389691841b234fa15
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/bd481f48a90373b2850a73494b63d63144c7793d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.1-apache, 9.0-apache, 9-apache, latest, 9.0.1, 9.0, 9
+Tags: apache, 9.0.2-apache, 9.0-apache, 9-apache, latest, 9.0.2, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
+GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
 Directory: apache
 
-Tags: fpm, 9.0.1-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.2-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
+GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.1-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.2-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
+GitCommit: 29cf2cf3bc4b865d3b5e92d4b3ca9e24f503e8c7
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/c75f6deaef3e685f6767a83014aba433b58e07a4/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.6-apache, 8.3-apache, 8-apache, latest, 8.3.6, 8.3, 8
+Tags: apache, 8.4.0-apache, 8.4-apache, 8-apache, latest, 8.4.0, 8.4, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
+GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
 Directory: apache
 
-Tags: fpm, 8.3.6-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.4.0-fpm, 8.4-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
+GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.6-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.4.0-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
+GitCommit: c75f6deaef3e685f6767a83014aba433b58e07a4
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cc79e54b192feb307c0b54a34f2d6c164aae7d1c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/bd481f48a90373b2850a73494b63d63144c7793d/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.0-apache, 9.0-apache, 9-apache, latest, 9.0.0, 9.0, 9
+Tags: apache, 9.0.1-apache, 9.0-apache, 9-apache, latest, 9.0.1, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
+GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
 Directory: apache
 
-Tags: fpm, 9.0.0-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.1-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
+GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.0-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.1-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
+GitCommit: bd481f48a90373b2850a73494b63d63144c7793d
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/1029b7a4cbc7bce1494c97383e04fc96d9c29ae0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/33718c149de426626382a54bd4b4ae9911df72f2/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.2-apache, 8.3-apache, 8-apache, latest, 8.3.2, 8.3, 8
+Tags: apache, 8.3.3-apache, 8.3-apache, 8-apache, latest, 8.3.3, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
+GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
 Directory: apache
 
-Tags: fpm, 8.3.2-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.3-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
+GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.2-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.3-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1029b7a4cbc7bce1494c97383e04fc96d9c29ae0
+GitCommit: 33718c149de426626382a54bd4b4ae9911df72f2
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/7b933d4fc7036f1a037e5c20b5e88fd2537c669f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cc79e54b192feb307c0b54a34f2d6c164aae7d1c/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.4.1-apache, 8.4-apache, 8-apache, latest, 8.4.1, 8.4, 8
-Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
+Tags: apache, 9.0.0-apache, 9.0-apache, 9-apache, latest, 9.0.0, 9.0, 9
+Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
+GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
 Directory: apache
 
-Tags: fpm, 8.4.1-fpm, 8.4-fpm, 8-fpm
-Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
+Tags: fpm, 9.0.0-fpm, 9.0-fpm, 9-fpm
+Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
+GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
 Directory: fpm
 
-Tags: fpm-alpine, 8.4.1-fpm-alpine, 8.4-fpm-alpine, 8-fpm-alpine
-Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7b933d4fc7036f1a037e5c20b5e88fd2537c669f
+Tags: fpm-alpine, 9.0.0-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
+GitCommit: cc79e54b192feb307c0b54a34f2d6c164aae7d1c
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b0b555425c5aa0b4e357a8fe431e06249f1489f5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/541e2ead27a98bffa809f9302bf4e78262c902c6/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.2.4-apache, 8.2-apache, 8-apache, latest, 8.2.4, 8.2, 8
+Tags: apache, 8.2.5-apache, 8.2-apache, 8-apache, latest, 8.2.5, 8.2, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
 Directory: apache
 
-Tags: fpm, 8.2.4-fpm, 8.2-fpm, 8-fpm
+Tags: fpm, 8.2.5-fpm, 8.2-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
 Directory: fpm
 
-Tags: fpm-alpine, 8.2.4-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.2.5-fpm-alpine, 8.2-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b0b555425c5aa0b4e357a8fe431e06249f1489f5
+GitCommit: 541e2ead27a98bffa809f9302bf4e78262c902c6
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/062527a437bbabb8d5712970938d5defdc937a04/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/12856eaa14480e6adec6420e9a294ff1a6ab41ea/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.0-apache, 8.3-apache, 8-apache, latest, 8.3.0, 8.3, 8
+Tags: apache, 8.3.1-apache, 8.3-apache, 8-apache, latest, 8.3.1, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
+GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
 Directory: apache
 
-Tags: fpm, 8.3.0-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.1-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
+GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.0-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.1-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 062527a437bbabb8d5712970938d5defdc937a04
+GitCommit: 12856eaa14480e6adec6420e9a294ff1a6ab41ea
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/197cc7af8afba800800aa32c600b3fed07a2436a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.5-apache, 8.3-apache, 8-apache, latest, 8.3.5, 8.3, 8
+Tags: apache, 8.3.6-apache, 8.3-apache, 8-apache, latest, 8.3.6, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
+GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
 Directory: apache
 
-Tags: fpm, 8.3.5-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.6-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
+GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.5-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.6-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
+GitCommit: 04e2777d95b3e4a21f8d1ffca8d5b7c59f4b052c
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9345bf125c1b7f0ced021c89ec12e3deecc79ac1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/197cc7af8afba800800aa32c600b3fed07a2436a/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 8.3.4-apache, 8.3-apache, 8-apache, latest, 8.3.4, 8.3, 8
+Tags: apache, 8.3.5-apache, 8.3-apache, 8-apache, latest, 8.3.5, 8.3, 8
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
+GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
 Directory: apache
 
-Tags: fpm, 8.3.4-fpm, 8.3-fpm, 8-fpm
+Tags: fpm, 8.3.5-fpm, 8.3-fpm, 8-fpm
 Architectures: amd64, i386, arm32v7, arm64v8, s390x
-GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
+GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
 Directory: fpm
 
-Tags: fpm-alpine, 8.3.4-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
+Tags: fpm-alpine, 8.3.5-fpm-alpine, 8.3-fpm-alpine, 8-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9345bf125c1b7f0ced021c89ec12e3deecc79ac1
+GitCommit: 197cc7af8afba800800aa32c600b3fed07a2436a
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/66e2486b7d38c8c1adbf11fd884b433cbf6931a5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/ea90b848d031de622860f27756e61b21f15241b3/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.6-apache, 9.1-apache, 9-apache, latest, 9.1.6, 9.1, 9
+Tags: apache, 9.1.7-apache, 9.1-apache, 9-apache, latest, 9.1.7, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
+GitCommit: ea90b848d031de622860f27756e61b21f15241b3
 Directory: apache
 
-Tags: fpm, 9.1.6-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.7-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
+GitCommit: ea90b848d031de622860f27756e61b21f15241b3
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.6-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.7-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
+GitCommit: ea90b848d031de622860f27756e61b21f15241b3
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/5758f446e9a4e6a7107f871d26b2848e200efac4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/42b0728740bd352c76f6e0192da54434e226c3f0/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.0-apache, 9.2-apache, 9-apache, latest, 9.2.0, 9.2, 9
+Tags: apache, 9.2.1-apache, 9.2-apache, 9-apache, latest, 9.2.1, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
+GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
 Directory: apache
 
-Tags: fpm, 9.2.0-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.1-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
+GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.0-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.1-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
+GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/ea90b848d031de622860f27756e61b21f15241b3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cdca470441ccf104f9a2f83ba946fb01f8af1c9b/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.7-apache, 9.1-apache, 9-apache, latest, 9.1.7, 9.1, 9
+Tags: apache, 9.1.8-apache, 9.1-apache, 9-apache, latest, 9.1.8, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: ea90b848d031de622860f27756e61b21f15241b3
+GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
 Directory: apache
 
-Tags: fpm, 9.1.7-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.8-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: ea90b848d031de622860f27756e61b21f15241b3
+GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.7-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.8-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: ea90b848d031de622860f27756e61b21f15241b3
+GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/42b0728740bd352c76f6e0192da54434e226c3f0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.1-apache, 9.2-apache, 9-apache, latest, 9.2.1, 9.2, 9
+Tags: apache, 9.2.2-apache, 9.2-apache, 9-apache, latest, 9.2.2, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
+GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
 Directory: apache
 
-Tags: fpm, 9.2.1-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.2-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
+GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.1-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.2-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 42b0728740bd352c76f6e0192da54434e226c3f0
+GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9d26996b93c8e75b51b32efc56e389250cb4d1a9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b06574a8e30b4dab1a7d1d5b215b9dffbffa4351/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.4-apache, 9.1-apache, 9-apache, latest, 9.1.4, 9.1, 9
+Tags: apache, 9.1.5-apache, 9.1-apache, 9-apache, latest, 9.1.5, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
+GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
 Directory: apache
 
-Tags: fpm, 9.1.4-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.5-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
+GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.4-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.5-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
+GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a1267f304aa5670e9ee81877e073a2fb19d76421/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/f2946680ac4e44dc4675931c888d32fb692b8537/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.3-apache, 9.2-apache, 9-apache, latest, 9.2.3, 9.2, 9
+Tags: apache, 9.2.4-apache, 9.2-apache, 9-apache, latest, 9.2.4, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
+GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
 Directory: apache
 
-Tags: fpm, 9.2.3-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.4-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
+GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.3-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.4-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
+GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/6922849308a870ae122bae1bbb2066f808481e96/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/9d26996b93c8e75b51b32efc56e389250cb4d1a9/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.3-apache, 9.1-apache, 9-apache, latest, 9.1.3, 9.1, 9
+Tags: apache, 9.1.4-apache, 9.1-apache, 9-apache, latest, 9.1.4, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
+GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
 Directory: apache
 
-Tags: fpm, 9.1.3-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.4-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
+GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.3-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.4-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
+GitCommit: 9d26996b93c8e75b51b32efc56e389250cb4d1a9
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b10b1d5e4f00e59ce385860849bd0e4b9e704c8a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a05094a159406838b09ead00f085688afb69a0bc/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.8-apache, 9.0-apache, 9-apache, latest, 9.0.8, 9.0, 9
+Tags: apache, 9.1.0-apache, 9.1-apache, 9-apache, latest, 9.1.0, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
+GitCommit: a05094a159406838b09ead00f085688afb69a0bc
 Directory: apache
 
-Tags: fpm, 9.0.8-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.1.0-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
+GitCommit: a05094a159406838b09ead00f085688afb69a0bc
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.8-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.0-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
+GitCommit: a05094a159406838b09ead00f085688afb69a0bc
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/19e32d1225bef7a6b199117bf48692c040b8d3f3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/fc4961a0589284315bb14401389bbdc49afc825b/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.6-apache, 9.2-apache, 9-apache, latest, 9.2.6, 9.2, 9
+Tags: apache, 9.2.7-apache, 9.2-apache, 9-apache, latest, 9.2.7, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
+GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
 Directory: apache
 
-Tags: fpm, 9.2.6-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.7-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
+GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.6-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.7-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
+GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cdca470441ccf104f9a2f83ba946fb01f8af1c9b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/57037499503323f197ee9f7f9a66bcf2b2de7e1f/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.8-apache, 9.1-apache, 9-apache, latest, 9.1.8, 9.1, 9
+Tags: apache, 9.1.9-apache, 9.1-apache, 9-apache, latest, 9.1.9, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
+GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
 Directory: apache
 
-Tags: fpm, 9.1.8-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.9-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
+GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.8-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.9-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: cdca470441ccf104f9a2f83ba946fb01f8af1c9b
+GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cea97c37b517bb2597fb9414e731c606813c74c2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/dca69efca3a7790b2ecea3a192b51efb950cede0/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.3.0-apache, 9.3-apache, 9-apache, latest, 9.3.0, 9.3, 9
+Tags: apache, 9.3.1-apache, 9.3-apache, 9-apache, latest, 9.3.1, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
+GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
 Directory: apache
 
-Tags: fpm, 9.3.0-fpm, 9.3-fpm, 9-fpm
+Tags: fpm, 9.3.1-fpm, 9.3-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
+GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
 Directory: fpm
 
-Tags: fpm-alpine, 9.3.0-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.3.1-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
+GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a1267f304aa5670e9ee81877e073a2fb19d76421/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.2-apache, 9.2-apache, 9-apache, latest, 9.2.2, 9.2, 9
+Tags: apache, 9.2.3-apache, 9.2-apache, 9-apache, latest, 9.2.3, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
+GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
 Directory: apache
 
-Tags: fpm, 9.2.2-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.3-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
+GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.2-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.3-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 99e3e51cf0d35b1d4367c67eb8dd7f7e7f9f503e
+GitCommit: a1267f304aa5670e9ee81877e073a2fb19d76421
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a05094a159406838b09ead00f085688afb69a0bc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/f809689b1b3848aa9f6fa4f419977e077734eb58/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.0-apache, 9.1-apache, 9-apache, latest, 9.1.0, 9.1, 9
+Tags: apache, 9.1.1-apache, 9.1-apache, 9-apache, latest, 9.1.1, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a05094a159406838b09ead00f085688afb69a0bc
+GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
 Directory: apache
 
-Tags: fpm, 9.1.0-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.1-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a05094a159406838b09ead00f085688afb69a0bc
+GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.0-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.1-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: a05094a159406838b09ead00f085688afb69a0bc
+GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/f809689b1b3848aa9f6fa4f419977e077734eb58/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a92a928b5f0eb5d9deb87dfafceded352d8e8b6e/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.1-apache, 9.1-apache, 9-apache, latest, 9.1.1, 9.1, 9
+Tags: apache, 9.1.2-apache, 9.1-apache, 9-apache, latest, 9.1.2, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
+GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
 Directory: apache
 
-Tags: fpm, 9.1.1-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.2-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
+GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.1-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.2-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: f809689b1b3848aa9f6fa4f419977e077734eb58
+GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/ffa773c6600a24e4025220c741da159e4f79518f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/8760415da429ce312fd5983b6fef59eb3f60bc15/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.4-apache, 9.0-apache, 9-apache, latest, 9.0.4, 9.0, 9
+Tags: apache, 9.0.5-apache, 9.0-apache, 9-apache, latest, 9.0.5, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
+GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
 Directory: apache
 
-Tags: fpm, 9.0.4-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.5-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
+GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.4-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.5-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: ffa773c6600a24e4025220c741da159e4f79518f
+GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/20dd34c7163e27db3bdb04f2fbb32501e106ccd9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b10b1d5e4f00e59ce385860849bd0e4b9e704c8a/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.7-apache, 9.0-apache, 9-apache, latest, 9.0.7, 9.0, 9
+Tags: apache, 9.0.8-apache, 9.0-apache, 9-apache, latest, 9.0.8, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
+GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
 Directory: apache
 
-Tags: fpm, 9.0.7-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.8-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
+GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.7-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.8-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
+GitCommit: b10b1d5e4f00e59ce385860849bd0e4b9e704c8a
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/8760415da429ce312fd5983b6fef59eb3f60bc15/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/da2831a9d80be02b01f5f65b350e343c069b347b/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.5-apache, 9.0-apache, 9-apache, latest, 9.0.5, 9.0, 9
+Tags: apache, 9.0.6-apache, 9.0-apache, 9-apache, latest, 9.0.6, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
+GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
 Directory: apache
 
-Tags: fpm, 9.0.5-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.6-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
+GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.5-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.6-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 8760415da429ce312fd5983b6fef59eb3f60bc15
+GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b06574a8e30b4dab1a7d1d5b215b9dffbffa4351/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/66e2486b7d38c8c1adbf11fd884b433cbf6931a5/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.5-apache, 9.1-apache, 9-apache, latest, 9.1.5, 9.1, 9
+Tags: apache, 9.1.6-apache, 9.1-apache, 9-apache, latest, 9.1.6, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
+GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
 Directory: apache
 
-Tags: fpm, 9.1.5-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.6-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
+GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.5-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.6-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: b06574a8e30b4dab1a7d1d5b215b9dffbffa4351
+GitCommit: 66e2486b7d38c8c1adbf11fd884b433cbf6931a5
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/da2831a9d80be02b01f5f65b350e343c069b347b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/20dd34c7163e27db3bdb04f2fbb32501e106ccd9/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.0.6-apache, 9.0-apache, 9-apache, latest, 9.0.6, 9.0, 9
+Tags: apache, 9.0.7-apache, 9.0-apache, 9-apache, latest, 9.0.7, 9.0, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
+GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
 Directory: apache
 
-Tags: fpm, 9.0.6-fpm, 9.0-fpm, 9-fpm
+Tags: fpm, 9.0.7-fpm, 9.0-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
+GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
 Directory: fpm
 
-Tags: fpm-alpine, 9.0.6-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.0.7-fpm-alpine, 9.0-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: da2831a9d80be02b01f5f65b350e343c069b347b
+GitCommit: 20dd34c7163e27db3bdb04f2fbb32501e106ccd9
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/fc4961a0589284315bb14401389bbdc49afc825b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/cea97c37b517bb2597fb9414e731c606813c74c2/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.7-apache, 9.2-apache, 9-apache, latest, 9.2.7, 9.2, 9
+Tags: apache, 9.3.0-apache, 9.3-apache, 9-apache, latest, 9.3.0, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
+GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
 Directory: apache
 
-Tags: fpm, 9.2.7-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.3.0-fpm, 9.3-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
+GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.7-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.3.0-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: fc4961a0589284315bb14401389bbdc49afc825b
+GitCommit: cea97c37b517bb2597fb9414e731c606813c74c2
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/f2946680ac4e44dc4675931c888d32fb692b8537/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/8a528624c35ff56b7d4d51bbedd18c5cecd50180/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.4-apache, 9.2-apache, 9-apache, latest, 9.2.4, 9.2, 9
+Tags: apache, 9.2.5-apache, 9.2-apache, 9-apache, latest, 9.2.5, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
+GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
 Directory: apache
 
-Tags: fpm, 9.2.4-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.5-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
+GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.4-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.5-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: f2946680ac4e44dc4675931c888d32fb692b8537
+GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/57037499503323f197ee9f7f9a66bcf2b2de7e1f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/5758f446e9a4e6a7107f871d26b2848e200efac4/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.9-apache, 9.1-apache, 9-apache, latest, 9.1.9, 9.1, 9
+Tags: apache, 9.2.0-apache, 9.2-apache, 9-apache, latest, 9.2.0, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
+GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
 Directory: apache
 
-Tags: fpm, 9.1.9-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.2.0-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
+GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.9-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.0-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 57037499503323f197ee9f7f9a66bcf2b2de7e1f
+GitCommit: 5758f446e9a4e6a7107f871d26b2848e200efac4
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/a92a928b5f0eb5d9deb87dfafceded352d8e8b6e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/6922849308a870ae122bae1bbb2066f808481e96/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.1.2-apache, 9.1-apache, 9-apache, latest, 9.1.2, 9.1, 9
+Tags: apache, 9.1.3-apache, 9.1-apache, 9-apache, latest, 9.1.3, 9.1, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
+GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
 Directory: apache
 
-Tags: fpm, 9.1.2-fpm, 9.1-fpm, 9-fpm
+Tags: fpm, 9.1.3-fpm, 9.1-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
+GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
 Directory: fpm
 
-Tags: fpm-alpine, 9.1.2-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.1.3-fpm-alpine, 9.1-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: a92a928b5f0eb5d9deb87dfafceded352d8e8b6e
+GitCommit: 6922849308a870ae122bae1bbb2066f808481e96
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/8a528624c35ff56b7d4d51bbedd18c5cecd50180/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/19e32d1225bef7a6b199117bf48692c040b8d3f3/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.2.5-apache, 9.2-apache, 9-apache, latest, 9.2.5, 9.2, 9
+Tags: apache, 9.2.6-apache, 9.2-apache, 9-apache, latest, 9.2.6, 9.2, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
+GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
 Directory: apache
 
-Tags: fpm, 9.2.5-fpm, 9.2-fpm, 9-fpm
+Tags: fpm, 9.2.6-fpm, 9.2-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
+GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
 Directory: fpm
 
-Tags: fpm-alpine, 9.2.5-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.2.6-fpm-alpine, 9.2-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 8a528624c35ff56b7d4d51bbedd18c5cecd50180
+GitCommit: 19e32d1225bef7a6b199117bf48692c040b8d3f3
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/d97fa10196d04b1adde50d6ccdb498a094bb3e3c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b7089c6d4272bd22623c9a62a338791f72391f1c/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.3.2-apache, 9.3-apache, 9-apache, latest, 9.3.2, 9.3, 9
+Tags: apache, 9.3.3-apache, 9.3-apache, 9-apache, latest, 9.3.3, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
+GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
 Directory: apache
 
-Tags: fpm, 9.3.2-fpm, 9.3-fpm, 9-fpm
+Tags: fpm, 9.3.3-fpm, 9.3-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
+GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
 Directory: fpm
 
-Tags: fpm-alpine, 9.3.2-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.3.3-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
+GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/b7089c6d4272bd22623c9a62a338791f72391f1c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.3.3-apache, 9.3-apache, 9-apache, latest, 9.3.3, 9.3, 9
+Tags: apache, 9.3.4-apache, 9.3-apache, 9-apache, latest, 9.3.4, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
+GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
 Directory: apache
 
-Tags: fpm, 9.3.3-fpm, 9.3-fpm, 9-fpm
+Tags: fpm, 9.3.4-fpm, 9.3-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
+GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
 Directory: fpm
 
-Tags: fpm-alpine, 9.3.3-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.3.4-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: b7089c6d4272bd22623c9a62a338791f72391f1c
+GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -5,15 +5,15 @@ GitRepo: https://github.com/espocrm/espocrm-docker.git
 
 Tags: apache, apache-trixie, 9.3.6-apache, 9.3.6-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.6, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
+GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
 Directory: latest/apache
 
 Tags: fpm, fpm-trixie, 9.3.6-fpm, 9.3.6-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
+GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
 Directory: latest/fpm
 
 Tags: fpm-alpine, fpm-alpine3.23, 9.3.6-fpm-alpine, 9.3.6-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
+GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/8adfa17f4183244ed15850386f161ba83bd0eca1/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.3.4-apache, 9.3-apache, 9-apache, latest, 9.3.4, 9.3, 9
+Tags: apache, apache-trixie, 9.3.5-apache, 9.3.5-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.5, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
-Directory: apache
+GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+Directory: latest/apache
 
-Tags: fpm, 9.3.4-fpm, 9.3-fpm, 9-fpm
+Tags: fpm, fpm-trixie, 9.3.5-fpm, 9.3.5-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
-Directory: fpm
+GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+Directory: latest/fpm
 
-Tags: fpm-alpine, 9.3.4-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.5-fpm-alpine, 9.3.5-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: c859ea8aa9ebb7d77d3d9cfdf8f3a96d076f06e7
-Directory: fpm-alpine
+GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.5-apache, 9.3.5-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.5, 9.3, 9
+Tags: apache, apache-trixie, 9.3.6-apache, 9.3.6-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.6, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.5-fpm, 9.3.5-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 9.3.6-fpm, 9.3.6-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.5-fpm-alpine, 9.3.5-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.6-fpm-alpine, 9.3.6-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: b17cece08f7f504373da28108b2bab65f3ba88c9
+GitCommit: 768fd2c5e32d59e4d9728b85f76b00986f7ed264
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/espocrm/espocrm-docker/blob/dca69efca3a7790b2ecea3a192b51efb950cede0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/espocrm/espocrm-docker/blob/d97fa10196d04b1adde50d6ccdb498a094bb3e3c/generate-stackbrew-library.sh
 
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, 9.3.1-apache, 9.3-apache, 9-apache, latest, 9.3.1, 9.3, 9
+Tags: apache, 9.3.2-apache, 9.3-apache, 9-apache, latest, 9.3.2, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
+GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
 Directory: apache
 
-Tags: fpm, 9.3.1-fpm, 9.3-fpm, 9-fpm
+Tags: fpm, 9.3.2-fpm, 9.3-fpm, 9-fpm
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
+GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
 Directory: fpm
 
-Tags: fpm-alpine, 9.3.1-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
+Tags: fpm-alpine, 9.3.2-fpm-alpine, 9.3-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: dca69efca3a7790b2ecea3a192b51efb950cede0
+GitCommit: d97fa10196d04b1adde50d6ccdb498a094bb3e3c
 Directory: fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.7-apache, 9.3.7-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.7, 9.3, 9
+Tags: apache, apache-trixie, 9.3.8-apache, 9.3.8-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.8, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
+GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.7-fpm, 9.3.7-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 9.3.8-fpm, 9.3.8-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
+GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.7-fpm-alpine, 9.3.7-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.8-fpm-alpine, 9.3.8-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
+GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.6-apache, 9.3.6-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.6, 9.3, 9
+Tags: apache, apache-trixie, 9.3.7-apache, 9.3.7-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.7, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
+GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.6-fpm, 9.3.6-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 9.3.7-fpm, 9.3.7-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
+GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.6-fpm-alpine, 9.3.6-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.7-fpm-alpine, 9.3.7-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 16f3884daeb19e5da470055456ec901a865985ec
+GitCommit: 7fc6a7bd1b472cf43c48256c41371664bda6227b
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.8-apache, 9.3.8-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.8, 9.3, 9
+Tags: apache, apache-trixie, 9.3.9-apache, 9.3.9-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.9, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
+GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.8-fpm, 9.3.8-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 9.3.9-fpm, 9.3.9-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
+GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.8-fpm-alpine, 9.3.8-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.9-fpm-alpine, 9.3.9-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: a6d862f43d825289dd219088d5187931ca7493d6
+GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.5-apache, 10.0.5-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.5, 10.0, 10
+Tags: apache, apache-trixie, 10.0.6-apache, 10.0.6-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.6, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
+GitCommit: 2add7383478baddeb5b444ca42de9d26c3257ff4
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.5-fpm, 10.0.5-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.6-fpm, 10.0.6-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
+GitCommit: 2add7383478baddeb5b444ca42de9d26c3257ff4
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.5-fpm-alpine, 10.0.5-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.6-fpm-alpine, 10.0.6-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
+GitCommit: 2add7383478baddeb5b444ca42de9d26c3257ff4
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.0-apache, 10.0.0-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.0, 10.0, 10
+Tags: apache, apache-trixie, 10.0.1-apache, 10.0.1-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.1, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
+GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.0-fpm, 10.0.0-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.1-fpm, 10.0.1-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
+GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.0-fpm-alpine, 10.0.0-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.1-fpm-alpine, 10.0.1-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
+GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.9-apache, 9.3.9-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.9, 9.3, 9
+Tags: apache, apache-trixie, 9.3.10-apache, 9.3.10-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.10, 9.3, 9
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
+GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.9-fpm, 9.3.9-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 9.3.10-fpm, 9.3.10-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
+GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.9-fpm-alpine, 9.3.9-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 9.3.10-fpm-alpine, 9.3.10-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 364bd010d89b1d0c5978840899a392b84d860c89
+GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.1-apache, 10.0.1-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.1, 10.0, 10
+Tags: apache, apache-trixie, 10.0.2-apache, 10.0.2-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.2, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
+GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.1-fpm, 10.0.1-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.2-fpm, 10.0.2-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
+GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.1-fpm-alpine, 10.0.1-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.2-fpm-alpine, 10.0.2-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: caf406127657b8c7e4f4a30510ae1c16ac434127
+GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.3-apache, 10.0.3-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.3, 10.0, 10
+Tags: apache, apache-trixie, 10.0.4-apache, 10.0.4-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.4, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: c74814619e248c086563574918c016328aa9ba19
+GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.3-fpm, 10.0.3-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.4-fpm, 10.0.4-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: c74814619e248c086563574918c016328aa9ba19
+GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.3-fpm-alpine, 10.0.3-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.4-fpm-alpine, 10.0.4-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: c74814619e248c086563574918c016328aa9ba19
+GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.4-apache, 10.0.4-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.4, 10.0, 10
+Tags: apache, apache-trixie, 10.0.5-apache, 10.0.5-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.5, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
+GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.4-fpm, 10.0.4-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.5-fpm, 10.0.5-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
+GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.4-fpm-alpine, 10.0.4-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.5-fpm-alpine, 10.0.5-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 350247461e051664e959b9043bd74ad75ac6e967
+GitCommit: a915bcca808c8fd6bb9f1d846b300511cb6a9be7
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.2-apache, 10.0.2-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.2, 10.0, 10
+Tags: apache, apache-trixie, 10.0.3-apache, 10.0.3-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.3, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
+GitCommit: c74814619e248c086563574918c016328aa9ba19
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.2-fpm, 10.0.2-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.3-fpm, 10.0.3-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
+GitCommit: c74814619e248c086563574918c016328aa9ba19
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.2-fpm-alpine, 10.0.2-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.3-fpm-alpine, 10.0.3-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: 5aca01b15f606e06fa596bf333a7f058d60c4ee5
+GitCommit: c74814619e248c086563574918c016328aa9ba19
 Directory: latest/fpm-alpine

--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 9.3.10-apache, 9.3.10-apache-trixie, 9.3-apache, 9.3-apache-trixie, 9-apache, 9-apache-trixie, latest, 9.3.10, 9.3, 9
+Tags: apache, apache-trixie, 10.0.0-apache, 10.0.0-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.0, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
+GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 9.3.10-fpm, 9.3.10-fpm-trixie, 9.3-fpm, 9.3-fpm-trixie, 9-fpm, 9-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.0-fpm, 10.0.0-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
+GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 9.3.10-fpm-alpine, 9.3.10-fpm-alpine3.23, 9.3-fpm-alpine, 9.3-fpm-alpine3.23, 9-fpm-alpine, 9-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.0-fpm-alpine, 10.0.0-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: d7f12c42946110f6aae21e8333f018da4e829220
+GitCommit: 33c65f2f888983fba168b6827bf062b899733e79
 Directory: latest/fpm-alpine


### PR DESCRIPTION
We would like to add the [EspoCRM](https://github.com/espocrm/docker) to the official image repository.

--------------------

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-   [x] associated with or contacted upstream?
    - https://github.com/espocrm/docker
-   [x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-   [x] is it reasonably popular, or does it solve a particular use case well?
-   [x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1672
-   [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-   [x] 2+ dockerization review?
-   [x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-   [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-   [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)