### PR TITLE
Updating Oracle Linux 6 for CVE-2019-5482

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 833eb6d332617fe47a3b3f6e76e85a354e4d581f
+amd64-GitCommit: 7a6d6716e9143eabc13a8c22c2d5771d71ef6575
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 7fb5fa359cb2d6a289690a5680b28d9ac3b9edc2


### PR DESCRIPTION
* Updated Oracle Linux `6` and `6-slim` images for `amd64`
  * Updated `curl` to `curl-7.19.7-54.0.2.el6_10`

Signed-off-by: Avi Miller <avi.miller@oracle.com>