### PR TITLE
Update redis 5.0.8

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -14,19 +14,19 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7678eb71afd668779635758a2e0005cd87cc6c16
 Directory: 6.0-rc/alpine
 
-Tags: 5.0.7, 5.0, 5, latest, 5.0.7-buster, 5.0-buster, 5-buster, buster
+Tags: 5.0.8, 5.0, 5, latest, 5.0.8-buster, 5.0-buster, 5-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
+GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
 Directory: 5.0
 
-Tags: 5.0.7-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.7-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
+Tags: 5.0.8-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.8-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
 Architectures: amd64
-GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
+GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
 Directory: 5.0/32bit
 
-Tags: 5.0.7-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.7-alpine3.11, 5.0-alpine3.11, 5-alpine3.11, alpine3.11
+Tags: 5.0.8-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.8-alpine3.11, 5.0-alpine3.11, 5-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
+GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
 Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-buster, 4.0-buster, 4-buster


### PR DESCRIPTION
Update to 5.0.8 https://github.com/docker-library/redis/commit/dc4e9c20b98b370069cff1d250a24d78d31c0f10