### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: f3db0f591ce42dd2ac3aec240ca47c87762bc385
 Directory: 8
 # Docker EOL: 2021-09-04
 
-# Last Modified: 2019-08-12
-Tags: 9.2.0, 9.2, 9, latest
+# Last Modified: 2020-03-12
+Tags: 9.3.0, 9.3, 9, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 65cee66f798434200d4efd651d97b4427bb82570
+GitCommit: d9a58942c8ff2c5c5a01e16bf0ffdf5e5dc61277
 Directory: 9
-# Docker EOL: 2021-02-12
+# Docker EOL: 2021-09-12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/d9a5894: Update to 9.3.0