### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.10.0, 3.10, 3, latest
+Tags: 3.11.0, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8d0c502c028c47f28b9038d555d016e9f3b1adca
+GitCommit: 4ac5492c07ddeabee9f37d071d750278a633ee81
 Directory: 3/debian
 
-Tags: 3.10.0-alpine, 3.10-alpine, 3-alpine, alpine
+Tags: 3.11.0-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d0c502c028c47f28b9038d555d016e9f3b1adca
+GitCommit: 4ac5492c07ddeabee9f37d071d750278a633ee81
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4ac5492: Update to 3.11.0, ghost-cli 1.13.1