### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f385008e7aeb1ed78975b1c3563904f157e3d91a
+GitCommit: f53deb9a1feee417e86ce276532eaa6bc1b44ae1
 Directory: 3.8/ubuntu
 
 Tags: 3.8.3-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f385008e7aeb1ed78975b1c3563904f157e3d91a
+GitCommit: f53deb9a1feee417e86ce276532eaa6bc1b44ae1
 Directory: 3.8/alpine
 
 Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.24, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf0c6a21d1b373f0c6d1dae02a9fcfc530ec8d77
+GitCommit: 84fc3639bf0da4d035b16f618c33b5013a885d70
 Directory: 3.7/ubuntu
 
 Tags: 3.7.24-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.24-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf0c6a21d1b373f0c6d1dae02a9fcfc530ec8d77
+GitCommit: 84fc3639bf0da4d035b16f618c33b5013a885d70
 Directory: 3.7/alpine
 
 Tags: 3.7.24-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/84fc363: Update to 3.7.24, Erlang/OTP 22.3, OpenSSL 1.1.1e
- https://github.com/docker-library/rabbitmq/commit/f53deb9: Update to 3.8.3, Erlang/OTP 22.3, OpenSSL 1.1.1e
- https://github.com/docker-library/rabbitmq/commit/a675424: Update to 3.7.24, Erlang/OTP 22.3, OpenSSL 1.1.1d
- https://github.com/docker-library/rabbitmq/commit/a38cac0: Update to 3.8.3, Erlang/OTP 22.3, OpenSSL 1.1.1d