### PR TITLE
Bump Traefik to v2.2.0-rc3, v2.1.7, v1.7.22

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.0-rc2-windowsservercore-1809, 2.2.0-rc2-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
+Tags: v2.2.0-rc3-windowsservercore-1809, 2.2.0-rc3-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: bb912443c1fab1913242aa9801fce676f73c0064
+GitCommit: e7133d0330d34ee9e126b81187640dbefde3a21b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.0-rc2, 2.2.0-rc2, v2.2, 2.2, chevrotin
+Tags: v2.2.0-rc3, 2.2.0-rc3, v2.2, 2.2, chevrotin
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: bb912443c1fab1913242aa9801fce676f73c0064
+GitCommit: e7133d0330d34ee9e126b81187640dbefde3a21b
 Directory: alpine
 
 Tags: v2.1.6-windowsservercore-1809, 2.1.6-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: e7133d0330d34ee9e126b81187640dbefde3a21b
 Directory: alpine
 
-Tags: v2.1.6-windowsservercore-1809, 2.1.6-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
+Tags: v2.1.7-windowsservercore-1809, 2.1.7-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: a1cd15373faf833121fbc5d6418d4f30c7738d88
+GitCommit: 8f3d0ebf322160dcf57f44a2ddbd1ac678f64a8b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.6, 2.1.6, v2.1, 2.1, cantal, latest
+Tags: v2.1.7, 2.1.7, v2.1, 2.1, cantal, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: a1cd15373faf833121fbc5d6418d4f30c7738d88
+GitCommit: 8f3d0ebf322160dcf57f44a2ddbd1ac678f64a8b
 Directory: alpine
 
 Tags: v1.7.22-windowsservercore-1809, 1.7.22-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -23,18 +23,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: a1cd15373faf833121fbc5d6418d4f30c7738d88
 Directory: alpine
 
-Tags: v1.7.21-windowsservercore-1809, 1.7.21-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.22-windowsservercore-1809, 1.7.22-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
+GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.21-alpine, 1.7.21-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.22-alpine, 1.7.22-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
+GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
 Directory: alpine
 
-Tags: v1.7.21, 1.7.21, v1.7, 1.7, maroilles
+Tags: v1.7.22, 1.7.22, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 0b074fb72cea580612c99f057e5c1b218183bad3
+GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
 Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to:

- [v2.2.0-rc3](https://github.com/containous/traefik/releases/tag/v2.2.0-rc3)
- [v2.1.7](https://github.com/containous/traefik/releases/tag/v2.1.7)
- [v1.7.22](https://github.com/containous/traefik/releases/tag/v1.7.22)

/cc @mmatur @emilevauge @SantoDE @dtomcej

Cheers
