### PR TITLE
Add SapMachine 11.0.6.0.1 and SapMachine 14

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,12 +1,12 @@
 Maintainers: Rene Schuenemann <sapmachine@sap.com> (@reshnm)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: 11, 11.0.6, lts
+Tags: 11, 11.0.6.0.1, lts
 Architectures: amd64
-GitCommit: 2c8a65f330ca09a10aea3581626218fd748f9401
+GitCommit: 569e25607d9a64dba5dc52d4b67c25b5c7a6e5a5
 Directory: dockerfiles/official/lts
 
-Tags: 13, 13.0.2, latest
+Tags: 14, latest
 Architectures: amd64
-GitCommit: c1f267171fbf6dc4520b7e14e4e5c421ddfffb81
+GitCommit: 86821cc58ac3d16004c0d3fcf326eecd1a8d07d9
 Directory: dockerfiles/official/stable


### PR DESCRIPTION
Updated SapMachine lts to 11.0.6.0.1
Switched SapMachine latest to 14.

For compatibility reasons we are keeping Ubuntu 18.04 as base image for 11.0.6.0.1.
Starting from SapMachine 14 and the upcoming 11.0.7 release we are switching to Ubuntu 20.04.