### PR TITLE
Bump Traefik to v2.2.0-rc4 and v2.1.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.0-rc3-windowsservercore-1809, 2.2.0-rc3-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
+Tags: v2.2.0-rc4-windowsservercore-1809, 2.2.0-rc4-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: e7133d0330d34ee9e126b81187640dbefde3a21b
+GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.0-rc3, 2.2.0-rc3, v2.2, 2.2, chevrotin
+Tags: v2.2.0-rc4, 2.2.0-rc4, v2.2, 2.2, chevrotin
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e7133d0330d34ee9e126b81187640dbefde3a21b
+GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
 Directory: alpine
 
 Tags: v2.1.7-windowsservercore-1809, 2.1.7-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
 Directory: alpine
 
-Tags: v2.1.7-windowsservercore-1809, 2.1.7-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
+Tags: v2.1.8-windowsservercore-1809, 2.1.8-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 8f3d0ebf322160dcf57f44a2ddbd1ac678f64a8b
+GitCommit: 54c85ae7aae481a322866441eddc662dc4466b23
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.7, 2.1.7, v2.1, 2.1, cantal, latest
+Tags: v2.1.8, 2.1.8, v2.1, 2.1, cantal, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 8f3d0ebf322160dcf57f44a2ddbd1ac678f64a8b
+GitCommit: 54c85ae7aae481a322866441eddc662dc4466b23
 Directory: alpine
 
 Tags: v1.7.22-windowsservercore-1809, 1.7.22-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to:
- [v2.2.0-rc4](https://github.com/containous/traefik/releases/tag/v2.2.0-rc4)
- [v2.1.8](https://github.com/containous/traefik/releases/tag/v2.1.8)

/cc @mmatur @emilevauge @SantoDE @dtomcej

Cheers
