### PR TITLE
Bump Traefik to v2.1.9 and v1.7.23

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -23,18 +23,19 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
 Directory: alpine
 
-Tags: v1.7.22-windowsservercore-1809, 1.7.22-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+
+Tags: v1.7.23-windowsservercore-1809, 1.7.23-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
+GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.22-alpine, 1.7.22-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.23-alpine, 1.7.23-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
+GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
 Directory: alpine
 
-Tags: v1.7.22, 1.7.22, v1.7, 1.7, maroilles
+Tags: v1.7.23, 1.7.23, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 6008680615736b1db5070d8d5ad159e9d04d28ec
+GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
 Directory: scratch

--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
 Directory: alpine
 
-Tags: v2.1.8-windowsservercore-1809, 2.1.8-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
+Tags: v2.1.9-windowsservercore-1809, 2.1.9-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 54c85ae7aae481a322866441eddc662dc4466b23
+GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.1.8, 2.1.8, v2.1, 2.1, cantal, latest
+Tags: v2.1.9, 2.1.9, v2.1, 2.1, cantal, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 54c85ae7aae481a322866441eddc662dc4466b23
+GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
 Directory: alpine
 
 Tags: v1.7.22-windowsservercore-1809, 1.7.22-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -23,7 +23,6 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
 Directory: alpine
 
-
 Tags: v1.7.23-windowsservercore-1809, 1.7.23-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
 GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa


### PR DESCRIPTION
Hello,

This PR updates Traefik to:
- [v2.1.9](https://github.com/containous/traefik/releases/tag/v2.1.9)
- [v1.7.23](https://github.com/containous/traefik/releases/tag/v1.7.23)

/cc @mmatur @emilevauge @SantoDE @dtomcej

Cheers
