### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.11.0, 3.11, 3, latest
+Tags: 3.12.0, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4ac5492c07ddeabee9f37d071d750278a633ee81
+GitCommit: 698b7407674e87fc0519d173e7da877e02171e71
 Directory: 3/debian
 
-Tags: 3.11.0-alpine, 3.11-alpine, 3-alpine, alpine
+Tags: 3.12.0-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ac5492c07ddeabee9f37d071d750278a633ee81
+GitCommit: 698b7407674e87fc0519d173e7da877e02171e71
 Directory: 3/alpine
 
 Tags: 2.38.0, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/698b740: Update to 3.12.0, ghost-cli 1.13.1