### PR TITLE
alpine: bump 3.11.5

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.3, 3.11, 3, latest
+Tags: 3.11.5, 3.11, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: ae7bffab75367525cd3c799cb0ecafa4858e6446
+GitCommit: bafe72e7d06184fe1a7e7a0cf65631fe2ddd67b7
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
3.11.4 was skipped due to error in release process