### PR TITLE
Update open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: e79100818d3cd27b42eae6bc90350c018b900ed5
+GitCommit: ad000f92774051d4c07197c1fdb8fa816b486a8c
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9


### PR DESCRIPTION
Reducing the number of warm-up iterations from 3 to 2, as our performance team concluded that after 2 runs we have an optimized class cache already.