### PR TITLE
Update websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 487d78ee8b916b85eb0215933c4fd12285c5ac25
+GitCommit: 97bec01666d1946ec35337080a28d0c3a13214f7
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Bringing WebSphere Liberty to parity with Open Liberty in terms of populating a class cache during the build phase of the images.  