### PR TITLE
[SECURITY] Update to Memcached 1.6.2

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.1, 1.6, 1, latest
+Tags: 1.6.2, 1.6, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb057edbac4b089c45857de35e8a824b5d937e83
+GitCommit: 2620ba5e65c6b606966f71f6e95e29c7a36b487c
 Directory: debian
 
-Tags: 1.6.1-alpine, 1.6-alpine, 1-alpine, alpine
+Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb057edbac4b089c45857de35e8a824b5d937e83
+GitCommit: 2620ba5e65c6b606966f71f6e95e29c7a36b487c
 Directory: alpine


### PR DESCRIPTION
This is a security update.

See: memcached/memcached@02c6a2b62ddcb6fa4569a591d3461a156a636305