### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,6 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
+Tags: 2.2-dev5, 2.2-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7f2c1472693b6676caac1b60bcfa70c5c53c8897
+Directory: 2.2-rc
+
+Tags: 2.2-dev5-alpine, 2.2-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+Directory: 2.2-rc/alpine
+
 Tags: 2.1.3, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 52ce628f49cd7d355b7486e1c8dd9be51e492f4e
@@ -11,7 +21,7 @@ Directory: 2.1
 
 Tags: 2.1.3-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 52ce628f49cd7d355b7486e1c8dd9be51e492f4e
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 2.1/alpine
 
 Tags: 2.0.13, 2.0
@@ -21,7 +31,7 @@ Directory: 2.0
 
 Tags: 2.0.13-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73e364d5e78bf73c79cf3cbb36c0c888934dfb3f
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 2.0/alpine
 
 Tags: 1.9.14, 1.9, 1
@@ -31,7 +41,7 @@ Directory: 1.9
 
 Tags: 1.9.14-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c8c7a34289beee92e5d9648cd1f26cd89b1d1b3
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 1.9/alpine
 
 Tags: 1.8.24, 1.8
@@ -41,7 +51,7 @@ Directory: 1.8
 
 Tags: 1.8.24-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a55f971303062964269d0730d23e2ef1c78143f4
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
@@ -51,7 +61,7 @@ Directory: 1.7
 
 Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fcb217989a970805d4dfee5903fec5d97870a54a
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 1.7/alpine
 
 Tags: 1.6.15, 1.6
@@ -61,5 +71,5 @@ Directory: 1.6
 
 Tags: 1.6.15-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
+GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 1.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/046b97b: Merge pull request https://github.com/docker-library/haproxy/pull/109 from TimWolla/2.2-rc
- https://github.com/docker-library/haproxy/commit/9b20744: Disable USE_BACKTRACE for alpine
- https://github.com/docker-library/haproxy/commit/7f2c147: Add HAProxy 2.2-dev5 as 2.2-rc