### PR TITLE
Bump Traefik to v2.2.0 and v1.7.24

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.0-rc4-windowsservercore-1809, 2.2.0-rc4-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809
+Tags: v2.2.0-windowsservercore-1809, 2.2.0-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
+GitCommit: 6dcd8fe17189e8076ee052a614dda5550afb2930
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.0-rc4, 2.2.0-rc4, v2.2, 2.2, chevrotin
+Tags: v2.2.0, 2.2.0, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 1462e946e3f26e1f9e1304b871ae5601f2ea51c9
-Directory: alpine
-
-Tags: v2.1.9-windowsservercore-1809, 2.1.9-windowsservercore-1809, v2.1-windowsservercore-1809, 2.1-windowsservercore-1809, cantal-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.1.9, 2.1.9, v2.1, 2.1, cantal, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: e1cd38299fd7732c7327cf7eb6300b6a14839b9a
+GitCommit: 6dcd8fe17189e8076ee052a614dda5550afb2930
 Directory: alpine
 
 Tags: v1.7.23-windowsservercore-1809, 1.7.23-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -12,18 +12,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 6dcd8fe17189e8076ee052a614dda5550afb2930
 Directory: alpine
 
-Tags: v1.7.23-windowsservercore-1809, 1.7.23-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.24-windowsservercore-1809, 1.7.24-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
+GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.23-alpine, 1.7.23-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.24-alpine, 1.7.24-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
+GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
 Directory: alpine
 
-Tags: v1.7.23, 1.7.23, v1.7, 1.7, maroilles
+Tags: v1.7.24, 1.7.24, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 965cd47f7962448401b402d1e251e19fe2135faa
+GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
 Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to:
-  [v2.2.0](https://github.com/containous/traefik/releases/tag/v2.2.0)
-  [v1.7.24](https://github.com/containous/traefik/releases/tag/v1.7.24)

/cc @mmatur @emilevauge @SantoDE @dtomcej

Cheers
