### PR TITLE
Update telegraf

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -1,14 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              Daniel Nelson <daniel.nelson@influxdata.com> (@danielnelson)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 09b60f55e558e3be5cb0c142440bdfb25b090476
-
-Tags: 1.11, 1.11.5
-Architectures: amd64, arm32v7, arm64v8
-Directory: telegraf/1.11
-
-Tags: 1.11-alpine, 1.11.5-alpine
-Directory: telegraf/1.11/alpine
+GitCommit: 29ba80899c7755d801db4b9c638c90e69325ceb5
 
 Tags: 1.12, 1.12.6
 Architectures: amd64, arm32v7, arm64v8
@@ -17,9 +10,16 @@ Directory: telegraf/1.12
 Tags: 1.12-alpine, 1.12.6-alpine
 Directory: telegraf/1.12/alpine
 
-Tags: 1.13, 1.13.4, latest
+Tags: 1.13, 1.13.4
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.13
 
-Tags: 1.13-alpine, 1.13.4-alpine, alpine
+Tags: 1.13-alpine, 1.13.4-alpine
 Directory: telegraf/1.13/alpine
+
+Tags: 1.14, 1.14.0, latest
+Architectures: amd64, arm32v7, arm64v8
+Directory: telegraf/1.14
+
+Tags: 1.14-alpine, 1.14.0-alpine, alpine
+Directory: telegraf/1.14/alpine


### PR DESCRIPTION
Bump latest version to 1.14.0, drop 1.11 tag