### PR TITLE
re release 1.5.1 for an openshift permission issue

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -22,19 +22,19 @@ Directory: centos
 Architectures: amd64
 
 Tags: 1.5.1-alpine, 1.5.1, 1.5
-GitCommit: 610aa77c9d81b4e5fac2c8c8231b7054f3adc20d
+GitCommit: 8ba4389169d5873be65a09001d06293ccdfc7caf
 GitFetch: refs/tags/1.5.1
 Directory: alpine
 Architectures: amd64
 
 Tags: 1.5.1-ubuntu, 1.5-ubuntu
-GitCommit: 610aa77c9d81b4e5fac2c8c8231b7054f3adc20d
+GitCommit: 8ba4389169d5873be65a09001d06293ccdfc7caf
 GitFetch: refs/tags/1.5.1
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 1.5.1-centos, 1.5-centos
-GitCommit: 610aa77c9d81b4e5fac2c8c8231b7054f3adc20d
+GitCommit: 8ba4389169d5873be65a09001d06293ccdfc7caf
 GitFetch: refs/tags/1.5.1
 Constraints: !aufs
 Directory: centos


### PR DESCRIPTION
closes https://github.com/Kong/kong/issues/5708

There's no change in the Kong asset itself just how we run Kong within docker so we don't hit permission issues with openshift