### PR TITLE
Update Solr to 8.5

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,105 +1,95 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/32c24945a2cb785c32d5974b18e9ad35ebe429f5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/96477231f35e50cc9bd8cb0c8e9b004e841a126a/generate-stackbrew-library.sh
 
 Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.4.1, 8.4, 8, latest
+Tags: 8.5.0, 8.5, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+Directory: 8.5
+
+Tags: 8.5.0-slim, 8.5-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 1c32fcc7352046c3a67749c32506aa3ad2fa912d
+Directory: 8.5/slim
+
+Tags: 8.4.1, 8.4
+Architectures: amd64, arm64v8
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 8.4
 
-Tags: 8.4.1-slim, 8.4-slim, 8-slim, slim
+Tags: 8.4.1-slim, 8.4-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 8.4/slim
 
 Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 8.3
 
 Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 8.0/slim
 
 Tags: 7.7.2, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 7.7
 
 Tags: 7.7.2-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
 Directory: 7.7/slim
-
-Tags: 7.6.0, 7.6
-Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
-Directory: 7.6
-
-Tags: 7.6.0-slim, 7.6-slim
-Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
-Directory: 7.6/slim
-
-Tags: 7.5.0, 7.5
-Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
-Directory: 7.5
-
-Tags: 7.5.0-slim, 7.5-slim
-Architectures: amd64, arm64v8
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
-Directory: 7.5/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 0b13c14c7ae9190044b5d14c1268ba7f49a4dc33
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 394ead2fa128d90afb072284bce5f1715345c53c
+GitCommit: 0b13c14c7ae9190044b5d14c1268ba7f49a4dc33
 Directory: 5.5/slim


### PR DESCRIPTION
See preparations in issue https://github.com/docker-solr/docker-solr/issues/297
Solr release note: https://lucene.apache.org/solr/news.html#apache-solrtm-850-available