### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.2, 1.6, 1, latest
+Tags: 1.6.3, 1.6, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2620ba5e65c6b606966f71f6e95e29c7a36b487c
+GitCommit: 4ebaad36b7e21f5600eb21c1e211cbecb81141e6
 Directory: debian
 
-Tags: 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
+Tags: 1.6.3-alpine, 1.6-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2620ba5e65c6b606966f71f6e95e29c7a36b487c
+GitCommit: 4ebaad36b7e21f5600eb21c1e211cbecb81141e6
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/4ebaad3: Update to 1.6.3
- https://github.com/docker-library/memcached/commit/59fc52b: Fix version scraping so we pick up 1.6.3 properly (doh!)