### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,112 +4,112 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 2.7.0-buster, 2.7-buster, 2-buster, buster, 2.7.0, 2.7, 2, latest
+Tags: 2.7.1-buster, 2.7-buster, 2-buster, buster, 2.7.1, 2.7, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/buster
 
-Tags: 2.7.0-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.0-slim, 2.7-slim, 2-slim, slim
+Tags: 2.7.1-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.1-slim, 2.7-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/buster/slim
 
-Tags: 2.7.0-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11, 2.7.0-alpine, 2.7-alpine, 2-alpine, alpine
+Tags: 2.7.1-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11, 2.7.1-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/alpine3.11
 
-Tags: 2.7.0-alpine3.10, 2.7-alpine3.10, 2-alpine3.10, alpine3.10
+Tags: 2.7.1-alpine3.10, 2.7-alpine3.10, 2-alpine3.10, alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/alpine3.10
 
-Tags: 2.6.5-buster, 2.6-buster, 2.6.5, 2.6
+Tags: 2.6.6-buster, 2.6-buster, 2.6.6, 2.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/buster
 
-Tags: 2.6.5-slim-buster, 2.6-slim-buster, 2.6.5-slim, 2.6-slim
+Tags: 2.6.6-slim-buster, 2.6-slim-buster, 2.6.6-slim, 2.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/buster/slim
 
-Tags: 2.6.5-stretch, 2.6-stretch
+Tags: 2.6.6-stretch, 2.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/stretch
 
-Tags: 2.6.5-slim-stretch, 2.6-slim-stretch
+Tags: 2.6.6-slim-stretch, 2.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/stretch/slim
 
-Tags: 2.6.5-alpine3.11, 2.6-alpine3.11, 2.6.5-alpine, 2.6-alpine
+Tags: 2.6.6-alpine3.11, 2.6-alpine3.11, 2.6.6-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/alpine3.11
 
-Tags: 2.6.5-alpine3.10, 2.6-alpine3.10
+Tags: 2.6.6-alpine3.10, 2.6-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/alpine3.10
 
-Tags: 2.5.7-buster, 2.5-buster, 2.5.7, 2.5
+Tags: 2.5.8-buster, 2.5-buster, 2.5.8, 2.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/buster
 
-Tags: 2.5.7-slim-buster, 2.5-slim-buster, 2.5.7-slim, 2.5-slim
+Tags: 2.5.8-slim-buster, 2.5-slim-buster, 2.5.8-slim, 2.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/buster/slim
 
-Tags: 2.5.7-stretch, 2.5-stretch
+Tags: 2.5.8-stretch, 2.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/stretch
 
-Tags: 2.5.7-slim-stretch, 2.5-slim-stretch
+Tags: 2.5.8-slim-stretch, 2.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/stretch/slim
 
-Tags: 2.5.7-alpine3.11, 2.5-alpine3.11, 2.5.7-alpine, 2.5-alpine
+Tags: 2.5.8-alpine3.11, 2.5-alpine3.11, 2.5.8-alpine, 2.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/alpine3.11
 
-Tags: 2.5.7-alpine3.10, 2.5-alpine3.10
+Tags: 2.5.8-alpine3.10, 2.5-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/alpine3.10
 
-Tags: 2.4.9-buster, 2.4-buster, 2.4.9, 2.4
+Tags: 2.4.10-buster, 2.4-buster, 2.4.10, 2.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/buster
 
-Tags: 2.4.9-slim-buster, 2.4-slim-buster, 2.4.9-slim, 2.4-slim
+Tags: 2.4.10-slim-buster, 2.4-slim-buster, 2.4.10-slim, 2.4-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/buster/slim
 
-Tags: 2.4.9-stretch, 2.4-stretch
+Tags: 2.4.10-stretch, 2.4-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/stretch
 
-Tags: 2.4.9-slim-stretch, 2.4-slim-stretch
+Tags: 2.4.10-slim-stretch, 2.4-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/stretch/slim
 
-Tags: 2.4.9-alpine3.11, 2.4-alpine3.11, 2.4.9-alpine, 2.4-alpine
+Tags: 2.4.10-alpine3.11, 2.4-alpine3.11, 2.4.10-alpine, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/alpine3.11
 
-Tags: 2.4.9-alpine3.10, 2.4-alpine3.10
+Tags: 2.4.10-alpine3.10, 2.4-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82eecb7596c3cb466dd87d4b0350d189a330b925
+GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.4/alpine3.10


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/a564fea: Upgrade Ruby version 2.4.9 to 2.4.10, 2.5.7 to 2.5.8, 2.6.5 to 2.6.6, 2.7.0 to 2.7.1 (https://github.com/docker-library/ruby/pull/310)