### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f53deb9a1feee417e86ce276532eaa6bc1b44ae1
+GitCommit: 904c509139716f355ad59678a4ad8a93c1a6bbdc
 Directory: 3.8/ubuntu
 
 Tags: 3.8.3-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f53deb9a1feee417e86ce276532eaa6bc1b44ae1
+GitCommit: 904c509139716f355ad59678a4ad8a93c1a6bbdc
 Directory: 3.8/alpine
 
 Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.24, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc3639bf0da4d035b16f618c33b5013a885d70
+GitCommit: bca6e73c4c559f4aa931c933a22da3a2c6e6564f
 Directory: 3.7/ubuntu
 
 Tags: 3.7.24-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.24-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84fc3639bf0da4d035b16f618c33b5013a885d70
+GitCommit: bca6e73c4c559f4aa931c933a22da3a2c6e6564f
 Directory: 3.7/alpine
 
 Tags: 3.7.24-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/bca6e73: Update to 3.7.24, Erlang/OTP 22.3, OpenSSL 1.1.1f
- https://github.com/docker-library/rabbitmq/commit/904c509: Update to 3.8.3, Erlang/OTP 22.3, OpenSSL 1.1.1f
- https://github.com/docker-library/rabbitmq/commit/0b47a9f: Merge pull request https://github.com/docker-library/rabbitmq/pull/394 from gerhard/default-to-python3
- https://github.com/docker-library/rabbitmq/commit/28ec81f: Handle Python v2 vs v3 requirement via update.sh Plain python defaults to v2 & it fails with: