### PR TITLE
[security] Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 2.2-rc/alpine
 
-Tags: 2.1.3, 2.1, latest
+Tags: 2.1.4, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 52ce628f49cd7d355b7486e1c8dd9be51e492f4e
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.1
 
-Tags: 2.1.3-alpine, 2.1-alpine, alpine
+Tags: 2.1.4-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.1/alpine
 
-Tags: 2.0.13, 2.0
+Tags: 2.0.14, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73e364d5e78bf73c79cf3cbb36c0c888934dfb3f
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.0
 
-Tags: 2.0.13-alpine, 2.0-alpine
+Tags: 2.0.14-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.0/alpine
 
-Tags: 1.9.14, 1.9, 1
+Tags: 1.9.15, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c8c7a34289beee92e5d9648cd1f26cd89b1d1b3
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.9
 
-Tags: 1.9.14-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.15-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.9/alpine
 
-Tags: 1.8.24, 1.8
+Tags: 1.8.25, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a55f971303062964269d0730d23e2ef1c78143f4
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.8
 
-Tags: 1.8.24-alpine, 1.8-alpine
+Tags: 1.8.25-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3dd3917: Merge pull request https://github.com/docker-library/haproxy/pull/110 from TimWolla/haproxy-2.1.4-and-others
- https://github.com/docker-library/haproxy/commit/eeaaa57: Update to HAProxy 2.1.4, 2.0.14, 1.9.15, 1.8.25