### PR TITLE
Add mountebank image

### DIFF
--- a/library/mountebank
+++ b/library/mountebank
@@ -1,0 +1,18 @@
+Maintainers: Mijail Rondon <mijail@riseup.net> (@MijailR)
+GitRepo: https://github.com/bbyars/mountebank.git
+
+Tags: latest, 2, 2.2.0
+GitCommit: 7ec1098e1c81221a7079321cd8b210a5ab572e74
+GitFetch: refs/tags/v2.2.0
+
+Tags: 2.1.2
+GitCommit: 273b7b669a608fc6e32751cee1c3932dc32300c8
+GitFetch: refs/tags/v2.1.2
+
+Tags: 2.1.1
+GitCommit: 31d14058892c8bfdf7a4f05d1e02fd504eb93522
+GitFetch: refs/tags/v2.1.1
+
+Tags: 1.16.0, 1
+GitCommit: 6c6d9356df567e76e7846a48fe3ee16bd33646cc
+GitFetch: refs/tags/v1.16.0

--- a/library/mountebank
+++ b/library/mountebank
@@ -4,19 +4,15 @@ GitRepo: https://github.com/bbyars/mountebank.git
 Tags: latest, 2, 2.2.0
 Architectures: amd64
 GitCommit: 7ec1098e1c81221a7079321cd8b210a5ab572e74
-GitFetch: refs/tags/v2.2.0
 
 Tags: 2.1.2
 Architectures: amd64
 GitCommit: 273b7b669a608fc6e32751cee1c3932dc32300c8
-GitFetch: refs/tags/v2.1.2
 
 Tags: 2.1.1
 Architectures: amd64
 GitCommit: 31d14058892c8bfdf7a4f05d1e02fd504eb93522
-GitFetch: refs/tags/v2.1.1
 
 Tags: 1.16.0, 1
 Architectures: amd64
 GitCommit: 6c6d9356df567e76e7846a48fe3ee16bd33646cc
-GitFetch: refs/tags/v1.16.0

--- a/library/mountebank
+++ b/library/mountebank
@@ -2,17 +2,21 @@ Maintainers: Mijail Rondon <mijail@riseup.net> (@MijailR)
 GitRepo: https://github.com/bbyars/mountebank.git
 
 Tags: latest, 2, 2.2.0
+Architectures: amd64
 GitCommit: 7ec1098e1c81221a7079321cd8b210a5ab572e74
 GitFetch: refs/tags/v2.2.0
 
 Tags: 2.1.2
+Architectures: amd64
 GitCommit: 273b7b669a608fc6e32751cee1c3932dc32300c8
 GitFetch: refs/tags/v2.1.2
 
 Tags: 2.1.1
+Architectures: amd64
 GitCommit: 31d14058892c8bfdf7a4f05d1e02fd504eb93522
 GitFetch: refs/tags/v2.1.1
 
 Tags: 1.16.0, 1
+Architectures: amd64
 GitCommit: 6c6d9356df567e76e7846a48fe3ee16bd33646cc
 GitFetch: refs/tags/v1.16.0

--- a/library/mountebank
+++ b/library/mountebank
@@ -4,15 +4,4 @@ GitRepo: https://github.com/bbyars/mountebank.git
 Tags: latest, 2, 2.2.0
 Architectures: amd64
 GitCommit: 7ec1098e1c81221a7079321cd8b210a5ab572e74
-
-Tags: 2.1.2
-Architectures: amd64
-GitCommit: 273b7b669a608fc6e32751cee1c3932dc32300c8
-
-Tags: 2.1.1
-Architectures: amd64
-GitCommit: 31d14058892c8bfdf7a4f05d1e02fd504eb93522
-
-Tags: 1.16.0, 1
-Architectures: amd64
-GitCommit: 6c6d9356df567e76e7846a48fe3ee16bd33646cc
+GitFetch: refs/tags/v2.2.0


### PR DESCRIPTION
Hey docker community, I will like to maintain the official image for [Mountebank](https://github.com/bbyars/mountebank)

Mountebank is is the first open source tool to provide cross-platform, multi-protocol test doubles over the wire.

This is the docs PR docker-library/docs#1693

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)