### PR TITLE
Release of GeoNetwork 3.10.1

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,18 +1,18 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/9fcf08514e1cbcd6b4f48a1d6acfac9fd23afa2d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7d75802aac878467f185f5fc2b9b800eb38c959b/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
-Tags: 3.10.0, 3.10, latest
+Tags: 3.10.1, 3.10, latest
 Architectures: amd64
-GitCommit: 2e46c3594c3d47db12d6bd3344d474f4a408027a
-Directory: 3.10.0
+GitCommit: 7d75802aac878467f185f5fc2b9b800eb38c959b
+Directory: 3.10.1
 
-Tags: 3.10.0-postgres, 3.10-postgres, postgres
+Tags: 3.10.1-postgres, 3.10-postgres, postgres
 Architectures: amd64
-GitCommit: 2e46c3594c3d47db12d6bd3344d474f4a408027a
-Directory: 3.10.0/postgres
+GitCommit: 7d75802aac878467f185f5fc2b9b800eb38c959b
+Directory: 3.10.1/postgres
 
 Tags: 3.8.3, 3.8
 Architectures: amd64


### PR DESCRIPTION
Updated official GN version to its latest release (3.10.1), to catch up with [latest changes on the image code](https://github.com/geonetwork/docker-geonetwork).