### PR TITLE
Release of Oracle Linux 7 Update 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7a6d6716e9143eabc13a8c22c2d5771d71ef6575
+amd64-GitCommit: fa8a3af589188ab306578f8f59a50ea05423ec19
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7fb5fa359cb2d6a289690a5680b28d9ac3b9edc2
+arm64v8-GitCommit: a0212e605af7ad92e25879470b5fb7e41648d48b
 Constraints: !aufs
 
 Tags: 8.1, 8
@@ -22,9 +22,9 @@ Tags: 8-slim
 Architectures: amd64, arm64v8
 Directory: 8-slim
 
-Tags: 7.7, 7, latest
+Tags: 7.8, 7, latest
 Architectures: amd64, arm64v8
-Directory: 7.7
+Directory: 7.8
 
 Tags: 7-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updating the `7-slim` and `7` images to point to `7.8` or use the `7.8` packages as applicable for both `amd64` and `arm64v8`.

Signed-off-by: Avi Miller <avi.miller@oracle.com>