### PR TITLE
Release of GeoNetwork 3.10.2

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,18 +1,18 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7d75802aac878467f185f5fc2b9b800eb38c959b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/f81b111fbe3d765ee56f61c5474099764ee07004/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
-Tags: 3.10.1, 3.10, latest
+Tags: 3.10.2, 3.10, latest
 Architectures: amd64
-GitCommit: 7d75802aac878467f185f5fc2b9b800eb38c959b
-Directory: 3.10.1
+GitCommit: f81b111fbe3d765ee56f61c5474099764ee07004
+Directory: 3.10.2
 
-Tags: 3.10.1-postgres, 3.10-postgres, postgres
+Tags: 3.10.2-postgres, 3.10-postgres, postgres
 Architectures: amd64
-GitCommit: 7d75802aac878467f185f5fc2b9b800eb38c959b
-Directory: 3.10.1/postgres
+GitCommit: f81b111fbe3d765ee56f61c5474099764ee07004
+Directory: 3.10.2/postgres
 
 Tags: 3.8.3, 3.8
 Architectures: amd64


### PR DESCRIPTION
Updated official GN version to its latest release (3.10.2), to catch up with [latest changes on the image code](https://github.com/geonetwork/docker-geonetwork).