### PR TITLE
Adding Oracle Linux 7 Update 8 for amd64 and arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7a6d6716e9143eabc13a8c22c2d5771d71ef6575
+amd64-GitCommit: b22bc0aae247d85ec26d2acf9d5e2e801fc4ab22
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7fb5fa359cb2d6a289690a5680b28d9ac3b9edc2
+arm64v8-GitCommit: 80fb8201a6467bcb9f47431b9b8fa5187b8908a2
 Constraints: !aufs
 
 Tags: 8.1, 8
@@ -22,9 +22,9 @@ Tags: 8-slim
 Architectures: amd64, arm64v8
 Directory: 8-slim
 
-Tags: 7.7, 7, latest
+Tags: 7.8, 7, latest
 Architectures: amd64, arm64v8
-Directory: 7.7
+Directory: 7.8
 
 Tags: 7-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Release notes: https://docs.oracle.com/en/operating-systems/oracle-linux/7/relnotes7.8/

Signed-off-by: Avi Miller <avi.miller@oracle.com>