### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -83,33 +83,3 @@ Tags: 2.5.8-alpine3.10, 2.5-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/alpine3.10
-
-Tags: 2.4.10-buster, 2.4-buster, 2.4.10, 2.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/buster
-
-Tags: 2.4.10-slim-buster, 2.4-slim-buster, 2.4.10-slim, 2.4-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/buster/slim
-
-Tags: 2.4.10-stretch, 2.4-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/stretch
-
-Tags: 2.4.10-slim-stretch, 2.4-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/stretch/slim
-
-Tags: 2.4.10-alpine3.11, 2.4-alpine3.11, 2.4.10-alpine, 2.4-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/alpine3.11
-
-Tags: 2.4.10-alpine3.10, 2.4-alpine3.10
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
-Directory: 2.4/alpine3.10


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/96bcb37: Merge pull request https://github.com/docker-library/ruby/pull/315 from infosiftr/eol-2.4
- https://github.com/docker-library/ruby/commit/c27ff1e: Remove 2.4 (EOL)