### PR TITLE
Update PyPy to Debian Buster

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2.7-7.3.0, 2.7-7.3, 2.7-7, 2.7, 2-7.3.0, 2-7.3, 2-7, 2, 2.7-7.3.0-jessie, 2.7-7.3-jessie, 2.7-7-jessie, 2.7-jessie, 2-7.3.0-jessie, 2-7.3-jessie, 2-7-jessie, 2-jessie
-Architectures: amd64, i386
-GitCommit: 42257a4c727f8c698883ba2dc9d1e91dcf8e93b2
+Tags: 2.7-7.3.0, 2.7-7.3, 2.7-7, 2.7, 2-7.3.0, 2-7.3, 2-7, 2, 2.7-7.3.0-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.0-buster, 2-7.3-buster, 2-7-buster, 2-buster
+Architectures: amd64, arm64v8, i386
+GitCommit: ac6a989a09815fc6ff38da92ea1154bc048caae3
 Directory: 2.7
 
-Tags: 2.7-7.3.0-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.0-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.0-slim-jessie, 2.7-7.3-slim-jessie, 2.7-7-slim-jessie, 2.7-slim-jessie, 2-7.3.0-slim-jessie, 2-7.3-slim-jessie, 2-7-slim-jessie, 2-slim-jessie
-Architectures: amd64, i386
-GitCommit: 42257a4c727f8c698883ba2dc9d1e91dcf8e93b2
+Tags: 2.7-7.3.0-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.0-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.0-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.0-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
+Architectures: amd64, arm64v8, i386
+GitCommit: ac6a989a09815fc6ff38da92ea1154bc048caae3
 Directory: 2.7/slim
 
-Tags: 3.6-7.3.0, 3.6-7.3, 3.6-7, 3.6, 3-7.3.0, 3-7.3, 3-7, 3, latest, 3.6-7.3.0-stretch, 3.6-7.3-stretch, 3.6-7-stretch, 3.6-stretch, 3-7.3.0-stretch, 3-7.3-stretch, 3-7-stretch, 3-stretch, stretch
+Tags: 3.6-7.3.0, 3.6-7.3, 3.6-7, 3.6, 3-7.3.0, 3-7.3, 3-7, 3, latest, 3.6-7.3.0-buster, 3.6-7.3-buster, 3.6-7-buster, 3.6-buster, 3-7.3.0-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: 42257a4c727f8c698883ba2dc9d1e91dcf8e93b2
+GitCommit: ac6a989a09815fc6ff38da92ea1154bc048caae3
 Directory: 3.6
 
-Tags: 3.6-7.3.0-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.0-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.0-slim-stretch, 3.6-7.3-slim-stretch, 3.6-7-slim-stretch, 3.6-slim-stretch, 3-7.3.0-slim-stretch, 3-7.3-slim-stretch, 3-7-slim-stretch, 3-slim-stretch, slim-stretch
+Tags: 3.6-7.3.0-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.0-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.0-slim-buster, 3.6-7.3-slim-buster, 3.6-7-slim-buster, 3.6-slim-buster, 3-7.3.0-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: 42257a4c727f8c698883ba2dc9d1e91dcf8e93b2
+GitCommit: ac6a989a09815fc6ff38da92ea1154bc048caae3
 Directory: 3.6/slim


### PR DESCRIPTION
https://github.com/docker-library/pypy/pull/37