### PR TITLE
caddy: Add arm32/arm64 architectures

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,16 +1,16 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/82359bcbcd3d43b8703605afc60370b6c5f87d1f/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/b665b72798e3e26c9483d3df80af3515e1c0c016/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.0.0-rc.3, 2.0.0-rc.3-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 82359bcbcd3d43b8703605afc60370b6c5f87d1f
-Architectures: amd64
+GitCommit: b665b72798e3e26c9483d3df80af3515e1c0c016
+Architectures: amd64, arm64v8, arm32v6, arm32v7
 
 Tags: 2.0.0-rc.3-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
 GitCommit: 82359bcbcd3d43b8703605afc60370b6c5f87d1f
-Architectures: amd64
+Architectures: amd64, arm64v8, arm32v6, arm32v7


### PR DESCRIPTION
Adding Linux/ARM support. Windows support will likely come at some point later...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>