### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/9a912d0e83db821040cbe3a4d4f543b857e9c61c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/50acaf8cbc81f4f987ddb75b1ea5fbbcd5462bf4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 9a912d0e83db821040cbe3a4d4f543b857e9c61c
+GitCommit: 50acaf8cbc81f4f987ddb75b1ea5fbbcd5462bf4
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9bb427f4dcafc97cf3f8b523fc8ed147d8bba7d8
+amd64-GitCommit: 08d3f7114ee5ac055c0fedad0a930e67c5f8b6f4
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d3f085e1d42fe99d11bee29b556f386fafcae04d
+arm32v5-GitCommit: 6219d5edb1d20afa0b80e29ab7a69165d1f90b75
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: fc02c9f154d0b02ee0e4ca95161b0ca8ab726147
+arm32v6-GitCommit: 49e7aa905bfadddbad90002925f4ce8872215fbc
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0504f1abd6d89443e2223b73159c7f3d77393710
+arm32v7-GitCommit: 8cc6110cfc031f859fe3f251a5f742bec8e9af3f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b87bf5287e8126d473c607a5669919784f2b66de
+arm64v8-GitCommit: 2fa8a48dd97c90c0da68c00fd60a104242a25b88
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e05006df43b2dc008ce63e50109a138844434653
+i386-GitCommit: 1e9e91d4ccf98236a6a86b7eae6d0a5e6dd4cb29
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 1a032fa4206559a7b5ab7ca671244e18ef1e829d
+ppc64le-GitCommit: dbdb1569a13fd471906468518bc877828abcb25d
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 19381f29c950469136109dc48bfccc6f47c1ef31
+s390x-GitCommit: e33236a4281c705ecf4dfdd0606277c7cfa4bd72
 
 Tags: 1.31.1-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/50acaf8: Update Buildroot to 2020.02.1