### PR TITLE
Update Amazon Corretto (8.252.09.1 and 11.0.7.10.1).

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -3,14 +3,14 @@ Maintainers: Amazon Corretto Team (@corretto),
              Ziyi Luo (@ziyiluo),
              David Alvarez (@alvdavi)
 
-Tags: 8, 8u242, 8-al2-full, latest
+Tags: 8, 8u252, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: ae31a3e5106d3d16e0a3154bca567c10879522af
+GitCommit: 46b4f7ab6fd46df966834c4b16c216ab8aa5e5bd
 Architectures: amd64, arm64v8
 
-Tags: 11, 11.0.6, 11-al2-full
+Tags: 11, 11.0.7, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: a797c24219a9262e581ee70fc928c57acacde331
+GitCommit: 7be0d778aa15aa887054450c79cda9aea50526fe
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This updates the Amazon Corretto image to use the 8u252 PSU patch baseline of OpenJDK8 and 11.0.7 of OpenJDK11.

Here's a quick link to the Dockerfile:

Amazon Corretto 8: [46b4f7a/Dockerfile](https://github.com/corretto/corretto-8-docker/blob/46b4f7ab6fd46df966834c4b16c216ab8aa5e5bd/Dockerfile)
Amazon Corretto 11: [7be0d77/Dockerfile](https://github.com/corretto/corretto-11-docker/blob/7be0d778aa15aa887054450c79cda9aea50526fe/Dockerfile)