### PR TITLE
Update bashbrew bits for mips64le (still a WIP, but this lets us progress further)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Some images have been ported for other architectures, and many of these are offi
 	-	ARMv5 32-bit (`arm32v5`): https://hub.docker.com/u/arm32v5/
 	-	IBM POWER8 (`ppc64le`): https://hub.docker.com/u/ppc64le/
 	-	IBM z Systems (`s390x`): https://hub.docker.com/u/s390x/
+	-	MIPS64 (`mips64le`): https://hub.docker.com/u/mips64le/
 	-	x86/i686 (`i386`): https://hub.docker.com/u/i386/
 
 As of 2017-09-12, these other architectures are included under the non-prefixed images via ["manifest lists"](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) (also known as ["indexes" in the OCI image specification](https://github.com/opencontainers/image-spec/blob/v1.0.0/image-index.md)), such that, for example, `docker run hello-world` should run as-is on all supported platforms.

--- a/bashbrew/Dockerfile.release
+++ b/bashbrew/Dockerfile.release
@@ -15,6 +15,7 @@ ENV BASHBREW_ARCHES \
 		arm64v8 \
 		darwin-amd64 \
 		i386 \
+		mips64le \
 		ppc64le \
 		s390x \
 		windows-amd64

--- a/bashbrew/go/go.mod
+++ b/bashbrew/go/go.mod
@@ -1,8 +1,10 @@
 module bashbrew
 
+go 1.13
+
 require (
 	github.com/codegangsta/cli v1.20.0
-	github.com/docker-library/go-dockerlibrary v0.0.0-20190627000812-fed46530e521
+	github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 // indirect
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc // indirect

--- a/bashbrew/go/go.sum
+++ b/bashbrew/go/go.sum
@@ -6,8 +6,8 @@ github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNT
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker-library/go-dockerlibrary v0.0.0-20190627000812-fed46530e521 h1:hYKiUmiBfNQAqpkuujxeo0Ixei72G6PBb23IF0iY0cQ=
-github.com/docker-library/go-dockerlibrary v0.0.0-20190627000812-fed46530e521/go.mod h1:ijRhN3WM71dD8TfohKoUdX46BT2uz/Ek5O+5PINI880=
+github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db h1:qxSDuZDqrt7X9gU75CD3GliYYSMLbHcO69VP7XWmoxk=
+github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db/go.mod h1:ijRhN3WM71dD8TfohKoUdX46BT2uz/Ek5O+5PINI880=
 github.com/emirpasic/gods v1.9.0 h1:rUF4PuzEjMChMiNsVjdI+SyLu7rEqpQ5reNFnhC7oFo=
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=

--- a/bashbrew/go/vendor/github.com/docker-library/go-dockerlibrary/architecture/oci-platform.go
+++ b/bashbrew/go/vendor/github.com/docker-library/go-dockerlibrary/architecture/oci-platform.go
@@ -1,6 +1,6 @@
 package architecture
 
-// https://github.com/opencontainers/image-spec/blob/v1.0.0-rc6/image-index.md#image-index-property-descriptions
+// https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md#image-index-property-descriptions
 // see "platform" (under "manifests")
 type OCIPlatform struct {
 	OS           string `json:"os"`
@@ -12,14 +12,15 @@ type OCIPlatform struct {
 }
 
 var SupportedArches = map[string]OCIPlatform{
-	"amd64":   {OS: "linux", Architecture: "amd64"},
-	"arm32v5": {OS: "linux", Architecture: "arm", Variant: "v5"},
-	"arm32v6": {OS: "linux", Architecture: "arm", Variant: "v6"},
-	"arm32v7": {OS: "linux", Architecture: "arm", Variant: "v7"},
-	"arm64v8": {OS: "linux", Architecture: "arm64", Variant: "v8"},
-	"i386":    {OS: "linux", Architecture: "386"},
-	"ppc64le": {OS: "linux", Architecture: "ppc64le"},
-	"s390x":   {OS: "linux", Architecture: "s390x"},
+	"amd64":    {OS: "linux", Architecture: "amd64"},
+	"arm32v5":  {OS: "linux", Architecture: "arm", Variant: "v5"},
+	"arm32v6":  {OS: "linux", Architecture: "arm", Variant: "v6"},
+	"arm32v7":  {OS: "linux", Architecture: "arm", Variant: "v7"},
+	"arm64v8":  {OS: "linux", Architecture: "arm64", Variant: "v8"},
+	"i386":     {OS: "linux", Architecture: "386"},
+	"mips64le": {OS: "linux", Architecture: "mips64le"},
+	"ppc64le":  {OS: "linux", Architecture: "ppc64le"},
+	"s390x":    {OS: "linux", Architecture: "s390x"},
 
 	"windows-amd64": {OS: "windows", Architecture: "amd64"},
 }

--- a/bashbrew/go/vendor/modules.txt
+++ b/bashbrew/go/vendor/modules.txt
@@ -1,18 +1,18 @@
 # github.com/codegangsta/cli v1.20.0
 github.com/codegangsta/cli
-# github.com/docker-library/go-dockerlibrary v0.0.0-20190627000812-fed46530e521
+# github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db
 github.com/docker-library/go-dockerlibrary/architecture
 github.com/docker-library/go-dockerlibrary/manifest
 github.com/docker-library/go-dockerlibrary/pkg/execpipe
 github.com/docker-library/go-dockerlibrary/pkg/stripper
 github.com/docker-library/go-dockerlibrary/pkg/templatelib
 # github.com/emirpasic/gods v1.9.0
-github.com/emirpasic/gods/trees/binaryheap
 github.com/emirpasic/gods/containers
+github.com/emirpasic/gods/lists
 github.com/emirpasic/gods/lists/arraylist
 github.com/emirpasic/gods/trees
+github.com/emirpasic/gods/trees/binaryheap
 github.com/emirpasic/gods/utils
-github.com/emirpasic/gods/lists
 # github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
 github.com/jbenet/go-context/io
 # github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e
@@ -31,44 +31,50 @@ github.com/src-d/gcfg/types
 # github.com/xanzy/ssh-agent v0.2.0
 github.com/xanzy/ssh-agent
 # golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
+golang.org/x/crypto/cast5
+golang.org/x/crypto/curve25519
+golang.org/x/crypto/ed25519
+golang.org/x/crypto/ed25519/internal/edwards25519
+golang.org/x/crypto/internal/chacha20
+golang.org/x/crypto/internal/subtle
 golang.org/x/crypto/openpgp
-golang.org/x/crypto/openpgp/clearsign
 golang.org/x/crypto/openpgp/armor
+golang.org/x/crypto/openpgp/clearsign
+golang.org/x/crypto/openpgp/elgamal
 golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/openpgp/packet
 golang.org/x/crypto/openpgp/s2k
-golang.org/x/crypto/cast5
-golang.org/x/crypto/openpgp/elgamal
-golang.org/x/crypto/ssh
-golang.org/x/crypto/ssh/knownhosts
-golang.org/x/crypto/ssh/agent
-golang.org/x/crypto/curve25519
-golang.org/x/crypto/ed25519
-golang.org/x/crypto/internal/chacha20
 golang.org/x/crypto/poly1305
-golang.org/x/crypto/ed25519/internal/edwards25519
-golang.org/x/crypto/internal/subtle
+golang.org/x/crypto/ssh
+golang.org/x/crypto/ssh/agent
+golang.org/x/crypto/ssh/knownhosts
 # golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 golang.org/x/net/context
 # golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc
-golang.org/x/sys/windows
 golang.org/x/sys/cpu
+golang.org/x/sys/windows
 # gopkg.in/src-d/go-billy.v4 v4.2.1
 gopkg.in/src-d/go-billy.v4
-gopkg.in/src-d/go-billy.v4/osfs
-gopkg.in/src-d/go-billy.v4/util
 gopkg.in/src-d/go-billy.v4/helper/chroot
 gopkg.in/src-d/go-billy.v4/helper/polyfill
+gopkg.in/src-d/go-billy.v4/osfs
+gopkg.in/src-d/go-billy.v4/util
 # gopkg.in/src-d/go-git.v4 v4.11.0
 gopkg.in/src-d/go-git.v4
 gopkg.in/src-d/go-git.v4/config
-gopkg.in/src-d/go-git.v4/plumbing
 gopkg.in/src-d/go-git.v4/internal/revision
+gopkg.in/src-d/go-git.v4/internal/url
+gopkg.in/src-d/go-git.v4/plumbing
 gopkg.in/src-d/go-git.v4/plumbing/cache
 gopkg.in/src-d/go-git.v4/plumbing/filemode
+gopkg.in/src-d/go-git.v4/plumbing/format/config
+gopkg.in/src-d/go-git.v4/plumbing/format/diff
 gopkg.in/src-d/go-git.v4/plumbing/format/gitignore
+gopkg.in/src-d/go-git.v4/plumbing/format/idxfile
 gopkg.in/src-d/go-git.v4/plumbing/format/index
+gopkg.in/src-d/go-git.v4/plumbing/format/objfile
 gopkg.in/src-d/go-git.v4/plumbing/format/packfile
+gopkg.in/src-d/go-git.v4/plumbing/format/pktline
 gopkg.in/src-d/go-git.v4/plumbing/object
 gopkg.in/src-d/go-git.v4/plumbing/protocol/packp
 gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability
@@ -77,30 +83,24 @@ gopkg.in/src-d/go-git.v4/plumbing/revlist
 gopkg.in/src-d/go-git.v4/plumbing/storer
 gopkg.in/src-d/go-git.v4/plumbing/transport
 gopkg.in/src-d/go-git.v4/plumbing/transport/client
+gopkg.in/src-d/go-git.v4/plumbing/transport/file
+gopkg.in/src-d/go-git.v4/plumbing/transport/git
+gopkg.in/src-d/go-git.v4/plumbing/transport/http
+gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common
+gopkg.in/src-d/go-git.v4/plumbing/transport/server
+gopkg.in/src-d/go-git.v4/plumbing/transport/ssh
 gopkg.in/src-d/go-git.v4/storage
 gopkg.in/src-d/go-git.v4/storage/filesystem
+gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit
 gopkg.in/src-d/go-git.v4/storage/memory
+gopkg.in/src-d/go-git.v4/utils/binary
 gopkg.in/src-d/go-git.v4/utils/diff
 gopkg.in/src-d/go-git.v4/utils/ioutil
 gopkg.in/src-d/go-git.v4/utils/merkletrie
 gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem
 gopkg.in/src-d/go-git.v4/utils/merkletrie/index
-gopkg.in/src-d/go-git.v4/utils/merkletrie/noder
-gopkg.in/src-d/go-git.v4/internal/url
-gopkg.in/src-d/go-git.v4/plumbing/format/config
-gopkg.in/src-d/go-git.v4/utils/binary
-gopkg.in/src-d/go-git.v4/plumbing/format/idxfile
-gopkg.in/src-d/go-git.v4/plumbing/format/diff
-gopkg.in/src-d/go-git.v4/plumbing/format/pktline
-gopkg.in/src-d/go-git.v4/plumbing/transport/file
-gopkg.in/src-d/go-git.v4/plumbing/transport/git
-gopkg.in/src-d/go-git.v4/plumbing/transport/http
-gopkg.in/src-d/go-git.v4/plumbing/transport/ssh
-gopkg.in/src-d/go-git.v4/plumbing/format/objfile
-gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit
 gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame
-gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common
-gopkg.in/src-d/go-git.v4/plumbing/transport/server
+gopkg.in/src-d/go-git.v4/utils/merkletrie/noder
 # gopkg.in/warnings.v0 v0.1.2
 gopkg.in/warnings.v0
 # pault.ag/go/debian v0.0.0-20190109175134-a131cb0ae041


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/issues/6709.