### PR TITLE
Update hello-world

### DIFF
--- a/library/hello-world
+++ b/library/hello-world
@@ -7,7 +7,7 @@ GitCommit: 837f63a4a9cc1e06320f47abb98965b6c5672b30
 
 Tags: linux
 SharedTags: latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 amd64-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716
 amd64-Directory: amd64/hello-world
 arm32v5-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716
@@ -18,6 +18,8 @@ arm64v8-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716
 arm64v8-Directory: arm64v8/hello-world
 i386-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716
 i386-Directory: i386/hello-world
+mips64le-GitCommit: 1b6581761dbcc3925f73a87214ec2c8cba06aec6
+mips64le-Directory: mips64le/hello-world
 ppc64le-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716
 ppc64le-Directory: ppc64le/hello-world
 s390x-GitCommit: 7ecae6978055d2fb6960e2a29d24a2af612e2716


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/hello-world/commit/eff5b9a: Merge pull request https://github.com/docker-library/hello-world/pull/68 from infosiftr/mips64le
- https://github.com/docker-library/hello-world/commit/ad5a6e8: Merge pull request https://github.com/docker-library/hello-world/pull/69 from CrafterKolyan/patch-2
- https://github.com/docker-library/hello-world/commit/8cec84c: Remove magic constant in syscall
- https://github.com/docker-library/hello-world/commit/1b65817: Add support for mips64le

Our first `mips64le` image!  This is in the pursuit of https://github.com/docker-library/official-images/issues/6709 (see also https://github.com/docker-library/official-images/pull/7796 which makes this possible at a high level).