### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.13.1, 3.13, 3, latest
+Tags: 3.13.3, 3.13, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 222443fa4933a4a068d3f8eb4d6d0b92d39e01d1
+GitCommit: 31e1d0376605a886a869eb4eea15d768c5f7bbc4
 Directory: 3/debian
 
-Tags: 3.13.1-alpine, 3.13-alpine, 3-alpine, alpine
+Tags: 3.13.3-alpine, 3.13-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 222443fa4933a4a068d3f8eb4d6d0b92d39e01d1
+GitCommit: 31e1d0376605a886a869eb4eea15d768c5f7bbc4
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/31e1d03: Update to 3.13.3, ghost-cli 1.13.1