### PR TITLE
caddy: Update image (add mailcap)

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -6,7 +6,7 @@ Maintainers: Dave Henderson (@hairyhenderson)
 Tags: 2.0.0-rc.3, 2.0.0-rc.3-alpine, alpine, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: b665b72798e3e26c9483d3df80af3515e1c0c016
+GitCommit: 94a0098157df267d23e54782d962b9f41b0d15c5
 Architectures: amd64, arm64v8, arm32v6, arm32v7
 
 Tags: 2.0.0-rc.3-builder, builder


### PR DESCRIPTION
Allows Caddy to understand more media types: https://github.com/caddyserver/caddy-docker/pull/70

Signed-off-by: Dave Henderson <dhenderson@gmail.com>