### PR TITLE
Add a collection of mips64le images

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 2.2-dev5, 2.2-rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 7f2c1472693b6676caac1b60bcfa70c5c53c8897
 Directory: 2.2-rc
 
@@ -15,7 +15,7 @@ GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.4, 2.1, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.1
 
@@ -25,7 +25,7 @@ GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.1/alpine
 
 Tags: 2.0.14, 2.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.0
 
@@ -35,7 +35,7 @@ GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.9
 
@@ -45,7 +45,7 @@ GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.9/alpine
 
 Tags: 1.8.25, 1.8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.8
 
@@ -55,7 +55,7 @@ GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 14431e31ab981456585021f7dca35626c5e060c1
 Directory: 1.7
 
@@ -65,7 +65,7 @@ GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
 Directory: 1.7/alpine
 
 Tags: 1.6.15, 1.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
 Directory: 1.6
 

--- a/library/httpd
+++ b/library/httpd
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.43, 2.4, 2, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 6c8e82e20ecefc94c616439f15d14c4bb215b200
 Directory: 2.4
 

--- a/library/irssi
+++ b/library/irssi
@@ -5,7 +5,7 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
 GitRepo: https://github.com/jessfraz/irssi.git
 
 Tags: 1.2.2, 1.2, 1, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 773216139cd3685fd710b77dc7d4ee26ec9fb187
 Directory: debian
 

--- a/library/memcached
+++ b/library/memcached
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.6.5, 1.6, 1, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 54f0aa6b002c2849425505dce9a344dd98417263
 Directory: debian
 

--- a/library/php
+++ b/library/php
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.4.4-cli-buster, 7.4-cli-buster, 7-cli-buster, cli-buster, 7.4.4-buster, 7.4-buster, 7-buster, buster, 7.4.4-cli, 7.4-cli, 7-cli, cli, 7.4.4, 7.4, 7, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 16766c6e5fe421432234020a21f2aba09e2a10c4
 Directory: 7.4/buster/cli
 
 Tags: 7.4.4-apache-buster, 7.4-apache-buster, 7-apache-buster, apache-buster, 7.4.4-apache, 7.4-apache, 7-apache, apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 16766c6e5fe421432234020a21f2aba09e2a10c4
 Directory: 7.4/buster/apache
 
 Tags: 7.4.4-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, fpm-buster, 7.4.4-fpm, 7.4-fpm, 7-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 16766c6e5fe421432234020a21f2aba09e2a10c4
 Directory: 7.4/buster/fpm
 
 Tags: 7.4.4-zts-buster, 7.4-zts-buster, 7-zts-buster, zts-buster, 7.4.4-zts, 7.4-zts, 7-zts, zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 16766c6e5fe421432234020a21f2aba09e2a10c4
 Directory: 7.4/buster/zts
 
@@ -55,42 +55,42 @@ GitCommit: 16766c6e5fe421432234020a21f2aba09e2a10c4
 Directory: 7.4/alpine3.10/zts
 
 Tags: 7.3.16-cli-buster, 7.3-cli-buster, 7.3.16-buster, 7.3-buster, 7.3.16-cli, 7.3-cli, 7.3.16, 7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/buster/cli
 
 Tags: 7.3.16-apache-buster, 7.3-apache-buster, 7.3.16-apache, 7.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/buster/apache
 
 Tags: 7.3.16-fpm-buster, 7.3-fpm-buster, 7.3.16-fpm, 7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/buster/fpm
 
 Tags: 7.3.16-zts-buster, 7.3-zts-buster, 7.3.16-zts, 7.3-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/buster/zts
 
 Tags: 7.3.16-cli-stretch, 7.3-cli-stretch, 7.3.16-stretch, 7.3-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.16-apache-stretch, 7.3-apache-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.16-fpm-stretch, 7.3-fpm-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.16-zts-stretch, 7.3-zts-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/stretch/zts
 
@@ -125,42 +125,42 @@ GitCommit: 33b1561787600482eb9aa024ad191ecb3d21bf65
 Directory: 7.3/alpine3.10/zts
 
 Tags: 7.2.29-cli-buster, 7.2-cli-buster, 7.2.29-buster, 7.2-buster, 7.2.29-cli, 7.2-cli, 7.2.29, 7.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/buster/cli
 
 Tags: 7.2.29-apache-buster, 7.2-apache-buster, 7.2.29-apache, 7.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/buster/apache
 
 Tags: 7.2.29-fpm-buster, 7.2-fpm-buster, 7.2.29-fpm, 7.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/buster/fpm
 
 Tags: 7.2.29-zts-buster, 7.2-zts-buster, 7.2.29-zts, 7.2-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/buster/zts
 
 Tags: 7.2.29-cli-stretch, 7.2-cli-stretch, 7.2.29-stretch, 7.2-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.29-apache-stretch, 7.2-apache-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.29-fpm-stretch, 7.2-fpm-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.29-zts-stretch, 7.2-zts-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
 Directory: 7.2/stretch/zts
 

--- a/library/postgres
+++ b/library/postgres
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 12.2, 12, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17c71aef1940ef0d2cc8bdc8bf7fb0a2856c8326
 Directory: 12
 
@@ -15,7 +15,7 @@ GitCommit: 33bccfcaddd0679f55ee1028c012d26cd196537d
 Directory: 12/alpine
 
 Tags: 11.7, 11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17c71aef1940ef0d2cc8bdc8bf7fb0a2856c8326
 Directory: 11
 
@@ -25,7 +25,7 @@ GitCommit: 33bccfcaddd0679f55ee1028c012d26cd196537d
 Directory: 11/alpine
 
 Tags: 10.12, 10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17c71aef1940ef0d2cc8bdc8bf7fb0a2856c8326
 Directory: 10
 
@@ -35,7 +35,7 @@ GitCommit: 33bccfcaddd0679f55ee1028c012d26cd196537d
 Directory: 10/alpine
 
 Tags: 9.6.17, 9.6, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17c71aef1940ef0d2cc8bdc8bf7fb0a2856c8326
 Directory: 9.6
 
@@ -45,7 +45,7 @@ GitCommit: 33bccfcaddd0679f55ee1028c012d26cd196537d
 Directory: 9.6/alpine
 
 Tags: 9.5.21, 9.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17c71aef1940ef0d2cc8bdc8bf7fb0a2856c8326
 Directory: 9.5
 

--- a/library/python
+++ b/library/python
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/python.git
 
 Tags: 3.9.0a5-buster, 3.9-rc-buster, rc-buster
 SharedTags: 3.9.0a5, 3.9-rc, rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 9f79a9df8fec373757cd0c2a2a75ce41c113e28b
 Directory: 3.9-rc/buster
 
@@ -31,12 +31,12 @@ Constraints: windowsservercore-1809
 
 Tags: 3.8.2-buster, 3.8-buster, 3-buster, buster
 SharedTags: 3.8.2, 3.8, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 21d2ab0a50100ebdaf32f4bbb214bf21f857d1da
 Directory: 3.8/buster
 
 Tags: 3.8.2-slim-buster, 3.8-slim-buster, 3-slim-buster, slim-buster, 3.8.2-slim, 3.8-slim, 3-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 21d2ab0a50100ebdaf32f4bbb214bf21f857d1da
 Directory: 3.8/buster/slim
 
@@ -66,22 +66,22 @@ Constraints: windowsservercore-1809
 
 Tags: 3.7.7-buster, 3.7-buster
 SharedTags: 3.7.7, 3.7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 695bd3c10cdf1692a2af9abdc51f0eff99731e78
 Directory: 3.7/buster
 
 Tags: 3.7.7-slim-buster, 3.7-slim-buster, 3.7.7-slim, 3.7-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 695bd3c10cdf1692a2af9abdc51f0eff99731e78
 Directory: 3.7/buster/slim
 
 Tags: 3.7.7-stretch, 3.7-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 695bd3c10cdf1692a2af9abdc51f0eff99731e78
 Directory: 3.7/stretch
 
 Tags: 3.7.7-slim-stretch, 3.7-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 695bd3c10cdf1692a2af9abdc51f0eff99731e78
 Directory: 3.7/stretch/slim
 
@@ -111,22 +111,22 @@ Constraints: windowsservercore-1809
 
 Tags: 3.6.10-buster, 3.6-buster
 SharedTags: 3.6.10, 3.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ac47c1bc7bffe22af0c4193f1b1656ca07a24a97
 Directory: 3.6/buster
 
 Tags: 3.6.10-slim-buster, 3.6-slim-buster, 3.6.10-slim, 3.6-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ac47c1bc7bffe22af0c4193f1b1656ca07a24a97
 Directory: 3.6/buster/slim
 
 Tags: 3.6.10-stretch, 3.6-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ac47c1bc7bffe22af0c4193f1b1656ca07a24a97
 Directory: 3.6/stretch
 
 Tags: 3.6.10-slim-stretch, 3.6-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ac47c1bc7bffe22af0c4193f1b1656ca07a24a97
 Directory: 3.6/stretch/slim
 
@@ -142,22 +142,22 @@ Directory: 3.6/alpine3.10
 
 Tags: 3.5.9-buster, 3.5-buster
 SharedTags: 3.5.9, 3.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 4a844ea3151d1452f3f824f4a9b9231c2acb75a2
 Directory: 3.5/buster
 
 Tags: 3.5.9-slim-buster, 3.5-slim-buster, 3.5.9-slim, 3.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 4a844ea3151d1452f3f824f4a9b9231c2acb75a2
 Directory: 3.5/buster/slim
 
 Tags: 3.5.9-stretch, 3.5-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 4a844ea3151d1452f3f824f4a9b9231c2acb75a2
 Directory: 3.5/stretch
 
 Tags: 3.5.9-slim-stretch, 3.5-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 4a844ea3151d1452f3f824f4a9b9231c2acb75a2
 Directory: 3.5/stretch/slim
 
@@ -173,22 +173,22 @@ Directory: 3.5/alpine3.10
 
 Tags: 2.7.17-buster, 2.7-buster, 2-buster
 SharedTags: 2.7.17, 2.7, 2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aab9eaf66f960332ab6e19c0d81e0b6e6fa90a3b
 Directory: 2.7/buster
 
 Tags: 2.7.17-slim-buster, 2.7-slim-buster, 2-slim-buster, 2.7.17-slim, 2.7-slim, 2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aab9eaf66f960332ab6e19c0d81e0b6e6fa90a3b
 Directory: 2.7/buster/slim
 
 Tags: 2.7.17-stretch, 2.7-stretch, 2-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aab9eaf66f960332ab6e19c0d81e0b6e6fa90a3b
 Directory: 2.7/stretch
 
 Tags: 2.7.17-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aab9eaf66f960332ab6e19c0d81e0b6e6fa90a3b
 Directory: 2.7/stretch/slim
 

--- a/library/redis
+++ b/library/redis
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 6.0-rc3, 6.0-rc, rc, 6.0-rc3-buster, 6.0-rc-buster, rc-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 886e71565ce748fd265c262d782b6c22c7540173
 Directory: 6.0-rc
 
@@ -15,7 +15,7 @@ GitCommit: 886e71565ce748fd265c262d782b6c22c7540173
 Directory: 6.0-rc/alpine
 
 Tags: 5.0.8, 5.0, 5, latest, 5.0.8-buster, 5.0-buster, 5-buster, buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
 Directory: 5.0
 
@@ -30,7 +30,7 @@ GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
 Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-buster, 4.0-buster, 4-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b6d413ceff3a2bca10a430ace121597fa8fe2a2c
 Directory: 4.0
 

--- a/library/ruby
+++ b/library/ruby
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 2.7.1-buster, 2.7-buster, 2-buster, buster, 2.7.1, 2.7, 2, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/buster
 
 Tags: 2.7.1-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.1-slim, 2.7-slim, 2-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/buster/slim
 
@@ -25,22 +25,22 @@ GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.7/alpine3.10
 
 Tags: 2.6.6-buster, 2.6-buster, 2.6.6, 2.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/buster
 
 Tags: 2.6.6-slim-buster, 2.6-slim-buster, 2.6.6-slim, 2.6-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/buster/slim
 
 Tags: 2.6.6-stretch, 2.6-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/stretch
 
 Tags: 2.6.6-slim-stretch, 2.6-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/stretch/slim
 
@@ -55,22 +55,22 @@ GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.6/alpine3.10
 
 Tags: 2.5.8-buster, 2.5-buster, 2.5.8, 2.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/buster
 
 Tags: 2.5.8-slim-buster, 2.5-slim-buster, 2.5.8-slim, 2.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/buster/slim
 
 Tags: 2.5.8-stretch, 2.5-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/stretch
 
 Tags: 2.5.8-slim-stretch, 2.5-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a564feaaee4c8647c299ab11d41498468bb9af7b
 Directory: 2.5/stretch/slim
 


### PR DESCRIPTION
- `haproxy`
- `httpd`
- `irssi`
- `memcached`
- `php`
- `postgres`
- `python`
- `redis`
- `ruby`

(This is the initial downstream effect of https://github.com/docker-library/official-images/pull/7804 and https://github.com/docker-library/official-images/pull/7805.)