### PR TITLE
Update Nextcloud image

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,60 +5,105 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 16.0.9-apache, 16.0-apache, 16-apache, 16.0.9, 16.0, 16
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 16.0/apache
-
-Tags: 16.0.9-fpm-alpine, 16.0-fpm-alpine, 16-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
-Directory: 16.0/fpm-alpine
 
 Tags: 16.0.9-fpm, 16.0-fpm, 16-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 16.0/fpm
+
+Tags: 16.0.9-fpm-alpine, 16.0-fpm-alpine, 16-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
+Directory: 16.0/fpm-alpine
+
+Tags: 16.0.10RC1-apache, 16.0.10-rc-apache, 16.0-rc-apache, 16-rc-apache, 16.0.10RC1, 16.0.10-rc, 16.0-rc, 16-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 16.0-rc/apache
+
+Tags: 16.0.10RC1-fpm, 16.0.10-rc-fpm, 16.0-rc-fpm, 16-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 16.0-rc/fpm
+
+Tags: 16.0.10RC1-fpm-alpine, 16.0.10-rc-fpm-alpine, 16.0-rc-fpm-alpine, 16-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 16.0-rc/fpm-alpine
 
 Tags: 17.0.5-apache, 17.0-apache, 17-apache, production-apache, 17.0.5, 17.0, 17, production
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 17.0/apache
-
-Tags: 17.0.5-fpm-alpine, 17.0-fpm-alpine, 17-fpm-alpine, production-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
-Directory: 17.0/fpm-alpine
 
 Tags: 17.0.5-fpm, 17.0-fpm, 17-fpm, production-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 17.0/fpm
+
+Tags: 17.0.5-fpm-alpine, 17.0-fpm-alpine, 17-fpm-alpine, production-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
+Directory: 17.0/fpm-alpine
+
+Tags: 17.0.6RC1-apache, 17.0.6-rc-apache, 17.0-rc-apache, 17-rc-apache, 17.0.6RC1, 17.0.6-rc, 17.0-rc, 17-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 17.0-rc/apache
+
+Tags: 17.0.6RC1-fpm, 17.0.6-rc-fpm, 17.0-rc-fpm, 17-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 17.0-rc/fpm
+
+Tags: 17.0.6RC1-fpm-alpine, 17.0.6-rc-fpm-alpine, 17.0-rc-fpm-alpine, 17-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 17.0-rc/fpm-alpine
 
 Tags: 18.0.3-apache, 18.0-apache, 18-apache, apache, stable-apache, 18.0.3, 18.0, 18, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 18.0/apache
-
-Tags: 18.0.3-fpm-alpine, 18.0-fpm-alpine, 18-fpm-alpine, fpm-alpine, stable-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
-Directory: 18.0/fpm-alpine
 
 Tags: 18.0.3-fpm, 18.0-fpm, 18-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63438ef792fdedd4ceb80664d22391aca21f6bd1
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
 Directory: 18.0/fpm
 
-Tags: 19.0.0beta2-apache, 19.0.0-beta-apache, 19.0-beta-apache, 19-beta-apache, 19.0.0beta2, 19.0.0-beta, 19.0-beta, 19-beta
+Tags: 18.0.3-fpm-alpine, 18.0-fpm-alpine, 18-fpm-alpine, fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6d2390726fe7110b406c447d48aa345fc9d07122
+Directory: 18.0/fpm-alpine
+
+Tags: 18.0.4RC1-apache, 18.0.4-rc-apache, 18.0-rc-apache, 18-rc-apache, 18.0.4RC1, 18.0.4-rc, 18.0-rc, 18-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1891bfa5e09842b6d92719d44b7fe01594227c38
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 18.0-rc/apache
+
+Tags: 18.0.4RC1-fpm, 18.0.4-rc-fpm, 18.0-rc-fpm, 18-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 18.0-rc/fpm
+
+Tags: 18.0.4RC1-fpm-alpine, 18.0.4-rc-fpm-alpine, 18.0-rc-fpm-alpine, 18-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 18.0-rc/fpm-alpine
+
+Tags: 19.0.0beta4-apache, 19.0.0-beta-apache, 19.0-beta-apache, 19-beta-apache, 19.0.0beta4, 19.0.0-beta, 19.0-beta, 19-beta
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
 Directory: 19.0-beta/apache
 
-Tags: 19.0.0beta2-fpm-alpine, 19.0.0-beta-fpm-alpine, 19.0-beta-fpm-alpine, 19-beta-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1891bfa5e09842b6d92719d44b7fe01594227c38
-Directory: 19.0-beta/fpm-alpine
-
-Tags: 19.0.0beta2-fpm, 19.0.0-beta-fpm, 19.0-beta-fpm, 19-beta-fpm
+Tags: 19.0.0beta4-fpm, 19.0.0-beta-fpm, 19.0-beta-fpm, 19-beta-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1891bfa5e09842b6d92719d44b7fe01594227c38
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
 Directory: 19.0-beta/fpm
+
+Tags: 19.0.0beta4-fpm-alpine, 19.0.0-beta-fpm-alpine, 19.0-beta-fpm-alpine, 19-beta-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 546813d73fc501b558561934b6102caad3595edd
+Directory: 19.0-beta/fpm-alpine

--- a/test/tests/nextcloud-cli-mysql/run.sh
+++ b/test/tests/nextcloud-cli-mysql/run.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-dbImage='mariadb:10'
+dbImage='mariadb:10.3'
 serverImage="$1"
 dbPass="test-$RANDOM-password-$RANDOM-$$"
 dbName="test-$RANDOM-db"


### PR DESCRIPTION
Downgraded MariaDB due https://github.com/nextcloud/server/pull/19328/commits/f36ba8bb011bcb869cc41f1788ea0b7dbaa3f5d6
Manually stripped `mips64le` for now.