### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -6,190 +6,190 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 7.4.5-cli-buster, 7.4-cli-buster, 7-cli-buster, cli-buster, 7.4.5-buster, 7.4-buster, 7-buster, buster, 7.4.5-cli, 7.4-cli, 7-cli, cli, 7.4.5, 7.4, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/buster/cli
 
 Tags: 7.4.5-apache-buster, 7.4-apache-buster, 7-apache-buster, apache-buster, 7.4.5-apache, 7.4-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/buster/apache
 
 Tags: 7.4.5-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, fpm-buster, 7.4.5-fpm, 7.4-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/buster/fpm
 
 Tags: 7.4.5-zts-buster, 7.4-zts-buster, 7-zts-buster, zts-buster, 7.4.5-zts, 7.4-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/buster/zts
 
 Tags: 7.4.5-cli-alpine3.11, 7.4-cli-alpine3.11, 7-cli-alpine3.11, cli-alpine3.11, 7.4.5-alpine3.11, 7.4-alpine3.11, 7-alpine3.11, alpine3.11, 7.4.5-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, cli-alpine, 7.4.5-alpine, 7.4-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.11/cli
 
 Tags: 7.4.5-fpm-alpine3.11, 7.4-fpm-alpine3.11, 7-fpm-alpine3.11, fpm-alpine3.11, 7.4.5-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.11/fpm
 
 Tags: 7.4.5-zts-alpine3.11, 7.4-zts-alpine3.11, 7-zts-alpine3.11, zts-alpine3.11, 7.4.5-zts-alpine, 7.4-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.11/zts
 
 Tags: 7.4.5-cli-alpine3.10, 7.4-cli-alpine3.10, 7-cli-alpine3.10, cli-alpine3.10, 7.4.5-alpine3.10, 7.4-alpine3.10, 7-alpine3.10, alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.10/cli
 
 Tags: 7.4.5-fpm-alpine3.10, 7.4-fpm-alpine3.10, 7-fpm-alpine3.10, fpm-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.10/fpm
 
 Tags: 7.4.5-zts-alpine3.10, 7.4-zts-alpine3.10, 7-zts-alpine3.10, zts-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2cc2e726f77ef6bf2488870ff39e3858ffdc692
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.4/alpine3.10/zts
 
 Tags: 7.3.17-cli-buster, 7.3-cli-buster, 7.3.17-buster, 7.3-buster, 7.3.17-cli, 7.3-cli, 7.3.17, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/buster/cli
 
 Tags: 7.3.17-apache-buster, 7.3-apache-buster, 7.3.17-apache, 7.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/buster/apache
 
 Tags: 7.3.17-fpm-buster, 7.3-fpm-buster, 7.3.17-fpm, 7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/buster/fpm
 
 Tags: 7.3.17-zts-buster, 7.3-zts-buster, 7.3.17-zts, 7.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/buster/zts
 
 Tags: 7.3.17-cli-stretch, 7.3-cli-stretch, 7.3.17-stretch, 7.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/stretch/cli
 
 Tags: 7.3.17-apache-stretch, 7.3-apache-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/stretch/apache
 
 Tags: 7.3.17-fpm-stretch, 7.3-fpm-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/stretch/fpm
 
 Tags: 7.3.17-zts-stretch, 7.3-zts-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/stretch/zts
 
 Tags: 7.3.17-cli-alpine3.11, 7.3-cli-alpine3.11, 7.3.17-alpine3.11, 7.3-alpine3.11, 7.3.17-cli-alpine, 7.3-cli-alpine, 7.3.17-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.11/cli
 
 Tags: 7.3.17-fpm-alpine3.11, 7.3-fpm-alpine3.11, 7.3.17-fpm-alpine, 7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.11/fpm
 
 Tags: 7.3.17-zts-alpine3.11, 7.3-zts-alpine3.11, 7.3.17-zts-alpine, 7.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.11/zts
 
 Tags: 7.3.17-cli-alpine3.10, 7.3-cli-alpine3.10, 7.3.17-alpine3.10, 7.3-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.10/cli
 
 Tags: 7.3.17-fpm-alpine3.10, 7.3-fpm-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.10/fpm
 
 Tags: 7.3.17-zts-alpine3.10, 7.3-zts-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d66997097a239dbd89332e7dd3f89fa5f0988e6f
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.3/alpine3.10/zts
 
 Tags: 7.2.29-cli-buster, 7.2-cli-buster, 7.2.29-buster, 7.2-buster, 7.2.29-cli, 7.2-cli, 7.2.29, 7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/buster/cli
 
 Tags: 7.2.29-apache-buster, 7.2-apache-buster, 7.2.29-apache, 7.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/buster/apache
 
 Tags: 7.2.29-fpm-buster, 7.2-fpm-buster, 7.2.29-fpm, 7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/buster/fpm
 
 Tags: 7.2.29-zts-buster, 7.2-zts-buster, 7.2.29-zts, 7.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/buster/zts
 
 Tags: 7.2.29-cli-stretch, 7.2-cli-stretch, 7.2.29-stretch, 7.2-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/stretch/cli
 
 Tags: 7.2.29-apache-stretch, 7.2-apache-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/stretch/apache
 
 Tags: 7.2.29-fpm-stretch, 7.2-fpm-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/stretch/fpm
 
 Tags: 7.2.29-zts-stretch, 7.2-zts-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/stretch/zts
 
 Tags: 7.2.29-cli-alpine3.11, 7.2-cli-alpine3.11, 7.2.29-alpine3.11, 7.2-alpine3.11, 7.2.29-cli-alpine, 7.2-cli-alpine, 7.2.29-alpine, 7.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.11/cli
 
 Tags: 7.2.29-fpm-alpine3.11, 7.2-fpm-alpine3.11, 7.2.29-fpm-alpine, 7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.11/fpm
 
 Tags: 7.2.29-zts-alpine3.11, 7.2-zts-alpine3.11, 7.2.29-zts-alpine, 7.2-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.11/zts
 
 Tags: 7.2.29-cli-alpine3.10, 7.2-cli-alpine3.10, 7.2.29-alpine3.10, 7.2-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.10/cli
 
 Tags: 7.2.29-fpm-alpine3.10, 7.2-fpm-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.10/fpm
 
 Tags: 7.2.29-zts-alpine3.10, 7.2-zts-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 03574f961844ad2a56d4c2c5304ffb30d3bfdc2b
+GitCommit: 7ccfc9272c3b5a5f100b38a75e91c99fdd2cb47a
 Directory: 7.2/alpine3.10/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/94ed60e: Merge pull request https://github.com/docker-library/php/pull/999 from infosiftr/hash-style
- https://github.com/docker-library/php/commit/7ccfc92: Remove "--hash-style=both"

This should fix our `mips64le` build. :+1: