### PR TITLE
Odoo: update 11.0-13.0 to release 20200417

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 6d92142da193f60c161f97eea1079f437dd51d7e
+GitCommit: f116a674ca62595d0fbf1ded206ec2e4d962ebf0
 
 Tags: 13.0, 13, latest
 Architectures: amd64


### PR DESCRIPTION
Hello, 

This is the latest release of Odoo in all supported versions.
Those fixes in Dockerfile are included:

    * Expose port 8072
    * Install Odoo Debian package in one command
    * Set default shell to bash
    * Use --no-install-recommends
    * Avoid masking of return values when assign and export
    * Remove postgresql source list after install

Thanks