### PR TITLE
caddy: Add Windows images

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,9 +1,10 @@
 # this file is generated with gomplate:
-# template: https://github.com/caddyserver/caddy-docker/blob/0097550f86a7ac7cb95042149d4d62ca415750a3/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/b665b72798e3e26c9483d3df80af3515e1c0c016/stackbrew-config.yaml
+# template: https://github.com/caddyserver/caddy-docker/blob/8779f909a654f865839d244bbb3edee602f87d85/stackbrew.tmpl
+# config context: https://github.com/caddyserver/caddy-docker/blob/f906d9d2a8aafeef912d8a3f061bf6dd022f5e17/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-rc.3, 2.0.0-rc.3-alpine, alpine, latest
+Tags: 2.0.0-rc.3-alpine, alpine
+SharedTags: 2.0.0-rc.3, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
 GitCommit: 94a0098157df267d23e54782d962b9f41b0d15c5
@@ -14,3 +15,19 @@ GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
 GitCommit: 82359bcbcd3d43b8703605afc60370b6c5f87d1f
 Architectures: amd64, arm64v8, arm32v6, arm32v7
+
+Tags: 2.0.0-rc.3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.0.0-rc.3-windowsservercore, windowsservercore, 2.0.0-rc.3, latest
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: windows/1809
+GitCommit: 98d0b9b4f9ce8cffaed0653c8730153338c01c71
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.0.0-rc.3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.0.0-rc.3-windowsservercore, windowsservercore, 2.0.0-rc.3, latest
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: windows/ltsc2016
+GitCommit: 98d0b9b4f9ce8cffaed0653c8730153338c01c71
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
(From https://github.com/caddyserver/caddy-docker/pull/69)

This adds two new tags for `windows-amd64`: `windowsservercore-1809` and `windowsservercore-ltsc2016`.

This is the very first real Windows image I've produced (beyond the tutorials I did at DockerCon years ago 😂). And it's been about 15 years since I've had any real Windows expertise... So I'm open to any criticisms/corrections! I copied much of it from other official images, though I added on the checksum-verification stuff myself since I felt it was important to stay close to the Linux version.

A few things:
- I didn't include any `nanoserver` flags. Looks like very few official images have this, and it seemed like the benefits were fleeting
- I included both a `ltsc2016` as well as an `1809` flavour - that seems to be the convention (and I guess you can't run `1809` on Server 2016 at all?).
  - I wasn't able to test out the `ltsc2016` tag, but I presume it'll be much the same as `1809`. Hopefully the janky tests can suss that out...
- I'm not _certain_ I did the `SharedTags` thing right - should `windowsservercore-ltsc2016` also have `latest`, or is it ok that only `windowsservercore-1809` has it?

/cc @tianon @yosifkit 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>