### PR TITLE
bashbrew:go:cmd-cat: remove extra v in Sprintf

### DIFF
--- a/bashbrew/go/src/bashbrew/cmd-cat.go
+++ b/bashbrew/go/src/bashbrew/cmd-cat.go
@@ -77,7 +77,7 @@ func cmdCat(c *cli.Context) error {
 				case manifest.Manifest2822Entry:
 					entries = append(entries, v)
 				default:
-					panic(fmt.Sprintf(`"archFilter" encountered unknown type: %T`, v, v))
+					panic(fmt.Sprintf(`"archFilter" encountered unknown type: %T`, v))
 				}
 			}
 			filtered := []manifest.Manifest2822Entry{}


### PR DESCRIPTION
The panic Sprintf for cmd-cat.go has an extra 'v' argument, which
triggers a failure when running go test. Remove the extra 'v' argument.