### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0-rc3, 6.0-rc, rc, 6.0-rc3-buster, 6.0-rc-buster, rc-buster
+Tags: 6.0-rc4, 6.0-rc, rc, 6.0-rc4-buster, 6.0-rc-buster, rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a12431fe712de586182cdf0ef4fd191b8e0bd196
+GitCommit: f5c670afed78af489252e29157da974272188e77
 Directory: 6.0-rc
 
-Tags: 6.0-rc3-alpine, 6.0-rc-alpine, rc-alpine, 6.0-rc3-alpine3.11, 6.0-rc-alpine3.11, rc-alpine3.11
+Tags: 6.0-rc4-alpine, 6.0-rc-alpine, rc-alpine, 6.0-rc4-alpine3.11, 6.0-rc-alpine3.11, rc-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 886e71565ce748fd265c262d782b6c22c7540173
+GitCommit: f5c670afed78af489252e29157da974272188e77
 Directory: 6.0-rc/alpine
 
-Tags: 5.0.8, 5.0, 5, latest, 5.0.8-buster, 5.0-buster, 5-buster, buster
+Tags: 5.0.9, 5.0, 5, latest, 5.0.9-buster, 5.0-buster, 5-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a12431fe712de586182cdf0ef4fd191b8e0bd196
+GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
 Directory: 5.0
 
-Tags: 5.0.8-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.8-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
+Tags: 5.0.9-32bit, 5.0-32bit, 5-32bit, 32bit, 5.0.9-32bit-buster, 5.0-32bit-buster, 5-32bit-buster, 32bit-buster
 Architectures: amd64
-GitCommit: a12431fe712de586182cdf0ef4fd191b8e0bd196
+GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
 Directory: 5.0/32bit
 
-Tags: 5.0.8-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.8-alpine3.11, 5.0-alpine3.11, 5-alpine3.11, alpine3.11
+Tags: 5.0.9-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.9-alpine3.11, 5.0-alpine3.11, 5-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc4e9c20b98b370069cff1d250a24d78d31c0f10
+GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
 Directory: 5.0/alpine
 
 Tags: 4.0.14, 4.0, 4, 4.0.14-buster, 4.0-buster, 4-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/d3a0f3d: Update to 5.0.9
- https://github.com/docker-library/redis/commit/f5c670a: Update to 6.0-rc4