### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev5, 2.2-rc
+Tags: 2.2-dev6, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f2c1472693b6676caac1b60bcfa70c5c53c8897
+GitCommit: eaec0e4daa5078cf47fe0ccf7a8f75497e40d153
 Directory: 2.2-rc
 
-Tags: 2.2-dev5-alpine, 2.2-rc-alpine
+Tags: 2.2-dev6-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.4, 2.1, latest
@@ -21,7 +21,7 @@ Directory: 2.1
 
 Tags: 2.1.4-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 2.1/alpine
 
 Tags: 2.0.14, 2.0
@@ -31,7 +31,7 @@ Directory: 2.0
 
 Tags: 2.0.14-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1
@@ -41,7 +41,7 @@ Directory: 1.9
 
 Tags: 1.9.15-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 1.9/alpine
 
 Tags: 1.8.25, 1.8
@@ -51,7 +51,7 @@ Directory: 1.8
 
 Tags: 1.8.25-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
@@ -61,7 +61,7 @@ Directory: 1.7
 
 Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 1.7/alpine
 
 Tags: 1.6.15, 1.6
@@ -71,5 +71,5 @@ Directory: 1.6
 
 Tags: 1.6.15-alpine, 1.6-alpine
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 9b20744178ed26f3486d9fa206c8249c46b97343
+GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 1.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6cd53ed: Merge pull request https://github.com/docker-library/haproxy/pull/111 from TimWolla/target-musl
- https://github.com/docker-library/haproxy/commit/bfa23c1: Switch to TARGET=linux-musl for alpine
- https://github.com/docker-library/haproxy/commit/eaec0e4: Update to 2.2-dev6