### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 4.1.1, 4.1, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fc2372f36ad91692c845d62fb1973d8ff8f99a11
+GitCommit: f5895d1d4bff53a590b6048e294dc96b26206883
 Directory: 4.1
 
 Tags: 4.1.1-passenger, 4.1-passenger, 4-passenger, passenger
@@ -19,7 +19,7 @@ Directory: 4.1/alpine
 
 Tags: 4.0.7, 4.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fc2372f36ad91692c845d62fb1973d8ff8f99a11
+GitCommit: f5895d1d4bff53a590b6048e294dc96b26206883
 Directory: 4.0
 
 Tags: 4.0.7-passenger, 4.0-passenger


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/f5895d1: Update tini to 0.19.0 (esp. for mips64le)