### PR TITLE
Remove EOL python 2.x

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/d6a0035b00d564666b8f53a1ab2d77aa1423552f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/ab8db2f89a236e9a3a23b099edfbcfec2944e2e6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -170,48 +170,3 @@ Tags: 3.5.9-alpine3.10, 3.5-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4a844ea3151d1452f3f824f4a9b9231c2acb75a2
 Directory: 3.5/alpine3.10
-
-Tags: 2.7.18-buster, 2.7-buster, 2-buster
-SharedTags: 2.7.18, 2.7, 2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/buster
-
-Tags: 2.7.18-slim-buster, 2.7-slim-buster, 2-slim-buster, 2.7.18-slim, 2.7-slim, 2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/buster/slim
-
-Tags: 2.7.18-stretch, 2.7-stretch, 2-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/stretch
-
-Tags: 2.7.18-slim-stretch, 2.7-slim-stretch, 2-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/stretch/slim
-
-Tags: 2.7.18-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, 2.7.18-alpine, 2.7-alpine, 2-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/alpine3.11
-
-Tags: 2.7.18-alpine3.10, 2.7-alpine3.10, 2-alpine3.10
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/alpine3.10
-
-Tags: 2.7.18-windowsservercore-ltsc2016, 2.7-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016
-SharedTags: 2.7.18-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.18, 2.7, 2
-Architectures: windows-amd64
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 2.7.18-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809
-SharedTags: 2.7.18-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, 2.7.18, 2.7, 2
-Architectures: windows-amd64
-GitCommit: f1e613f48eb4fc88748b36787f5ed74c14914636
-Directory: 2.7/windows/windowsservercore-1809
-Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/7acb0a3: Merge pull request https://github.com/docker-library/python/pull/470 from infosiftr/bye-caveman
- https://github.com/docker-library/python/commit/ab8db2f: Remove Python 2