### PR TITLE
caddy: Windows 2016 TLS 1.2 fix

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -7,7 +7,7 @@ Tags: 2.0.0-rc.3-alpine, alpine
 SharedTags: 2.0.0-rc.3, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
-GitCommit: 94a0098157df267d23e54782d962b9f41b0d15c5
+GitCommit: f0ba1e0c75e4410e129b3cb9f74f0f3a55d77e2d
 Architectures: amd64, arm64v8, arm32v6, arm32v7
 
 Tags: 2.0.0-rc.3-builder, builder
@@ -20,7 +20,7 @@ Tags: 2.0.0-rc.3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 2.0.0-rc.3-windowsservercore, windowsservercore, 2.0.0-rc.3, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: windows/1809
-GitCommit: 98d0b9b4f9ce8cffaed0653c8730153338c01c71
+GitCommit: 8ac69cfc9c0ad5a82f6399519fb256275f7228d8
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -28,6 +28,6 @@ Tags: 2.0.0-rc.3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 2.0.0-rc.3-windowsservercore, windowsservercore, 2.0.0-rc.3, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: windows/ltsc2016
-GitCommit: 98d0b9b4f9ce8cffaed0653c8730153338c01c71
+GitCommit: 8ac69cfc9c0ad5a82f6399519fb256275f7228d8
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Apparently Windows 2016 doesn't enable TLS 1.2 by default (thanks @tianon for helping me with that!)

Followup to #7827 

From https://github.com/caddyserver/caddy-docker/pull/75 and https://github.com/caddyserver/caddy-docker/pull/76

Fixes build https://doi-janky.infosiftr.net/view/generators/job/multiarch/job/windows-amd64/job/caddy/1/console

Also saves some space from the `alpine` tag: https://github.com/caddyserver/caddy-docker/pull/77

Signed-off-by: Dave Henderson <dhenderson@gmail.com>