### PR TITLE
alpine: bump 3.11.6, 3.10.5 and 3.9.6 (CVE-2020-1967)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.5, 3.11, 3, latest
+Tags: 3.11.6, 3.11, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: bafe72e7d06184fe1a7e7a0cf65631fe2ddd67b7
+GitCommit: c5510d5b1d2546d133f7b0938690c3c1e2cd9549
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -25,10 +25,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.4, 3.10
+Tags: 3.10.5, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: b05a5ce079ec947e76322ea7cf5900efd7ecae43
+GitCommit: a02be1f7da059d74c0743792b41d17626128c2a3
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -37,10 +37,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.9.5, 3.9
+Tags: 3.9.6, 3.9
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.9
-GitCommit: 9becb5e9835cd628110545a4475ff66615a5683e
+GitCommit: d7eb97a39abbdfe6ba73236f844cb80b756280d1
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fixes security issue in openssl.