### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -10,10 +10,10 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 9f79a9df8fec373757cd0c2a2a75ce41c113e28b
 Directory: 3.9-rc/buster
 
-Tags: 3.9.0a5-alpine3.10, 3.9-rc-alpine3.10, rc-alpine3.10
+Tags: 3.9.0a5-alpine3.11, 3.9-rc-alpine3.11, rc-alpine3.11, 3.9.0a5-alpine, 3.9-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f79a9df8fec373757cd0c2a2a75ce41c113e28b
-Directory: 3.9-rc/alpine3.10
+GitCommit: 5c38998d55d0396dab6658e579fdeec353d97660
+Directory: 3.9-rc/alpine3.11
 
 Tags: 3.9.0a5-windowsservercore-ltsc2016, 3.9-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.9.0a5-windowsservercore, 3.9-rc-windowsservercore, rc-windowsservercore, 3.9.0a5, 3.9-rc, rc


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/5c38998: Switch from Alpine 3.10 to 3.11 for Python 3.9-rc