### PR TITLE
Adopt Windows Update for Notarized Binaries

### DIFF
--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -11,18 +11,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8u252-b09-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u252-b09-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u252-b09-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+Tags: 8u252-b09.1-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
+SharedTags: 8u252-b09.1-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u252-b09.1-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-b09-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
-SharedTags: 8u252-b09-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u252-b09-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+Tags: 8u252-b09.1-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
+SharedTags: 8u252-b09.1-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u252-b09.1-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -34,18 +34,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8u252-b09-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u252-b09-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u252-b09-jre-hotspot, 8-jre-hotspot
+Tags: 8u252-b09.1-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 8u252-b09.1-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u252-b09.1-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-b09-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
-SharedTags: 8u252-b09-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u252-b09-jre-hotspot, 8-jre-hotspot
+Tags: 8u252-b09.1-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
+SharedTags: 8u252-b09.1-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u252-b09.1-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -59,18 +59,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11.0.7_10-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.7_10-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.7_10-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Tags: 11.0.7_10.1-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
+SharedTags: 11.0.7_10.1-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.7_10.1-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7_10-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
-SharedTags: 11.0.7_10-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.7_10-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Tags: 11.0.7_10.1-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
+SharedTags: 11.0.7_10.1-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.7_10.1-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -82,18 +82,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11.0.7_10-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.7_10-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.7_10-jre-hotspot, 11-jre-hotspot
+Tags: 11.0.7_10.1-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 11.0.7_10.1-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.7_10.1-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7_10-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
-SharedTags: 11.0.7_10-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.7_10-jre-hotspot, 11-jre-hotspot
+Tags: 11.0.7_10.1-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
+SharedTags: 11.0.7_10.1-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.7_10.1-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -155,18 +155,18 @@ GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
 Directory: 14/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 14.0.1_7-jdk-hotspot-windowsservercore-ltsc2016, 14-jdk-hotspot-windowsservercore-ltsc2016, 14-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
-SharedTags: 14.0.1_7-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, hotspot-windowsservercore, 14.0.1_7-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, hotspot, latest
+Tags: 14.0.1_7.1-jdk-hotspot-windowsservercore-ltsc2016, 14-jdk-hotspot-windowsservercore-ltsc2016, 14-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
+SharedTags: 14.0.1_7.1-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, hotspot-windowsservercore, 14.0.1_7.1-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.1_7-jdk-hotspot-windowsservercore-1809, 14-jdk-hotspot-windowsservercore-1809, 14-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
-SharedTags: 14.0.1_7-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, hotspot-windowsservercore, 14.0.1_7-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, hotspot, latest
+Tags: 14.0.1_7.1-jdk-hotspot-windowsservercore-1809, 14-jdk-hotspot-windowsservercore-1809, 14-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
+SharedTags: 14.0.1_7.1-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, hotspot-windowsservercore, 14.0.1_7.1-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -178,18 +178,18 @@ GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
 Directory: 14/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 14.0.1_7-jre-hotspot-windowsservercore-ltsc2016, 14-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 14.0.1_7-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.1_7-jre-hotspot, 14-jre-hotspot
+Tags: 14.0.1_7.1-jre-hotspot-windowsservercore-ltsc2016, 14-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 14.0.1_7.1-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.1_7.1-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.1_7-jre-hotspot-windowsservercore-1809, 14-jre-hotspot-windowsservercore-1809
-SharedTags: 14.0.1_7-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.1_7-jre-hotspot, 14-jre-hotspot
+Tags: 14.0.1_7.1-jre-hotspot-windowsservercore-1809, 14-jre-hotspot-windowsservercore-1809
+SharedTags: 14.0.1_7.1-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.1_7.1-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 2fb3fcc43ea049fd4bd020910e23ecdf492deb58
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -203,18 +203,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8u252-b09-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
-SharedTags: 8u252-b09-jdk-openj9-0.20.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u252-b09-jdk-openj9-0.20.0, 8-jdk-openj9, 8-openj9
+Tags: 8u252-b09.1-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
+SharedTags: 8u252-b09.1-jdk-openj9-0.20.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u252-b09.1-jdk-openj9-0.20.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-b09-jdk-openj9-0.20.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
-SharedTags: 8u252-b09-jdk-openj9-0.20.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u252-b09-jdk-openj9-0.20.0, 8-jdk-openj9, 8-openj9
+Tags: 8u252-b09.1-jdk-openj9-0.20.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
+SharedTags: 8u252-b09.1-jdk-openj9-0.20.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u252-b09.1-jdk-openj9-0.20.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -226,18 +226,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8u252-b09-jre-openj9-0.20.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 8u252-b09-jre-openj9-0.20.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u252-b09-jre-openj9-0.20.0, 8-jre-openj9
+Tags: 8u252-b09.1-jre-openj9-0.20.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 8u252-b09.1-jre-openj9-0.20.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u252-b09.1-jre-openj9-0.20.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-b09-jre-openj9-0.20.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
-SharedTags: 8u252-b09-jre-openj9-0.20.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u252-b09-jre-openj9-0.20.0, 8-jre-openj9
+Tags: 8u252-b09.1-jre-openj9-0.20.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
+SharedTags: 8u252-b09.1-jre-openj9-0.20.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u252-b09.1-jre-openj9-0.20.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -251,18 +251,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11.0.7_10-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
-SharedTags: 11.0.7_10-jdk-openj9-0.20.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10-jdk-openj9-0.20.0, 11-jdk-openj9, 11-openj9
+Tags: 11.0.7_10.1-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
+SharedTags: 11.0.7_10.1-jdk-openj9-0.20.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10.1-jdk-openj9-0.20.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7_10-jdk-openj9-0.20.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
-SharedTags: 11.0.7_10-jdk-openj9-0.20.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10-jdk-openj9-0.20.0, 11-jdk-openj9, 11-openj9
+Tags: 11.0.7_10.1-jdk-openj9-0.20.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
+SharedTags: 11.0.7_10.1-jdk-openj9-0.20.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10.1-jdk-openj9-0.20.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -274,18 +274,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11.0.7_10-jre-openj9-0.20.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 11.0.7_10-jre-openj9-0.20.0-windowsservercore, 11-jre-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10-jre-openj9-0.20.0, 11-jre-openj9
+Tags: 11.0.7_10.1-jre-openj9-0.20.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 11.0.7_10.1-jre-openj9-0.20.0-windowsservercore, 11-jre-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.7_10.1-jre-openj9-0.20.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7_10-jre-openj9-0.20.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
-SharedTags: 11.0.7_10-jre-openj9-0.20.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.7_10-jre-openj9-0.20.0, 11-jre-openj9
+Tags: 11.0.7_10.1-jre-openj9-0.20.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
+SharedTags: 11.0.7_10.1-jre-openj9-0.20.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.7_10.1-jre-openj9-0.20.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -347,18 +347,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 14/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 14.0.1_7-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 14-jdk-openj9-windowsservercore-ltsc2016, 14-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
-SharedTags: 14.0.1_7-jdk-openj9-0.20.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, openj9-windowsservercore, 14.0.1_7-jdk-openj9-0.20.0, 14-jdk-openj9, 14-openj9, openj9
+Tags: 14.0.1_7.1-jdk-openj9-0.20.0-windowsservercore-ltsc2016, 14-jdk-openj9-windowsservercore-ltsc2016, 14-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
+SharedTags: 14.0.1_7.1-jdk-openj9-0.20.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, openj9-windowsservercore, 14.0.1_7.1-jdk-openj9-0.20.0, 14-jdk-openj9, 14-openj9, openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.1_7-jdk-openj9-0.20.0-windowsservercore-1809, 14-jdk-openj9-windowsservercore-1809, 14-openj9-windowsservercore-1809, openj9-windowsservercore-1809
-SharedTags: 14.0.1_7-jdk-openj9-0.20.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, openj9-windowsservercore, 14.0.1_7-jdk-openj9-0.20.0, 14-jdk-openj9, 14-openj9, openj9
+Tags: 14.0.1_7.1-jdk-openj9-0.20.0-windowsservercore-1809, 14-jdk-openj9-windowsservercore-1809, 14-openj9-windowsservercore-1809, openj9-windowsservercore-1809
+SharedTags: 14.0.1_7.1-jdk-openj9-0.20.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, openj9-windowsservercore, 14.0.1_7.1-jdk-openj9-0.20.0, 14-jdk-openj9, 14-openj9, openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -370,18 +370,18 @@ GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
 Directory: 14/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 14.0.1_7-jre-openj9-0.20.0-windowsservercore-ltsc2016, 14-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 14.0.1_7-jre-openj9-0.20.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.1_7-jre-openj9-0.20.0, 14-jre-openj9
+Tags: 14.0.1_7.1-jre-openj9-0.20.0-windowsservercore-ltsc2016, 14-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 14.0.1_7.1-jre-openj9-0.20.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.1_7.1-jre-openj9-0.20.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.1_7-jre-openj9-0.20.0-windowsservercore-1809, 14-jre-openj9-windowsservercore-1809
-SharedTags: 14.0.1_7-jre-openj9-0.20.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.1_7-jre-openj9-0.20.0, 14-jre-openj9
+Tags: 14.0.1_7.1-jre-openj9-0.20.0-windowsservercore-1809, 14-jre-openj9-windowsservercore-1809
+SharedTags: 14.0.1_7.1-jre-openj9-0.20.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.1_7.1-jre-openj9-0.20.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: f104ef0fd80dc1d8e2b796a80f00512ab06a1465
+GitCommit: facb9fef4e720ca5e037862e19ca8ac5b883cc48
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Windows binaries were missing notarization and have been updated and re-released as versions 8u252-b09.1, 11.0.7+10.1 and 14.0.1+7.1.