### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.13.4, 3.13, 3, latest
+Tags: 3.14.0, 3.14, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a79811a2e4522ed03bf1b1c969def16ac439abbf
+GitCommit: 29e0b3ccd4b502e88e09ff1b2a67cd526ed13124
 Directory: 3/debian
 
-Tags: 3.13.4-alpine, 3.13-alpine, 3-alpine, alpine
+Tags: 3.14.0-alpine, 3.14-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a79811a2e4522ed03bf1b1c969def16ac439abbf
+GitCommit: 29e0b3ccd4b502e88e09ff1b2a67cd526ed13124
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/29e0b3c: Update to 3.14.0, ghost-cli 1.13.1