### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a38bc83b431ac84c2fb8bebbe57ddb7cf612a95a
+GitCommit: f768c59e159528e99465202c5adca95056dd4218
 Directory: 3.8/ubuntu
 
 Tags: 3.8.3-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a38bc83b431ac84c2fb8bebbe57ddb7cf612a95a
+GitCommit: f768c59e159528e99465202c5adca95056dd4218
 Directory: 3.8/alpine
 
 Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.25, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45fd9957f540f4ae4dce16a7db749ac08374023d
+GitCommit: 0f1f78a32ba879b7d2e3481faa56c9031f3f77d2
 Directory: 3.7/ubuntu
 
 Tags: 3.7.25-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.25-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45fd9957f540f4ae4dce16a7db749ac08374023d
+GitCommit: 0f1f78a32ba879b7d2e3481faa56c9031f3f77d2
 Directory: 3.7/alpine
 
 Tags: 3.7.25-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/f768c59: Update to 3.8.3, Erlang/OTP 22.3.3, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/0f1f78a: Update to 3.7.25, Erlang/OTP 22.3.3, OpenSSL 1.1.1g