### PR TITLE
Update rakudo-star to version 2020.01

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,11 +1,11 @@
-Maintainers: Rob Hoelz <robAThoelz.ro> (@hoelzro)
-GitRepo: https://github.com/perl6/docker
+Maintainers: Moritz Lenz <moritz.lenz@gmail.com> (@moritz)
+GitRepo: https://github.com/raku/docker
 
-Tags: latest, 2019.03
+Tags: latest, 2020.01
 Architectures: amd64, arm64v8
-GitCommit: e26d1937190790a6b6110ba8220b98fe3bb97c04
+GitCommit: d893fa621e755045c80fb4d0615c2810812d98f7
 
-Tags: alpine, 2019.03-alpine
+Tags: alpine, 2020.01-alpine
 Architectures: amd64, arm64v8
-GitCommit: d2175a31e85d52cfad674814422ecf9779ea08e1
+GitCommit: d893fa621e755045c80fb4d0615c2810812d98f7
 Directory: alpine


### PR DESCRIPTION
Also change repository URL due to [recent project rename](https://www.edument.se/en/blog/post/perl-6-becomes-raku-but-what-does-this-mean), and remove original maintainer by his own wishes, see https://colabti.org/irclogger/irclogger_log/raku-dev?date=2020-04-28#l153