### PR TITLE
Bump Traefik to v2.2.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.0-windowsservercore-1809, 2.2.0-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.1-windowsservercore-1809, 2.2.1-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 6dcd8fe17189e8076ee052a614dda5550afb2930
+GitCommit: 4aa0b86550fec343ad25e330624c887ad48e5e08
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.0, 2.2.0, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.1, 2.2.1, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 6dcd8fe17189e8076ee052a614dda5550afb2930
+GitCommit: 4aa0b86550fec343ad25e330624c887ad48e5e08
 Directory: alpine
 
 Tags: v1.7.24-windowsservercore-1809, 1.7.24-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.1](https://github.com/containous/traefik/releases/tag/v2.2.1).

/cc @mmatur @emilevauge @SantoDE @dtomcej

Cheers
