### PR TITLE
Update Amazon Corretto (Remove src.zip)

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -6,11 +6,11 @@ Maintainers: Amazon Corretto Team (@corretto),
 Tags: 8, 8u252, 8-al2-full, latest
 GitRepo: https://github.com/corretto/corretto-8-docker.git
 GitFetch: refs/heads/8-al2-full
-GitCommit: 46b4f7ab6fd46df966834c4b16c216ab8aa5e5bd
+GitCommit: a1e2c7e4fb1d00430b76963020aa2861bba7658f
 Architectures: amd64, arm64v8
 
 Tags: 11, 11.0.7, 11-al2-full
 GitRepo: https://github.com/corretto/corretto-11-docker.git
 GitFetch: refs/heads/11-al2-full
-GitCommit: 7be0d778aa15aa887054450c79cda9aea50526fe
+GitCommit: 6ae94c922f550dfd3d9d08b04c10f6c114ee0e51
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Hi there, this updates the Amazon Corretto images to delete src.zip during the build time in order to reduce the image size.

Links to the Dockerfile:

Amazon Corretto 8: [a1e2c7e/Dockerfile](https://github.com/corretto/corretto-8-docker/blob/a1e2c7e4fb1d00430b76963020aa2861bba7658f/Dockerfile);
Amazon Corretto 11: [6ae94c9/Dockerfile](https://github.com/corretto/corretto-11-docker/blob/6ae94c922f550dfd3d9d08b04c10f6c114ee0e51/Dockerfile);

Thank you!