### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -113,7 +113,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.7-jdk-nanoserver-1809, 11.0.7-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.7-jdk-nanoserver, 11.0.7-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -145,7 +145,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.7-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.7-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -177,7 +177,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u252-jdk-nanoserver-1809, 8u252-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u252-jdk-nanoserver, 8u252-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -209,6 +209,6 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u252-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u252-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/3f6ab87: Fix JDK vs JRE on Nano Server variants