### PR TITLE
Update Solr to 8.5.1 and 7.7.3

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -4,92 +4,92 @@ Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
              Shalin Mangar <shalin@apache.org> (@shalinmangar)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.5.0, 8.5, 8, latest
+Tags: 8.5.1, 8.5, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.5
 
-Tags: 8.5.0-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.1-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 1c32fcc7352046c3a67749c32506aa3ad2fa912d
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.5/slim
 
 Tags: 8.4.1, 8.4
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.4
 
 Tags: 8.4.1-slim, 8.4-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.4/slim
 
 Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.3
 
 Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 8.0/slim
 
-Tags: 7.7.2, 7.7, 7
+Tags: 7.7.3, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 7.7
 
-Tags: 7.7.2-slim, 7.7-slim, 7-slim
+Tags: 7.7.3-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 400e7842eac8346c6a79bc45cf083a296a779976
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 7.7/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 0b13c14c7ae9190044b5d14c1268ba7f49a4dc33
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: abb53a71bec0c23d4a7d851a79d329f6c2be0aeb
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 0b13c14c7ae9190044b5d14c1268ba7f49a4dc33
+GitCommit: 574d3d15742dce60957d423240337a3962f265f6
 Directory: 5.5/slim


### PR DESCRIPTION
See release announcement for 8.5.1
* https://lucene.apache.org/solr/news.html#apache-solrtm-851-available

7.7.3 is already released, but the release announcement is not yet out. See VOTE thread: https://lists.apache.org/thread.html/r72562e70df1ae40c1a4fa5c8b6ed880570784ec7ff865eee2970d010%40%3Cdev.lucene.apache.org%3E

PS: The new images are built with Dockerfiles that pull gosu and tini from apt instead of manual installs