### PR TITLE
upgrade r-base to R 4.0.0 released last Friday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -5,4 +5,4 @@ GitRepo: https://github.com/rocker-org/rocker.git
 Tags: 4.0.0, latest
 Architectures: amd64, arm64v8
 GitCommit: 1286d1fa0165a06b93ea9c4cebd94a54cbf86227
-Directory: r-base
+Directory: r-base/latest

--- a/library/r-base
+++ b/library/r-base
@@ -3,6 +3,6 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
 GitRepo: https://github.com/rocker-org/rocker.git
 
 Tags: 4.0.0, latest
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: 1286d1fa0165a06b93ea9c4cebd94a54cbf86227
 Directory: r-base/latest

--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 3.6.3, latest
+Tags: 4.0.0, latest
 Architectures: amd64, arm64v8
-GitCommit: e76a46e4d082c0294437c34df1072f48c6fa3685
+GitCommit: 1286d1fa0165a06b93ea9c4cebd94a54cbf86227
 Directory: r-base


### PR DESCRIPTION
Note that because R 4.0.0 requires a transition (which has not yet started) we (just
this once) pivot to experimental---and because r-recommended requires a good
dozen or so "recommended" packages from CRAN (all maintained by R Core too)
I have placed binaries for these into a PPA-alike repo on GitHub.