### PR TITLE
Correcting tags for couchbase.

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -3,7 +3,8 @@
 latest: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.1
 enterprise: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.1
 6.5.1: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.1
-enterprise-6.5.0: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.1
+enterprise-6.5.1: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.1
+enterprise-6.5.0: https://github.com/couchbase/docker@46de65611374973ecf7ec28b0c582a8175d3bda0 enterprise/couchbase-server/6.5.0
 
 community: https://github.com/couchbase/docker@f17df7695bbd6efb756b90b683bd5f34d08b5708 community/couchbase-server/6.5.1
 community-6.5.1: https://github.com/couchbase/docker@f17df7695bbd6efb756b90b683bd5f34d08b5708 community/couchbase-server/6.5.1


### PR DESCRIPTION
:enterprise-6.5.0 was accidentally pointed to the 6.5.1 EE image, and the
:enterprise-6.5.1 tag was omitted. This change re-creates both tags to
fix things.