### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0.0, 6.0, 6, latest, 6.0.0-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.1, 6.0, 6, latest, 6.0.1-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9a598d433acf8fbf3d1f07223c164b3bd7ead3b3
+GitCommit: cc1b618d51eb5f6bf6e3a03c7842317b38dbd7f9
 Directory: 6.0
 
-Tags: 6.0.0-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.0-alpine3.11, 6.0-alpine3.11, 6-alpine3.11, alpine3.11
+Tags: 6.0.1-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.1-alpine3.11, 6.0-alpine3.11, 6-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9a598d433acf8fbf3d1f07223c164b3bd7ead3b3
+GitCommit: cc1b618d51eb5f6bf6e3a03c7842317b38dbd7f9
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/cc1b618: Update to 6.0.1