### PR TITLE
Updating Oracle Linux 6 and 7 for tzdata-2020a.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b22bc0aae247d85ec26d2acf9d5e2e801fc4ab22
+amd64-GitCommit: c06255193f1e03df034ca0ae218c080f29326e0a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 80fb8201a6467bcb9f47431b9b8fa5187b8908a2
+arm64v8-GitCommit: ea50c856c6e1a8dc1b9786be4e68d430e03a4ffa
 Constraints: !aufs
 
 Tags: 8.1, 8


### PR DESCRIPTION
* Updated Oracle Linux `7.8` image for `amd64` and `arm64v8`
  * `tzdata-2020a-1.el7`
  * `systemd-219-73.0.1.el7_8.5`, `systemd-libs-219-73.0.1.el7_8.5`, `libgudev1-219-73.0.1.el7_8.5`
  * `device-mapper-7:1.02.164-7.0.1.el7_8.1`, `device-mapper-libs-7:1.02.164-7.0.1.el7_8.1`
  * `bind-export-libs-32:9.11.4-16.P2.el7_8.2`
* Updated Oracle Linux `6.10` and `6-slim`, `7-slim` images for `amd64` and `arm64v8`
  * `tzdata-2020a-1.el7`


Signed-off-by: Avi Miller <avi.miller@oracle.com>