### PR TITLE
Release CouchDB 3.0.1 and 3.1.0

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,11 +3,15 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: f56c425bb7d64918a57936376e0070e7742768cd
+GitCommit: 01e1c16bb405c1174393c76a7ebc3792b0c5e2c9
 
-Tags: latest, 3.0.0, 3.0, 3
+Tags: latest, 3.1.0, 3.1, 3
 Architectures: amd64, arm64v8, ppc64le
-Directory: 3.0.0
+Directory: 3.1.0
+
+Tags: 3.0.1, 3.0
+Architectures: amd64, arm64v8, ppc64le
+Directory: 3.0.1
 
 Tags: 2.3.1, 2.3, 2
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
Our announcement goes out at 12:00 UTC-4 (EDT) today, so feel free to release this to master anytime.

Only meaningful change is updating the version of the CouchDB package installed.