### PR TITLE
Update CentOS Images for 7.8.2003

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -14,15 +14,15 @@ Architectures: amd64, arm64v8, ppc64le
 
 Tags: centos7, 7
 GitFetch: refs/heads/CentOS-7-x86_64
-GitCommit: d9560a37644faaeac50162582f82a5ee920dc37e
+GitCommit: b521221b5c8ac3ac88698e77941a2414ce6e778d
 arm32v7-GitFetch: refs/heads/CentOS-7armhfp
 arm32v7-GitCommit: 8022ae6d18ddf031b1b3a80549eeb46d1deb6dcd
 arm64v8-GitFetch: refs/heads/CentOS-7-aarch64
-arm64v8-GitCommit: 5828bda61bc9685a6282b322d5563d5cb509a002
+arm64v8-GitCommit: c72c9d7fc0d926fcc0d1345feeaae8fc4a3fcb14
 ppc64le-GitFetch: refs/heads/CentOS-7-ppc64le
-ppc64le-GitCommit: 624a803079cdfa81d40f39e75690f27a07b8ac36
+ppc64le-GitCommit: 25f6987f8e8423fe926138a4166077d69ce69d20
 i386-GitFetch: refs/heads/CentOS-7i386
-i386-GitCommit: 544a072ae2bb6eb378cf3ba587b24127629e9505
+i386-GitCommit: c59f5c7a73c182e8a25d43058b65b99ca93c6636
 Architectures: amd64, arm64v8, arm32v7, ppc64le, i386
 
 Tags: centos6, 6
@@ -31,6 +31,11 @@ GitCommit: 23b05f6a35520ebf338e4df918e4952830da068b
 i386-GitFetch: refs/heads/CentOS-6i386
 i386-GitCommit: 53cd22704a89c6ed59d43e2e70e63316026af4f7
 Architectures: amd64, i386
+
+Tags: centos7.8.2003, 7.8.2003
+GitFetch: refs/heads/CentOS-7.8.2003-x86_64
+GitCommit: 216a920c467977bbd0f456d3bc381100a88b3768
+Architectures: amd64
 
 Tags: centos7.7.1908, 7.7.1908
 GitFetch: refs/heads/CentOS-7.7.1908-x86_64


### PR DESCRIPTION
We recently updated the CentOS images for the 7.8.2003 release. Here's a
new tag, and some updated 7 tags.