### PR TITLE
arangodb 3.6.3.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -12,6 +12,6 @@
 3.4.9: https://github.com/arangodb/arangodb-docker@4aa774dd973b77f958fbe7a90285ca2452ca22aa alpine/3.4.9
 3.5: https://github.com/arangodb/arangodb-docker@8fa0c5d9b74ca36cf3e7ed6e8df8954c87cf04a6 alpine/3.5.4
 3.5.4: https://github.com/arangodb/arangodb-docker@8fa0c5d9b74ca36cf3e7ed6e8df8954c87cf04a6 alpine/3.5.4
-3.6: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
-3.6.3: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
-latest: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
+3.6: https://github.com/arangodb/arangodb-docker@8f7d55580407838958ae8e7677de8c9803280e18 alpine/3.6.3
+3.6.3: https://github.com/arangodb/arangodb-docker@8f7d55580407838958ae8e7677de8c9803280e18 alpine/3.6.3
+latest: https://github.com/arangodb/arangodb-docker@8f7d55580407838958ae8e7677de8c9803280e18 alpine/3.6.3


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.3.1 (3.6.3 with Hotfix 1).