### PR TITLE
Remove the "!aufs" constraint from all images

### DIFF
--- a/library/alt
+++ b/library/alt
@@ -3,7 +3,6 @@ Maintainers: ALT Linux Team Cloud <alt-cloud@altlinux.org> (@alt-cloud),
              Gleb Fotengauer-Malinovskiy <glebfm@altlinux.org> (@glebfm),
              Mikhail Gordeev <obirvalger@altlunux.org> (@obirvalger)
 GitRepo: https://github.com/alt-cloud/docker-brew-alt.git
-Constraints: !aufs
 
 Tags: p9, latest
 Architectures: amd64, i386, arm64v8, ppc64le

--- a/library/centos
+++ b/library/centos
@@ -1,7 +1,6 @@
 Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
 GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
 Directory: docker
-Constraints: !aufs
 
 Tags: latest, centos8, 8, centos8.1.1911, 8.1.1911
 GitFetch: refs/heads/CentOS-8.1.1911-x86_64

--- a/library/clefos
+++ b/library/clefos
@@ -1,6 +1,5 @@
 Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealef)
 GitRepo: https://github.com/nealef/clefos.git
-Constraints: !aufs
 
 Tags: 7, 7.6.1810, latest
 GitFetch: refs/heads/7.4.1708

--- a/library/fedora
+++ b/library/fedora
@@ -1,6 +1,5 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
-Constraints: !aufs
 
 Tags: 26
 Architectures: amd64, arm32v7, arm64v8, ppc64le

--- a/library/kong
+++ b/library/kong
@@ -17,7 +17,6 @@ Architectures: amd64, arm64v8
 Tags: 2.0.4-centos, 2.0-centos, centos
 GitCommit: 74c5796ec1789d13b794c7cda0a5bca692aa6d53
 GitFetch: refs/tags/2.0.4
-Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
@@ -36,7 +35,6 @@ Architectures: amd64, arm64v8
 Tags: 1.5.1-centos, 1.5-centos
 GitCommit: 8ba4389169d5873be65a09001d06293ccdfc7caf
 GitFetch: refs/tags/1.5.1
-Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
@@ -55,7 +53,6 @@ Architectures: amd64, arm64v8
 Tags: 1.4.3-centos, 1.4-centos
 GitCommit: d2884ee222e72c3edb9abd48d4062991e41ea7bc
 GitFetch: refs/tags/1.4.3
-Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
@@ -74,7 +71,6 @@ Architectures: amd64, arm64v8
 Tags: 1.3.1-centos, 1.3-centos
 GitCommit: 48b240c47a4d902ddcc20de408e2c08855a5feca
 GitFetch: refs/tags/1.3.1
-Constraints: !aufs
 Directory: centos
 Architectures: amd64
 
@@ -86,7 +82,6 @@ Directory: alpine
 Tags: 1.2.3-centos, 1.2-centos
 GitCommit: f5512d2898dad8ad6c95d42b1762ea004713d519
 GitFetch: refs/tags/1.2.3
-Constraints: !aufs
 Directory: centos
 
 Tags: 1.1.3-alpine, 1.1.3, 1.1
@@ -97,7 +92,6 @@ Directory: alpine
 Tags: 1.1.3-centos, 1.1-centos
 GitCommit: 196331b1e6b4798032af4d6c218a441e2c8db74d
 GitFetch: refs/tags/1.1.3
-Constraints: !aufs
 Directory: centos
 
 Tags: 1.0.4-alpine, 1.0.4, 1.0
@@ -108,6 +102,5 @@ Directory: alpine
 Tags: 1.0.4-centos, 1.0-centos
 GitCommit: 5a47f391b479e6660edab76813891326630bed0e
 GitFetch: refs/tags/1.0.4
-Constraints: !aufs
 Directory: centos
 

--- a/library/maven
+++ b/library/maven
@@ -20,7 +20,6 @@ Tags: 3.6.3-jdk-14, 3.6-jdk-14, 3-jdk-14
 Architectures: amd64
 GitCommit: 26ba49149787c85b9c51222b47c00879b2a0afde
 Directory: openjdk-14
-Constraints: !aufs
 
 Tags: 3.6.3-jdk-8, 3.6-jdk-8, 3-jdk-8
 Architectures: amd64
@@ -51,7 +50,6 @@ Tags: 3.6.3-openjdk-14, 3.6.3, 3.6.3-openjdk, 3.6-openjdk-14, 3.6, 3.6-openjdk, 
 Architectures: amd64
 GitCommit: 26ba49149787c85b9c51222b47c00879b2a0afde
 Directory: openjdk-14
-Constraints: !aufs
 
 Tags: 3.6.3-openjdk-14-slim, 3.6.3-slim, 3.6-openjdk-14-slim, 3.6-slim, 3-openjdk-14-slim, slim
 Architectures: amd64
@@ -62,7 +60,6 @@ Tags: 3.6.3-openjdk-15, 3.6-openjdk-15, 3-openjdk-15
 Architectures: amd64
 GitCommit: 4ba4f1c3b6600e64c8c430dfea2ef65ff18608ff
 Directory: openjdk-15
-Constraints: !aufs
 
 Tags: 3.6.3-openjdk-8, 3.6-openjdk-8, 3-openjdk-8
 Architectures: amd64

--- a/library/openjdk
+++ b/library/openjdk
@@ -9,7 +9,6 @@ SharedTags: 15-ea-21-jdk, 15-ea-21, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
 GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
 Directory: 15/jdk/oracle
-Constraints: !aufs
 
 Tags: 15-ea-21-jdk-buster, 15-ea-21-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
@@ -52,7 +51,6 @@ SharedTags: 14.0.1-jdk, 14.0.1, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: amd64
 GitCommit: cd0e316abc515747ef6c9edc8a40914b50163ad2
 Directory: 14/jdk/oracle
-Constraints: !aufs
 
 Tags: 14.0.1-jdk-buster, 14.0.1-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
 Architectures: amd64

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -8,7 +8,6 @@ amd64-GitCommit: f15c4cdc4a1483e541eb00d18c8058d2b5988fff
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: b7cacb29fd0ac3998a852fae86607b544d8a7a04
-Constraints: !aufs
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8

--- a/library/sl
+++ b/library/sl
@@ -1,6 +1,5 @@
 Maintainers: Scientific Linux Development Team <scientific-linux-devel@fnal.gov> (@sl-team)
 GitRepo: https://github.com/scientificlinux/sl-docker.git
-Constraints: !aufs
 
 # Currently SL7 is the 'latest'
 # For the SL7 container

--- a/library/tomcat
+++ b/library/tomcat
@@ -8,7 +8,6 @@ Tags: 10.0.0-M4-jdk14-openjdk-oracle, 10.0.0-jdk14-openjdk-oracle, 10.0-jdk14-op
 Architectures: amd64
 GitCommit: 236eadcac2f760d0b88ef8a950c4d0f33ad3da45
 Directory: 10.0/jdk14/openjdk-oracle
-Constraints: !aufs
 
 Tags: 10.0.0-M4-jdk14-openjdk-buster, 10.0.0-jdk14-openjdk-buster, 10.0-jdk14-openjdk-buster, 10-jdk14-openjdk-buster
 Architectures: amd64
@@ -74,7 +73,6 @@ Tags: 9.0.34-jdk14-openjdk-oracle, 9.0-jdk14-openjdk-oracle, 9-jdk14-openjdk-ora
 Architectures: amd64
 GitCommit: 236eadcac2f760d0b88ef8a950c4d0f33ad3da45
 Directory: 9.0/jdk14/openjdk-oracle
-Constraints: !aufs
 
 Tags: 9.0.34-jdk14-openjdk-buster, 9.0-jdk14-openjdk-buster, 9-jdk14-openjdk-buster, jdk14-openjdk-buster
 Architectures: amd64
@@ -140,7 +138,6 @@ Tags: 8.5.54-jdk14-openjdk-oracle, 8.5-jdk14-openjdk-oracle, 8-jdk14-openjdk-ora
 Architectures: amd64
 GitCommit: 236eadcac2f760d0b88ef8a950c4d0f33ad3da45
 Directory: 8.5/jdk14/openjdk-oracle
-Constraints: !aufs
 
 Tags: 8.5.54-jdk14-openjdk-buster, 8.5-jdk14-openjdk-buster, 8-jdk14-openjdk-buster
 Architectures: amd64

--- a/naughty-constraints.sh
+++ b/naughty-constraints.sh
@@ -96,10 +96,6 @@ for img in $tags; do
 			imgMissing[$from]+=$'\n'"$missing"
 		fi
 		extra="$(comm -23 <(echo "$constraints") <(echo "$allExpected"))"
-		if [ "$from" = 'scratch' ]; then
-			# if a given image is "FROM scratch", then consider "!aufs" an acceptable constraint that doesn't show
-			extra="$(grep -vE '^!aufs$' <<<"$extra" || :)"
-		fi
 		if [ -n "$extra" ]; then
 			imgExtra[$from]+=$'\n'"$extra"
 		fi


### PR DESCRIPTION
We haven't used or needed this constraint in many years now, and the `aufs` storage driver is also discouraged in Docker itself for quite some time (since the stabilization of the `overlayfs`-based driver really), and officially deprecated in 19.03+ (https://github.com/moby/moby/pull/38090).

(We've also been actively ignoring failing CI checks where missing this constraint is the only failure for a while, so I think it's finally time we pulled off this band-aid. :sweat_smile:)

Including affected image maintainers for reference (especially in case you've got tooling which generates your image manifest that needs to be updated to account for this change):

- `alt`: @shaba @glebfm @obirvalger
- `centos`: @bstinsonmhk (and @jperrin :heart:)
- `clefos`: @nealef
- `fedora`: @cverna
- `kong`: @hutchic @hishamhm @gszr @kikito @locao
- `maven`: @carlossg
- `oraclelinux`: @Djelibeybi (I'm happy to keep an eye on https://github.com/docker-library/official-images/pull/7955 and rebase this when that's done to avoid conflicts for you :+1:)
- `sl`: @sl-team @jcpunk

If you do not have a script, program, tool, etc which is auto-generating your `library/foo` file, you do not need to do anything (we'll merge this PR and there will just be one less line that might show up in the context of diffs on your PRs :smile:).

(Also, sorry if I got too many or too few folks in the above ping!  Some of y'all include a team alias, full org, or bot account in your `Maintainers:` entry, and GitHub doesn't allow us to ping a full org or a team we're not part of so I tried to glean who to ping from the last page of PRs to your respective image. :sweat_smile: :heart:)