### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev6, 2.2-rc
+Tags: 2.2-dev7, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaec0e4daa5078cf47fe0ccf7a8f75497e40d153
+GitCommit: e5884936dca8ee8968522abff21713042983a898
 Directory: 2.2-rc
 
-Tags: 2.2-dev6-alpine, 2.2-rc-alpine
+Tags: 2.2-dev7-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: e5884936dca8ee8968522abff21713042983a898
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.4, 2.1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e588493: Update to 2.2-dev7
- https://github.com/docker-library/haproxy/commit/14c229d: Merge pull request https://github.com/docker-library/haproxy/pull/113 from docker-library/github-actions
- https://github.com/docker-library/haproxy/commit/ff672fd: Add initial GitHub Actions CI