### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.15.0, 3.15, 3, latest
+Tags: 3.15.1, 3.15, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 38f1500b0b0d395a91cb286b788e96b2c21be1ca
+GitCommit: 165a7dc502db0e53d1eb314097902d83d40bfd92
 Directory: 3/debian
 
-Tags: 3.15.0-alpine, 3.15-alpine, 3-alpine, alpine
+Tags: 3.15.1-alpine, 3.15-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 38f1500b0b0d395a91cb286b788e96b2c21be1ca
+GitCommit: 165a7dc502db0e53d1eb314097902d83d40bfd92
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/165a7dc: Update to 3.15.1, ghost-cli 1.13.1