### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-21-jdk-oraclelinux7, 15-ea-21-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-21-jdk-oracle, 15-ea-21-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-21-jdk, 15-ea-21, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-22-jdk-oraclelinux7, 15-ea-22-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-22-jdk-oracle, 15-ea-22-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk/oracle
 Constraints: !aufs
 
-Tags: 15-ea-21-jdk-buster, 15-ea-21-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-22-jdk-buster, 15-ea-22-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk
 
-Tags: 15-ea-21-jdk-slim-buster, 15-ea-21-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-21-jdk-slim, 15-ea-21-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-22-jdk-slim-buster, 15-ea-22-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-22-jdk-slim, 15-ea-22-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -26,24 +26,24 @@ Architectures: amd64
 GitCommit: ee26e3735002dfb83551faf0f3b73822addc4799
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-21-jdk-windowsservercore-1809, 15-ea-21-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-21-jdk-windowsservercore, 15-ea-21-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-21-jdk, 15-ea-21, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-22-jdk-windowsservercore-1809, 15-ea-22-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-22-jdk-windowsservercore, 15-ea-22-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-21-jdk-windowsservercore-ltsc2016, 15-ea-21-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-21-jdk-windowsservercore, 15-ea-21-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-21-jdk, 15-ea-21, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-22-jdk-windowsservercore-ltsc2016, 15-ea-22-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-22-jdk-windowsservercore, 15-ea-22-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-21-jdk-nanoserver-1809, 15-ea-21-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-21-jdk-nanoserver, 15-ea-21-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-22-jdk-nanoserver-1809, 15-ea-22-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-22-jdk-nanoserver, 15-ea-22-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: d99cc7ed3be85c89b6ac3968f270e670c243b807
+GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/bb67c6a: Update to 15-ea+22