### PR TITLE
arangodb 3.4.10, 3.5.5, 3.6.3.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,16 +2,10 @@
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 # maintainer: Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
 
-2.8: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
-2.8.11: https://github.com/arangodb/arangodb-docker@d6fca9a137cd21345b1d380fc0e72daacb6130ce jessie/2.8.11
-3.2: https://github.com/arangodb/arangodb-docker@b4c22ad8bf4facbbc7c3b24e985251a09fcdbcec stretch/3.2.17
-3.2.17: https://github.com/arangodb/arangodb-docker@b4c22ad8bf4facbbc7c3b24e985251a09fcdbcec stretch/3.2.17
-3.3: https://github.com/arangodb/arangodb-docker@27ab30feeccb87295f838ed6e0d0d9a7b67908bc stretch/3.3.25
-3.3.25: https://github.com/arangodb/arangodb-docker@27ab30feeccb87295f838ed6e0d0d9a7b67908bc stretch/3.3.25
-3.4: https://github.com/arangodb/arangodb-docker@4aa774dd973b77f958fbe7a90285ca2452ca22aa alpine/3.4.9
-3.4.9: https://github.com/arangodb/arangodb-docker@4aa774dd973b77f958fbe7a90285ca2452ca22aa alpine/3.4.9
-3.5: https://github.com/arangodb/arangodb-docker@8fa0c5d9b74ca36cf3e7ed6e8df8954c87cf04a6 alpine/3.5.4
-3.5.4: https://github.com/arangodb/arangodb-docker@8fa0c5d9b74ca36cf3e7ed6e8df8954c87cf04a6 alpine/3.5.4
-3.6: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
-3.6.3: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
-latest: https://github.com/arangodb/arangodb-docker@ef37ecea1c60befdf513eb2cad81d01b447dc28a alpine/3.6.3
+3.4: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
+3.4.10: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
+3.5: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.5.5
+3.5.5: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.5.5
+3.6: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
+3.6.3: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
+latest: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1


### PR DESCRIPTION
Updated ArangoDB 3.4 to 3.4.10, 3.5 to 3.5.5, 3.6 to 3.6.3.1 (3.6.3 with Hotfix 1) and remove unsupported versions.