### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,33 +1,26 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/f006cdf540ef05b3ca20c0d4243f43c0794b867b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/fd2dbbe5303e1339babc6d22e47831b60f6a5b12/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2018-10-30
-Tags: 6.5.0, 6.5, 6
-Architectures: amd64, arm32v5, arm32v7
-GitCommit: e17fd3097b743216f292e50ea8e84b3b3bcc4e53
-Directory: 6
-# Docker EOL: 2020-04-30
+# Last Modified: 2020-05-07
+Tags: 10.1.0, 10.1, 10, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+GitCommit: 97b046b578bd86cae5414d80b3ad0027c590aebd
+Directory: 10
+# Docker EOL: 2021-11-07
 
-# Last Modified: 2019-11-14
-Tags: 7.5.0, 7.5, 7
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: aab71caeb1be048b44fd140a102cb7f17f995276
-Directory: 7
-# Docker EOL: 2021-05-14
+# Last Modified: 2020-03-12
+Tags: 9.3.0, 9.3, 9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
+Directory: 9
+# Docker EOL: 2021-09-12
 
 # Last Modified: 2020-03-04
 Tags: 8.4.0, 8.4, 8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f3db0f591ce42dd2ac3aec240ca47c87762bc385
+Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
 Directory: 8
 # Docker EOL: 2021-09-04
-
-# Last Modified: 2020-03-12
-Tags: 9.3.0, 9.3, 9, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d9a58942c8ff2c5c5a01e16bf0ffdf5e5dc61277
-Directory: 9
-# Docker EOL: 2021-09-12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/fd2dbbe: Sort version numbers with the highest first
- https://github.com/docker-library/gcc/commit/97b046b: Add 10.1.0
- https://github.com/docker-library/gcc/commit/3aed962: Improve generate-stackbrew-library.sh
- https://github.com/docker-library/gcc/commit/05aef2f: Update mirrorlist and remove unnecessary fallback
- https://github.com/docker-library/gcc/commit/f67402e: Improve update.sh to no longer create a temporary file (but still have nice debuggability via "bash -x")
- https://github.com/docker-library/gcc/commit/48d2a53: Remove GCC 6 (Last Modified: 2018-10-30, Docker EOL: 2020-04-30)
- https://github.com/docker-library/gcc/commit/de06dd2: Merge pull request https://github.com/docker-library/gcc/pull/66 from docker-library/github-actions
- https://github.com/docker-library/gcc/commit/f211dc2: Add intial GitHub Actions CI