### PR TITLE
1.7.3

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,9 +1,9 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.7.2, 1.7, latest 
+Tags: 1.7.3, 1.7, latest 
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 20657edd8a3d66ee155b1d050a7a9400e8ab3bdd 
+GitCommit: 9cb67358af03c73222da3badebc7c69d765c456a
 Directory: 0.X
 
 Tags: 1.6.4, 1.6


### PR DESCRIPTION
Using this one in favor of https://github.com/docker-library/official-images/pull/7945.