### PR TITLE
Haskell GHC 8.10.1 and Debian variants.

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,12 +1,19 @@
 Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
-             Christopher Biscardi <chris@christopherbiscardi.com> (@ChristopherBiscardi),
              Herbert Valerio Riedel <hvr@gnu.org> (@hvr)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 8.8.3, 8.8, 8, latest
-GitCommit: c7675920a33d47aa30ff5456ee622cd61a2d62be
-Directory: 8.8
+Tags: 8.10.1-buster, 8.10-buster, 8-buster, buster, 8.10.1, 8.10, 8, latest
+GitCommit: 82f44382a183fcc1d0026d8abe58259195a8930c
+Directory: 8.10/buster
 
-Tags: 8.6.5, 8.6
-GitCommit: c7675920a33d47aa30ff5456ee622cd61a2d62be
-Directory: 8.6
+Tags: 8.10.1-stretch, 8.10-stretch, 8-stretch, stretch
+GitCommit: 82f44382a183fcc1d0026d8abe58259195a8930c
+Directory: 8.10/stretch
+
+Tags: 8.8.3-buster, 8.8-buster, 8.8.3, 8.8
+GitCommit: 82f44382a183fcc1d0026d8abe58259195a8930c
+Directory: 8.8/buster
+
+Tags: 8.8.3-stretch, 8.8-stretch
+GitCommit: 82f44382a183fcc1d0026d8abe58259195a8930c
+Directory: 8.8/stretch

--- a/test/tests/haskell-cabal/container.sh
+++ b/test/tests/haskell-cabal/container.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-cabal new-update
-cabal new-install --lib hashable
+cabal update
+cabal install --lib hashable


### PR DESCRIPTION
The Cabal test gets an update since "install"
is now the default "new-install". We also drop
8.6.5 per "two latest minor releases" policy.