### PR TITLE
arangodb 3.5.5.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,8 +4,8 @@
 
 3.4: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
 3.4.10: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
-3.5: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.5.5
-3.5.5: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.5.5
+3.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
+3.5.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
 3.6: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
 3.6.3: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
 latest: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1


### PR DESCRIPTION
Updated ArangoDB 3.5 to 3.5.5.1 (3.5.5 with Hotfix 1).

Didn't put https://github.com/docker-library/official-images/pull/7962#issuecomment-625527353 workaround yet (planned for the next version only) so `npm ERR! lifecycle could not get uid/gid` can happen.