### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f768c59e159528e99465202c5adca95056dd4218
+GitCommit: 91be7cf597c069c9a038ae2619adac1a85e68d4d
 Directory: 3.8/ubuntu
 
 Tags: 3.8.3-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f768c59e159528e99465202c5adca95056dd4218
+GitCommit: 91be7cf597c069c9a038ae2619adac1a85e68d4d
 Directory: 3.8/alpine
 
 Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.26, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2dffcb0d854e9916e98eebd00108e5813567cf6c
+GitCommit: c24b3b15b1128272e64cba8d1dba37603c2b1d68
 Directory: 3.7/ubuntu
 
 Tags: 3.7.26-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.26-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2dffcb0d854e9916e98eebd00108e5813567cf6c
+GitCommit: c24b3b15b1128272e64cba8d1dba37603c2b1d68
 Directory: 3.7/alpine
 
 Tags: 3.7.26-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/91be7cf: Update to 3.8.3, Erlang/OTP 22.3.4, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/c24b3b1: Update to 3.7.26, Erlang/OTP 22.3.4, OpenSSL 1.1.1g