### PR TITLE
Updating WebSphere Liberty and Open Liberty to 20.0.0.5

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 230f689cd2b492a48dbaa0c6f7699318c1b4e10b
+GitCommit: 25e572550c72f31c931bf569d95d83ecd6c2590b
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
@@ -15,13 +15,13 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.4-kernel-java8-openj9
-Directory: releases/20.0.0.4/kernel
+Tags: 20.0.0.5-kernel-java8-openj9
+Directory: releases/20.0.0.5/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.4-full-java8-openj9
-Directory: releases/20.0.0.4/full
+Tags: 20.0.0.5-full-java8-openj9
+Directory: releases/20.0.0.5/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 7485d9fc658bd10ac9a2400221dc2f144ed36df7
+GitCommit: c89d127a536ed68bbf8d3d5ad92da443fb1a87d0
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -16,12 +16,12 @@ Tags: full, latest
 Directory: ga/latest/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.4-kernel-java8-ibmjava
-Directory: ga/20.0.0.4/kernel
+Tags: 20.0.0.5-kernel-java8-ibmjava
+Directory: ga/20.0.0.5/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.4-full-java8-ibmjava
-Directory: ga/20.0.0.4/full
+Tags: 20.0.0.5-full-java8-ibmjava
+Directory: ga/20.0.0.5/full
 File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.3-kernel-java8-ibmjava


### PR DESCRIPTION
Replaces the following PRs:
https://github.com/docker-library/official-images/pull/7972
https://github.com/docker-library/official-images/pull/7973

* Updating both WebSphere Liberty and Open Liberty to 20.0.0.5
* Adding support for Infinispan to WebSphere Liberty
* Fixing the permissions settings after SCC for Open Liberty