### PR TITLE
Update to Flink 1.10.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -14,12 +14,12 @@ Architectures: amd64
 GitCommit: 379970e8d2a9e138d1291d83b47e7ea643421b3a
 Directory: 1.9/scala_2.12-debian
 
-Tags: 1.10.0-scala_2.11, 1.10-scala_2.11, scala_2.11
+Tags: 1.10.1-scala_2.11, 1.10-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 346809e6cab2ca0ac702fb4d2bf56afb6ee3c437
+GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
 Directory: 1.10/scala_2.11-debian
 
-Tags: 1.10.0-scala_2.12, 1.10-scala_2.12, scala_2.12, 1.10.0, 1.10, latest
+Tags: 1.10.1-scala_2.12, 1.10-scala_2.12, scala_2.12, 1.10.1, 1.10, latest
 Architectures: amd64
-GitCommit: 346809e6cab2ca0ac702fb4d2bf56afb6ee3c437
+GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
 Directory: 1.10/scala_2.12-debian


### PR DESCRIPTION
Update to include the latest 1.10.1 release. The Dockerfiles have already been added into flink-docker repo through [this PR](https://github.com/apache/flink-docker/pull/21).