### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/68c99dc583c8755e7dce77acdd356bfde00046b6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/1cf2cba27e47cac63b2b705d6d237d0e84b07b31/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 68c99dc583c8755e7dce77acdd356bfde00046b6
+GitCommit: 1cf2cba27e47cac63b2b705d6d237d0e84b07b31
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 08d3f7114ee5ac055c0fedad0a930e67c5f8b6f4
+amd64-GitCommit: 7c3206169c4d32ae0afbb36b90cb9f9b77011f7a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 6219d5edb1d20afa0b80e29ab7a69165d1f90b75
+arm32v5-GitCommit: 442b9471a07fe059fdce27fc4f8caef1be19e73f
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 49e7aa905bfadddbad90002925f4ce8872215fbc
+arm32v6-GitCommit: aef519f3e26970dd1278cddfadc1bc42d34a75b1
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 8cc6110cfc031f859fe3f251a5f742bec8e9af3f
+arm32v7-GitCommit: c695e0ffd7df9df64869ee77dcfb571464fce183
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2fa8a48dd97c90c0da68c00fd60a104242a25b88
+arm64v8-GitCommit: 80cf7031e73b261c7a9204e8b221b22a7f85f8a1
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 1e9e91d4ccf98236a6a86b7eae6d0a5e6dd4cb29
+i386-GitCommit: 4a983e50400610588620dc5a0e9606942f2c852f
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 6ed838e3538d927d93e3d312305c14790f3b13b4
+mips64le-GitCommit: 5df054ae2279437bd95320c19344a9b9d9b5f435
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: dbdb1569a13fd471906468518bc877828abcb25d
+ppc64le-GitCommit: 44486923d5dd699f25fd25d1c36ea1225e5de492
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e33236a4281c705ecf4dfdd0606277c7cfa4bd72
+s390x-GitCommit: 284ef4842056051a8f16ad810b666f07a9490090
 
 Tags: 1.31.1-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/1cf2cba: Merge pull request https://github.com/docker-library/busybox/pull/82 from infosiftr/buildroot-2020.02.2
- https://github.com/docker-library/busybox/commit/aa2414e: Update Buildroot to 2020.02.2
- https://github.com/docker-library/busybox/commit/363154b: Update README stub
- https://github.com/docker-library/busybox/commit/8454c26: Merge pull request https://github.com/docker-library/busybox/pull/81 from infosiftr/github-actions
- https://github.com/docker-library/busybox/commit/eb35037: Update GitHub Actions to take advantage of a generated matrix