### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/fd2dbbe5303e1339babc6d22e47831b60f6a5b12/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/7f1fc5e8be598446b2546b808572db546e959643/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,21 +6,21 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2020-05-07
 Tags: 10.1.0, 10.1, 10, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 97b046b578bd86cae5414d80b3ad0027c590aebd
 Directory: 10
 # Docker EOL: 2021-11-07
 
 # Last Modified: 2020-03-12
 Tags: 9.3.0, 9.3, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
 Directory: 9
 # Docker EOL: 2021-09-12
 
 # Last Modified: 2020-03-04
 Tags: 8.4.0, 8.4, 8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
 Directory: 8
 # Docker EOL: 2021-09-04


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/7f1fc5e: Fix architecture exclusion
- https://github.com/docker-library/gcc/commit/febea33: Remove mips64le, per https://github.com/docker-library/gcc/issues/67