### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,23 +1,23 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/8a2c63d97853e695d5d11e7fb7e512de5cfb767a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/65b577f2e6cfdc4ee69cb700116f5964656a379c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-22-jdk-oraclelinux7, 15-ea-22-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-22-jdk-oracle, 15-ea-22-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-23-jdk-oraclelinux7, 15-ea-23-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-23-jdk-oracle, 15-ea-23-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-23-jdk, 15-ea-23, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk/oracle
 
-Tags: 15-ea-22-jdk-buster, 15-ea-22-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-23-jdk-buster, 15-ea-23-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk
 
-Tags: 15-ea-22-jdk-slim-buster, 15-ea-22-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-22-jdk-slim, 15-ea-22-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-23-jdk-slim-buster, 15-ea-23-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-23-jdk-slim, 15-ea-23-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -25,24 +25,24 @@ Architectures: amd64
 GitCommit: ee26e3735002dfb83551faf0f3b73822addc4799
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-22-jdk-windowsservercore-1809, 15-ea-22-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-22-jdk-windowsservercore, 15-ea-22-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-23-jdk-windowsservercore-1809, 15-ea-23-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-23-jdk-windowsservercore, 15-ea-23-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-23-jdk, 15-ea-23, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-22-jdk-windowsservercore-ltsc2016, 15-ea-22-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-22-jdk-windowsservercore, 15-ea-22-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-22-jdk, 15-ea-22, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-23-jdk-windowsservercore-ltsc2016, 15-ea-23-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-23-jdk-windowsservercore, 15-ea-23-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-23-jdk, 15-ea-23, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-22-jdk-nanoserver-1809, 15-ea-22-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-22-jdk-nanoserver, 15-ea-22-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-23-jdk-nanoserver-1809, 15-ea-23-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-23-jdk-nanoserver, 15-ea-23-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: bb67c6a174eea23128977c4da1257d84fa7b24cc
+GitCommit: 0a152d425165c851fbfc5b456191c4aeab9fc049
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0a152d4: Update to 15-ea+23
- https://github.com/docker-library/openjdk/commit/65b577f: Remove "!aufs" constraint