### PR TITLE
Update Github Actions to use our local clone for running tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://github.com/actions/checkout/issues/135#issuecomment-613361104
+* text eol=lf

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -47,6 +47,14 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Prepare Git
+        run: |
+          # enable symlinks on Windows (https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresymlinks)
+          git config --global core.symlinks true
+          # also, make sure Windows symlinks are *real* symlinks (https://github.com/git-for-windows/git/pull/156)
+          echo '::set-env name=MSYS::winsymlinks:nativestrict'
+          # https://github.com/docker-library/bashbrew/blob/a40a54d4d81b9fd2e39b4d7ba3fe203e8b022a67/scripts/github-actions/generate.sh#L146-L149
+        if: runner.os == 'Windows'
       - uses: actions/checkout@v2
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}

--- a/test/config.sh
+++ b/test/config.sh
@@ -255,10 +255,6 @@ imageTests+=(
 	[zookeeper]='
 		zookeeper-basics
 	'
-# example onbuild
-#	[python:onbuild]='
-#		py-onbuild
-#	'
 )
 
 globalExcludeTests+=(
@@ -274,18 +270,7 @@ globalExcludeTests+=(
 	[traefik_no-hard-coded-passwords]=1
 	[traefik_utc]=1
 
-	# windows!
-	[:nanoserver_cve-2014--shellshock]=1
-	[:nanoserver_no-hard-coded-passwords]=1
-	[:nanoserver_utc]=1
-	[:windowsservercore_cve-2014--shellshock]=1
-	[:windowsservercore_no-hard-coded-passwords]=1
-	[:windowsservercore_utc]=1
-	# https://github.com/docker-library/official-images/pull/2578#issuecomment-274889851
-	[nats:nanoserver_override-cmd]=1
-	[nats:windowsservercore_override-cmd]=1
-
-	# clearlinux has no /etc/password
+	# clearlinux has no /etc/passwd
 	# https://github.com/docker-library/official-images/pull/1721#issuecomment-234128477
 	[clearlinux_no-hard-coded-passwords]=1
 
@@ -293,20 +278,32 @@ globalExcludeTests+=(
 	[openjdk:alpine_java-uimanager-font]=1
 	[openjdk:slim_java-uimanager-font]=1
 	[openjdk:nanoserver_java-uimanager-font]=1
-	# and adoptopenjdk has opted not to
-	[adoptopenjdk_java-uimanager-font]=1
+
+	# the Swift slim images are not expected to be able to run the swift-hello-world test because it involves compiling Swift code. The slim images are for running an already built binary.
+	# https://github.com/docker-library/official-images/pull/6302#issuecomment-512181863
+	[swift:slim_swift-hello-world]=1
 
 	# no "native" dependencies
 	[ruby:alpine_ruby-bundler]=1
 	[ruby:alpine_ruby-gems]=1
 	[ruby:slim_ruby-bundler]=1
 	[ruby:slim_ruby-gems]=1
+
+	# MySQL-assuming tests cannot be run on MongoDB-providing images
 	[percona:psmdb_percona-tokudb]=1
 	[percona:psmdb_percona-rocksdb]=1
 
-	# the Swift slim images are not expected to be able to run the swift-hello-world test because it involves compiling Swift code. The slim images are for running an already built binary.
-	# https://github.com/docker-library/official-images/pull/6302#issuecomment-512181863
-	[swift:slim_swift-hello-world]=1
+	# windows!
+	[:nanoserver_cve-2014--shellshock]=1
+	[:nanoserver_no-hard-coded-passwords]=1
+	[:nanoserver_utc]=1
+	[:windowsservercore_cve-2014--shellshock]=1
+	[:windowsservercore_no-hard-coded-passwords]=1
+	[:windowsservercore_utc]=1
+
+	# https://github.com/docker-library/official-images/pull/2578#issuecomment-274889851
+	[nats:nanoserver_override-cmd]=1
+	[nats:windowsservercore_override-cmd]=1
 
 	# TODO adjust MongoDB tests to use docker networks instead of links so they can work on Windows (and consider using PowerShell to generate appropriate certificates for TLS tests instead of openssl)
 	[mongo:windowsservercore_mongo-basics]=1


### PR DESCRIPTION
This allows test changes to be tested too, if they live in the PR with the image change.

(This was discovered over in https://github.com/docker-library/official-images/pull/8010 :sweat_smile:)