### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0.2, 6.0, 6, latest, 6.0.2-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.3, 6.0, 6, latest, 6.0.3-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3914a0256d549b8323c94c62854d8ca06107aec4
+GitCommit: 9c9d49d25acd7428ea30669f0395506f4a7f78fc
 Directory: 6.0
 
-Tags: 6.0.2-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.2-alpine3.11, 6.0-alpine3.11, 6-alpine3.11, alpine3.11
+Tags: 6.0.3-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.3-alpine3.11, 6.0-alpine3.11, 6-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3914a0256d549b8323c94c62854d8ca06107aec4
+GitCommit: 9c9d49d25acd7428ea30669f0395506f4a7f78fc
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/9c9d49d: Update to 6.0.3