### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.15.3, 3.15, 3, latest
+Tags: 3.16.0, 3.16, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b565e6288d0c41bbdba4fcc763169e471a448cb5
+GitCommit: ca2a759ec4cc1111151cc4f20a172d210225fbb3
 Directory: 3/debian
 
-Tags: 3.15.3-alpine, 3.15-alpine, 3-alpine, alpine
+Tags: 3.16.0-alpine, 3.16-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b565e6288d0c41bbdba4fcc763169e471a448cb5
+GitCommit: ca2a759ec4cc1111151cc4f20a172d210225fbb3
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/ca2a759: Update to 3.16.0, ghost-cli 1.13.1