### PR TITLE
[ros] move build tools to ros-base image

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: f2b13092747c0f60cf7608369b57ea89bc01e22d
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -59,22 +59,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: c1585532a5e6ddc4c3ded239a1caff366c34117f
+GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
 Directory: ros/melodic/debian/stretch/perception
 
 
@@ -86,12 +86,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d188a5a15dba3d3fa266e4578c1ed2e1b4421c72
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 
@@ -103,10 +103,10 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 9b63c2f2a11ef18c93f7c8f35770625fc48181d8
+GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-base


### PR DESCRIPTION
This PR moves the installation of the build and compilation tools from the `ros-core` to `ros-base`
It also adds the flag `--no-install-recommends` to all apt installation calls to reduce image size

Related to https://github.com/osrf/docker_images/pull/357