### PR TITLE
R 4.0.0 can now be installed from unstable, add arm64v8 back in

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -3,6 +3,6 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
 GitRepo: https://github.com/rocker-org/rocker.git
 
 Tags: 4.0.0, latest
-Architectures: amd64
-GitCommit: 1286d1fa0165a06b93ea9c4cebd94a54cbf86227
+Architectures: amd64, arm64v8
+GitCommit: 0317dc922dc7b9181d86446436acdd7f77ee0f17
 Directory: r-base/latest


### PR DESCRIPTION
Now that R 4.0.0 (via source package `r-base`) is back in unstable (with the r-4.0 transition in full swing having done more than 800 of the 950 or so packages) we can revert back to using unstable only (and not experimental).  

We also get to add arm64v8 back in.