### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/9024f3f2012caaf06774bdddc6c9ff485205c6ca/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/507ed106bd8e8e26c32d2d7f10364a3b2d8bc991/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,12 +24,12 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 2.1/alpine
 
-Tags: 2.0.14, 2.0
+Tags: 2.0.14, 2.0, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
 Directory: 2.0
 
-Tags: 2.0.14-alpine, 2.0-alpine
+Tags: 2.0.14-alpine, 2.0-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/507ed10: Add link to upstream download page which makes the LTS split more clear
- https://github.com/docker-library/haproxy/commit/26056c5: Merge pull request https://github.com/docker-library/haproxy/pull/79 from TimWolla/lts