### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.16.0, 3.16, 3, latest
+Tags: 3.16.1, 3.16, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ca2a759ec4cc1111151cc4f20a172d210225fbb3
+GitCommit: 83fdb8fc72c69c3cf7d54ffd2fd3541a9fed391f
 Directory: 3/debian
 
-Tags: 3.16.0-alpine, 3.16-alpine, 3-alpine, alpine
+Tags: 3.16.1-alpine, 3.16-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ca2a759ec4cc1111151cc4f20a172d210225fbb3
+GitCommit: 83fdb8fc72c69c3cf7d54ffd2fd3541a9fed391f
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/83fdb8f: Update to 3.16.1, ghost-cli 1.13.1