### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.4-rc.3, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: fa268f0763da9cb08a185120989dd3dc755b8a76
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.4-rc.3-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.4-rc.3-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: fa268f0763da9cb08a185120989dd3dc755b8a76
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.4-rc.3-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.3, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91be7cf597c069c9a038ae2619adac1a85e68d4d
+GitCommit: 7aa93f2563dd6558322b2f7b4b813003be7e0816
 Directory: 3.8/ubuntu
 
 Tags: 3.8.3-management, 3.8-management, 3-management, management
@@ -16,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91be7cf597c069c9a038ae2619adac1a85e68d4d
+GitCommit: 7aa93f2563dd6558322b2f7b4b813003be7e0816
 Directory: 3.8/alpine
 
 Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +46,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.26, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c24b3b15b1128272e64cba8d1dba37603c2b1d68
+GitCommit: 7f42f9325352afc1625fbf1cc928e1f66bb6cd5c
 Directory: 3.7/ubuntu
 
 Tags: 3.7.26-management, 3.7-management
@@ -36,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.26-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c24b3b15b1128272e64cba8d1dba37603c2b1d68
+GitCommit: 7f42f9325352afc1625fbf1cc928e1f66bb6cd5c
 Directory: 3.7/alpine
 
 Tags: 3.7.26-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7aa93f2: Update to 3.8.3, Erlang/OTP 22.3.4.1, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/7f42f93: Update to 3.7.26, Erlang/OTP 22.3.4.1, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/fa268f0: Update to 3.8.4-rc.3, Erlang/OTP 22.3.4.1, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/13ec1c8: Update to 3.8.4-rc.3, Erlang/OTP 22.3.4, OpenSSL 1.1.1g