### PR TITLE
Release of GeoNetwork 4.0.0-alpha.1

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/f81b111fbe3d765ee56f61c5474099764ee07004/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/e9c89e02c270371fe96848cc0557997cb1e9e9bb/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
@@ -23,3 +23,8 @@ Tags: 3.8.3-postgres, 3.8-postgres
 Architectures: amd64
 GitCommit: af81a4ff8f592d27b4911ad20d569379864ee85f
 Directory: 3.8.3/postgres
+
+Tags: 4.0.0-alpha.1, 4.0.0-alpha, 4.0-alpha, 4-alpha
+Architectures: amd64
+GitCommit: 322b19a848bdc0ab227e40f2e1b84dec059550bb
+Directory: 4.0.0-alpha.1


### PR DESCRIPTION
Release of alpha version. 

Check the documents at https://github.com/geonetwork/docker-geonetwork/blob/master/4.0.0-alpha.1/README.md