### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev7, 2.2-rc
+Tags: 2.2-dev8, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e5884936dca8ee8968522abff21713042983a898
+GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
 Directory: 2.2-rc
 
-Tags: 2.2-dev7-alpine, 2.2-rc-alpine
+Tags: 2.2-dev8-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e5884936dca8ee8968522abff21713042983a898
+GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.4, 2.1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8acafe8: Update to 2.2-dev8