### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,44 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.4-rc.3, 3.8-rc
+Tags: 3.8.4, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa268f0763da9cb08a185120989dd3dc755b8a76
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.4-rc.3-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.4-rc.3-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa268f0763da9cb08a185120989dd3dc755b8a76
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.4-rc.3-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.3, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa93f2563dd6558322b2f7b4b813003be7e0816
+GitCommit: 5f111eef86fe44b85f7db613497372fc54eeeee9
 Directory: 3.8/ubuntu
 
-Tags: 3.8.3-management, 3.8-management, 3-management, management
+Tags: 3.8.4-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
+GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.3-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.4-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa93f2563dd6558322b2f7b4b813003be7e0816
+GitCommit: 5f111eef86fe44b85f7db613497372fc54eeeee9
 Directory: 3.8/alpine
 
-Tags: 3.8.3-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.4-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5f6ff9a3916d89be6d190d562d247ae12ffa73
+GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/alpine/management
 
 Tags: 3.7.26, 3.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/13d4334: Update to 3.8.4, Erlang/OTP 22.3.4.1, OpenSSL 1.1.1g