### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.4, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f111eef86fe44b85f7db613497372fc54eeeee9
+GitCommit: 88ac0b2054040237276a30c1494d2b29030889f0
 Directory: 3.8/ubuntu
 
 Tags: 3.8.4-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.4-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f111eef86fe44b85f7db613497372fc54eeeee9
+GitCommit: 88ac0b2054040237276a30c1494d2b29030889f0
 Directory: 3.8/alpine
 
 Tags: 3.8.4-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/88ac0b2: Update to 3.8.4, Erlang/OTP 23.0.2, OpenSSL 1.1.1g