### PR TITLE
consul: switch generic beta tag to 1.8.0-beta

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,6 +1,6 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.8.0-beta2, beta
+Tags: 1.8.0-beta2, 1.8.0-beta
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 47c5def6b37c59a5e1ec01d3cd7d5c3ef074c52b


### PR DESCRIPTION
The generic `beta` tag was unclear and would be ephemeral (appearing shortly before new releases rather than being a consistent channel like `latest` or `nightly`). This switches to a more specific `1.8.0-beta` tag to be more descriptive and allow clearly opting in to testing a series of beta releases for a specific upcoming release.