### PR TITLE
[Swift] Add support for Ubuntu 20.04, CentOS 8, and Amazon Linux 2. A…

### DIFF
--- a/library/swift
+++ b/library/swift
@@ -32,11 +32,11 @@ Directory: 5.2/ubuntu/20.04
 
 Tags: 5.2.4-amazonlinux2, 5.2-amazonlinux2, amazonlinux2
 GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
-Directory: 5.2/ubuntu/amazonlinux/2
+Directory: 5.2/amazonlinux/2
 
 Tags: 5.2.4-centos8, 5.2-centos8, centos8
 GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
-Directory: 5.2/ubuntu/centos/8
+Directory: 5.2/centos/8
 
 Tags: 5.1.5, 5.1, 5.1.5-bionic, 5.1-bionic
 GitCommit: 05538e13a3015675d83e2553cdce5d1d67e17235

--- a/library/swift
+++ b/library/swift
@@ -6,21 +6,37 @@ Maintainers: Ted Kremenek <kremenek@apple.com> (@tkremenek),
 GitRepo: https://github.com/apple/swift-docker.git
 
 
-Tags: 5.2.3, 5.2, 5.2.3-bionic, 5.2-bionic, bionic, latest
-GitCommit: 38f179345ace24236d6c09de84e77d91384014cd
+Tags: 5.2.4, 5.2, 5.2.4-bionic, 5.2-bionic, bionic, latest
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
 Directory: 5.2/ubuntu/18.04
 
-Tags: 5.2.3-xenial, 5.2-xenial, xenial
-GitCommit: 38f179345ace24236d6c09de84e77d91384014cd
+Tags: 5.2.4-xenial, 5.2-xenial, xenial
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
 Directory: 5.2/ubuntu/16.04
 
-Tags: 5.2.3-slim, 5.2-slim, 5.2.3-bionic-slim, 5.2-bionic-slim, bionic-slim, slim
-GitCommit: 38f179345ace24236d6c09de84e77d91384014cd
+Tags: 5.2.4-slim, 5.2-slim, 5.2.4-bionic-slim, 5.2-bionic-slim, bionic-slim, slim
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
 Directory: 5.2/ubuntu/18.04/slim
 
-Tags: 5.2.3-xenial-slim, 5.2-xenial-slim, xenial-slim
-GitCommit: 38f179345ace24236d6c09de84e77d91384014cd
+Tags: 5.2.4-xenial-slim, 5.2-xenial-slim, xenial-slim
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
 Directory: 5.2/ubuntu/16.04/slim
+
+Tags: 5.2.4-focal-slim, 5.2-focal-slim, focal-slim
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
+Directory: 5.2/ubuntu/20.04/slim
+
+Tags: 5.2.4-focal, 5.2-focal, focal
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
+Directory: 5.2/ubuntu/20.04
+
+Tags: 5.2.4-amazonlinux2, 5.2-amazonlinux2, amazonlinux2
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
+Directory: 5.2/ubuntu/amazonlinux/2
+
+Tags: 5.2.4-centos8, 5.2-centos8, centos8
+GitCommit: bcaa665ab185e9af7d82612c9436950e92466451
+Directory: 5.2/ubuntu/centos/8
 
 Tags: 5.1.5, 5.1, 5.1.5-bionic, 5.1-bionic
 GitCommit: 05538e13a3015675d83e2553cdce5d1d67e17235


### PR DESCRIPTION
…lso, update the hash for Swift 5.2.4 release