### PR TITLE
[security] Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 19.03.10, 19.03, 19, stable, test, latest
+Tags: 19.03.11, 19.03, 19, stable, test, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 23814eff7f7e45a8fb5898740cabf24e377c64c4
+GitCommit: 1e1315f53a45ee2563afb97880feadfad2eb3059
 Directory: 19.03
 
-Tags: 19.03.10-dind, 19.03-dind, 19-dind, stable-dind, test-dind, dind
+Tags: 19.03.11-dind, 19.03-dind, 19-dind, stable-dind, test-dind, dind
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: a73d96e731e2dd5d6822c99a9af4dcbfbbedb2be
 Directory: 19.03/dind
 
-Tags: 19.03.10-dind-rootless, 19.03-dind-rootless, 19-dind-rootless, stable-dind-rootless, test-dind-rootless, dind-rootless
+Tags: 19.03.11-dind-rootless, 19.03-dind-rootless, 19-dind-rootless, stable-dind-rootless, test-dind-rootless, dind-rootless
 Architectures: amd64
 GitCommit: 25c81c65fe4e971ff75e67df38e8b9970b523f6e
 Directory: 19.03/dind-rootless
 
-Tags: 19.03.10-git, 19.03-git, 19-git, stable-git, test-git, git
+Tags: 19.03.11-git, 19.03-git, 19-git, stable-git, test-git, git
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 7a67842e7ff12c1426ae6a67ac1b7a701b51f3df
 Directory: 19.03/git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/1e1315f: Update to 19.03.11

(See CVE-2020-13401 / https://github.com/docker/docker-ce/releases/tag/v19.03.11 for details.)