### PR TITLE
sonar-scanner-cli 4.5

### DIFF
--- a/library/sonar-scanner-cli
+++ b/library/sonar-scanner-cli
@@ -1,0 +1,6 @@
+Maintainers: Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource), Mark Rekveld <mark.rekveld@sonarsource.com> (@mark-rekveld-sonarsource), Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis)
+GitRepo: https://github.com/SonarSource/sonar-scanner-cli-docker
+GitCommit: 2903afe66a4ba33a77303b6cb5d213615553b021
+
+Tags: 4.5, 4, latest
+Directory: 4


### PR DESCRIPTION
SonarScanner CLI is the official scanner used to run code analysis on SonarQube and SonarCloud. 

Please don't merge this PR yet even if everything is ok- we still have to release version 4.4 of the scanner, so we will have to update the version of the binary that is downloaded in the image.

Docs PR: https://github.com/docker-library/docs/pull/1728
