### PR TITLE
arangodb 3.6.4

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -6,6 +6,6 @@
 3.4.10: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
 3.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
 3.5.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
-3.6: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
-3.6.3: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
-latest: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.6.3.1
+3.6: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4
+3.6.4: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4
+latest: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.4.

Didn't put #7962 (comment) workaround yet (planned for the next version only) so `npm ERR! lifecycle could not get uid/gid` can happen.