### PR TITLE
Updating Oracle Linux 7 and 8.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f15c4cdc4a1483e541eb00d18c8058d2b5988fff
+amd64-GitCommit: 11347da2d2eae123483ea72dbfb7d221fab18527
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b7cacb29fd0ac3998a852fae86607b544d8a7a04
+arm64v8-GitCommit: 093a8032e91a521a73db38de7923b1f378930afb
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
* Updated `oraclelinux:8.2` images for `amd64` and `arm64v8`
  * Updated `systemd-239-30.0.2.el8_2`
  * <https://linux.oracle.com/errata/ELBA-2020-5701.html>
  * Resolves issue #22
* Updated `oraclelinux:7.8` images for `amd64` and `arm64v8`
  * Updated `bind-export-libs-9.11.4-16.P2.el7_8.6` to address CVE-2020-8616 and CVE-2020-8617
  * <https://linux.oracle.com/errata/ELSA-2020-2344.html>


Signed-off-by: Avi Miller <avi.miller@oracle.com>