### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
 Directory: 2.2-rc/alpine
 
-Tags: 2.1.4, 2.1, latest
+Tags: 2.1.5, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: d76be00039099fafaceeab939b0fa17f05203cb5
 Directory: 2.1
 
-Tags: 2.1.4-alpine, 2.1-alpine, alpine
+Tags: 2.1.5-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: d76be00039099fafaceeab939b0fa17f05203cb5
 Directory: 2.1/alpine
 
 Tags: 2.0.14, 2.0, lts
@@ -63,13 +63,3 @@ Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
 Directory: 1.7/alpine
-
-Tags: 1.6.15, 1.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4e917ff7cbc629b29af59d02057ceece8102e4e0
-Directory: 1.6
-
-Tags: 1.6.15-alpine, 1.6-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
-Directory: 1.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8714e94: Merge pull request https://github.com/docker-library/haproxy/pull/115 from infosiftr/remove-1.6
- https://github.com/docker-library/haproxy/commit/0105dbc: Remove 1.6
- https://github.com/docker-library/haproxy/commit/d76be00: Update to 2.1.5

---------

see: https://github.com/haproxy/haproxy/issues/661#issuecomment-636697129