### PR TITLE
Updated nginx 1.19 hashes

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -5,22 +5,22 @@ GitRepo: https://github.com/nginxinc/docker-nginx.git
 
 Tags: 1.19.0, mainline, 1, 1.19, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b607f324d208664f37f7c1136ada6b249ddcd9b
+GitCommit: 2ef3fa66f2a434cd5e44e35a02f4ac502cf50808
 Directory: mainline/buster
 
 Tags: 1.19.0-perl, mainline-perl, 1-perl, 1.19-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b607f324d208664f37f7c1136ada6b249ddcd9b
+GitCommit: 2ef3fa66f2a434cd5e44e35a02f4ac502cf50808
 Directory: mainline/buster-perl
 
 Tags: 1.19.0-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 0b607f324d208664f37f7c1136ada6b249ddcd9b
+GitCommit: 2ef3fa66f2a434cd5e44e35a02f4ac502cf50808
 Directory: mainline/alpine
 
 Tags: 1.19.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 0b607f324d208664f37f7c1136ada6b249ddcd9b
+GitCommit: 2ef3fa66f2a434cd5e44e35a02f4ac502cf50808
 Directory: mainline/alpine-perl
 
 Tags: 1.18.0, stable, 1.18


### PR DESCRIPTION
This fixes https://github.com/nginxinc/docker-nginx/issues/416 -
inability to start a container on a read-only filesystem.