### PR TITLE
mosquitto 1.6.10

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,9 +1,9 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 68c1e51035467ade10533c7bb88aa9765241c104
+GitCommit: f39bf49f9059bfbf2b802fbe8ea435dab42ebf0c
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 1.6.9, 1.6, latest
+Tags: 1.6.10, 1.6, latest
 Directory: docker/1.6
 
 Tags: 1.5.9, 1.5


### PR DESCRIPTION
Update to alpine:3.12
Use openssl instead of libressl.
Enable TLS-PSK support.

Thanks for the ping on alpine:3.8 being EOL.