### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/1cf2cba27e47cac63b2b705d6d237d0e84b07b31/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/b94efb437360c7c796e1ab445b070c4b305fb6f4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 1cf2cba27e47cac63b2b705d6d237d0e84b07b31
+GitCommit: b94efb437360c7c796e1ab445b070c4b305fb6f4
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7c3206169c4d32ae0afbb36b90cb9f9b77011f7a
+amd64-GitCommit: a115b72591a71442fbbb7e833ed120eb63f9df2e
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 442b9471a07fe059fdce27fc4f8caef1be19e73f
+arm32v5-GitCommit: ef0062b8d4978ca5f3e0e021e4edb22bf71dfe2c
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: aef519f3e26970dd1278cddfadc1bc42d34a75b1
+arm32v6-GitCommit: 7a2a8fbfa863d544d721e918a6449805e7b3e102
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: c695e0ffd7df9df64869ee77dcfb571464fce183
+arm32v7-GitCommit: 584141e233889fd82a67bedc29ded576b80637c1
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 80cf7031e73b261c7a9204e8b221b22a7f85f8a1
+arm64v8-GitCommit: 9751087f0f4d47445d7b753849e9a6d98069e62a
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 4a983e50400610588620dc5a0e9606942f2c852f
+i386-GitCommit: d383b9a171b956550e4390e53d2366007140b903
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 5df054ae2279437bd95320c19344a9b9d9b5f435
+mips64le-GitCommit: ff7306b139cf065dca9fe87ba9202ecbdefae924
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 44486923d5dd699f25fd25d1c36ea1225e5de492
+ppc64le-GitCommit: a7067bfe3738477c95b5c3164d5f9d42e5c42ab0
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 284ef4842056051a8f16ad810b666f07a9490090
+s390x-GitCommit: 3f69ea46f6b3b796b93dab40318c80b68290c34b
 
 Tags: 1.31.1-uclibc, 1.31-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/b94efb4: Merge pull request https://github.com/docker-library/busybox/pull/84 from infosiftr/alpine3.12
- https://github.com/docker-library/busybox/commit/f8fa731: Update to Alpine 3.12
- https://github.com/docker-library/busybox/commit/3922e05: Merge pull request https://github.com/docker-library/busybox/pull/83 from infosiftr/buildroot-2020.05
- https://github.com/docker-library/busybox/commit/a9c111f: Update Buildroot to 2020.05