### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.17.1, 3.17, 3, latest
+Tags: 3.18.1, 3.18, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e395a5a01987c10fd462c676875469489e103f93
+GitCommit: 44ff14774b66266299a13a705cdbb45d7fc72238
 Directory: 3/debian
 
-Tags: 3.17.1-alpine, 3.17-alpine, 3-alpine, alpine
+Tags: 3.18.1-alpine, 3.18-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e395a5a01987c10fd462c676875469489e103f93
+GitCommit: 44ff14774b66266299a13a705cdbb45d7fc72238
 Directory: 3/alpine
 
 Tags: 2.38.1, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/44ff147: Update to 3.18.1, ghost-cli 1.14.0