### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.7.0
-GitCommit: 9a07fe301328cb6dfc6cc6aeed784bdc51c31eca
+Tags: 7.7.1
+GitCommit: 474535936a32ff1a04aefa197d7ee11e77cd2e21
 Directory: 7
 
-Tags: 6.8.9
-GitCommit: 9a07fe301328cb6dfc6cc6aeed784bdc51c31eca
+Tags: 6.8.10
+GitCommit: 859c4b22df4b8cec2cc589e0253bfff46d54af9f
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.7.0
-GitCommit: f3512f90b2c0be7c3547095a0bd1e607e18e9af3
+Tags: 7.7.1
+GitCommit: 293a582c8ec9a78ec4c137ddb77d37c6312c97f3
 Directory: 7
 
-Tags: 6.8.9
-GitCommit: f3512f90b2c0be7c3547095a0bd1e607e18e9af3
+Tags: 6.8.10
+GitCommit: 96976f5b4fabedc3fdf052ecdab323d2a08337e9
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.7.0
-GitCommit: 0d647982be457e2a1f1910a143eff0778ba09f76
+Tags: 7.7.1
+GitCommit: fbf2a117c43ddfc581210f3e884fcab4b03213f6
 Directory: 7
 
-Tags: 6.8.9
-GitCommit: 0d647982be457e2a1f1910a143eff0778ba09f76
+Tags: 6.8.10
+GitCommit: 4a45fc4bc7159024f8bbe33a0801b6ca8a643c4f
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/859c4b2: Update to 6.8.10
- https://github.com/docker-library/elasticsearch/commit/4745359: Update to 7.7.1

logstash:
- https://github.com/docker-library/logstash/commit/4a45fc4: Update to 6.8.10
- https://github.com/docker-library/logstash/commit/fbf2a11: Update to 7.7.1

kibana:
- https://github.com/docker-library/kibana/commit/96976f5: Update to 6.8.10
- https://github.com/docker-library/kibana/commit/293a582: Update to 7.7.1