### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 23af5b6adb271bcebbcebc93308884438512a4af
 Directory: 6.0
 
-Tags: 6.0.4-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.4-alpine3.11, 6.0-alpine3.11, 6-alpine3.11, alpine3.11
+Tags: 6.0.4-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.4-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 23af5b6adb271bcebbcebc93308884438512a4af
+GitCommit: f6496e4885b8b43e375adaf230354d4076858c8a
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster
@@ -24,7 +24,7 @@ Architectures: amd64
 GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
 Directory: 5.0/32bit
 
-Tags: 5.0.9-alpine, 5.0-alpine, 5-alpine, 5.0.9-alpine3.11, 5.0-alpine3.11, 5-alpine3.11
+Tags: 5.0.9-alpine, 5.0-alpine, 5-alpine, 5.0.9-alpine3.12, 5.0-alpine3.12, 5-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
+GitCommit: f6496e4885b8b43e375adaf230354d4076858c8a
 Directory: 5.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/9a9be72: Merge pull request https://github.com/docker-library/redis/pull/246 from flori/use-alpine-3.12
- https://github.com/docker-library/redis/commit/14982a3: Use alpine:3.12 in template as well
- https://github.com/docker-library/redis/commit/f6496e4: Use alpine 3.12