### PR TITLE
[ros] Release ROS foxy images and make them latest

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -39,7 +39,7 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
-Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
+Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-base
@@ -160,3 +160,21 @@ Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-base
+
+
+################################################################################
+# Release: foxy
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: foxy-ros-core, foxy-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-core
+
+Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-base
+


### PR DESCRIPTION
Images for the new ROS 2 release: [Foxy Fitzroy](https://github.com/ros-infrastructure/official-images/pull/new/foxy)
This is a new LTS and will be the target of the latest tag.