### PR TITLE
[ros] add ros1-bridge images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -144,6 +144,11 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
+Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
+Directory: ros/dashing/ubuntu/bionic/ros1-bridge
+
 
 ################################################################################
 # Release: eloquent
@@ -161,6 +166,11 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-base
 
+Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
+Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
+
 
 ################################################################################
 # Release: foxy
@@ -177,4 +187,9 @@ Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
 Architectures: amd64, arm64v8
 GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
 Directory: ros/foxy/ubuntu/focal/ros-base
+
+Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
+Architectures: amd64, arm64v8
+GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
+Directory: ros/foxy/ubuntu/focal/ros1-bridge
 

--- a/library/ros
+++ b/library/ros
@@ -39,7 +39,7 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
-Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
+Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-base
@@ -160,3 +160,21 @@ Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-base
+
+
+################################################################################
+# Release: foxy
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: foxy-ros-core, foxy-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-core
+
+Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-base
+


### PR DESCRIPTION
this builds on top of https://github.com/docker-library/official-images/pull/8138
The only new commit is https://github.com/ros-infrastructure/official-images/commit/c60c4ca6eb9ba1e5198e19c772caa46acc88092b that adds the ros1-bridge images.

ROS 2 is the new default in the ROS ecosystem. The majority of users are still using ROS 1 and migrate their systems progressively over to ROS 2 using bridges to reconcile the two worlds.

These images have been hosted on the osrf profile for a while. Following user requests to be able to use these images on ARM platforms and the fact that these images do not bring in GUI dependencies we decided to submit them here along the other ROS official images.

These images are used in the examples at https://github.com/docker-library/docs/pull/1381
Related discussions https://github.com/osrf/docker_images/issues/414 https://github.com/osrf/docker_images/pull/415, 
 
cc @ruffsl 