### PR TITLE
upgrade r-base to R 4.0.1 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,7 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.0.0, latest
+Tags: 4.0.1, latest
 Architectures: amd64, arm64v8
-GitCommit: 0317dc922dc7b9181d86446436acdd7f77ee0f17
+GitCommit: dee1c76816be5c370771243bee9a0e594717ed0f
 Directory: r-base/latest
+


### PR DESCRIPTION
standard upgrade to new upstream release today

added gcc-9-base to allow clean gcc-9 upgrade