### PR TITLE
Update Solr to 8.5.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,95 +1,97 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/96477231f35e50cc9bd8cb0c8e9b004e841a126a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/a71f2522d58b57ef9be9cdd42525379d980479b2/generate-stackbrew-library.sh
 
-Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
-             Shalin Mangar <shalin@apache.org> (@shalinmangar)
+Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org>,
+             Shalin Mangar (@shalinmangar),
+             David Smiley (@dsmiley),
+             Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.5.1, 8.5, 8, latest
+Tags: 8.5.2, 8.5, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.5
 
-Tags: 8.5.1-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.2-slim, 8.5-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.5/slim
 
 Tags: 8.4.1, 8.4
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.4
 
 Tags: 8.4.1-slim, 8.4-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.4/slim
 
 Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.3
 
 Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.0/slim
 
 Tags: 7.7.3, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 7.7
 
 Tags: 7.7.3-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 7.7/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 574d3d15742dce60957d423240337a3962f265f6
+GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 5.5/slim

--- a/library/solr
+++ b/library/solr
@@ -1,6 +1,6 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/a71f2522d58b57ef9be9cdd42525379d980479b2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/9bd7de97e84615eb9eacc7a243dfc5519153933a/generate-stackbrew-library.sh
 
-Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org>,
+Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfbot),
              Shalin Mangar (@shalinmangar),
              David Smiley (@dsmiley),
              Jan Høydahl (@janhoy)


### PR DESCRIPTION
Release note: https://lucene.apache.org/solr/news.html#apache-solrtm-852-available

This version also includes

* New jattach tool https://github.com/docker-solr/docker-solr/pull/321 
* Update maintainer info https://github.com/docker-solr/docker-solr/pull/313
* Various bug fixes