### PR TITLE
Fix a problem in GeoNetwork 4.0.0-alpha.1 entrypoint

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -26,5 +26,5 @@ Directory: 3.8.3/postgres
 
 Tags: 4.0.0-alpha.1, 4.0.0-alpha, 4.0-alpha, 4-alpha
 Architectures: amd64
-GitCommit: 322b19a848bdc0ab227e40f2e1b84dec059550bb
+GitCommit: 4b3fa67a1869eb82609f4117bfe39ccfdd6b2387
 Directory: 4.0.0-alpha.1


### PR DESCRIPTION
Fix a problem with a `sed` replace command in the image entrypoint for 4.0.0-alpha.1 tag.

See https://github.com/geonetwork/docker-geonetwork/pull/49.