### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
 Directory: 2.2-rc/alpine
 
-Tags: 2.1.5, 2.1, latest
+Tags: 2.1.7, 2.1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d76be00039099fafaceeab939b0fa17f05203cb5
+GitCommit: ff559288c519c0792bccb5c2e0d1e9d5fd5a87c9
 Directory: 2.1
 
-Tags: 2.1.5-alpine, 2.1-alpine, alpine
+Tags: 2.1.7-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d76be00039099fafaceeab939b0fa17f05203cb5
+GitCommit: ff559288c519c0792bccb5c2e0d1e9d5fd5a87c9
 Directory: 2.1/alpine
 
 Tags: 2.0.14, 2.0, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ff55928: Update to 2.1.7
- https://github.com/docker-library/haproxy/commit/66d6cd4: Update to 2.1.6