### PR TITLE
Updating Oracle Linux 7

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 11347da2d2eae123483ea72dbfb7d221fab18527
+amd64-GitCommit: 616b148f9d90a9b7c8470d666e3f605ef49bc0d2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 093a8032e91a521a73db38de7923b1f378930afb
+arm64v8-GitCommit: 75360219db2abea36f9ca353d6e60940f51f4e0e
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
* Updated `oraclelinux:7.8` and `oraclelinux:7-slim` images for `amd64` and `arm64v8`
  * Updated `systemd-219-73.0.1`
  * <https://linux.oracle.com/errata/ELBA-2020-5711.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>