### PR TITLE
Add version 7.10.5 of Bonita

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -12,7 +12,7 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: b58b05d989055ca3521fc92211d10ff640b4028f
 Directory: 7.9
 
-Tags: 7.10.4, 7.10, latest
+Tags: 7.10.5, 7.10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c25c0b161fe2f5ec620122822317e4985cc3b6f2
+GitCommit: 80b6eebd5281c5597e2f38ed4d3a8c4b8449261c
 Directory: 7.10


### PR DESCRIPTION
This pull request updates the `bonita` docker image to the latest maintenance version
7.10.4 -> 7.10.5

Documentation PR to come