### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.4.1-php7.2-apache, 5.4-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.4.1-php7.2, 5.4-php7.2, 5-php7.2, php7.2
+Tags: 5.4.2-php7.2-apache, 5.4-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.4.2-php7.2, 5.4-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.2/apache
 
-Tags: 5.4.1-php7.2-fpm, 5.4-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
+Tags: 5.4.2-php7.2-fpm, 5.4-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.2/fpm
 
-Tags: 5.4.1-php7.2-fpm-alpine, 5.4-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.4.2-php7.2-fpm-alpine, 5.4-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 835fae921ebfbdf5b50949c8efe971bc94a05fa0
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.2/fpm-alpine
 
-Tags: 5.4.1-apache, 5.4-apache, 5-apache, apache, 5.4.1, 5.4, 5, latest, 5.4.1-php7.3-apache, 5.4-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.4.1-php7.3, 5.4-php7.3, 5-php7.3, php7.3
+Tags: 5.4.2-apache, 5.4-apache, 5-apache, apache, 5.4.2, 5.4, 5, latest, 5.4.2-php7.3-apache, 5.4-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.4.2-php7.3, 5.4-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.3/apache
 
-Tags: 5.4.1-fpm, 5.4-fpm, 5-fpm, fpm, 5.4.1-php7.3-fpm, 5.4-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.4.2-fpm, 5.4-fpm, 5-fpm, fpm, 5.4.2-php7.3-fpm, 5.4-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.3/fpm
 
-Tags: 5.4.1-fpm-alpine, 5.4-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.4.1-php7.3-fpm-alpine, 5.4-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.4.2-fpm-alpine, 5.4-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.4.2-php7.3-fpm-alpine, 5.4-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 835fae921ebfbdf5b50949c8efe971bc94a05fa0
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.3/fpm-alpine
 
-Tags: 5.4.1-php7.4-apache, 5.4-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.4.1-php7.4, 5.4-php7.4, 5-php7.4, php7.4
+Tags: 5.4.2-php7.4-apache, 5.4-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.4.2-php7.4, 5.4-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.4/apache
 
-Tags: 5.4.1-php7.4-fpm, 5.4-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.4.2-php7.4-fpm, 5.4-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8215003254de4bf0a8ddd717c3c393e778b872ce
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.4/fpm
 
-Tags: 5.4.1-php7.4-fpm-alpine, 5.4-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.4.2-php7.4-fpm-alpine, 5.4-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 835fae921ebfbdf5b50949c8efe971bc94a05fa0
+GitCommit: 2e0d223a67a645307559e05f3fa4a154b2bbb983
 Directory: php7.4/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/2e0d223: Update to 5.4.2