### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev8, 2.2-rc
+Tags: 2.2-dev9, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
+GitCommit: 7cd3bc51a2a05a95db0c5521c1788846018cef77
 Directory: 2.2-rc
 
-Tags: 2.2-dev8-alpine, 2.2-rc-alpine
+Tags: 2.2-dev9-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8acafe8ca3217a6d67afdd95a474206d79d857b0
+GitCommit: 7cd3bc51a2a05a95db0c5521c1788846018cef77
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.7, 2.1, latest
@@ -21,7 +21,7 @@ Directory: 2.1
 
 Tags: 2.1.7-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ff559288c519c0792bccb5c2e0d1e9d5fd5a87c9
+GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 2.1/alpine
 
 Tags: 2.0.14, 2.0, lts
@@ -31,7 +31,7 @@ Directory: 2.0
 
 Tags: 2.0.14-alpine, 2.0-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1
@@ -41,7 +41,7 @@ Directory: 1.9
 
 Tags: 1.9.15-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 1.9/alpine
 
 Tags: 1.8.25, 1.8
@@ -51,7 +51,7 @@ Directory: 1.8
 
 Tags: 1.8.25-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
@@ -61,5 +61,5 @@ Directory: 1.7
 
 Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfa23c19cffdb4247474b2138feeeb14f48b7fe4
+GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7cd3bc5: Update to 2.2-dev9
- https://github.com/docker-library/haproxy/commit/16c4c8b: Merge pull request https://github.com/docker-library/haproxy/pull/116 from J0WI/alpine-3.12
- https://github.com/docker-library/haproxy/commit/7aa6757: Upgrade Alpine to 3.12