### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.19.0, 3.19, 3, latest
+Tags: 3.19.2, 3.19, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0af5021d89a510830b136c7bc2b7a8f6b6c2c162
+GitCommit: bb433b29ec66d893f33b2ff0912f56abed4aa998
 Directory: 3/debian
 
-Tags: 3.19.0-alpine, 3.19-alpine, 3-alpine, alpine
+Tags: 3.19.2-alpine, 3.19-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0af5021d89a510830b136c7bc2b7a8f6b6c2c162
+GitCommit: bb433b29ec66d893f33b2ff0912f56abed4aa998
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/bb433b2: Update to 3.19.2, ghost-cli 1.14.1