### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
 Directory: 2.1/alpine
 
-Tags: 2.0.14, 2.0, lts
+Tags: 2.0.15, 2.0, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: f85b33d7a5fd97fd7852fe18d602009ab093289c
 Directory: 2.0
 
-Tags: 2.0.14-alpine, 2.0-alpine, lts-alpine
+Tags: 2.0.15-alpine, 2.0-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
+GitCommit: f85b33d7a5fd97fd7852fe18d602009ab093289c
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f85b33d: Update to 2.0.15