### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 15-ea-26-jdk-oraclelinux7, 15-ea-26-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-26-jdk-oracle, 15-ea-26-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-26-jdk, 15-ea-26, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-27-jdk-oraclelinux7, 15-ea-27-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-27-jdk-oracle, 15-ea-27-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk/oracle
 
-Tags: 15-ea-26-jdk-buster, 15-ea-26-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-27-jdk-buster, 15-ea-27-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk
 
-Tags: 15-ea-26-jdk-slim-buster, 15-ea-26-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-26-jdk-slim, 15-ea-26-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-27-jdk-slim-buster, 15-ea-27-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-27-jdk-slim, 15-ea-27-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -25,24 +25,24 @@ Architectures: amd64
 GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-26-jdk-windowsservercore-1809, 15-ea-26-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-26-jdk-windowsservercore, 15-ea-26-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-26-jdk, 15-ea-26, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-27-jdk-windowsservercore-1809, 15-ea-27-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-27-jdk-windowsservercore, 15-ea-27-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-26-jdk-windowsservercore-ltsc2016, 15-ea-26-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-26-jdk-windowsservercore, 15-ea-26-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-26-jdk, 15-ea-26, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-27-jdk-windowsservercore-ltsc2016, 15-ea-27-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-27-jdk-windowsservercore, 15-ea-27-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-26-jdk-nanoserver-1809, 15-ea-26-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-26-jdk-nanoserver, 15-ea-26-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-27-jdk-nanoserver-1809, 15-ea-27-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-27-jdk-nanoserver, 15-ea-27-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 1c30e1a7505bb3cf78dbe921e9394ebe10e3c273
+GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/1679aaf: Update to 15-ea+27