### PR TITLE
[ros] update ros1-bridge images with latest ros_comm

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -146,7 +146,7 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
+GitCommit: b6ac6f8488dc48ddc9715ccee93bade072395ff1
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
+GitCommit: c640c49dc488d0373ba7fa8014349f2b3e4e0217
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
Includes changes of https://github.com/osrf/docker_images/pull/420 and https://github.com/osrf/docker_images/pull/419