### PR TITLE
eclipse-mosquitto: Add images with openssl support.

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,10 +1,16 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: f39bf49f9059bfbf2b802fbe8ea435dab42ebf0c
+GitCommit: 6084685e0c5b09d67e4c801e9f346408c5bba446
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 1.6.10, 1.6, latest
 Directory: docker/1.6
 
+Tags: 1.6.10-openssl, 1.6-openssl, latest-openssl
+Directory: docker/1.6-openssl
+
 Tags: 1.5.9, 1.5
 Directory: docker/1.5
+
+Tags: 1.5.9-openssl, 1.5-openssl
+Directory: docker/1.5-openssl


### PR DESCRIPTION
The unlabelled images revert to libressl.