### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -11,7 +11,7 @@ Directory: 2.2-rc
 
 Tags: 2.2-dev9-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7cd3bc51a2a05a95db0c5521c1788846018cef77
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.7, 2.1, latest
@@ -21,7 +21,7 @@ Directory: 2.1
 
 Tags: 2.1.7-alpine, 2.1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 2.1/alpine
 
 Tags: 2.0.15, 2.0, lts
@@ -31,7 +31,7 @@ Directory: 2.0
 
 Tags: 2.0.15-alpine, 2.0-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f85b33d7a5fd97fd7852fe18d602009ab093289c
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1
@@ -41,7 +41,7 @@ Directory: 1.9
 
 Tags: 1.9.15-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 1.9/alpine
 
 Tags: 1.8.25, 1.8
@@ -51,7 +51,7 @@ Directory: 1.8
 
 Tags: 1.8.25-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
@@ -61,5 +61,5 @@ Directory: 1.7
 
 Tags: 1.7.12-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7aa67573aa25a94de9285264d292d65756e2ecbf
+GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/13fdeb1: Merge pull request https://github.com/docker-library/haproxy/pull/119 from infosiftr/alpine-ca-certs
- https://github.com/docker-library/haproxy/commit/e538b03: Remove "ca-certificates" package from Alpine build-deps