### PR TITLE
[registry:2.7] update to alpine 3.11, remove apache2-utils, remove 2.6 tags

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -5,7 +5,7 @@ GitRepo: https://github.com/docker/distribution-library-image.git
 Tags: 2.7.1, 2.7, 2, latest
 Architectures: amd64, arm64v8, arm32v6
 GitFetch: refs/heads/release/2.7
-GitCommit: 0b6ea3ba50b65563600a717f07db4cfa6f18f957
+GitCommit: ab00e8dae12d4515ed259015eab771ec92e92dd4
 amd64-Directory: amd64
 arm32v6-Directory: arm
 arm64v8-Directory: arm64

--- a/library/registry
+++ b/library/registry
@@ -9,11 +9,3 @@ GitCommit: ab00e8dae12d4515ed259015eab771ec92e92dd4
 amd64-Directory: amd64
 arm32v6-Directory: arm
 arm64v8-Directory: arm64
-
-Tags: 2.6.2, 2.6
-Architectures: amd64, arm64v8, arm32v6
-GitFetch: refs/heads/release/2.6
-GitCommit: fc40f1f1051bb4a42ee4661ccaa190c1bd6c6be9
-amd64-Directory: amd64
-arm32v6-Directory: arm
-arm64v8-Directory: arm64


### PR DESCRIPTION
Scanning the image showed some vulnerabilities, and apache2-utils was not an essential dependency at runtime, only included for "convenience", so has been removed.

diff: https://github.com/docker/distribution-library-image/compare/0b6ea3ba50b65563600a717f07db4cfa6f18f957...ab00e8dae12d4515ed259015eab771ec92e92dd4


brings in the changes from https://github.com/docker/distribution-library-image/pull/92 / https://github.com/docker/distribution-library-image/pull/104