### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,13 +1,15 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/979987de2091ad61eceab054545f7dc7968a952c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/elasticsearch/blob/551cff2cb19d99d2c76a8717d7d3007bb23c3a7a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.7.1
-GitCommit: 474535936a32ff1a04aefa197d7ee11e77cd2e21
+Tags: 7.8.0
+Architectures: amd64, arm64v8
+GitCommit: 551cff2cb19d99d2c76a8717d7d3007bb23c3a7a
 Directory: 7
 
 Tags: 6.8.10
-GitCommit: 859c4b22df4b8cec2cc589e0253bfff46d54af9f
+Architectures: amd64
+GitCommit: 551cff2cb19d99d2c76a8717d7d3007bb23c3a7a
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.7.1
-GitCommit: 293a582c8ec9a78ec4c137ddb77d37c6312c97f3
+Tags: 7.8.0
+GitCommit: d7dff7c685a19c7fb47b28ea41d5174792c3447b
 Directory: 7
 
 Tags: 6.8.10

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.7.1
-GitCommit: fbf2a117c43ddfc581210f3e884fcab4b03213f6
+Tags: 7.8.0
+GitCommit: f9a68426beb578052b01cccd0ecfd87614cb9b9e
 Directory: 7
 
 Tags: 6.8.10

--- a/naughty-from.sh
+++ b/naughty-from.sh
@@ -39,6 +39,9 @@ _is_naughty() {
 		| amd64=docker.elastic.co/elasticsearch/elasticsearch:* \
 		| amd64=docker.elastic.co/kibana/kibana:* \
 		| amd64=docker.elastic.co/logstash/logstash:* \
+		| arm64v8=docker.elastic.co/elasticsearch/elasticsearch:* \
+		| arm64v8=docker.elastic.co/kibana/kibana:* \
+		| arm64v8=docker.elastic.co/logstash/logstash:* \
 		| windows-*=mcr.microsoft.com/windows/nanoserver:* \
 		| windows-*=mcr.microsoft.com/windows/servercore:* \
 		) return 1 ;;


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/7e31439: Merge pull request https://github.com/docker-library/elasticsearch/pull/194 from infosiftr/multiarch
- https://github.com/docker-library/elasticsearch/commit/551cff2: Add support for multiple supported upstream architectures
- https://github.com/docker-library/elasticsearch/commit/acc3930: Update to 7.8.0

logstash:
- https://github.com/docker-library/logstash/commit/f9a6842: Update to 7.8.0

kibana:
- https://github.com/docker-library/kibana/commit/d7dff7c: Update to 7.8.0