### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.20.1, 3.20, 3, latest
+Tags: 3.20.2, 3.20, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1686d6e3a4344fce6c5dab0928c1280f1444e469
+GitCommit: 21a896fb737d54e16ed3fe308fb88e32fd836435
 Directory: 3/debian
 
-Tags: 3.20.1-alpine, 3.20-alpine, 3-alpine, alpine
+Tags: 3.20.2-alpine, 3.20-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1686d6e3a4344fce6c5dab0928c1280f1444e469
+GitCommit: 21a896fb737d54e16ed3fe308fb88e32fd836435
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/21a896f: Update to 3.20.2, ghost-cli 1.14.1