### PR TITLE
Removing the latest tag from Oracle Linux

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -25,7 +25,7 @@ Tags: 8-slim
 Architectures: amd64, arm64v8
 Directory: 8-slim
 
-Tags: 7.8, 7, latest
+Tags: 7.8, 7
 Architectures: amd64, arm64v8
 Directory: 7.8
 


### PR DESCRIPTION
Removal of the `latest` tag from the official Oracle Linux images to reduce confusion and ambiguity when selecting a version for downstream images.

Documentation updated via https://github.com/docker-library/docs/pull/1743

Signed-off-by: Avi Miller <avi.miller@oracle.com>