### PR TITLE
Revert "Update ZNC to 1.8.1" to fix wrong tags

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,6 +1,6 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
-GitCommit: cb2cabf8d63bc992f530b0fb86d0ad9cf955819d
+GitCommit: 91f58af10b62197187af1f0a9695488e88279e98
 Architectures: amd64, arm32v6, arm64v8
 
 Tags: 1.8.0, 1.8, latest


### PR DESCRIPTION
#8141 Updated ZNC to 1.8.1 but forgot to update the tags.

This should be merged before #8224 to fix currently wrong tags `1.8.0` and `1.8.0-slim` which incorrectly point to ZNC 1.8.1.

This reverts commit ea0cd533ec25a4999bcc6b4db7318ce47d5e2936.