### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,57 +4,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-1-jdk-oraclelinux7, 16-ea-1-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-1-jdk-oracle, 16-ea-1-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-1-jdk, 16-ea-1, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-2-jdk-oraclelinux7, 16-ea-2-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-2-jdk-oracle, 16-ea-2-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-2-jdk, 16-ea-2, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk/oracle
 
-Tags: 16-ea-1-jdk-buster, 16-ea-1-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-2-jdk-buster, 16-ea-2-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk
 
-Tags: 16-ea-1-jdk-slim-buster, 16-ea-1-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-1-jdk-slim, 16-ea-1-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-2-jdk-slim-buster, 16-ea-2-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-2-jdk-slim, 16-ea-2-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk/slim
 
-Tags: 16-ea-1-jdk-windowsservercore-1809, 16-ea-1-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-1-jdk-windowsservercore, 16-ea-1-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-1-jdk, 16-ea-1, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-2-jdk-windowsservercore-1809, 16-ea-2-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-2-jdk-windowsservercore, 16-ea-2-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-2-jdk, 16-ea-2, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-1-jdk-windowsservercore-ltsc2016, 16-ea-1-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-1-jdk-windowsservercore, 16-ea-1-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-1-jdk, 16-ea-1, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-2-jdk-windowsservercore-ltsc2016, 16-ea-2-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-2-jdk-windowsservercore, 16-ea-2-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-2-jdk, 16-ea-2, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-1-jdk-nanoserver-1809, 16-ea-1-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-1-jdk-nanoserver, 16-ea-1-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-2-jdk-nanoserver-1809, 16-ea-2-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-2-jdk-nanoserver, 16-ea-2-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: d756977d0e276667d058208811f450e1a8a80a87
+GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-ea-27-jdk-oraclelinux7, 15-ea-27-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-27-jdk-oracle, 15-ea-27-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-28-jdk-oraclelinux7, 15-ea-28-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-28-jdk-oracle, 15-ea-28-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-28-jdk, 15-ea-28, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk/oracle
 
-Tags: 15-ea-27-jdk-buster, 15-ea-27-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-28-jdk-buster, 15-ea-28-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk
 
-Tags: 15-ea-27-jdk-slim-buster, 15-ea-27-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-27-jdk-slim, 15-ea-27-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-28-jdk-slim-buster, 15-ea-28-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-28-jdk-slim, 15-ea-28-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -62,24 +62,24 @@ Architectures: amd64
 GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-27-jdk-windowsservercore-1809, 15-ea-27-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-27-jdk-windowsservercore, 15-ea-27-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-28-jdk-windowsservercore-1809, 15-ea-28-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-28-jdk-windowsservercore, 15-ea-28-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-28-jdk, 15-ea-28, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-27-jdk-windowsservercore-ltsc2016, 15-ea-27-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-27-jdk-windowsservercore, 15-ea-27-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-27-jdk, 15-ea-27, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-28-jdk-windowsservercore-ltsc2016, 15-ea-28-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-28-jdk-windowsservercore, 15-ea-28-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-28-jdk, 15-ea-28, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-27-jdk-nanoserver-1809, 15-ea-27-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-27-jdk-nanoserver, 15-ea-27-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-28-jdk-nanoserver-1809, 15-ea-28-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-28-jdk-nanoserver, 15-ea-28-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 1679aaf254c29bae2d2a9755d65b9b4c926343ae
+GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/033c6fe: Update to 15-ea+28
- https://github.com/docker-library/openjdk/commit/c4b1cc3: Update to 16-ea+2