### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev9, 2.2-rc
+Tags: 2.2-dev10, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7cd3bc51a2a05a95db0c5521c1788846018cef77
+GitCommit: b9c5c19567d56723b5138ea7a8b587ba6c9b209b
 Directory: 2.2-rc
 
-Tags: 2.2-dev9-alpine, 2.2-rc-alpine
+Tags: 2.2-dev10-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
+GitCommit: b9c5c19567d56723b5138ea7a8b587ba6c9b209b
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.7, 2.1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b9c5c19: Update to 2.2-dev10