### PR TITLE
upgrade r-base to R 4.0.2 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.0.1, latest
+Tags: 4.0.2, latest
 Architectures: amd64, arm64v8
-GitCommit: dee1c76816be5c370771243bee9a0e594717ed0f
+GitCommit: f814667c5e2bacbc4aa4f1fc35a4307e3d41154a
 Directory: r-base/latest
 


### PR DESCRIPTION
Regular update to new upstream release from this morning 

Also added libopenblas0-pthread (which is the highest priority BLAS/LAPACK package besides the reference blas) giving us multithreaded matrix ops which is nice improvement over the basic reference BLAS/LAPACK. 

(Ah yes, and added a simple softlink reference for another [littler helper script](https://github.com/eddelbuettel/littler/tree/master/inst/examples), this one to install from [BioConductor](http://bioconductor.org/).)