### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/openjdk.git
 Tags: 16-ea-2-jdk-oraclelinux7, 16-ea-2-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-2-jdk-oracle, 16-ea-2-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
 SharedTags: 16-ea-2-jdk, 16-ea-2, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: c4b1cc35eab01bd19ee2c0a460d32c3b9d1c014d
+GitCommit: 8861d32919e87e879cbadcd11a1c8841e9ddfa80
 Directory: 16/jdk/oracle
 
 Tags: 16-ea-2-jdk-buster, 16-ea-2-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
@@ -44,7 +44,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 15-ea-28-jdk-oraclelinux7, 15-ea-28-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-28-jdk-oracle, 15-ea-28-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
 SharedTags: 15-ea-28-jdk, 15-ea-28, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 033c6fea3e9dab1c9f0cf80a2dc5bdafea769ee1
+GitCommit: 8861d32919e87e879cbadcd11a1c8841e9ddfa80
 Directory: 15/jdk/oracle
 
 Tags: 15-ea-28-jdk-buster, 15-ea-28-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
@@ -59,7 +59,7 @@ Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
 Architectures: amd64
-GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
+GitCommit: ba84c1878998602129f0d7d94d26aae5e04bc872
 Directory: 15/jdk/alpine
 
 Tags: 15-ea-28-jdk-windowsservercore-1809, 15-ea-28-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
@@ -86,7 +86,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 14.0.1-jdk-oraclelinux7, 14.0.1-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 14.0.1-jdk-oracle, 14.0.1-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
 SharedTags: 14.0.1-jdk, 14.0.1, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: amd64
-GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
+GitCommit: 8861d32919e87e879cbadcd11a1c8841e9ddfa80
 Directory: 14/jdk/oracle
 
 Tags: 14.0.1-jdk-buster, 14.0.1-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/29ba3b2: Merge pull request https://github.com/docker-library/openjdk/pull/419 from infosiftr/oracle-cacerts
- https://github.com/docker-library/openjdk/commit/8861d32: Symlink Oracle-based "cacerts" to the "update-ca-trust"-maintained "/etc/pki/ca-trust/extracted/java/cacerts" file
- https://github.com/docker-library/openjdk/commit/c0b708f: Merge pull request https://github.com/docker-library/openjdk/pull/418 from infosiftr/alpine-cacerts
- https://github.com/docker-library/openjdk/commit/ba84c18: Add "java-cacerts" to Alpine-based image to maintain "$JAVA_HOME/lib/security/cacerts" for us