### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.26, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f42f9325352afc1625fbf1cc928e1f66bb6cd5c
+GitCommit: acec97e07a54919e006f4fbec3934c44ee4c391b
 Directory: 3.7/ubuntu
 
 Tags: 3.7.26-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.26-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f42f9325352afc1625fbf1cc928e1f66bb6cd5c
+GitCommit: acec97e07a54919e006f4fbec3934c44ee4c391b
 Directory: 3.7/alpine
 
 Tags: 3.7.26-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/acec97e: Update to 3.7.26, Erlang/OTP 22.3.4.2, OpenSSL 1.1.1g