### PR TITLE
Revert "Fix ZNC tags for 1.8.0"

### DIFF
--- a/library/znc
+++ b/library/znc
@@ -1,19 +1,10 @@
 Maintainers: Alexey Sokolov <alexey+znc@asokolov.org> (@DarthGandalf)
 GitRepo: https://github.com/znc/znc-docker.git
+GitCommit: cb2cabf8d63bc992f530b0fb86d0ad9cf955819d
 Architectures: amd64, arm32v6, arm64v8
 
 Tags: 1.8.1, 1.8, latest
-GitCommit: cb2cabf8d63bc992f530b0fb86d0ad9cf955819d
 Directory: full
 
 Tags: 1.8.1-slim, 1.8-slim, slim
-GitCommit: cb2cabf8d63bc992f530b0fb86d0ad9cf955819d
-Directory: slim
-
-Tags: 1.8.0
-GitCommit: 91f58af10b62197187af1f0a9695488e88279e98
-Directory: full
-
-Tags: 1.8.0-slim
-GitCommit: 91f58af10b62197187af1f0a9695488e88279e98
 Directory: slim


### PR DESCRIPTION
Reverts docker-library/official-images#8235

cc @DarthGandalf