### PR TITLE
Release of GeoNetwork v3.10.3

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,18 +1,18 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/e9c89e02c270371fe96848cc0557997cb1e9e9bb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7259ce435432fe1814da0e444328f450b8b6654b/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
 
-Tags: 3.10.2, 3.10, latest
+Tags: 3.10.3, 3.10, latest
 Architectures: amd64
-GitCommit: f81b111fbe3d765ee56f61c5474099764ee07004
-Directory: 3.10.2
+GitCommit: 2c9bc51a681916fba85dd84b0e278c1c608d7d56
+Directory: 3.10.3
 
-Tags: 3.10.2-postgres, 3.10-postgres, postgres
+Tags: 3.10.3-postgres, 3.10-postgres, postgres
 Architectures: amd64
-GitCommit: f81b111fbe3d765ee56f61c5474099764ee07004
-Directory: 3.10.2/postgres
+GitCommit: 2c9bc51a681916fba85dd84b0e278c1c608d7d56
+Directory: 3.10.3/postgres
 
 Tags: 3.8.3, 3.8
 Architectures: amd64


### PR DESCRIPTION
Release of GeoNetwork v3.10.3.
Changelog https://www.geonetwork-opensource.org/manuals/trunk/en/overview/change-log/version-3.10.3.html