### PR TITLE
Stop building "opcache" in "php-ext-install" test

### DIFF
--- a/test/tests/php-ext-install/container.sh
+++ b/test/tests/php-ext-install/container.sh
@@ -5,6 +5,7 @@ docker-php-ext-install pdo_mysql 2>&1
 php -r 'exit(extension_loaded("pdo_mysql") ? 0 : 1);'
 grep -q '^extension=' /usr/local/etc/php/conf.d/*pdo_mysql*.ini
 
-docker-php-ext-install opcache 2>&1
+# opcache is pre-built by default at least as far back as PHP 5.5
+docker-php-ext-enable opcache 2>&1
 php -r 'exit(extension_loaded("Zend OPcache") ? 0 : 1);'
 grep -q '^zend_extension=' /usr/local/etc/php/conf.d/*opcache*.ini


### PR DESCRIPTION
In my testing, `/usr/local/lib/php/extensions/*/opcache.so` already exists as far back as `php:5.5`...  So we don't need to build it.

Also, it fails to build here (for some reason) on PHP 8.0 with ZTS enabled, but the pre-built version works fine and is available (https://github.com/docker-library/php/pull/1028; https://travis-ci.org/github/docker-library/php/jobs/702119532).