### PR TITLE
[ros] add rolling distribution images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -193,3 +193,25 @@ Architectures: amd64, arm64v8
 GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
+
+################################################################################
+# Release: rolling
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: rolling-ros-core, rolling-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros-core
+
+Tags: rolling-ros-base, rolling-ros-base-focal, rolling
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros-base
+
+Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros1-bridge
+


### PR DESCRIPTION
ROS(2) has now a rolling / unstable distribution.
Relevant links:
- Definition of the rolling release https://www.ros.org/reps/rep-2002.html
- Announcement https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley-2020-06-23/15019
- dockerfiles creation PR: https://github.com/osrf/docker_images/pull/422 
