### PR TITLE
caddy: some Dockerfile updates

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -7,7 +7,7 @@ Tags: 2.1.0-beta.1-alpine
 SharedTags: 2.1.0-beta.1
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.1/alpine
-GitCommit: 6355eb99a01d12c55a7e043129bda9cb90da81d6
+GitCommit: 4d9226a81a17ff7da5b3976550f9c2e0b8d61aad
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.1.0-beta.1-builder
@@ -36,7 +36,7 @@ Tags: 2.0.0-alpine, 2-alpine, alpine
 SharedTags: 2.0.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.0/alpine
-GitCommit: 6355eb99a01d12c55a7e043129bda9cb90da81d6
+GitCommit: 4d9226a81a17ff7da5b3976550f9c2e0b8d61aad
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.0.0-builder, 2-builder, builder


### PR DESCRIPTION
A couple updates to the Dockerfile:
- Adding an `/etc/nsswitch.conf` file (https://github.com/caddyserver/caddy-docker/pull/96)
- Setting `WORKDIR` to `/srv` (https://github.com/caddyserver/caddy-docker/pull/97)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>