### PR TITLE
Re-releasing Neo4j 4.1.0 docker image

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -11,12 +11,12 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 
 Tags: 4.1.0, 4.1, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0c0b08572dbaa55b28f2f7daddb410dd0a9e6a9e
+GitCommit: c22866bb7f4baac356bf65494a003e490082b6c0
 Directory: 4.1.0/community
 
 Tags: 4.1.0-enterprise, 4.1-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 0c0b08572dbaa55b28f2f7daddb410dd0a9e6a9e
+GitCommit: c22866bb7f4baac356bf65494a003e490082b6c0
 Directory: 4.1.0/enterprise
 
 Tags: 4.0.6, 4.0


### PR DESCRIPTION
fixed Neo4j 4.1.0 docker bug where NEO4J_AUTH=none was not being honoured.
It is severe enough that I need to re-release the neo4j:4.1.0 image, if that's ok? 