### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/9ee913eea382b5d79f852a2301d4390904d2e4d2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/cc4ec5941e2b5dddda488c507b636ac68ce54100/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.4.2-php7.2-apache, 5.4-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.4.2-php7.2, 5.4-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.2/apache
 
 Tags: 5.4.2-php7.2-fpm, 5.4-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.2/fpm
 
 Tags: 5.4.2-php7.2-fpm-alpine, 5.4-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.2/fpm-alpine
 
-Tags: 5.4.2-apache, 5.4-apache, 5-apache, apache, 5.4.2, 5.4, 5, latest, 5.4.2-php7.3-apache, 5.4-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.4.2-php7.3, 5.4-php7.3, 5-php7.3, php7.3
+Tags: 5.4.2-php7.3-apache, 5.4-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.4.2-php7.3, 5.4-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.3/apache
 
-Tags: 5.4.2-fpm, 5.4-fpm, 5-fpm, fpm, 5.4.2-php7.3-fpm, 5.4-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.4.2-php7.3-fpm, 5.4-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.3/fpm
 
-Tags: 5.4.2-fpm-alpine, 5.4-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.4.2-php7.3-fpm-alpine, 5.4-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.4.2-php7.3-fpm-alpine, 5.4-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.3/fpm-alpine
 
-Tags: 5.4.2-php7.4-apache, 5.4-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.4.2-php7.4, 5.4-php7.4, 5-php7.4, php7.4
+Tags: 5.4.2-apache, 5.4-apache, 5-apache, apache, 5.4.2, 5.4, 5, latest, 5.4.2-php7.4-apache, 5.4-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.4.2-php7.4, 5.4-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.4/apache
 
-Tags: 5.4.2-php7.4-fpm, 5.4-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.4.2-fpm, 5.4-fpm, 5-fpm, fpm, 5.4.2-php7.4-fpm, 5.4-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.4/fpm
 
-Tags: 5.4.2-php7.4-fpm-alpine, 5.4-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.4.2-fpm-alpine, 5.4-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.4.2-php7.4-fpm-alpine, 5.4-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5a0d85b98e13b8784611eb039d7427ff39e06034
+GitCommit: def14e3e6e6a376dcfb856f9eb542e3e399457af
 Directory: php7.4/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
@@ -56,12 +56,12 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
 Directory: php7.2/cli
 
-Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
 Directory: php7.3/cli
 
-Tags: cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
+Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
 Directory: php7.4/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/6e29f5a: Merge pull request https://github.com/docker-library/wordpress/pull/510 from infosiftr/php7.4
- https://github.com/docker-library/wordpress/commit/68c8c47: Merge pull request https://github.com/docker-library/wordpress/pull/511 from infosiftr/opcache
- https://github.com/docker-library/wordpress/commit/def14e3: Stop building "opcache" (it's already pre-built in the "php" images)
- https://github.com/docker-library/wordpress/commit/cc4ec59: Update default PHP version to 7.4