### PR TITLE
Bump IBM Java version to 1.8.0_sr6fp11 (8.0.6.11).

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,30 +5,30 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/jre/alpine
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sfj-alpine, sfj-alpine
 Architectures: amd64
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/sfj/alpine
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/sdk/ubuntu
 
 Tags: 8-sdk-alpine, sdk-alpine
 Architectures: amd64
-GitCommit: a2149c3634333f2917f917153253db7397a2b4cf
+GitCommit: b06e2b03d895881261fcfe40d2c983e5e338d777
 Directory: ibmjava/8/sdk/alpine


### PR DESCRIPTION
Bump IBM Java version to 1.8.0_sr6fp11 (8.0.6.11).