### PR TITLE
add trickster

### DIFF
--- a/library/trickster
+++ b/library/trickster
@@ -1,0 +1,8 @@
+Maintainers: James Ranson <james@ranson.org> (@jranson),
+             Christopher Randles <randles.chris@gmail.com> (@crandles)
+GitRepo: https://github.com/tricksterproxy/trickster-docker-images.git
+
+Tags: 1.1.2, 1.1, 1, latest
+GitFetch: refs/heads/v1.1.x
+GitCommit: 1693bafcc2d33362d8d2483df093eca62f71cfa8
+Directory: alpine


### PR DESCRIPTION
The Trickster team at Comcast is very pleased to submit Trickster to the Docker Official Images library. Trickster is used and contributed to by users all around the globe at places like Adobe, DigitalOcean, InfluxDB, Hostinger, GitLab and beyond.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - I am the creator and primary maintainer of Trickster
-	[x] does it fit into one of the common categories? ("**service**", "language stack", "base distribution")
    - Trickster is an HTTP proxy service that fronts prometheus, influxdb, a static website, etc.
-	[x] is it reasonably popular, or does it solve a particular use case well?
    - Trickster has just crossed 900K downloads on Docker Hub (and accelerating) in under 2 years of availability, and is widely used throughout the technology industry. Also, we bought some stickers on sticker mule.
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1755
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)