### PR TITLE
Odoo: update 11.0-13.0 to release 20200629

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f116a674ca62595d0fbf1ded206ec2e4d962ebf0
+GitCommit: b4c45baf1f0579c654129ac9efe99a929569dab6
 
 Tags: 13.0, 13, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest releases of the supported versions of Odoo.

Thanks.