### PR TITLE
Add Presto image

### DIFF
--- a/library/presto
+++ b/library/presto
@@ -1,0 +1,6 @@
+Maintainers: Martin Traverso <mtraverso@gmail.com> (@martint)
+GitRepo: https://github.com/prestosql/presto-docker.git
+
+Tags: latest, 337
+Architectures: amd64
+GitCommit: a4f211d8582fb8b550cea154cf6c487cb3fa5cbd

--- a/test/tests/presto/run.sh
+++ b/test/tests/presto/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+CONTAINER_ID=
+
+function cleanup {
+    if [[ ! -z ${CONTAINER_ID:-} ]]; then
+        docker stop "${CONTAINER_ID}"
+    fi
+}
+
+function test_container {
+    local QUERY_PERIOD=5
+    local QUERY_RETRIES=30
+
+    trap cleanup EXIT
+
+    local CONTAINER_NAME=$1
+    CONTAINER_ID=$(docker run -d --rm "${CONTAINER_NAME}")
+
+    set +e
+    I=0
+    until RESULT=$(docker exec "${CONTAINER_ID}" presto --execute "SELECT 'success'"); do
+        if [[ $((I++)) -ge ${QUERY_RETRIES} ]]; then
+            echo "Too many retries waiting for Presto to start."
+            break
+        fi
+        sleep ${QUERY_PERIOD}
+    done
+    set -e
+
+    # Return proper exit code.
+    [[ ${RESULT} == '"success"' ]]
+}
+
+test_container $1


### PR DESCRIPTION
This adds an image for Presto, a distributed SQL engine for big data (https://prestosql.io)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/prestosql
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-	[x] is it reasonably popular, or does it solve a particular use case well?
    - over 1.5k stars on GitHub
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1759
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)