### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.2-dev11, 2.2-rc
+Tags: 2.2-dev12, 2.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 61e383040c3c2f3aa48eacdb4037a343aa116106
+GitCommit: 423c687b7fd5229abd2d030f4de5a89c27f1270b
 Directory: 2.2-rc
 
-Tags: 2.2-dev11-alpine, 2.2-rc-alpine
+Tags: 2.2-dev12-alpine, 2.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 61e383040c3c2f3aa48eacdb4037a343aa116106
+GitCommit: 423c687b7fd5229abd2d030f4de5a89c27f1270b
 Directory: 2.2-rc/alpine
 
 Tags: 2.1.7, 2.1, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/423c687: Update to 2.2-dev12