### PR TITLE
Update to Flink 1.11.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,25 +1,25 @@
-# this file is generated via https://github.com/apache/flink-docker/blob/dfe8ffece905785268d1d237b173d47d82ff20e6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/apache/flink-docker/blob/9dd55f459eedaf137eea6f0f825f24935d92c19e/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.9.3-scala_2.11, 1.9-scala_2.11
-Architectures: amd64
-GitCommit: 379970e8d2a9e138d1291d83b47e7ea643421b3a
-Directory: 1.9/scala_2.11-debian
-
-Tags: 1.9.3-scala_2.12, 1.9-scala_2.12, 1.9.3, 1.9
-Architectures: amd64
-GitCommit: 379970e8d2a9e138d1291d83b47e7ea643421b3a
-Directory: 1.9/scala_2.12-debian
-
-Tags: 1.10.1-scala_2.11, 1.10-scala_2.11, scala_2.11
+Tags: 1.10.1-scala_2.11, 1.10-scala_2.11
 Architectures: amd64
 GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
 Directory: 1.10/scala_2.11-debian
 
-Tags: 1.10.1-scala_2.12, 1.10-scala_2.12, scala_2.12, 1.10.1, 1.10, latest
+Tags: 1.10.1-scala_2.12, 1.10-scala_2.12, 1.10.1, 1.10
 Architectures: amd64
 GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
 Directory: 1.10/scala_2.12-debian
+
+Tags: 1.11.0-scala_2.11, 1.11-scala_2.11, scala_2.11
+Architectures: amd64
+GitCommit: 949e445006c4fc288813900c264847d23d3e33d4
+Directory: 1.11/scala_2.11-debian
+
+Tags: 1.11.0-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.0, 1.11, latest
+Architectures: amd64
+GitCommit: 949e445006c4fc288813900c264847d23d3e33d4
+Directory: 1.11/scala_2.12-debian


### PR DESCRIPTION
Update to include the latest 1.11.0 release. The Dockerfiles have already been added into flink-docker repo through [this PR.](https://github.com/apache/flink-docker/pull/27)