### PR TITLE
Update to latest clojure commit

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: b4522de15e3f6ad151ce68194d9501c707df9c3c
+GitCommit: 949f75ad0f004c1da917b01414018f54b89feaf1
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: cb156811c43485f43d0d1199b33bcac93044b887
+GitCommit: b4522de15e3f6ad151ce68194d9501c707df9c3c
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest


### PR DESCRIPTION
Fixes an issue where certain desired-at-runtime packages weren't
installed in buster image variants (e.g. `make` for tools-deps).