### PR TITLE
Bump Traefik to v2.2.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -11,19 +11,3 @@ Tags: v2.2.2, 2.2.2, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 296caddf8ba97b52841872b2192758af9e9d7775
 Directory: alpine
-
-Tags: v1.7.24-windowsservercore-1809, 1.7.24-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
-Architectures: windows-amd64
-GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v1.7.24-alpine, 1.7.24-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
-Directory: alpine
-
-Tags: v1.7.24, 1.7.24, v1.7, 1.7, maroilles
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 7b90db1b9b495c897bb92a8d3de4f98957fd460d
-Directory: scratch

--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.1-windowsservercore-1809, 2.2.1-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.2-windowsservercore-1809, 2.2.2-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 4aa0b86550fec343ad25e330624c887ad48e5e08
+GitCommit: 8176c4d46628c0ef312283f6695f3df2c1e6bf36
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.1, 2.2.1, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.2, 2.2.2, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 4aa0b86550fec343ad25e330624c887ad48e5e08
+GitCommit: 8176c4d46628c0ef312283f6695f3df2c1e6bf36
 Directory: alpine
 
 Tags: v1.7.24-windowsservercore-1809, 1.7.24-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -3,13 +3,13 @@ GitRepo: https://github.com/containous/traefik-library-image.git
 
 Tags: v2.2.2-windowsservercore-1809, 2.2.2-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 8176c4d46628c0ef312283f6695f3df2c1e6bf36
+GitCommit: 296caddf8ba97b52841872b2192758af9e9d7775
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.2.2, 2.2.2, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 8176c4d46628c0ef312283f6695f3df2c1e6bf36
+GitCommit: 296caddf8ba97b52841872b2192758af9e9d7775
 Directory: alpine
 
 Tags: v1.7.24-windowsservercore-1809, 1.7.24-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.2](https://github.com/containous/traefik/releases/tag/v2.2.2).

/cc @ldez @mmatur @SantoDE

Cheers
