### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.22.1, 3.22, 3, latest
+Tags: 3.22.2, 3.22, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6f37d79247ca28f20b3aa4fe2da8f1ba7d527737
+GitCommit: e2945d9aea564dd990f75819ec51601ee487c042
 Directory: 3/debian
 
-Tags: 3.22.1-alpine, 3.22-alpine, 3-alpine, alpine
+Tags: 3.22.2-alpine, 3.22-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f37d79247ca28f20b3aa4fe2da8f1ba7d527737
+GitCommit: e2945d9aea564dd990f75819ec51601ee487c042
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/e2945d9: Update to 3.22.2, ghost-cli 1.14.1