### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,6 +4,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
+Tags: 2.3-dev0, 2.3-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
+Directory: 2.3-rc
+
+Tags: 2.3-dev0-alpine, 2.3-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
+Directory: 2.3-rc/alpine
+
 Tags: 2.2.0, 2.2, latest, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b9e54c2c29daa41f5045c7e95c887abe1933ea03


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/978bc5d: Merge pull request https://github.com/docker-library/haproxy/pull/121 from tao12345666333/add-2.3-rc
- https://github.com/docker-library/haproxy/commit/abcf89e: add 2.3-dev0