### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.22.2, 3.22, 3, latest
+Tags: 3.24.0, 3.24, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e2945d9aea564dd990f75819ec51601ee487c042
+GitCommit: 418b2875039d0d8f583388727bd303db7f851aeb
 Directory: 3/debian
 
-Tags: 3.22.2-alpine, 3.22-alpine, 3-alpine, alpine
+Tags: 3.24.0-alpine, 3.24-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e2945d9aea564dd990f75819ec51601ee487c042
+GitCommit: 418b2875039d0d8f583388727bd303db7f851aeb
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- docker-library/ghost@418b287: Update to 3.24.0, ghost-cli 1.14.1
- docker-library/ghost@ee9d5d1: Update to 3.23.1, ghost-cli 1.14.1
- docker-library/ghost@20d024b: Update to 3.23.0, ghost-cli 1.14.1