### PR TITLE
Bump Traefik to v2.2.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.2-windowsservercore-1809, 2.2.2-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.3-windowsservercore-1809, 2.2.3-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 296caddf8ba97b52841872b2192758af9e9d7775
+GitCommit: afd07131364252ecf9c43a202f9f5151b0cb0bb9
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.2, 2.2.2, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.3, 2.2.3, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 296caddf8ba97b52841872b2192758af9e9d7775
+GitCommit: afd07131364252ecf9c43a202f9f5151b0cb0bb9
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.3](https://github.com/containous/traefik/releases/tag/v2.2.3).

/cc @ldez @mmatur @SantoDE

Cheers
