### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,57 +4,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-4-jdk-oraclelinux7, 16-ea-4-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-4-jdk-oracle, 16-ea-4-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-4-jdk, 16-ea-4, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-5-jdk-oraclelinux7, 16-ea-5-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-5-jdk-oracle, 16-ea-5-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk/oracle
 
-Tags: 16-ea-4-jdk-buster, 16-ea-4-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-5-jdk-buster, 16-ea-5-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk
 
-Tags: 16-ea-4-jdk-slim-buster, 16-ea-4-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-4-jdk-slim, 16-ea-4-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-5-jdk-slim-buster, 16-ea-5-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-5-jdk-slim, 16-ea-5-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk/slim
 
-Tags: 16-ea-4-jdk-windowsservercore-1809, 16-ea-4-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-4-jdk-windowsservercore, 16-ea-4-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-4-jdk, 16-ea-4, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-5-jdk-windowsservercore-1809, 16-ea-5-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-5-jdk-windowsservercore, 16-ea-5-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-4-jdk-windowsservercore-ltsc2016, 16-ea-4-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-4-jdk-windowsservercore, 16-ea-4-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-4-jdk, 16-ea-4, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-5-jdk-windowsservercore-ltsc2016, 16-ea-5-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-5-jdk-windowsservercore, 16-ea-5-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-4-jdk-nanoserver-1809, 16-ea-4-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-4-jdk-nanoserver, 16-ea-4-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-5-jdk-nanoserver-1809, 16-ea-5-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-5-jdk-nanoserver, 16-ea-5-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 9cbe01ae20c38e4569d4c16f7c1b18368096db66
+GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-ea-30-jdk-oraclelinux7, 15-ea-30-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-30-jdk-oracle, 15-ea-30-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-30-jdk, 15-ea-30, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-31-jdk-oraclelinux7, 15-ea-31-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-31-jdk-oracle, 15-ea-31-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/oracle
 
-Tags: 15-ea-30-jdk-buster, 15-ea-30-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-31-jdk-buster, 15-ea-31-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk
 
-Tags: 15-ea-30-jdk-slim-buster, 15-ea-30-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-30-jdk-slim, 15-ea-30-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-31-jdk-slim-buster, 15-ea-31-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-31-jdk-slim, 15-ea-31-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -62,24 +62,24 @@ Architectures: amd64
 GitCommit: ba84c1878998602129f0d7d94d26aae5e04bc872
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-30-jdk-windowsservercore-1809, 15-ea-30-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-30-jdk-windowsservercore, 15-ea-30-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-30-jdk, 15-ea-30, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-31-jdk-windowsservercore-1809, 15-ea-31-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-31-jdk-windowsservercore, 15-ea-31-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-30-jdk-windowsservercore-ltsc2016, 15-ea-30-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-30-jdk-windowsservercore, 15-ea-30-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-30-jdk, 15-ea-30, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-31-jdk-windowsservercore-ltsc2016, 15-ea-31-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-31-jdk-windowsservercore, 15-ea-31-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-30-jdk-nanoserver-1809, 15-ea-30-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-30-jdk-nanoserver, 15-ea-30-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-31-jdk-nanoserver-1809, 15-ea-31-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-31-jdk-nanoserver, 15-ea-31-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 04d949a7f8f1ae5a6bd3a5b9f7534329d4f326ab
+GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9ddd374: Update to 15-ea+31
- https://github.com/docker-library/openjdk/commit/c3a5b6c: Update to 16-ea+5