### PR TITLE
bump kong to 2.1.0-rc.1

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,21 +2,21 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 2.1.0-beta.1-alpine, 2.1-alpine, 2.1.0-beta.1, 2.1
-GitCommit: d89a2a8f20ce55d537d20aa97a10203fd5bf3039
+Tags: 2.1.0-rc.1-alpine, 2.1-alpine, 2.1.0-beta.1, 2.1
+GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
 GitFetch: refs/tags/2.1.0-beta.1
 Directory: alpine
 Architectures: amd64
 
-Tags: 2.1.0-beta.1-ubuntu, 2.1-ubuntu
-GitCommit: d89a2a8f20ce55d537d20aa97a10203fd5bf3039
-GitFetch: refs/tags/2.1.0-beta.1
+Tags: 2.1.0-rc.1-ubuntu, 2.1-ubuntu
+GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
+GitFetch: refs/tags/2.1.0-rc.1
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 2.1.0-beta.1-centos, 2.1-centos
-GitCommit: d89a2a8f20ce55d537d20aa97a10203fd5bf3039
-GitFetch: refs/tags/2.1.0-beta.1
+Tags: 2.1.0-rc.1-centos, 2.1-centos
+GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
+GitFetch: refs/tags/2.1.0-rc.1
 Directory: centos
 Architectures: amd64
 


### PR DESCRIPTION
sorry for the flurry of commits (2.0.5 immediately followed by 2.1.0-rc.1)

Going forward we need the `zlib-dev` packages because https://github.com/hamishforbes/lua-ffi-zlib/blob/master/lib/ffi-zlib.lua#L98 tries to load the zlib.so via the symlink that's only included in the `-dev` packages.