### PR TITLE
caddy: update builder image

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -13,7 +13,7 @@ Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 Tags: 2.1.1-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.1/builder
-GitCommit: 324fa6bd5b5e7fa3fcbcc5c69f17443fbd1eeebf
+GitCommit: 465c686ce698896381a2ebe69ca704260f21ca7b
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.1.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Update for fix in https://github.com/caddyserver/caddy-docker/pull/102

Signed-off-by: Dave Henderson <dhenderson@gmail.com>