### PR TITLE
add ppc64le to Architectures, support sudo in container

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -3,7 +3,7 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
 GitRepo: https://github.com/rocker-org/rocker.git
 
 Tags: 4.0.2, latest
-Architectures: amd64, arm64v8
-GitCommit: f814667c5e2bacbc4aa4f1fc35a4307e3d41154a
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 206d35749495c5309183bfabaea90091eaff5cf4
 Directory: r-base/latest
 


### PR DESCRIPTION
This addresses https://github.com/rocker-org/rocker/issues/409 requesting ppc64le support by adding, and updates the Dockerfile by one commit adding `sudo` support which is useful if one launches container with `-u 1000:1000` as I now do more often :)