### PR TITLE
Bump Traefik to v2.2.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.4-windowsservercore-1809, 2.2.4-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.5-windowsservercore-1809, 2.2.5-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: f3987516ba5bf9051d7ea16dfffed4af58cfb765
+GitCommit: 82775bf63eca8bb6772905fcfc363e4ba786b8da
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.4, 2.2.4, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.5, 2.2.5, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: f3987516ba5bf9051d7ea16dfffed4af58cfb765
+GitCommit: 82775bf63eca8bb6772905fcfc363e4ba786b8da
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.5](https://github.com/containous/traefik/releases/tag/v2.2.5).

/cc @mmatur @SantoDE

Cheers
