### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.27-rc.1, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 817847dd5566c5d0526d7b654f19c45c91f3289d
+GitCommit: 647bd8139147c087a6de4d9e35cf2c1407dc6b42
 Directory: 3.7-rc/ubuntu
 
 Tags: 3.7.27-rc.1-management, 3.7-rc-management
@@ -36,7 +36,7 @@ Directory: 3.7-rc/ubuntu/management
 
 Tags: 3.7.27-rc.1-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 817847dd5566c5d0526d7b654f19c45c91f3289d
+GitCommit: 647bd8139147c087a6de4d9e35cf2c1407dc6b42
 Directory: 3.7-rc/alpine
 
 Tags: 3.7.27-rc.1-management-alpine, 3.7-rc-management-alpine
@@ -46,7 +46,7 @@ Directory: 3.7-rc/alpine/management
 
 Tags: 3.7.26, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5cccf2aa061d8855259d7a05ad8774ee04c4a6f
+GitCommit: 89f09be17193eb13f520166333ba299a971051ad
 Directory: 3.7/ubuntu
 
 Tags: 3.7.26-management, 3.7-management
@@ -56,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.26-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f8112ffb99b813a1b46bcfc704c02e1b8821773
+GitCommit: 89f09be17193eb13f520166333ba299a971051ad
 Directory: 3.7/alpine
 
 Tags: 3.7.26-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/89f09be: Update to 3.7.26, Erlang/OTP 22.3.4.3, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/647bd81: Update to 3.7.27-rc.1, Erlang/OTP 22.3.4.3, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/e5da520: Remove now-unnecessary python2/python3 switching code