### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/b9e54c2c29daa41f5045c7e95c887abe1933ea03/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/92f0ecae850d2cd8cdc89f2655f1339182e47a1b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev0, 2.3-rc
+Tags: 2.3-dev0, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
 Directory: 2.3-rc
 
-Tags: 2.3-dev0-alpine, 2.3-rc-alpine
+Tags: 2.3-dev0-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
 Directory: 2.3-rc/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/319d41e: Merge pull request https://github.com/docker-library/haproxy/pull/123 from infosiftr/dev-alias
- https://github.com/docker-library/haproxy/commit/92f0eca: Replace "2.3-rc" alias with "2.3-dev"