### PR TITLE
kong: adjust the 2.0.5 and 2.1.0-rc.1 entrypoints to allow empty values as a default

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -2,38 +2,38 @@ Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
 GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
-Tags: 2.1.0-rc.1-alpine, 2.1-alpine, 2.1.0-beta.1, 2.1
-GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
-GitFetch: refs/tags/2.1.0-beta.1
+Tags: 2.1.0-rc.1-alpine, 2.1-alpine, 2.1.0-rc.1, 2.1
+GitCommit: 5b5169dff2834cc867f3156950c4e52eb0c907b2
+GitFetch: refs/tags/2.1.0-rc.1
 Directory: alpine
 Architectures: amd64
 
 Tags: 2.1.0-rc.1-ubuntu, 2.1-ubuntu
-GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
+GitCommit: 5b5169dff2834cc867f3156950c4e52eb0c907b2
 GitFetch: refs/tags/2.1.0-rc.1
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 2.1.0-rc.1-centos, 2.1-centos
-GitCommit: 82d0514a2850b03252bbe3847532ee3edca197c0
+GitCommit: 5b5169dff2834cc867f3156950c4e52eb0c907b2
 GitFetch: refs/tags/2.1.0-rc.1
 Directory: centos
 Architectures: amd64
 
 Tags: 2.0.5-alpine, 2.0.5, 2.0, 2, latest, alpine
-GitCommit: d908daa2aec80281076198f2114cf121e96fc1a6
+GitCommit: 60626098f2f32fe1528eb4ffacff13fd1c3e919f
 GitFetch: refs/tags/2.0.5
 Directory: alpine
 Architectures: amd64
 
 Tags: 2.0.5-ubuntu, 2.0-ubuntu, ubuntu
-GitCommit: d908daa2aec80281076198f2114cf121e96fc1a6
+GitCommit: 60626098f2f32fe1528eb4ffacff13fd1c3e919f
 GitFetch: refs/tags/2.0.5
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 2.0.5-centos, 2.0-centos, centos
-GitCommit: d908daa2aec80281076198f2114cf121e96fc1a6
+GitCommit: 60626098f2f32fe1528eb4ffacff13fd1c3e919f
 GitFetch: refs/tags/2.0.5
 Directory: centos
 Architectures: amd64


### PR DESCRIPTION
fixes https://github.com/Kong/docker-kong/issues/379
fixes https://github.com/Kong/kong/issues/6106

also fixed two spots where we missed `s/beta/rc` in a previous update