### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -83,40 +83,40 @@ GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14.0.1-jdk-oraclelinux7, 14.0.1-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 14.0.1-jdk-oracle, 14.0.1-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
-SharedTags: 14.0.1-jdk, 14.0.1, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
+SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: amd64
-GitCommit: 8861d32919e87e879cbadcd11a1c8841e9ddfa80
+GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
 Directory: 14/jdk/oracle
 
-Tags: 14.0.1-jdk-buster, 14.0.1-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
+Tags: 14.0.2-jdk-buster, 14.0.2-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
 Architectures: amd64
-GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
+GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
 Directory: 14/jdk
 
-Tags: 14.0.1-jdk-slim-buster, 14.0.1-slim-buster, 14.0-jdk-slim-buster, 14.0-slim-buster, 14-jdk-slim-buster, 14-slim-buster, jdk-slim-buster, slim-buster, 14.0.1-jdk-slim, 14.0.1-slim, 14.0-jdk-slim, 14.0-slim, 14-jdk-slim, 14-slim, jdk-slim, slim
+Tags: 14.0.2-jdk-slim-buster, 14.0.2-slim-buster, 14.0-jdk-slim-buster, 14.0-slim-buster, 14-jdk-slim-buster, 14-slim-buster, jdk-slim-buster, slim-buster, 14.0.2-jdk-slim, 14.0.2-slim, 14.0-jdk-slim, 14.0-slim, 14-jdk-slim, 14-slim, jdk-slim, slim
 Architectures: amd64
-GitCommit: 1e3425cc20e6a3bf052e2fe6c7f6a18054c92570
+GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
 Directory: 14/jdk/slim
 
-Tags: 14.0.1-jdk-windowsservercore-1809, 14.0.1-windowsservercore-1809, 14.0-jdk-windowsservercore-1809, 14.0-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 14.0.1-jdk-windowsservercore, 14.0.1-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.1-jdk, 14.0.1, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-windowsservercore-1809, 14.0.2-windowsservercore-1809, 14.0-jdk-windowsservercore-1809, 14.0-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: windows-amd64
-GitCommit: cd0e316abc515747ef6c9edc8a40914b50163ad2
+GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14.0.1-jdk-windowsservercore-ltsc2016, 14.0.1-windowsservercore-ltsc2016, 14.0-jdk-windowsservercore-ltsc2016, 14.0-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 14.0.1-jdk-windowsservercore, 14.0.1-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.1-jdk, 14.0.1, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-windowsservercore-ltsc2016, 14.0.2-windowsservercore-ltsc2016, 14.0-jdk-windowsservercore-ltsc2016, 14.0-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: windows-amd64
-GitCommit: cd0e316abc515747ef6c9edc8a40914b50163ad2
+GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.1-jdk-nanoserver-1809, 14.0.1-nanoserver-1809, 14.0-jdk-nanoserver-1809, 14.0-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 14.0.1-jdk-nanoserver, 14.0.1-nanoserver, 14.0-jdk-nanoserver, 14.0-nanoserver, 14-jdk-nanoserver, 14-nanoserver, jdk-nanoserver, nanoserver
+Tags: 14.0.2-jdk-nanoserver-1809, 14.0.2-nanoserver-1809, 14.0-jdk-nanoserver-1809, 14.0-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 14.0.2-jdk-nanoserver, 14.0.2-nanoserver, 14.0-jdk-nanoserver, 14.0-nanoserver, 14-jdk-nanoserver, 14-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: cd0e316abc515747ef6c9edc8a40914b50163ad2
+GitCommit: ff0e8fce865700e3632272a3acc70ed3a1a2065c
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/29c17de: Update to 14.0.2
- https://github.com/docker-library/openjdk/commit/ff0e8fc: Update to 14.0.2