### PR TITLE
Update Amazon Corretto (8.262.10.1 and 11.0.8.10.1).

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -1,15 +1,15 @@
 Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              James Guo <junguoj@amazon.com> (@jguo11),
              Ziyi Luo <ziyiluo@amazon.com> (@ziyiluo),
-             David Alvarez <alvdavi@amazon.com> (@alvdavi)
+             Clive Verghese <verghese@amazon.com> (@cliveverghese)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/master
-GitCommit: 619edf4eceed8bc4392509cfb29a4cdaac4787d8
+GitCommit: 62ad57b8dec957bae1f29975a567cd67cd841d2a
 
-Tags: 8, 8u252, 8u252-al2, 8-al2-full,8-al2-jdk, latest
+Tags: 8, 8u262, 8u262-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 11, 11.0.7, 11.0.7-al2, 11-al2-jdk, 11-al2-full
+Tags: 11, 11.0.8, 11.0.8-al2, 11-al2-jdk, 11-al2-full
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2


### PR DESCRIPTION
This updates the Amazon Corretto image to use the 8u262 PSU patch baseline of OpenJDK8 and 11.0.8 of OpenJDK11.

Here's a quick link to the Dockerfile:

Amazon Corretto 11:
- [11/jdk/al2](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/11/jdk/al2/Dockerfile)
- [11/jdk/alpine](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/11/jdk/alpine/Dockerfile)
- [11/jre/alpine](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/11/jre/alpine/Dockerfile)

Amazon Corretto 8:
- [8/jdk/al2](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/8/jdk/al2/Dockerfile)
- [8/jdk/alpine](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/8/jdk/alpine/Dockerfile)
- [8/jre/alpine](https://github.com/corretto/corretto-docker/blob/62ad57b8dec957bae1f29975a567cd67cd841d2a/8/jre/alpine/Dockerfile)

We also replace @alvdavi with @cliveverghese as maintainer.