### PR TITLE
Bump Traefik to v2.3.0-rc2 and v1.7.25

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -11,3 +11,30 @@ Tags: v2.2.5, 2.2.5, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 82775bf63eca8bb6772905fcfc363e4ba786b8da
 Directory: alpine
+
+Tags: v2.3.0-rc2-windowsservercore-1809, 2.3.0-rc2-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Architectures: windows-amd64
+GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.3.0-rc2, 2.3.0-rc2, v2.3, 2.3, picodon
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
+Directory: alpine
+
+Tags: v1.7.25-windowsservercore-1809, 1.7.25-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Architectures: windows-amd64
+GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v1.7.25-alpine, 1.7.25-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+Directory: alpine
+
+Tags: v1.7.25, 1.7.25, v1.7, 1.7, maroilles
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to:
-  [v2.3.0-rc2](https://github.com/containous/traefik/releases/tag/v2.3.0-rc2)
-  [v1.7.25](https://github.com/containous/traefik/releases/tag/v1.7.25)

/cc @mmatur @juliens @SantoDE @jbdoumenjou

Cheers
