### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,57 +4,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-5-jdk-oraclelinux7, 16-ea-5-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-5-jdk-oracle, 16-ea-5-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-6-jdk-oraclelinux7, 16-ea-6-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-6-jdk-oracle, 16-ea-6-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-6-jdk, 16-ea-6, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/oracle
 
-Tags: 16-ea-5-jdk-buster, 16-ea-5-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-6-jdk-buster, 16-ea-6-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk
 
-Tags: 16-ea-5-jdk-slim-buster, 16-ea-5-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-5-jdk-slim, 16-ea-5-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-6-jdk-slim-buster, 16-ea-6-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-6-jdk-slim, 16-ea-6-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/slim
 
-Tags: 16-ea-5-jdk-windowsservercore-1809, 16-ea-5-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-5-jdk-windowsservercore, 16-ea-5-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-6-jdk-windowsservercore-1809, 16-ea-6-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-6-jdk-windowsservercore, 16-ea-6-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-6-jdk, 16-ea-6, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-5-jdk-windowsservercore-ltsc2016, 16-ea-5-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-5-jdk-windowsservercore, 16-ea-5-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-5-jdk, 16-ea-5, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-6-jdk-windowsservercore-ltsc2016, 16-ea-6-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-6-jdk-windowsservercore, 16-ea-6-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-6-jdk, 16-ea-6, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-5-jdk-nanoserver-1809, 16-ea-5-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-5-jdk-nanoserver, 16-ea-5-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-6-jdk-nanoserver-1809, 16-ea-6-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-6-jdk-nanoserver, 16-ea-6-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: c3a5b6c4dc910f6f27cb95df86614d2cc99642f8
+GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-ea-31-jdk-oraclelinux7, 15-ea-31-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-31-jdk-oracle, 15-ea-31-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-32-jdk-oraclelinux7, 15-ea-32-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-32-jdk-oracle, 15-ea-32-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-32-jdk, 15-ea-32, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/oracle
 
-Tags: 15-ea-31-jdk-buster, 15-ea-31-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-32-jdk-buster, 15-ea-32-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk
 
-Tags: 15-ea-31-jdk-slim-buster, 15-ea-31-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-31-jdk-slim, 15-ea-31-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-32-jdk-slim-buster, 15-ea-32-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-32-jdk-slim, 15-ea-32-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/slim
 
 Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -62,24 +62,24 @@ Architectures: amd64
 GitCommit: ba84c1878998602129f0d7d94d26aae5e04bc872
 Directory: 15/jdk/alpine
 
-Tags: 15-ea-31-jdk-windowsservercore-1809, 15-ea-31-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-31-jdk-windowsservercore, 15-ea-31-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-32-jdk-windowsservercore-1809, 15-ea-32-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-32-jdk-windowsservercore, 15-ea-32-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-32-jdk, 15-ea-32, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-31-jdk-windowsservercore-ltsc2016, 15-ea-31-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-31-jdk-windowsservercore, 15-ea-31-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-31-jdk, 15-ea-31, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-32-jdk-windowsservercore-ltsc2016, 15-ea-32-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-32-jdk-windowsservercore, 15-ea-32-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-32-jdk, 15-ea-32, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-31-jdk-nanoserver-1809, 15-ea-31-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-31-jdk-nanoserver, 15-ea-31-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-32-jdk-nanoserver-1809, 15-ea-32-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-32-jdk-nanoserver, 15-ea-32-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 9ddd374c137ed44828edada4921ba7cbefbef279
+GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -120,130 +120,130 @@ GitCommit: ff0e8fce865700e3632272a3acc70ed3a1a2065c
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.7-jdk-buster, 11.0.7-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
-SharedTags: 11.0.7-jdk, 11.0.7, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.8-jdk-buster, 11.0.8-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+SharedTags: 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jdk
 
-Tags: 11.0.7-jdk-slim-buster, 11.0.7-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.7-jdk-slim, 11.0.7-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.8-jdk-slim-buster, 11.0.8-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.8-jdk-slim, 11.0.8-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jdk/slim
 
-Tags: 11.0.7-jdk-windowsservercore-1809, 11.0.7-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.7-jdk-windowsservercore, 11.0.7-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.7-jdk, 11.0.7, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.8-jdk-windowsservercore-1809, 11.0.8-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.8-jdk-windowsservercore, 11.0.8-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.7-jdk-windowsservercore-ltsc2016, 11.0.7-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.7-jdk-windowsservercore, 11.0.7-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.7-jdk, 11.0.7, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.8-jdk-windowsservercore-ltsc2016, 11.0.8-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.8-jdk-windowsservercore, 11.0.8-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7-jdk-nanoserver-1809, 11.0.7-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.7-jdk-nanoserver, 11.0.7-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.8-jdk-nanoserver-1809, 11.0.8-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.8-jdk-nanoserver, 11.0.8-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.7-jre-buster, 11.0-jre-buster, 11-jre-buster
-SharedTags: 11.0.7-jre, 11.0-jre, 11-jre
+Tags: 11.0.8-jre-buster, 11.0-jre-buster, 11-jre-buster
+SharedTags: 11.0.8-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jre
 
-Tags: 11.0.7-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.7-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.8-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.8-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jre/slim
 
-Tags: 11.0.7-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.7-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.7-jre, 11.0-jre, 11-jre
+Tags: 11.0.8-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.8-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.8-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.7-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.7-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.7-jre, 11.0-jre, 11-jre
+Tags: 11.0.8-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.8-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.8-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: bce2fa373dc270cccf539a8e31b5f2a432d23738
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.7-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.7-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.8-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.8-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
+GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u252-jdk-buster, 8u252-buster, 8-jdk-buster, 8-buster
-SharedTags: 8u252-jdk, 8u252, 8-jdk, 8
+Tags: 8u262-jdk-buster, 8u262-buster, 8-jdk-buster, 8-buster
+SharedTags: 8u262-jdk, 8u262, 8-jdk, 8
 Architectures: amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jdk
 
-Tags: 8u252-jdk-slim-buster, 8u252-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u252-jdk-slim, 8u252-slim, 8-jdk-slim, 8-slim
+Tags: 8u262-jdk-slim-buster, 8u262-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u262-jdk-slim, 8u262-slim, 8-jdk-slim, 8-slim
 Architectures: amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jdk/slim
 
-Tags: 8u252-jdk-windowsservercore-1809, 8u252-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u252-jdk-windowsservercore, 8u252-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u252-jdk, 8u252, 8-jdk, 8
+Tags: 8u262-jdk-windowsservercore-1809, 8u262-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u262-jdk-windowsservercore, 8u262-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u262-jdk, 8u262, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u252-jdk-windowsservercore-ltsc2016, 8u252-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u252-jdk-windowsservercore, 8u252-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u252-jdk, 8u252, 8-jdk, 8
+Tags: 8u262-jdk-windowsservercore-ltsc2016, 8u262-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u262-jdk-windowsservercore, 8u262-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u262-jdk, 8u262, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-jdk-nanoserver-1809, 8u252-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u252-jdk-nanoserver, 8u252-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u262-jdk-nanoserver-1809, 8u262-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u262-jdk-nanoserver, 8u262-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u252-jre-buster, 8-jre-buster
-SharedTags: 8u252-jre, 8-jre
+Tags: 8u262-jre-buster, 8-jre-buster
+SharedTags: 8u262-jre, 8-jre
 Architectures: amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jre
 
-Tags: 8u252-jre-slim-buster, 8-jre-slim-buster, 8u252-jre-slim, 8-jre-slim
+Tags: 8u262-jre-slim-buster, 8-jre-slim-buster, 8u262-jre-slim, 8-jre-slim
 Architectures: amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jre/slim
 
-Tags: 8u252-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u252-jre-windowsservercore, 8-jre-windowsservercore, 8u252-jre, 8-jre
+Tags: 8u262-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u262-jre-windowsservercore, 8-jre-windowsservercore, 8u262-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u252-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u252-jre-windowsservercore, 8-jre-windowsservercore, 8u252-jre, 8-jre
+Tags: 8u262-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
+SharedTags: 8u262-jre-windowsservercore, 8-jre-windowsservercore, 8u262-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: e24f1c142d0a2fa1852b5ea899b691483fc72a02
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u252-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u252-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u262-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u262-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 3f6ab87ebe4bdea4470d0ff1e26f61dadd646c64
+GitCommit: b5d14d9165fad693901c285d6e7bbc36d1cde41f
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- docker-library/openjdk@7483400: Update to 15-ea+32
- docker-library/openjdk@b5d14d9: Update to 8u262
- docker-library/openjdk@f28e00f: Update to 16-ea+6
- docker-library/openjdk@601cc5f: Update to 11.0.8
