### PR TITLE
Updating Oracle Linux 7 images for CVE-2020-12049

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 882cefa4aa450fca21f8d2697ced7765c8339b58
+amd64-GitCommit: 068e333948652d97671e031cb56b0bc092790b6d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: afa99b65b64f62421b3c91179e409b621af9a374

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 616b148f9d90a9b7c8470d666e3f605ef49bc0d2
+amd64-GitCommit: 882cefa4aa450fca21f8d2697ced7765c8339b58
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 75360219db2abea36f9ca353d6e60940f51f4e0e
+arm64v8-GitCommit: afa99b65b64f62421b3c91179e409b621af9a374
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
* Updated `dbus-1.10.24-14.0.1.el7_8` for CVE-2020-12049
* <https://oss.oracle.com/pipermail/el-errata/2020-July/010117.html>

We're also simplifying tarball names and things.

Signed-off-by: Avi Miller <avi.miller@oracle.com>