### PR TITLE
chmod groovy home so other users can use volume

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -1,6 +1,6 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/groovy/docker-groovy.git
-GitCommit: 6301e19926a4668ac470e4ce9b850e4b9380bfc3
+GitCommit: d4782a5dc5d4a5b0e6546e548b1b97efa9e3bd2b
 
 Tags: 3.0.4-jdk8, 3.0-jdk8, 3.0.4-jdk, 3.0-jdk, jdk8, jdk
 Architectures: amd64, ppc64le, s390x


### PR DESCRIPTION
A user [reported](https://github.com/groovy/docker-groovy/issues/61) an issue where they needed to run as a particular user in a Jenkins environment, for accessing (and potentially writing to) a mounted volume.  In such a case, there is no home for that user in the container for grapes to be written to.  This chmods the groovy home directory so they can specify that directory/volume as the home to use.