### PR TITLE
Bump Traefik to v2.2.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,17 +1,6 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.2.5-windowsservercore-1809, 2.2.5-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitCommit: 82775bf63eca8bb6772905fcfc363e4ba786b8da
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.2.5, 2.2.5, v2.2, 2.2, chevrotin, latest
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 82775bf63eca8bb6772905fcfc363e4ba786b8da
-Directory: alpine
-
 Tags: v2.3.0-rc2-windowsservercore-1809, 2.3.0-rc2-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
 Architectures: windows-amd64
 GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
@@ -21,6 +10,17 @@ Constraints: windowsservercore-1809
 Tags: v2.3.0-rc2, 2.3.0-rc2, v2.3, 2.3, picodon
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
+Directory: alpine
+
+Tags: v2.2.6-windowsservercore-1809, 2.2.6-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Architectures: windows-amd64
+GitCommit: 4aae6578b672bd24965fa48245543ad0dbd05494
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.2.6, 2.2.6, v2.2, 2.2, chevrotin, latest
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 4aae6578b672bd24965fa48245543ad0dbd05494
 Directory: alpine
 
 Tags: v1.7.25-windowsservercore-1809, 1.7.25-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.6](https://github.com/containous/traefik/releases/tag/v2.2.6).

/cc @mmatur @SantoDE @juliens

Cheers
