### PR TITLE
arangodb 3.6.5

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,10 +2,10 @@
 # maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
 # maintainer: Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
 
-3.4: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
-3.4.10: https://github.com/arangodb/arangodb-docker@63dc866beb0546ba3b172e76f64759abfe1a0a28 alpine/3.4.10
-3.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
-3.5.5: https://github.com/arangodb/arangodb-docker@8690d4d6c3f3f0aaea34af72455a2c78a5669149 alpine/3.5.5.1
-3.6: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4
-3.6.4: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4
-latest: https://github.com/arangodb/arangodb-docker@fd0bd633cbbb5ddf96366e5e0e8d48356a450fef alpine/3.6.4
+3.4: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.4.10
+3.4.10: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.4.10
+3.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.5.5.1
+3.5.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.5.5.1
+3.6: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5
+3.6.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5
+latest: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.5 and fix foxx-cli version to 1.3.0 in 3.4.10 and 3.5.5.

Didn't put #7962 (comment) workaround yet (planned for the next version only) so npm ERR! lifecycle could not get uid/gid can happen.