### PR TITLE
Bump Traefik to v2.2.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
 Directory: alpine
 
-Tags: v2.2.6-windowsservercore-1809, 2.2.6-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.7-windowsservercore-1809, 2.2.7-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 4aae6578b672bd24965fa48245543ad0dbd05494
+GitCommit: 7a86a2ad2473d95a31ac9cda52bc5d540916c233
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.6, 2.2.6, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.7, 2.2.7, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 4aae6578b672bd24965fa48245543ad0dbd05494
+GitCommit: 7a86a2ad2473d95a31ac9cda52bc5d540916c233
 Directory: alpine
 
 Tags: v1.7.25-windowsservercore-1809, 1.7.25-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.7](https://github.com/containous/traefik/releases/tag/v2.2.7).

/cc @ldez @mmatur @juliens

Cheers
