### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.5, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9effc7f5dce28daa1024aeb3746580ec9e6ece92
+GitCommit: 6c780661c0d9fe667a8a6f5c9edc2a267aa38c85
 Directory: 3.8/ubuntu
 
 Tags: 3.8.5-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.5-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f8112ffb99b813a1b46bcfc704c02e1b8821773
+GitCommit: 6c780661c0d9fe667a8a6f5c9edc2a267aa38c85
 Directory: 3.8/alpine
 
 Tags: 3.8.5-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/6c78066: Update to 3.8.5, Erlang/OTP 23.0.3, OpenSSL 1.1.1g