### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -20,6 +20,11 @@ Architectures: amd64, arm64v8
 GitCommit: f28e00f31f9b3e60a60d70a138af3528a89f9f40
 Directory: 16/jdk/slim
 
+Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
+Architectures: amd64
+GitCommit: 9efa5c2bd28c10d07e70ceac416187a011dd6184
+Directory: 16/jdk/alpine
+
 Tags: 16-ea-6-jdk-windowsservercore-1809, 16-ea-6-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16-ea-6-jdk-windowsservercore, 16-ea-6-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-6-jdk, 16-ea-6, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
@@ -57,9 +62,9 @@ Architectures: amd64, arm64v8
 GitCommit: 748340041f02cdc9956b7653b6144224a97bf71d
 Directory: 15/jdk/slim
 
-Tags: 15-ea-10-jdk-alpine3.11, 15-ea-10-alpine3.11, 15-ea-jdk-alpine3.11, 15-ea-alpine3.11, 15-jdk-alpine3.11, 15-alpine3.11, 15-ea-10-jdk-alpine, 15-ea-10-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
+Tags: 15-ea-31-jdk-alpine3.12, 15-ea-31-alpine3.12, 15-ea-jdk-alpine3.12, 15-ea-alpine3.12, 15-jdk-alpine3.12, 15-alpine3.12, 15-ea-31-jdk-alpine, 15-ea-31-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
 Architectures: amd64
-GitCommit: ba84c1878998602129f0d7d94d26aae5e04bc872
+GitCommit: 9efa5c2bd28c10d07e70ceac416187a011dd6184
 Directory: 15/jdk/alpine
 
 Tags: 15-ea-32-jdk-windowsservercore-1809, 15-ea-32-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/68069ca: Merge pull request https://github.com/docker-library/openjdk/pull/423 from infosiftr/alpine3.12
- https://github.com/docker-library/openjdk/commit/9efa5c2: Update Alpine to 3.12
- https://github.com/docker-library/openjdk/commit/e3021b3: Update to 15-ea+31
- https://github.com/docker-library/openjdk/commit/e9243a2: Update to 16-ea+5