### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev0, 2.3-dev
+Tags: 2.3-dev1, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
+GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
 Directory: 2.3-rc
 
-Tags: 2.3-dev0-alpine, 2.3-dev-alpine
+Tags: 2.3-dev1-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: abcf89e58d99e59c1ce7c456ae5c218cdcc35052
+GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
 Directory: 2.3-rc/alpine
 
 Tags: 2.2.0, 2.2, latest, lts
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
 Directory: 2.1/alpine
 
-Tags: 2.0.15, 2.0
+Tags: 2.0.16, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f85b33d7a5fd97fd7852fe18d602009ab093289c
+GitCommit: c4081598aacb56651940e84a04c8e03c403aec3c
 Directory: 2.0
 
-Tags: 2.0.15-alpine, 2.0-alpine
+Tags: 2.0.16-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
+GitCommit: c4081598aacb56651940e84a04c8e03c403aec3c
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9081978: Merge pull request https://github.com/docker-library/haproxy/pull/126 from infosiftr/2.0.16
- https://github.com/docker-library/haproxy/commit/c408159: Update to 2.0.16
- https://github.com/docker-library/haproxy/commit/6e4facd: Update to 2.3-dev1