### PR TITLE
Updating oraclelinux:8 and oraclelinux:8-slim images 

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 736cce885590774639fef26fd6043933113d8737
+amd64-GitCommit: 5e224363b816d4a6cb0ef47c3e93e4b4f7b0982d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 937a079f044028555a0690e06797ca1e4ecd2680
+arm64v8-GitCommit: fcd00cad22bfe5ab3628c3ecc6ec6c9c97f372bc
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This change is purely structural. The underlying tarball names have been made less ambiguous and documentation is retained within the generated image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>