### PR TITLE
Update to Flink 1.11.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -14,12 +14,12 @@ Architectures: amd64
 GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
 Directory: 1.10/scala_2.12-debian
 
-Tags: 1.11.0-scala_2.11, 1.11-scala_2.11, scala_2.11
+Tags: 1.11.1-scala_2.11, 1.11-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 949e445006c4fc288813900c264847d23d3e33d4
+GitCommit: 253b8844a4bd96762ab14410624db4d7f3cc5f51
 Directory: 1.11/scala_2.11-debian
 
-Tags: 1.11.0-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.0, 1.11, latest
+Tags: 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1, 1.11, latest
 Architectures: amd64
-GitCommit: 949e445006c4fc288813900c264847d23d3e33d4
+GitCommit: 253b8844a4bd96762ab14410624db4d7f3cc5f51
 Directory: 1.11/scala_2.12-debian


### PR DESCRIPTION
Update to include the latest 1.11.1 release. The Dockerfiles have already been added into flink-docker repo.