### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0.5, 6.0, 6, latest, 6.0.5-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.6, 6.0, 6, latest, 6.0.6-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3a0b4f1d370e4efd30a0db32b0e0cf878f3133d3
+GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
 Directory: 6.0
 
-Tags: 6.0.5-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.5-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
+Tags: 6.0.6-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.6-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a0b4f1d370e4efd30a0db32b0e0cf878f3133d3
+GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster
@@ -26,5 +26,5 @@ Directory: 5.0/32bit
 
 Tags: 5.0.9-alpine, 5.0-alpine, 5-alpine, 5.0.9-alpine3.12, 5.0-alpine3.12, 5-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6496e4885b8b43e375adaf230354d4076858c8a
+GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
 Directory: 5.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/312e4a1: Merge pull request https://github.com/docker-library/redis/pull/253 from infosiftr/6.0.6
- https://github.com/docker-library/redis/commit/bfd904a: Update to 6.0.6