### PR TITLE
Telegraf 1.15.1

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -3,14 +3,7 @@ Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Steven Soroka <ssoroka@influxdata.com> (@ssoroka)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 4453ec8e090467ded8987168c8bbf85f3d65418d
-
-Tags: 1.12, 1.12.6
-Architectures: amd64, arm32v7, arm64v8
-Directory: telegraf/1.12
-
-Tags: 1.12-alpine, 1.12.6-alpine
-Directory: telegraf/1.12/alpine
+GitCommit: a61952ec7aabd497848df4f82dd0161be76ccdea
 
 Tags: 1.13, 1.13.4
 Architectures: amd64, arm32v7, arm64v8
@@ -19,9 +12,16 @@ Directory: telegraf/1.13
 Tags: 1.13-alpine, 1.13.4-alpine
 Directory: telegraf/1.13/alpine
 
-Tags: 1.14, 1.14.5, latest
+Tags: 1.14, 1.14.5
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.14
 
-Tags: 1.14-alpine, 1.14.5-alpine, alpine
+Tags: 1.14-alpine, 1.14.5-alpine
 Directory: telegraf/1.14/alpine
+
+Tags: 1.15, 1.15.1, latest
+Architectures: amd64, arm32v7, arm64v8
+Directory: telegraf/1.15
+
+Tags: 1.15-alpine, 1.15.1-alpine, alpine
+Directory: telegraf/1.15/alpine


### PR DESCRIPTION
Bump Telegraf revision.

1.15.0 images are now based on Debian Buster and Alpine 3.12, previously Stretch and 3.9.