### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.26.0, 3.26, 3, latest
+Tags: 3.26.1, 3.26, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 92d7984a23e95d25270f6151cc129cd79f18051c
+GitCommit: 1790f346dcb1f944f197e04f4d3c911a80d56cd1
 Directory: 3/debian
 
-Tags: 3.26.0-alpine, 3.26-alpine, 3-alpine, alpine
+Tags: 3.26.1-alpine, 3.26-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92d7984a23e95d25270f6151cc129cd79f18051c
+GitCommit: 1790f346dcb1f944f197e04f4d3c911a80d56cd1
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1790f34: Update to 3.26.1, ghost-cli 1.14.1