### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.27-rc.1, 3.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 647bd8139147c087a6de4d9e35cf2c1407dc6b42
+GitCommit: f7a967c34a3f5670869cbcbee153d4d6298f6c2f
 Directory: 3.7-rc/ubuntu
 
 Tags: 3.7.27-rc.1-management, 3.7-rc-management
@@ -36,7 +36,7 @@ Directory: 3.7-rc/ubuntu/management
 
 Tags: 3.7.27-rc.1-alpine, 3.7-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 647bd8139147c087a6de4d9e35cf2c1407dc6b42
+GitCommit: f7a967c34a3f5670869cbcbee153d4d6298f6c2f
 Directory: 3.7-rc/alpine
 
 Tags: 3.7.27-rc.1-management-alpine, 3.7-rc-management-alpine
@@ -46,7 +46,7 @@ Directory: 3.7-rc/alpine/management
 
 Tags: 3.7.26, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89f09be17193eb13f520166333ba299a971051ad
+GitCommit: c58a834b652cb3d60a0f75cf757eb5662a3bcdc1
 Directory: 3.7/ubuntu
 
 Tags: 3.7.26-management, 3.7-management
@@ -56,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.26-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89f09be17193eb13f520166333ba299a971051ad
+GitCommit: c58a834b652cb3d60a0f75cf757eb5662a3bcdc1
 Directory: 3.7/alpine
 
 Tags: 3.7.26-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/c58a834: Update to 3.7.26, Erlang/OTP 22.3.4.4, OpenSSL 1.1.1g
- https://github.com/docker-library/rabbitmq/commit/f7a967c: Update to 3.7.27-rc.1, Erlang/OTP 22.3.4.4, OpenSSL 1.1.1g