### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -65,17 +65,17 @@ GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
 Directory: debian/sid
 
 Tags: stretch-curl, oldstable-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
 Directory: debian/stretch/curl
 
 Tags: stretch-scm, oldstable-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
 Directory: debian/stretch/scm
 
 Tags: stretch, oldstable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
 Directory: debian/stretch
 
@@ -93,21 +93,6 @@ Tags: bionic, 18.04
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
 Directory: ubuntu/bionic
-
-Tags: eoan-curl, 19.10-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
-Directory: ubuntu/eoan/curl
-
-Tags: eoan-scm, 19.10-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
-Directory: ubuntu/eoan/scm
-
-Tags: eoan, 19.10
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f84f6184d79f2cb7ab94c365ac4f47915e7ca2a8
-Directory: ubuntu/eoan
 
 Tags: focal-curl, 20.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/3229203: Remove Ubuntu Eoan (EOL)