### PR TITLE
Friendica Debian Buster Upgrade

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -4,30 +4,30 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2020.07-apache, apache, stable-apache, 2020.07, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.07/apache
 
 Tags: 2020.07-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.07/fpm
 
 Tags: 2020.07-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.07/fpm-alpine
 
 Tags: 2020.09-dev-apache, dev-apache, 2020.09-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.09-dev/apache
 
 Tags: 2020.09-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.09-dev/fpm
 
 Tags: 2020.09-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e38177e2e53641655d78f7bbdedf134c5645198
+GitCommit: 51a6dcc6fcf3fc1aa57c60477428646272778016
 Directory: 2020.09-dev/fpm-alpine


### PR DESCRIPTION
- Switch from SSMTP to MSMTP
- Switch from mysql-client to mariadb-client

Based on the suggestion from @yosifkit at https://github.com/docker-library/official-images/pull/8341#issuecomment-658308684