### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
 Directory: 2.3-rc/alpine
 
-Tags: 2.2.0, 2.2, latest, lts
+Tags: 2.2.1, 2.2, latest, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9e54c2c29daa41f5045c7e95c887abe1933ea03
+GitCommit: 8d69936c2bac1e20c720738761f85987f93b9a73
 Directory: 2.2
 
-Tags: 2.2.0-alpine, 2.2-alpine, alpine, lts-alpine
+Tags: 2.2.1-alpine, 2.2-alpine, alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9e54c2c29daa41f5045c7e95c887abe1933ea03
+GitCommit: 8d69936c2bac1e20c720738761f85987f93b9a73
 Directory: 2.2/alpine
 
 Tags: 2.1.7, 2.1
@@ -41,7 +41,7 @@ Directory: 2.0
 
 Tags: 2.0.16-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4081598aacb56651940e84a04c8e03c403aec3c
+GitCommit: 461dcbfa8538c9ab47d41b96f3c8d1835166382e
 Directory: 2.0/alpine
 
 Tags: 1.9.15, 1.9, 1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8d69936: Update to 2.2.1
- https://github.com/docker-library/haproxy/commit/4375313: Merge pull request https://github.com/docker-library/haproxy/pull/128 from infosiftr/apply-canonical-backported-patch
- https://github.com/docker-library/haproxy/commit/461dcbf: Apply the canonical backported ebtree patch from upstream