### PR TITLE
Update rocket.chat to use debian:buster-slim

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -4,10 +4,10 @@ Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
 Tags: 3.4.2, 3.4, 3, latest
-GitCommit: 35b45c11348b35a2c60222e68cbfecaf386d31a7
+GitCommit: e40e10215ede26cb53eb2cbeaccea526703381f4
 Directory: 3
 
 Tags: 2.4.12, 2.4, 2
-GitCommit: 9cc942405ca293ef01474e2c13a40894ee313851
+GitCommit: e40e10215ede26cb53eb2cbeaccea526703381f4
 Directory: 2
 


### PR DESCRIPTION
Changes: https://github.com/RocketChat/Docker.Official.Image/commit/e40e10215ede26cb53eb2cbeaccea526703381f4