### PR TITLE
Updating Oracle Linux 8 images for updated systemd and libdnf packages.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5e224363b816d4a6cb0ef47c3e93e4b4f7b0982d
+amd64-GitCommit: 01f8016e70f354062085a7f3fc156e071ea84943
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fcd00cad22bfe5ab3628c3ecc6ec6c9c97f372bc
+arm64v8-GitCommit: c7be2aedfddb50438c203f5ac2201f8853204f8c
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update `oraclelinux:8` and `oraclelinux:8-slim` for both `amd64` and `arm64v8`:

* `iptables`: https://oss.oracle.com/pipermail/el-errata/2020-July/010144.html
* `libdnf`: https://oss.oracle.com/pipermail/el-errata/2020-July/010146.html
* `systemd`: https://oss.oracle.com/pipermail/el-errata/2020-July/010149.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>