### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.8.0
+Tags: 7.8.1
 Architectures: amd64, arm64v8
-GitCommit: 551cff2cb19d99d2c76a8717d7d3007bb23c3a7a
+GitCommit: 5f77876bff63a699806e21e7ce3b23f264caf86e
 Directory: 7
 
-Tags: 6.8.10
+Tags: 6.8.11
 Architectures: amd64
-GitCommit: 551cff2cb19d99d2c76a8717d7d3007bb23c3a7a
+GitCommit: a307d268b244992f796b73ea51d9e25db0f8acb1
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.8.0
-GitCommit: d7dff7c685a19c7fb47b28ea41d5174792c3447b
+Tags: 7.8.1
+GitCommit: b922235278db729dd1e865c4df02637fd589c541
 Directory: 7
 
-Tags: 6.8.10
-GitCommit: 96976f5b4fabedc3fdf052ecdab323d2a08337e9
+Tags: 6.8.11
+GitCommit: 6721854df0e23db4bc4ca6ce2d8efa33738ad934
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.8.0
-GitCommit: f9a68426beb578052b01cccd0ecfd87614cb9b9e
+Tags: 7.8.1
+GitCommit: ea72914ddda62638a5afac3d3729d36143e1d4d1
 Directory: 7
 
-Tags: 6.8.10
-GitCommit: 4a45fc4bc7159024f8bbe33a0801b6ca8a643c4f
+Tags: 6.8.11
+GitCommit: 2a03356e097a604c50ade39ec5b07c15b6ed07b8
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/5f77876: Update to 7.8.1
- https://github.com/docker-library/elasticsearch/commit/a307d26: Update to 6.8.11

logstash:
- https://github.com/docker-library/logstash/commit/ea72914: Update to 7.8.1
- https://github.com/docker-library/logstash/commit/2a03356: Update to 6.8.11

kibana:
- https://github.com/docker-library/kibana/commit/b922235: Update to 7.8.1
- https://github.com/docker-library/kibana/commit/6721854: Update to 6.8.11