### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,42 +24,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/alpine/management
 
-Tags: 3.7.27-rc.1, 3.7-rc
+Tags: 3.7.27, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7a967c34a3f5670869cbcbee153d4d6298f6c2f
-Directory: 3.7-rc/ubuntu
-
-Tags: 3.7.27-rc.1-management, 3.7-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 817847dd5566c5d0526d7b654f19c45c91f3289d
-Directory: 3.7-rc/ubuntu/management
-
-Tags: 3.7.27-rc.1-alpine, 3.7-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7a967c34a3f5670869cbcbee153d4d6298f6c2f
-Directory: 3.7-rc/alpine
-
-Tags: 3.7.27-rc.1-management-alpine, 3.7-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 817847dd5566c5d0526d7b654f19c45c91f3289d
-Directory: 3.7-rc/alpine/management
-
-Tags: 3.7.26, 3.7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c58a834b652cb3d60a0f75cf757eb5662a3bcdc1
+GitCommit: b7ee0459ee49bd9d13f93782fa766f6d9970534f
 Directory: 3.7/ubuntu
 
-Tags: 3.7.26-management, 3.7-management
+Tags: 3.7.27-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bf2c73df6ee8475ac30c9773a8128852450ea518
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.26-alpine, 3.7-alpine
+Tags: 3.7.27-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c58a834b652cb3d60a0f75cf757eb5662a3bcdc1
+GitCommit: b7ee0459ee49bd9d13f93782fa766f6d9970534f
 Directory: 3.7/alpine
 
-Tags: 3.7.26-management-alpine, 3.7-management-alpine
+Tags: 3.7.27-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bf2c73df6ee8475ac30c9773a8128852450ea518
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/b7ee045: Update to 3.7.27, Erlang/OTP 22.3.4.4, OpenSSL 1.1.1g