### PR TITLE
Update Cassandra to 3.11.7

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -19,7 +19,7 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
 Directory: 3.0
 
-Tags: 3.11.6, 3.11, 3, latest
+Tags: 3.11.7, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
+GitCommit: 038fd5c0738b5543b2ad2052ceee4f18d7170cae
 Directory: 3.11


### PR DESCRIPTION
This notably does *not* include 2.2.17, thanks to https://github.com/apache/cassandra/commit/257fb0377343cbfdb58327da17f31d4eaed940f5#r40944000:

> ```diff
> -    public String[] data_file_directories;
> +    public String[] data_file_directories = new String[0];
> ```
> 
> This change breaks the comparison over in `DatabaseDescriptor.java`:
> 
> https://github.com/apache/cassandra/blob/cd006d275aa9b6e937c6ebd036d4d27c4ed18dbe/src/java/org/apache/cassandra/config/DatabaseDescriptor.java#L564-L570
> 
> Should this be changed back to `null`, or should that comparison be changed to look for `length == 0`?
> 
> Concretely, this is causing an exception on startup in 2.2.17 (which worked fine in 2.2.16) in https://github.com/apache/cassandra/blob/cd006d275aa9b6e937c6ebd036d4d27c4ed18dbe/src/java/org/apache/cassandra/config/DatabaseDescriptor.java#L826-L827 when using `-Dcassandra.storagedir=` due to the value of that property not being read properly.