### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/240a61a7cc82740c081d188b1f0faaa7d09b743e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/407a404a9aeb737ebba1d1e5420d9bae6319ccdf/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 240a61a7cc82740c081d188b1f0faaa7d09b743e
+GitCommit: 407a404a9aeb737ebba1d1e5420d9bae6319ccdf
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b9114f2de4e3859437d13318e5865091c803e50d
+amd64-GitCommit: 5f68e74ab5e43dfae266b6b02172d62108f0f85a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 40a7ed321950b905a475449d204f9297772465ca
+arm32v5-GitCommit: f377e3a13325b9f3de85868c955a222261de2044
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 9e1c50d1a3c6535eed3f3df0584712d56b32abc2
+arm32v6-GitCommit: 6bc27a9c2549745a781c10f153961be11772564a
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: d104160a3bf754c120ad47b85a51ae8a2ab62fbc
+arm32v7-GitCommit: 7be698bce4526b3a8f6c9e3288cfeaa884786576
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 01e1a7c8e631b87489b52b2177da58610315190f
+arm64v8-GitCommit: 2a108bdd465cab558edc9721448e31a0ccad4158
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 5b32017d68ebfbf7d6adc8567f75cad40821c279
+i386-GitCommit: 3b7b68f84ff42076e4cb683e9dec3d3863e98a85
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 59e7f618bdb583a86e3fcb59d2439f0ec6a9cf42
+mips64le-GitCommit: cd029cb21e5a7dc92d0853fd2d009a1225254695
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: fdeeefb303e572b1b26fd66313cf903f9a01ba9f
+ppc64le-GitCommit: 1fa95bed9df3a5700b9c7d0a43142425c0b06938
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: fa2da95aeda9fa72cea24494986f5d7c6abdc3a9
+s390x-GitCommit: 094f9a1d85289b730f19f5e516125b181ed5f7d2
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/407a404: Update Buildroot to 2020.05.1