### PR TITLE
Upgrade SonarQube 7.9 LTS

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,9 +4,9 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: fea13bf2bcabb72685f411c3e4bc4f18af789b20
+GitCommit: 1953a7cbde123be10152258c4d4dbcfbaf7c2679
 
-Tags: 7.9.3-community, 7.9-community, lts
+Tags: 7.9.4-community, 7.9-community, lts
 Directory: 7/community
 
 Tags: 8.4.1-community, 8.4-community, 8-community, community, latest


### PR DESCRIPTION
This is a bug fix release for SonarQube 7.9 LTS.