### PR TITLE
Bump rocket.chat to 3.5.0

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -3,8 +3,8 @@
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 3.4.2, 3.4, 3, latest
-GitCommit: e40e10215ede26cb53eb2cbeaccea526703381f4
+Tags: 3.5.0, 3.5, 3, latest
+GitCommit: 30f953b96b3d728df606e8a3e231f23e9bc94f48
 Directory: 3
 
 Tags: 2.4.12, 2.4, 2


### PR DESCRIPTION
Changes: https://github.com/RocketChat/Docker.Official.Image/commit/30f953b96b3d728df606e8a3e231f23e9bc94f48