### PR TITLE
Bump Traefik to v1.7.26 and v2.2.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
 Directory: alpine
 
-Tags: v2.2.7-windowsservercore-1809, 2.2.7-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.8-windowsservercore-1809, 2.2.8-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 7a86a2ad2473d95a31ac9cda52bc5d540916c233
+GitCommit: 3a918cb6253b82d01d5423266875617aeda0f1bc
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.7, 2.2.7, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.8, 2.2.8, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 7a86a2ad2473d95a31ac9cda52bc5d540916c233
+GitCommit: 3a918cb6253b82d01d5423266875617aeda0f1bc
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.3.0-rc2-windowsservercore-1809, 2.3.0-rc2-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-rc3-windowsservercore-1809, 2.3.0-rc3-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
+GitCommit: 06e008a7576a80d08e21c8592bfdca03b9707e09
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc2, 2.3.0-rc2, v2.3, 2.3, picodon
+Tags: v2.3.0-rc3, 2.3.0-rc3, v2.3, 2.3, picodon
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 5efcbc047ba54b98034add180d446af2ec7d885a
+GitCommit: 06e008a7576a80d08e21c8592bfdca03b9707e09
 Directory: alpine
 
 Tags: v2.2.8-windowsservercore-1809, 2.2.8-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -23,18 +23,18 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 7a86a2ad2473d95a31ac9cda52bc5d540916c233
 Directory: alpine
 
-Tags: v1.7.25-windowsservercore-1809, 1.7.25-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.25-alpine, 1.7.25-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.26-alpine, 1.7.26-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: alpine
 
-Tags: v1.7.25, 1.7.25, v1.7, 1.7, maroilles
+Tags: v1.7.26, 1.7.26, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 9ac00ce5eb8e85bc017d521eb9a57a5a9cd6298f
+GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v1.7.26](https://github.com/containous/traefik/releases/tag/v1.7.26) and  [v2.2.8](https://github.com/containous/traefik/releases/tag/v2.2.8).

/cc @ldez @mmatur @juliens

Cheers
