### PR TITLE
Update Amazon Corretto (8.265.01.1)

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -4,9 +4,9 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Clive Verghese <verghese@amazon.com> (@cliveverghese)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/master
-GitCommit: 62ad57b8dec957bae1f29975a567cd67cd841d2a
+GitCommit: fa556a8d84f2d2f39b1925b15f4fb7ebd3e6e4ed
 
-Tags: 8, 8u262, 8u262-al2, 8-al2-full,8-al2-jdk, latest
+Tags: 8, 8u265, 8u265-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 


### PR DESCRIPTION
This updates Amazon Corretto Image to use 8u265 of OpenJDK8. 

Dockerfiles updated. 

* [8/jdk/al2](https://github.com/corretto/corretto-docker/blob/fa556a8d84f2d2f39b1925b15f4fb7ebd3e6e4ed/8/jdk/al2/Dockerfile)