### PR TITLE
Request to add archivebox to official images

### DIFF
--- a/library/archivebox
+++ b/library/archivebox
@@ -1,0 +1,8 @@
+Maintainers: Nick Sweeting <archivebox-docker@sweeting.me> (@pirate)
+GitRepo: https://github.com/pirate/ArchiveBox.git
+GitCommit: c1f21880f36f4d8df5b62dd1413a8a1b2ea6d4cb
+
+Tags: 0.4.9, 0.4, latest
+Architectures: amd64
+amd64-GitFetch: refs/heads/master
+amd64-GitCommit: c1f21880f36f4d8df5b62dd1413a8a1b2ea6d4cb

--- a/library/archivebox
+++ b/library/archivebox
@@ -1,8 +1,8 @@
 Maintainers: Nick Sweeting <archivebox-docker@sweeting.me> (@pirate)
 GitRepo: https://github.com/pirate/ArchiveBox.git
-GitCommit: c1f21880f36f4d8df5b62dd1413a8a1b2ea6d4cb
+GitCommit: cd09d1b077695ea36c8d7514c2ebda8f15fbcc35
 
-Tags: 0.4.9, 0.4, latest
+Tags: 0.4.13, 0.4, latest
 Architectures: amd64
 amd64-GitFetch: refs/heads/master
-amd64-GitCommit: c1f21880f36f4d8df5b62dd1413a8a1b2ea6d4cb
+amd64-GitCommit: cd09d1b077695ea36c8d7514c2ebda8f15fbcc35


### PR DESCRIPTION
Hi! This is my first attempt at submitting an official image for ArchiveBox (sorry if I got anything wrong), ~~we've had many of our users request one since they're thrown off by my personal username being `nikisweeting`, and aren't sure what image they can trust out of the several options available.~~ (it's since been moved to https://hub.docker.com/r/archivebox/archivebox, but would still love to have it be an official image for brevity and security :grin:)

The project has about ~7.5k stars with 60+ contributors and 500K+ Docker hub pulls, I don't know if that's big enough to qualify or if there are additional steps needed. So far I've added the commit hashes for our latest release, 0.4.13 to the file in this PR. Here is the image in its current form if you'd like to vet it for quality:
- https://hub.docker.com/layers/archivebox/archivebox
- https://github.com/ArchiveBox/ArchiveBox/blob/master/Dockerfile
- https://github.com/ArchiveBox/ArchiveBox/blob/master/docker-compose.yml

I took great pains to try and make the docker CLI experience seamless and interchangeable with running directly on the host, including detecting the ownership of mounted volumes and changing the container user to match the host machine so as to "automagically" create files with the correct permissions. So far this seems to have gone well, and many of our users are moving towards using the Docker version exclusively.

<img src="https://user-images.githubusercontent.com/511499/88868292-c3bad380-d1dd-11ea-8e67-e9ba5d0c6c9f.png" width="400px" alt="ArchiveBox docker docs screenshot">

There's extensive docker-specific setup and usage documentation as well:
- https://github.com/ArchiveBox/ArchiveBox/wiki/Docker
- https://github.com/ArchiveBox/ArchiveBox/wiki/Configuration

I can provide regular security updates and improvements to the Docker image, and this project is actively maintained by me and my company Monadical.com (with more docker-specific features being added in the near future).

---

Leaving these unchecked as specified in the instructions, but I added my answers below for convenience. Feel free to edit those out as you check/review each item.

 - [ ] associated with or contacted upstream?
   > Yes, I'm the upstream author.
 - [ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
   > service
 - [ ] is it reasonably popular, or does it solve a particular use case well?
   > it's a mid-sized self-hosted internet archiving service on Github with an active community (7k stars, ~50 contributors)
 - [ ]  does a [documentation](https://github.com/docker-library/docs/blob/master/README.md?rgh-link-date=2020-07-03T01%3A19%3A30Z) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
   > Not yet, pending feedback on this PR. It will be a verbatim excerpt of the README quickstart sections though, so shouldn't take long.
 - [ ]  official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md?rgh-link-date=2020-07-03T01%3A19%3A30Z#review-guidelines))?
   > Passes all CI tests and follows standard Dockerfile best-practices to my knowledge
 - [ ] 2+ official-images maintainer dockerization review?
   > Pending
 - [ ]  existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
   > Yes, uses `FROM python:3.8-slim-buster`
 - [ ]  passes current tests? any simple new tests that might be appropriate to add? ([https://github.com/docker-library/official-images/tree/master/test](https://github.com/docker-library/official-images/tree/master/test?rgh-link-date=2020-07-03T01%3A19%3A30Z))
   > Yes, passes its own test suite and the `official-images` Github Actions suite