### PR TITLE
Add Java 11 release for Flink 1.11.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -4,7 +4,7 @@ Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.11.1-scala_2.12-java8, 1.11-scala_2.12-java8, scala_2.12-java8, 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1-java8, 1.11-java8, latest-java8, 1.11.1, 1.11, latest
+Tags: 1.11.1-scala_2.12-java8, 1.11-scala_2.12-java8, scala_2.12-java8, 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1-java8, 1.11-java8, java8, 1.11.1, 1.11, latest
 Architectures: amd64
 GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
 Directory: ./1.11/scala_2.12-java8-debian
@@ -14,7 +14,7 @@ Architectures: amd64
 GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
 Directory: ./1.11/scala_2.11-java8-debian
 
-Tags: 1.11.1-scala_2.12-java11, 1.11-scala_2.12-java11, scala_2.12-java11, 1.11.1-java11, 1.11-java11, latest-java11
+Tags: 1.11.1-scala_2.12-java11, 1.11-scala_2.12-java11, scala_2.12-java11, 1.11.1-java11, 1.11-java11, java11
 Architectures: amd64
 GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
 Directory: ./1.11/scala_2.12-java11-debian

--- a/library/flink
+++ b/library/flink
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/apache/flink-docker/blob/9dd55f459eedaf137eea6f0f825f24935d92c19e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/apache/flink-docker/blob/d82ab62895fddbeb10c963ef95f0860b2b515ddc/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.10.1-scala_2.11, 1.10-scala_2.11
+Tags: 1.11.1-scala_2.12-java8, 1.11-scala_2.12-java8, scala_2.12-java8, 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1-java8, 1.11-java8, latest-java8, 1.11.1, 1.11, latest
 Architectures: amd64
-GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
-Directory: 1.10/scala_2.11-debian
+GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+Directory: ./1.11/scala_2.12-java8-debian
+
+Tags: 1.11.1-scala_2.11-java8, 1.11-scala_2.11-java8, scala_2.11-java8, 1.11.1-scala_2.11, 1.11-scala_2.11, scala_2.11
+Architectures: amd64
+GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+Directory: ./1.11/scala_2.11-java8-debian
+
+Tags: 1.11.1-scala_2.12-java11, 1.11-scala_2.12-java11, scala_2.12-java11, 1.11.1-java11, 1.11-java11, latest-java11
+Architectures: amd64
+GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+Directory: ./1.11/scala_2.12-java11-debian
+
+Tags: 1.11.1-scala_2.11-java11, 1.11-scala_2.11-java11, scala_2.11-java11
+Architectures: amd64
+GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+Directory: ./1.11/scala_2.11-java11-debian
 
 Tags: 1.10.1-scala_2.12, 1.10-scala_2.12, 1.10.1, 1.10
 Architectures: amd64
 GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
-Directory: 1.10/scala_2.12-debian
+Directory: ./1.10/scala_2.12-debian
 
-Tags: 1.11.1-scala_2.11, 1.11-scala_2.11, scala_2.11
+Tags: 1.10.1-scala_2.11, 1.10-scala_2.11
 Architectures: amd64
-GitCommit: 253b8844a4bd96762ab14410624db4d7f3cc5f51
-Directory: 1.11/scala_2.11-debian
-
-Tags: 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1, 1.11, latest
-Architectures: amd64
-GitCommit: 253b8844a4bd96762ab14410624db4d7f3cc5f51
-Directory: 1.11/scala_2.12-debian
+GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
+Directory: ./1.10/scala_2.11-debian


### PR DESCRIPTION
This effectively adds 2 Java11-based images.
Since we've changed the tool that generates the the stackbrew library file, the order of the entries has changed. Future releases of Flink should not create such noisy pull requests.