### PR TITLE
Update Rust to 1.45.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/0e1e519c3c2b201312dc4869d1e8c3bf9eafee01/x.py
+# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/0345665196e5c245fb0f58f5fb93f85f24890222/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
 GitRepo: https://github.com/rust-lang-nursery/docker-rust.git
 
-Tags: 1-stretch, 1.45-stretch, 1.45.0-stretch, stretch
+Tags: 1-stretch, 1.45-stretch, 1.45.1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/stretch
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/stretch
 
-Tags: 1-slim-stretch, 1.45-slim-stretch, 1.45.0-slim-stretch, slim-stretch
+Tags: 1-slim-stretch, 1.45-slim-stretch, 1.45.1-slim-stretch, slim-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/stretch/slim
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/stretch/slim
 
-Tags: 1-buster, 1.45-buster, 1.45.0-buster, buster, 1, 1.45, 1.45.0, latest
+Tags: 1-buster, 1.45-buster, 1.45.1-buster, buster, 1, 1.45, 1.45.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/buster
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/buster
 
-Tags: 1-slim-buster, 1.45-slim-buster, 1.45.0-slim-buster, slim-buster, 1-slim, 1.45-slim, 1.45.0-slim, slim
+Tags: 1-slim-buster, 1.45-slim-buster, 1.45.1-slim-buster, slim-buster, 1-slim, 1.45-slim, 1.45.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/buster/slim
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/buster/slim
 
-Tags: 1-alpine3.11, 1.45-alpine3.11, 1.45.0-alpine3.11, alpine3.11
+Tags: 1-alpine3.11, 1.45-alpine3.11, 1.45.1-alpine3.11, alpine3.11
 Architectures: amd64
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/alpine3.11
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/alpine3.11
 
-Tags: 1-alpine3.12, 1.45-alpine3.12, 1.45.0-alpine3.12, alpine3.12, 1-alpine, 1.45-alpine, 1.45.0-alpine, alpine
+Tags: 1-alpine3.12, 1.45-alpine3.12, 1.45.1-alpine3.12, alpine3.12, 1-alpine, 1.45-alpine, 1.45.1-alpine, alpine
 Architectures: amd64
-GitCommit: 0e1e519c3c2b201312dc4869d1e8c3bf9eafee01
-Directory: 1.45.0/alpine3.12
+GitCommit: 0345665196e5c245fb0f58f5fb93f85f24890222
+Directory: 1.45.1/alpine3.12


### PR DESCRIPTION
We'll be dropping stretch images starting with 1.46.0, but I'm leaving them here since this is a patch release off of 1.45.0.