### PR TITLE
Update Jetty

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,115 +4,115 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.0-alpha0-jre11-slim
+Tags: 11.0.0.beta1-jre11-slim
 Architectures: amd64
 Directory: 11.0-jre11-slim
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 11.0.0-alpha0-jre11
+Tags: 11.0.0.beta1-jre11
 Architectures: amd64
 Directory: 11.0-jre11
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 11.0.0-alpha0-jdk14-slim
+Tags: 11.0.0.beta1-jdk14-slim
 Architectures: amd64
 Directory: 11.0-jdk14-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 11.0.0-alpha0, 11.0.0-alpha0-jdk14
+Tags: 11.0.0.beta1, 11.0.0.beta1-jdk14
 Architectures: amd64
 Directory: 11.0-jdk14
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 11.0.0-alpha0-jdk11-slim
+Tags: 11.0.0.beta1-jdk11-slim
 Architectures: amd64
 Directory: 11.0-jdk11-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 11.0.0-alpha0-jdk11
+Tags: 11.0.0.beta1-jdk11
 Architectures: amd64
 Directory: 11.0-jdk11
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0-jre11-slim
+Tags: 10.0.0.beta1-jre11-slim
 Architectures: amd64
 Directory: 10.0-jre11-slim
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0-jre11
+Tags: 10.0.0.beta1-jre11
 Architectures: amd64
 Directory: 10.0-jre11
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0-jdk14-slim
+Tags: 10.0.0.beta1-jdk14-slim
 Architectures: amd64
 Directory: 10.0-jdk14-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0, 10.0.0.beta0-jdk14
+Tags: 10.0.0.beta1, 10.0.0.beta1-jdk14
 Architectures: amd64
 Directory: 10.0-jdk14
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0-jdk11-slim
+Tags: 10.0.0.beta1-jdk11-slim
 Architectures: amd64
 Directory: 10.0-jdk11-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 10.0.0.beta0-jdk11
+Tags: 10.0.0.beta1-jdk11
 Architectures: amd64
 Directory: 10.0-jdk11
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.31-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.31-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.31-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64
 Directory: 9.4-jre8-slim
-GitCommit: f92d1fff1d1be3199fb0dfb2847f28636bf12157
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.31-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
+Tags: 9.4.31-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
 Architectures: amd64
 Directory: 9.4-jdk14-slim
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30, 9.4, 9, 9.4.30-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
+Tags: 9.4.31, 9.4, 9, 9.4.31-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
 Architectures: amd64
 Directory: 9.4-jdk14
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.31-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64
 Directory: 9.4-jdk11-slim
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.31-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64
 Directory: 9.4-jdk11
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.31-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
 Directory: 9.4-jdk8-slim
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
-Tags: 9.4.30-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.31-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64
 Directory: 9.4-jdk8
-GitCommit: dfaf2665196c13fc9b5d47c5cada3188d3d7fb30
+GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
 
 Tags: 9.3.28-jre8, 9.3-jre8
 Architectures: amd64


### PR DESCRIPTION
- Update Jetty 9.4 images to use 9.4.31
- Update Jetty 10 & 11 images to use beta1