### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-7-jdk-oraclelinux7, 16-ea-7-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-7-jdk-oracle, 16-ea-7-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-7-jdk, 16-ea-7, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-8-jdk-oraclelinux7, 16-ea-8-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-8-jdk-oracle, 16-ea-8-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-8-jdk, 16-ea-8, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-7-jdk-buster, 16-ea-7-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-8-jdk-buster, 16-ea-8-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/buster
 
-Tags: 16-ea-7-jdk-slim-buster, 16-ea-7-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-7-jdk-slim, 16-ea-7-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-8-jdk-slim-buster, 16-ea-8-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-8-jdk-slim, 16-ea-8-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -25,41 +25,41 @@ Architectures: amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-7-jdk-windowsservercore-1809, 16-ea-7-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-7-jdk-windowsservercore, 16-ea-7-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-7-jdk, 16-ea-7, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-8-jdk-windowsservercore-1809, 16-ea-8-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-8-jdk-windowsservercore, 16-ea-8-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-8-jdk, 16-ea-8, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-7-jdk-windowsservercore-ltsc2016, 16-ea-7-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-7-jdk-windowsservercore, 16-ea-7-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-7-jdk, 16-ea-7, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-8-jdk-windowsservercore-ltsc2016, 16-ea-8-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-8-jdk-windowsservercore, 16-ea-8-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-8-jdk, 16-ea-8, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-7-jdk-nanoserver-1809, 16-ea-7-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-7-jdk-nanoserver, 16-ea-7-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-8-jdk-nanoserver-1809, 16-ea-8-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-8-jdk-nanoserver, 16-ea-8-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: be46c34a1b45fc5746389b7b1d25751e76a9c6a0
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-ea-33-jdk-oraclelinux7, 15-ea-33-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-33-jdk-oracle, 15-ea-33-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15-ea-33-jdk, 15-ea-33, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-34-jdk-oraclelinux7, 15-ea-34-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-34-jdk-oracle, 15-ea-34-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15-ea-34-jdk, 15-ea-34, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/oraclelinux7
 
-Tags: 15-ea-33-jdk-buster, 15-ea-33-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
+Tags: 15-ea-34-jdk-buster, 15-ea-34-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/buster
 
-Tags: 15-ea-33-jdk-slim-buster, 15-ea-33-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-33-jdk-slim, 15-ea-33-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
+Tags: 15-ea-34-jdk-slim-buster, 15-ea-34-slim-buster, 15-ea-jdk-slim-buster, 15-ea-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15-ea-34-jdk-slim, 15-ea-34-slim, 15-ea-jdk-slim, 15-ea-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/slim-buster
 
 Tags: 15-ea-31-jdk-alpine3.12, 15-ea-31-alpine3.12, 15-ea-jdk-alpine3.12, 15-ea-alpine3.12, 15-jdk-alpine3.12, 15-alpine3.12, 15-ea-31-jdk-alpine, 15-ea-31-alpine, 15-ea-jdk-alpine, 15-ea-alpine, 15-jdk-alpine, 15-alpine
@@ -67,24 +67,24 @@ Architectures: amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 15/jdk/alpine3.12
 
-Tags: 15-ea-33-jdk-windowsservercore-1809, 15-ea-33-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-ea-33-jdk-windowsservercore, 15-ea-33-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-33-jdk, 15-ea-33, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-34-jdk-windowsservercore-1809, 15-ea-34-windowsservercore-1809, 15-ea-jdk-windowsservercore-1809, 15-ea-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15-ea-34-jdk-windowsservercore, 15-ea-34-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-34-jdk, 15-ea-34, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-ea-33-jdk-windowsservercore-ltsc2016, 15-ea-33-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-ea-33-jdk-windowsservercore, 15-ea-33-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-33-jdk, 15-ea-33, 15-ea-jdk, 15-ea, 15-jdk, 15
+Tags: 15-ea-34-jdk-windowsservercore-ltsc2016, 15-ea-34-windowsservercore-ltsc2016, 15-ea-jdk-windowsservercore-ltsc2016, 15-ea-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15-ea-34-jdk-windowsservercore, 15-ea-34-windowsservercore, 15-ea-jdk-windowsservercore, 15-ea-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15-ea-34-jdk, 15-ea-34, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-ea-33-jdk-nanoserver-1809, 15-ea-33-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-ea-33-jdk-nanoserver, 15-ea-33-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-ea-34-jdk-nanoserver-1809, 15-ea-34-nanoserver-1809, 15-ea-jdk-nanoserver-1809, 15-ea-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15-ea-34-jdk-nanoserver, 15-ea-34-nanoserver, 15-ea-jdk-nanoserver, 15-ea-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 5baa163193771b2f905db68405bd83b5887bd0d3
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5baa163: Update to 15-ea+34
- https://github.com/docker-library/openjdk/commit/be46c34: Update to 16-ea+8