### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
 Directory: 2.3-rc/alpine
 
-Tags: 2.2.1, 2.2, latest, lts
+Tags: 2.2.2, 2.2, latest, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d69936c2bac1e20c720738761f85987f93b9a73
+GitCommit: 69c34c84b187066a664ae2bc14600246a586f5f1
 Directory: 2.2
 
-Tags: 2.2.1-alpine, 2.2-alpine, alpine, lts-alpine
+Tags: 2.2.2-alpine, 2.2-alpine, alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d69936c2bac1e20c720738761f85987f93b9a73
+GitCommit: 69c34c84b187066a664ae2bc14600246a586f5f1
 Directory: 2.2/alpine
 
 Tags: 2.1.7, 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/69c34c8: Update to 2.2.2