### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev1, 2.3-dev
+Tags: 2.3-dev2, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
+GitCommit: ee573f899c6e14b8eb021cda4961ffbee8ba5bcd
 Directory: 2.3-rc
 
-Tags: 2.3-dev1-alpine, 2.3-dev-alpine
+Tags: 2.3-dev2-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e4facdc3a4cb4c4f1265e68c17d7c6edb2a9d1e
+GitCommit: ee573f899c6e14b8eb021cda4961ffbee8ba5bcd
 Directory: 2.3-rc/alpine
 
 Tags: 2.2.2, 2.2, latest, lts
@@ -24,34 +24,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 69c34c84b187066a664ae2bc14600246a586f5f1
 Directory: 2.2/alpine
 
-Tags: 2.1.7, 2.1
+Tags: 2.1.8, 2.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ff559288c519c0792bccb5c2e0d1e9d5fd5a87c9
+GitCommit: a9741204b7df9242954c77fed5fcaf61c81dfce5
 Directory: 2.1
 
-Tags: 2.1.7-alpine, 2.1-alpine
+Tags: 2.1.8-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
+GitCommit: a9741204b7df9242954c77fed5fcaf61c81dfce5
 Directory: 2.1/alpine
 
-Tags: 2.0.16, 2.0
+Tags: 2.0.17, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4081598aacb56651940e84a04c8e03c403aec3c
+GitCommit: c8d4c15cee0f5b6ad6b226a61cec408c44f19d6d
 Directory: 2.0
 
-Tags: 2.0.16-alpine, 2.0-alpine
+Tags: 2.0.17-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 461dcbfa8538c9ab47d41b96f3c8d1835166382e
+GitCommit: c8d4c15cee0f5b6ad6b226a61cec408c44f19d6d
 Directory: 2.0/alpine
 
-Tags: 1.9.15, 1.9, 1
+Tags: 1.9.16, 1.9, 1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: 1a794eaa3bde25a2a09f5ff88f3f2b792bd319bb
 Directory: 1.9
 
-Tags: 1.9.15-alpine, 1.9-alpine, 1-alpine
+Tags: 1.9.16-alpine, 1.9-alpine, 1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
+GitCommit: 1a794eaa3bde25a2a09f5ff88f3f2b792bd319bb
 Directory: 1.9/alpine
 
 Tags: 1.8.25, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a974120: Update to 2.1.8
- https://github.com/docker-library/haproxy/commit/1a794ea: Update to 1.9.16
- https://github.com/docker-library/haproxy/commit/ee573f8: Update to 2.3-dev2
- https://github.com/docker-library/haproxy/commit/c8d4c15: Update to 2.0.17
- https://github.com/docker-library/haproxy/commit/f542ba2: Revert ebtree patch in template so docker-library-bot can do version bumps

**Note:** this is the final release of HAProxy 1.9 (https://www.mail-archive.com/haproxy@formilux.org/msg38078.html; thanks @TimWolla :bow:)