### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -46,7 +46,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.27, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7ee0459ee49bd9d13f93782fa766f6d9970534f
+GitCommit: 541855565d21d6305f0daa80e8968e3cc2432547
 Directory: 3.7/ubuntu
 
 Tags: 3.7.27-management, 3.7-management
@@ -56,7 +56,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.27-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7ee0459ee49bd9d13f93782fa766f6d9970534f
+GitCommit: 541855565d21d6305f0daa80e8968e3cc2432547
 Directory: 3.7/alpine
 
 Tags: 3.7.27-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/5418555: Update to 3.7.27, Erlang/OTP 22.3.4.5, OpenSSL 1.1.1g