### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/92f0ecae850d2cd8cdc89f2655f1339182e47a1b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/66992739524afb5ef874199da3ba3d0aec9740b5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -44,24 +44,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c8d4c15cee0f5b6ad6b226a61cec408c44f19d6d
 Directory: 2.0/alpine
 
-Tags: 1.9.16, 1.9, 1
+Tags: 1.8.26, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a794eaa3bde25a2a09f5ff88f3f2b792bd319bb
-Directory: 1.9
-
-Tags: 1.9.16-alpine, 1.9-alpine, 1-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a794eaa3bde25a2a09f5ff88f3f2b792bd319bb
-Directory: 1.9/alpine
-
-Tags: 1.8.25, 1.8
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eeaaa570ccaeec6fa7e545b9314d6f246b6b283c
+GitCommit: 947eebe116d8256622545d804982620ceb18f88b
 Directory: 1.8
 
-Tags: 1.8.25-alpine, 1.8-alpine
+Tags: 1.8.26-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e538b03ce98ce2c9bb9e6e0db26d87ad45a137d0
+GitCommit: 947eebe116d8256622545d804982620ceb18f88b
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/947eebe: Update to 1.8.26
- https://github.com/docker-library/haproxy/commit/0b1cc77: Merge pull request https://github.com/docker-library/haproxy/pull/129 from infosiftr/1.9-eol
- https://github.com/docker-library/haproxy/commit/6699273: Remove "haproxy:1" alias (instead of downgrading it to 1.8, which is LTS)
- https://github.com/docker-library/haproxy/commit/24c34a7: Remove EOL 1.9 series