### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -7,18 +7,18 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.9.0b5-buster, 3.9-rc-buster, rc-buster
 SharedTags: 3.9.0b5, 3.9-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 606cdeb2f15758101b23c7c9616175ffde1cd260
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.9-rc/buster
+
+Tags: 3.9.0b5-slim-buster, 3.9-rc-slim-buster, rc-slim-buster, 3.9.0b5-slim, 3.9-rc-slim, rc-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: e7f98c09cc351394427f34671f778b5094458296
+Directory: 3.9-rc/buster/slim
 
 Tags: 3.9.0b5-alpine3.12, 3.9-rc-alpine3.12, rc-alpine3.12, 3.9.0b5-alpine, 3.9-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 606cdeb2f15758101b23c7c9616175ffde1cd260
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.9-rc/alpine3.12
-
-Tags: 3.9.0b5-alpine3.11, 3.9-rc-alpine3.11, rc-alpine3.11
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 606cdeb2f15758101b23c7c9616175ffde1cd260
-Directory: 3.9-rc/alpine3.11
 
 Tags: 3.9.0b5-windowsservercore-ltsc2016, 3.9-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.9.0b5-windowsservercore, 3.9-rc-windowsservercore, rc-windowsservercore, 3.9.0b5, 3.9-rc, rc
@@ -37,22 +37,22 @@ Constraints: windowsservercore-1809
 Tags: 3.8.5-buster, 3.8-buster, 3-buster, buster
 SharedTags: 3.8.5, 3.8, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e7fe61a25001e5e83fe56eb5fda003924190153
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.8/buster
 
 Tags: 3.8.5-slim-buster, 3.8-slim-buster, 3-slim-buster, slim-buster, 3.8.5-slim, 3.8-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e7fe61a25001e5e83fe56eb5fda003924190153
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.8/buster/slim
 
 Tags: 3.8.5-alpine3.12, 3.8-alpine3.12, 3-alpine3.12, alpine3.12, 3.8.5-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e7fe61a25001e5e83fe56eb5fda003924190153
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.8/alpine3.12
 
 Tags: 3.8.5-alpine3.11, 3.8-alpine3.11, 3-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e7fe61a25001e5e83fe56eb5fda003924190153
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.8/alpine3.11
 
 Tags: 3.8.5-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
@@ -72,32 +72,32 @@ Constraints: windowsservercore-1809
 Tags: 3.7.8-buster, 3.7-buster
 SharedTags: 3.7.8, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.7/buster
 
 Tags: 3.7.8-slim-buster, 3.7-slim-buster, 3.7.8-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.7/buster/slim
 
 Tags: 3.7.8-stretch, 3.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.7/stretch
 
 Tags: 3.7.8-slim-stretch, 3.7-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.8-alpine3.12, 3.7-alpine3.12, 3.7.8-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.7/alpine3.12
 
 Tags: 3.7.8-alpine3.11, 3.7-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f552d9467dcb6f7d0e9e0b6f0cac663a605413d
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.7/alpine3.11
 
 Tags: 3.7.8-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016
@@ -117,61 +117,61 @@ Constraints: windowsservercore-1809
 Tags: 3.6.11-buster, 3.6-buster
 SharedTags: 3.6.11, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.6/buster
 
 Tags: 3.6.11-slim-buster, 3.6-slim-buster, 3.6.11-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.6/buster/slim
 
 Tags: 3.6.11-stretch, 3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.6/stretch
 
 Tags: 3.6.11-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.11-alpine3.12, 3.6-alpine3.12, 3.6.11-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.6/alpine3.12
 
 Tags: 3.6.11-alpine3.11, 3.6-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dcf0dd45d022237390013a06ec19941ff63994d4
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.6/alpine3.11
 
 Tags: 3.5.9-buster, 3.5-buster
 SharedTags: 3.5.9, 3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.5/buster
 
 Tags: 3.5.9-slim-buster, 3.5-slim-buster, 3.5.9-slim, 3.5-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.5/buster/slim
 
 Tags: 3.5.9-stretch, 3.5-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.5/stretch
 
 Tags: 3.5.9-slim-stretch, 3.5-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 7a3801aafaae42930ab540c2dd396da06728e48d
 Directory: 3.5/stretch/slim
 
 Tags: 3.5.9-alpine3.12, 3.5-alpine3.12, 3.5.9-alpine, 3.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.5/alpine3.12
 
 Tags: 3.5.9-alpine3.11, 3.5-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bc65899cdba11cea46dd0e7b80709fb26133135
+GitCommit: 0bba31b097de3fa850e8a0976b49fb76f0dc3fa1
 Directory: 3.5/alpine3.11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/a0cb03f: Remove 3.9-rc/alpine3.11
- https://github.com/docker-library/python/commit/e7f98c0: Add missing 3.9-rc/buster/slim
- https://github.com/docker-library/python/commit/5d71a7c: Merge pull request https://github.com/docker-library/python/pull/508 from infosiftr/no-a-files
- https://github.com/docker-library/python/commit/7a3801a: Fix ldconfig ordering
- https://github.com/docker-library/python/commit/0bba31b: Also remove "wininst-*" on Python versions lower than 3.9
- https://github.com/docker-library/python/commit/ffd659a: Adjust installation order and purge "libpythonXX.a" files