### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.6-rc.1, 3.8-rc
+Tags: 3.8.6, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a999b78c07e4e717876edfc8170a44d5d34cc5f8
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.6-rc.1-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.6-rc.1-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a999b78c07e4e717876edfc8170a44d5d34cc5f8
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.6-rc.1-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13ec1c85a0882184b0bbaab2216822e7a3718d30
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.5, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c780661c0d9fe667a8a6f5c9edc2a267aa38c85
+GitCommit: 0c7faaf0fdcd1cf88b1299f85fc2d09af791e62b
 Directory: 3.8/ubuntu
 
-Tags: 3.8.5-management, 3.8-management, 3-management, management
+Tags: 3.8.6-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.5-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.6-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c780661c0d9fe667a8a6f5c9edc2a267aa38c85
+GitCommit: 0c7faaf0fdcd1cf88b1299f85fc2d09af791e62b
 Directory: 3.8/alpine
 
-Tags: 3.8.5-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.6-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/0c7faaf: Update to 3.8.6, Erlang/OTP 23.0.3, OpenSSL 1.1.1g