### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.27.0, 3.27, 3, latest
+Tags: 3.28.0, 3.28, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 83cacc75655bf26aae65465d66fd1b981e9203d5
+GitCommit: 437aff10a2f1359a9ff6ec77e23bc0b803d70f51
 Directory: 3/debian
 
-Tags: 3.27.0-alpine, 3.27-alpine, 3-alpine, alpine
+Tags: 3.28.0-alpine, 3.28-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83cacc75655bf26aae65465d66fd1b981e9203d5
+GitCommit: 437aff10a2f1359a9ff6ec77e23bc0b803d70f51
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/437aff1: Update to 3.28.0, ghost-cli 1.14.1