### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2.7-7.3.1, 2.7-7.3, 2.7-7, 2.7, 2-7.3.1, 2-7.3, 2-7, 2, 2.7-7.3.1-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.1-buster, 2-7.3-buster, 2-7-buster, 2-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 982b958afa27ca6d28ce2363199012ca781eee9d
+GitCommit: 7823435728677cc516632de760e8686c96aaa8f9
 Directory: 2.7
 
 Tags: 2.7-7.3.1-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.1-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.1-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.1-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 982b958afa27ca6d28ce2363199012ca781eee9d
+GitCommit: 7823435728677cc516632de760e8686c96aaa8f9
 Directory: 2.7/slim
 
 Tags: 3.6-7.3.1, 3.6-7.3, 3.6-7, 3.6, 3-7.3.1, 3-7.3, 3-7, 3, latest, 3.6-7.3.1-buster, 3.6-7.3-buster, 3.6-7-buster, 3.6-buster, 3-7.3.1-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: 982b958afa27ca6d28ce2363199012ca781eee9d
+GitCommit: 7823435728677cc516632de760e8686c96aaa8f9
 Directory: 3.6
 
 Tags: 3.6-7.3.1-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.1-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.1-slim-buster, 3.6-7.3-slim-buster, 3.6-7-slim-buster, 3.6-slim-buster, 3-7.3.1-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: 982b958afa27ca6d28ce2363199012ca781eee9d
+GitCommit: 7823435728677cc516632de760e8686c96aaa8f9
 Directory: 3.6/slim


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/7823435: Update to 7.3.1, pip 20.2.1
- https://github.com/docker-library/pypy/commit/dbe6fb9: Handle compressed responses from downloads.python.org when scraping versions