### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.43, 2.4, 2, latest
+Tags: 2.4.46, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6c8e82e20ecefc94c616439f15d14c4bb215b200
+GitCommit: 5bc2d71c4c1949d98a2e8671eadc5043b6c0b7f4
 Directory: 2.4
 
-Tags: 2.4.43-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.46-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f5ef4cc849a4ea7ed56e797b86ad06ccf9f93a9a
+GitCommit: 5bc2d71c4c1949d98a2e8671eadc5043b6c0b7f4
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/5bc2d71: Update to 2.4.46
- https://github.com/docker-library/httpd/commit/c228692: Add all keys from https://downloads.apache.org/httpd/KEYS (Alpine variant too)
- https://github.com/docker-library/httpd/commit/1b22e9e: Add all keys from https://downloads.apache.org/httpd/KEYS