### PR TITLE
Fixed permissions bug in Neo4j 4.0.7 and 4.1.1

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -10,12 +10,12 @@ Maintainers: Ben Butler-Cole <ben@neo4j.com> (@benbc),
 
 Tags: 4.1.1, 4.1, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: fa265c13d4c6fd8806ec1eed4792726ef8aa8987
+GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.1.1/community
 
 Tags: 4.1.1-enterprise, 4.1-enterprise, enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: fa265c13d4c6fd8806ec1eed4792726ef8aa8987
+GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.1.1/enterprise
 
 Tags: 4.1.0
@@ -30,12 +30,12 @@ Directory: 4.1.0/enterprise
 
 Tags: 4.0.7, 4.0
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 6b9071e673dbc67d53005777070ff6b015f666c0
+GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.0.7/community
 
 Tags: 4.0.7-enterprise, 4.0-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 6b9071e673dbc67d53005777070ff6b015f666c0
+GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.0.7/enterprise
 
 Tags: 4.0.6


### PR DESCRIPTION
I fixed a file permissions bug that I'd created in Neo4j 4.0.7 and 4.1.1 caused by different ownership defaults between host file mounting, named volumes and whatever docker-compose does by default.

Oh, and thanks for the `gosu` tool tianon, it's super useful!
