### PR TITLE
Update the CentOS images for August 2020

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -2,35 +2,26 @@ Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
 GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
 Directory: docker
 
-Tags: latest, centos8, 8, centos8.2.2004, 8.2.2004
+Tags: latest, centos8, 8
 GitFetch: refs/heads/CentOS-8-x86_64
-GitCommit: 5125788a241618b4d37254050d0bddcbd5b7df33
+GitCommit: 12a4f1c0d78e257ce3d33fe89092eee07e6574da
 arm64v8-GitFetch: refs/heads/CentOS-8-aarch64
-arm64v8-GitCommit: e95dba14f002e894a02ac0e7b8d51cb82035a30e
+arm64v8-GitCommit: 72306c7451107d95c82368e6faf9a58ae0a9c39b
 ppc64le-GitFetch: refs/heads/CentOS-8-ppc64le
-ppc64le-GitCommit: 006350a458663e8b30ac7fcf1f73f60933067c7c
-Architectures: amd64, arm64v8, ppc64le
-
-Tags: centos8.1.1911, 8.1.1911
-GitFetch: refs/heads/CentOS-8.1.1911-x86_64
-GitCommit: 52cc14a6dd2efc45265417a4690964d32cf13857
-arm64v8-GitFetch: refs/heads/CentOS-8.1.1911-aarch64
-arm64v8-GitCommit: 3e16a554bf8616acf0f64a952c38d345a6d1c331
-ppc64le-GitFetch: refs/heads/CentOS-8.1.1911-ppc64le
-ppc64le-GitCommit: 89eba33f3e442dc42808ef76194e2c91d09f3050
+ppc64le-GitCommit: 35604e16d4d1c2c9195abdf39787508feb34c456
 Architectures: amd64, arm64v8, ppc64le
 
 Tags: centos7, 7
 GitFetch: refs/heads/CentOS-7-x86_64
-GitCommit: b521221b5c8ac3ac88698e77941a2414ce6e778d
+GitCommit: f2788ce41161326a18420913b0195d1c6cfa1581
 arm32v7-GitFetch: refs/heads/CentOS-7armhfp
 arm32v7-GitCommit: 8022ae6d18ddf031b1b3a80549eeb46d1deb6dcd
 arm64v8-GitFetch: refs/heads/CentOS-7-aarch64
-arm64v8-GitCommit: c72c9d7fc0d926fcc0d1345feeaae8fc4a3fcb14
+arm64v8-GitCommit: e5273e922411fcacdf0eb3d27e925199da4ad2dc
 ppc64le-GitFetch: refs/heads/CentOS-7-ppc64le
-ppc64le-GitCommit: 25f6987f8e8423fe926138a4166077d69ce69d20
-i386-GitFetch: refs/heads/CentOS-7i386
-i386-GitCommit: c59f5c7a73c182e8a25d43058b65b99ca93c6636
+ppc64le-GitCommit: a7c33c6ee61c033b8047cdd3f63f26dd200dc4d5
+i386-GitFetch: refs/heads/CentOS-7-i386
+i386-GitCommit: f28507d5d256d5ddc2816148f4e2242057a28673
 Architectures: amd64, arm64v8, arm32v7, ppc64le, i386
 
 Tags: centos6, 6


### PR DESCRIPTION
Respin CentOS container images for updated content as of August 9th, 2020