### PR TITLE
Update Solr to 8.6.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,12 +6,22 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.5.2, 8.5, 8, latest
+Tags: 8.6.0, 8.6, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: d86046a9ea94e91ee494c86a9bae4b6b5a44c64d
+Directory: 8.6
+
+Tags: 8.6.0-slim, 8.6-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: d86046a9ea94e91ee494c86a9bae4b6b5a44c64d
+Directory: 8.6/slim
+
+Tags: 8.5.2, 8.5
 Architectures: amd64, arm64v8
 GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.5
 
-Tags: 8.5.2-slim, 8.5-slim, 8-slim, slim
+Tags: 8.5.2-slim, 8.5-slim
 Architectures: amd64, arm64v8
 GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
 Directory: 8.5/slim


### PR DESCRIPTION
See [Announcement](https://lists.apache.org/thread.html/rd0bf6ba079d86bb7af5f42ebb5990cceef769b61272b929aa0b289cc%40%3Csolr-user.lucene.apache.org%3E) which links to the release notes which further links to [upgrade considerations](https://github.com/apache/lucene-solr/blob/master/solr/solr-ref-guide/src/solr-upgrade-notes.adoc).

One the docker-solr side, we now include [jattach](https://github.com/apangin/jattach) to get some basic tooling equivalents to what the JDK provides.