### PR TITLE
[ros] bump ros1-bridge version on dashing and eloquent

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -146,7 +146,7 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0eae97e0fa2b34e99d684d88565553b1d67cc590
+GitCommit: d185c779fecbe0d84871a2a056c0dc1b74241711
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c640c49dc488d0373ba7fa8014349f2b3e4e0217
+GitCommit: 14470a8627614e420ef35f899428aef8f55dcf70
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
The dependency `ros-melodic-ros-comm` has bumped version: 1.14.6 -> 1.14.7
This updates the dashing and eloquent `ros1-bridge` images accordingly