### PR TITLE
eclipse-mosquitto: Don't abort on chmod error.

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,6 +1,6 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 6407abf717bcffb60e832fa3c2bcc3e5d1cc22ac
+GitCommit: 367a282c61460a1f021df086887ad195e26fc968
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 1.6.11, 1.6, latest


### PR DESCRIPTION
If the filesystem is read only this shouldn't cause a quit, for example.