### PR TITLE
Revert clojure:tools-deps variants to latest stable release

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: a6da0a5c9f6cde2dca4ce9aaa31dafad0b346520
+GitCommit: 1a75e7eb79c7e410829c638a1ce73f7a4c32ff5f
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
@@ -19,10 +19,10 @@ Directory: target/openjdk-8-buster/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.619, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.619-buster
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.561, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.561-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.619-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.561-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.3, lein, lein-2.9.3, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.3-buster, lein-buster, lein-2.9.3-buster
@@ -41,11 +41,11 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.619, tools-deps, tools-deps-1.10.1.619, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.619-buster, tools-deps-buster, tools-deps-1.10.1.619-buster
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.561, tools-deps, tools-deps-1.10.1.561, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.561-buster, tools-deps-buster, tools-deps-1.10.1.561-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.619-slim-buster, tools-deps-1.10.1.619-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.561-slim-buster, tools-deps-1.10.1.561-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
@@ -61,10 +61,10 @@ Directory: target/openjdk-14-slim-buster/boot
 Tags: openjdk-14-boot-buster, openjdk-14-boot-2.8.3-buster
 Directory: target/openjdk-14-buster/boot
 
-Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.619, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.619-slim-buster
+Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.561, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.561-slim-buster
 Directory: target/openjdk-14-slim-buster/tools-deps
 
-Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.619-buster
+Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.561-buster
 Directory: target/openjdk-14-buster/tools-deps
 
 Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.3, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.3-slim-buster
@@ -79,10 +79,10 @@ Directory: target/openjdk-15-slim-buster/boot
 Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
 Directory: target/openjdk-15-buster/boot
 
-Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.619, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.619-slim-buster
+Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.561, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.561-slim-buster
 Directory: target/openjdk-15-slim-buster/tools-deps
 
-Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.619-buster
+Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.561-buster
 Directory: target/openjdk-15-buster/tools-deps
 
 Tags: openjdk-15-alpine, openjdk-15-lein-alpine, openjdk-15-lein-2.9.3-alpine
@@ -91,5 +91,5 @@ Directory: target/openjdk-15-alpine/lein
 Tags: openjdk-15-boot-alpine, openjdk-15-boot-2.8.3-alpine
 Directory: target/openjdk-15-alpine/boot
 
-Tags: openjdk-15-tools-deps-alpine, openjdk-15-tools-deps-1.10.1.619-alpine
+Tags: openjdk-15-tools-deps-alpine, openjdk-15-tools-deps-1.10.1.561-alpine
 Directory: target/openjdk-15-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 1a75e7eb79c7e410829c638a1ce73f7a4c32ff5f
+GitCommit: 494a44db6fb37639bb2b1bcc19ce2ee30e7bb648
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
@@ -84,12 +84,3 @@ Directory: target/openjdk-15-slim-buster/tools-deps
 
 Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.561-buster
 Directory: target/openjdk-15-buster/tools-deps
-
-Tags: openjdk-15-alpine, openjdk-15-lein-alpine, openjdk-15-lein-2.9.3-alpine
-Directory: target/openjdk-15-alpine/lein
-
-Tags: openjdk-15-boot-alpine, openjdk-15-boot-2.8.3-alpine
-Directory: target/openjdk-15-alpine/boot
-
-Tags: openjdk-15-tools-deps-alpine, openjdk-15-tools-deps-1.10.1.561-alpine
-Directory: target/openjdk-15-alpine/tools-deps


### PR DESCRIPTION
I recently learned that 1.10.1.561 is the most recent clojure tools-deps stable release. And I inadvertently skipped right over it! So this makes it available as an explicit version tag, and (appropriately) makes it the default for `tools-deps` variants that don't specify a version.