### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.8/alpine/management
 
 Tags: 3.7.27, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 541855565d21d6305f0daa80e8968e3cc2432547
+GitCommit: e07d999b4f7e2c60459d79e504a4e008b86681ff
 Directory: 3.7/ubuntu
 
 Tags: 3.7.27-management, 3.7-management
@@ -36,7 +36,7 @@ Directory: 3.7/ubuntu/management
 
 Tags: 3.7.27-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 541855565d21d6305f0daa80e8968e3cc2432547
+GitCommit: e07d999b4f7e2c60459d79e504a4e008b86681ff
 Directory: 3.7/alpine
 
 Tags: 3.7.27-management-alpine, 3.7-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e07d999: Update to 3.7.27, Erlang/OTP 22.3.4.6, OpenSSL 1.1.1g