### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 13-beta2, 13
+Tags: 13-beta3, 13
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4c2e78c234a8e4293a5d6bb6a4d20421236d98d8
+GitCommit: 5e2746f8ff4b94d3b3aa56a6cd7bdbdcd88a1d64
 Directory: 13
 
-Tags: 13-beta2-alpine, 13-alpine
+Tags: 13-beta3-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb0d97951918e6d281f510adb3896da433a52bc4
+GitCommit: 06321b0cd97dc7e6523b1faed69b7a0d8fd3d2cc
 Directory: 13/alpine
 
-Tags: 12.3, 12, latest
+Tags: 12.4, 12, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 88173efa530f1a174a7ea311c5b6ee5e383f68bd
+GitCommit: 8787b168802a629ec12be1e7fed98b940baf90d7
 Directory: 12
 
-Tags: 12.3-alpine, 12-alpine, alpine
+Tags: 12.4-alpine, 12-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d140375b6830c65cfeaac3642c7fda6d3e1b29a
+GitCommit: 1abff660740cb2ba89d25fa1d00be8f6511dd157
 Directory: 12/alpine
 
-Tags: 11.8, 11
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa4f329a17fd82077536602da12f4264fa195b20
+Tags: 11.9, 11
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
+GitCommit: 1858993247748c52316b4690b0a6c6ea6c33f49f
 Directory: 11
 
-Tags: 11.8-alpine, 11-alpine
+Tags: 11.9-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d140375b6830c65cfeaac3642c7fda6d3e1b29a
+GitCommit: a5a072f08ad5499961875b7dd441e1b8ee8b4600
 Directory: 11/alpine
 
-Tags: 10.13, 10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e039c4ebd8e4691af65dfd6cf280df126039aa
+Tags: 10.14, 10
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
+GitCommit: 9f53bdfb953c67bfb030417b5038d78ff162ed2a
 Directory: 10
 
-Tags: 10.13-alpine, 10-alpine
+Tags: 10.14-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d140375b6830c65cfeaac3642c7fda6d3e1b29a
+GitCommit: 1657faac6b9918537da408915b65e92323f8c74b
 Directory: 10/alpine
 
-Tags: 9.6.18, 9.6, 9
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 95f4307ac7547094b5392d2a2a5aa7471301ffcb
+Tags: 9.6.19, 9.6, 9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
+GitCommit: 23fb6d25d168890aa4499b066306849e43936efa
 Directory: 9.6
 
-Tags: 9.6.18-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.19-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d140375b6830c65cfeaac3642c7fda6d3e1b29a
+GitCommit: 0f4abf741b320d7ac53207c03867c4ac24aad6b5
 Directory: 9.6/alpine
 
-Tags: 9.5.22, 9.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fa4482cec89b300589c30fc5590995a31f569a06
+Tags: 9.5.23, 9.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
+GitCommit: 7ea20406a8b723e9766cd436b625356e04e33092
 Directory: 9.5
 
-Tags: 9.5.22-alpine, 9.5-alpine
+Tags: 9.5.23-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d140375b6830c65cfeaac3642c7fda6d3e1b29a
+GitCommit: 63fb3178b5b2cdaf920454f7e30042e73c01d75f
 Directory: 9.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/7ea2040: Update to 9.5.23-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/1858993: Update to 11.9-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/63fb317: Update to 9.5.23
- https://github.com/docker-library/postgres/commit/06321b0: Update to 13beta3
- https://github.com/docker-library/postgres/commit/a5a072f: Update to 11.9
- https://github.com/docker-library/postgres/commit/5e2746f: Update to 13~beta3-1.pgdg100+1
- https://github.com/docker-library/postgres/commit/23fb6d2: Update to 9.6.19-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/1657faa: Update to 10.14
- https://github.com/docker-library/postgres/commit/1abff66: Update to 12.4
- https://github.com/docker-library/postgres/commit/0f4abf7: Update to 9.6.19
- https://github.com/docker-library/postgres/commit/9f53bdf: Update to 10.14-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/8787b16: Update to 12.4-1.pgdg100+1
- https://github.com/docker-library/postgres/commit/aa3a243: Merge pull request https://github.com/docker-library/postgres/pull/750 from infosiftr/ampersand
- https://github.com/docker-library/postgres/commit/1bddd08: Replace "&&" chains with ";" in Alpine variants