### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-9-jdk-oraclelinux7, 16-ea-9-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-9-jdk-oracle, 16-ea-9-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-9-jdk, 16-ea-9, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-11-jdk-oraclelinux7, 16-ea-11-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-11-jdk-oracle, 16-ea-11-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-9-jdk-buster, 16-ea-9-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-11-jdk-buster, 16-ea-11-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/buster
 
-Tags: 16-ea-9-jdk-slim-buster, 16-ea-9-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-9-jdk-slim, 16-ea-9-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-11-jdk-slim-buster, 16-ea-11-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-11-jdk-slim, 16-ea-11-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -25,54 +25,54 @@ Architectures: amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-9-jdk-windowsservercore-1809, 16-ea-9-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-9-jdk-windowsservercore, 16-ea-9-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-9-jdk, 16-ea-9, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-11-jdk-windowsservercore-1809, 16-ea-11-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-11-jdk-windowsservercore, 16-ea-11-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-9-jdk-windowsservercore-ltsc2016, 16-ea-9-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-9-jdk-windowsservercore, 16-ea-9-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-9-jdk, 16-ea-9, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-11-jdk-windowsservercore-ltsc2016, 16-ea-11-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-11-jdk-windowsservercore, 16-ea-11-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-9-jdk-nanoserver-1809, 16-ea-9-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-9-jdk-nanoserver, 16-ea-9-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-11-jdk-nanoserver-1809, 16-ea-11-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-11-jdk-nanoserver, 16-ea-11-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 25129334ccc476f03ff981d399c163f9f37da007
+GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 15-jdk-oraclelinux7, 15-oraclelinux7, 15-jdk-oracle, 15-oracle
 SharedTags: 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
+GitCommit: 82d5067061455260f202a00c42ce372d43038be0
 Directory: 15/jdk/oraclelinux7
 
 Tags: 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
+GitCommit: 82d5067061455260f202a00c42ce372d43038be0
 Directory: 15/jdk/buster
 
 Tags: 15-jdk-slim-buster, 15-slim-buster, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
+GitCommit: 82d5067061455260f202a00c42ce372d43038be0
 Directory: 15/jdk/slim-buster
 
 Tags: 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
 SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
+GitCommit: 73bb0adbae399094463dec65d1cdec506860c7e2
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
 SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
+GitCommit: 73bb0adbae399094463dec65d1cdec506860c7e2
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/82d5067: Update to 15
- https://github.com/docker-library/openjdk/commit/00da668: Update to 16-ea+11
- https://github.com/docker-library/openjdk/commit/73bb0ad: Update to 15

This OpenJDK 15 is Build 36, which according to https://jdk.java.net/15/ is still a release candidate (so no `latest` changes yet).

(According to https://openjdk.java.net/projects/jdk/15/, GA is planned for 2020-09-15.)