### PR TITLE
Add OpenJDK 16 based Clojure images

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 494a44db6fb37639bb2b1bcc19ce2ee30e7bb648
+GitCommit: 35746beec4783f59ef1835e98f512f65ea12bfad
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
@@ -84,3 +84,30 @@ Directory: target/openjdk-15-slim-buster/tools-deps
 
 Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.561-buster
 Directory: target/openjdk-15-buster/tools-deps
+
+Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.3, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.3-slim-buster
+Directory: target/openjdk-16-slim-buster/lein
+
+Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.3-buster
+Directory: target/openjdk-16-buster/lein
+
+Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
+Directory: target/openjdk-16-slim-buster/boot
+
+Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
+Directory: target/openjdk-16-buster/boot
+
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.561, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.561-slim-buster
+Directory: target/openjdk-16-slim-buster/tools-deps
+
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.561-buster
+Directory: target/openjdk-16-buster/tools-deps
+
+Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.3-alpine
+Directory: target/openjdk-16-alpine/lein
+
+Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
+Directory: target/openjdk-16-alpine/boot
+
+Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.561-alpine
+Directory: target/openjdk-16-alpine/tools-deps


### PR DESCRIPTION
Adding in OpenJDK 16 based Clojure images now that it is out. The experimental Alpine support has moved to this version now, as the OpenJDK folks tend to do.