### PR TITLE
Update Solr to 8.6.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,14 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.6.0, 8.6, 8, latest
+Tags: 8.6.1, 8.6, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: d86046a9ea94e91ee494c86a9bae4b6b5a44c64d
+GitCommit: c83769be23088cf543cd268699e8968a1aa1b27e
 Directory: 8.6
 
-Tags: 8.6.0-slim, 8.6-slim, 8-slim, slim
+Tags: 8.6.1-slim, 8.6-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: d86046a9ea94e91ee494c86a9bae4b6b5a44c64d
+GitCommit: c83769be23088cf543cd268699e8968a1aa1b27e
 Directory: 8.6/slim
 
 Tags: 8.5.2, 8.5


### PR DESCRIPTION
See [Announcement](https://lists.apache.org/thread.html/rf29da509afdc05b778c25a4ee775102f2bbad3826a1f06c12409a232%40%3Csolr-user.lucene.apache.org%3E) which links to the release notes which further links to [upgrade considerations](https://github.com/apache/lucene-solr/blob/master/solr/solr-ref-guide/src/solr-upgrade-notes.adoc).

Note: we'll continue to keep older images, even if the oldest ones are not really "supported" but kinda/sorta are.  If we "shouldn't" or there are limitations, let us know.