### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev2, 2.3-dev
+Tags: 2.3-dev3, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ee573f899c6e14b8eb021cda4961ffbee8ba5bcd
+GitCommit: dd549577662cdcae1a57873b2dbb1ad2b682d990
 Directory: 2.3-rc
 
-Tags: 2.3-dev2-alpine, 2.3-dev-alpine
+Tags: 2.3-dev3-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ee573f899c6e14b8eb021cda4961ffbee8ba5bcd
+GitCommit: dd549577662cdcae1a57873b2dbb1ad2b682d990
 Directory: 2.3-rc/alpine
 
 Tags: 2.2.2, 2.2, latest, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dd54957: Update to 2.3-dev3