### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -24,22 +24,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/alpine/management
 
-Tags: 3.7.27, 3.7
+Tags: 3.7.28, 3.7
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e07d999b4f7e2c60459d79e504a4e008b86681ff
+GitCommit: 7257ddb5361d42bc5a952b6d2e357fc623131627
 Directory: 3.7/ubuntu
 
-Tags: 3.7.27-management, 3.7-management
+Tags: 3.7.28-management, 3.7-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bf2c73df6ee8475ac30c9773a8128852450ea518
 Directory: 3.7/ubuntu/management
 
-Tags: 3.7.27-alpine, 3.7-alpine
+Tags: 3.7.28-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e07d999b4f7e2c60459d79e504a4e008b86681ff
+GitCommit: 7257ddb5361d42bc5a952b6d2e357fc623131627
 Directory: 3.7/alpine
 
-Tags: 3.7.27-management-alpine, 3.7-management-alpine
+Tags: 3.7.28-management-alpine, 3.7-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bf2c73df6ee8475ac30c9773a8128852450ea518
 Directory: 3.7/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7257ddb: Update to 3.7.28, Erlang/OTP 22.3.4.7, OpenSSL 1.1.1g