### PR TITLE
[security] Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.6, 3.8, 3, latest
+Tags: 3.8.7, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c7faaf0fdcd1cf88b1299f85fc2d09af791e62b
+GitCommit: d2c116b97e4a76e91564a994aed3db8dfa634b02
 Directory: 3.8/ubuntu
 
-Tags: 3.8.6-management, 3.8-management, 3-management, management
+Tags: 3.8.7-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.6-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.7-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c7faaf0fdcd1cf88b1299f85fc2d09af791e62b
+GitCommit: d2c116b97e4a76e91564a994aed3db8dfa634b02
 Directory: 3.8/alpine
 
-Tags: 3.8.6-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.7-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/d2c116b: Update to 3.8.7, Erlang/OTP 23.0.3, OpenSSL 1.1.1g