### PR TITLE
arangodb 3.7.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,11 +1,14 @@
-# maintainer: Frank Celler <info@arangodb.com> (@fceller)
-# maintainer: Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart)
-# maintainer: Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
+Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart), Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
+GitRepo: https://github.com/arangodb/arangodb-docker
 
-3.4: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.4.10
-3.4.10: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.4.10
-3.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.5.5.1
-3.5.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.5.5.1
-3.6: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5
-3.6.5: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5
-latest: https://github.com/arangodb/arangodb-docker@26a907ab559d36823a7de6d1e2eeee24aeade1e2 alpine/3.6.5
+Tags: 3.5, 3.5.5
+GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483 
+Directory: alpine/3.5.5.1
+
+Tags: 3.6, 3.6.5
+GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483
+Directory: alpine/3.6.5
+
+Tags: 3.7, 3.7.1, latest
+GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483
+Directory: alpine/3.7.1


### PR DESCRIPTION
Updated ArangoDB to 3.7.1, fixed ArangoDB 3.5 and ArangoDB 3.6, removed ArangoDB 3.4, addressed https://github.com/docker-library/bashbrew/issues/16.