### PR TITLE
Bump Traefik to v2.3.0-rc4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.3.0-rc3-windowsservercore-1809, 2.3.0-rc3-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-rc4-windowsservercore-1809, 2.3.0-rc4-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 06e008a7576a80d08e21c8592bfdca03b9707e09
+GitCommit: 2012b77109a5d9c40c829b3b1471179c490a6472
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc3, 2.3.0-rc3, v2.3, 2.3, picodon
+Tags: v2.3.0-rc4, 2.3.0-rc4, v2.3, 2.3, picodon
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 06e008a7576a80d08e21c8592bfdca03b9707e09
+GitCommit: 2012b77109a5d9c40c829b3b1471179c490a6472
 Directory: alpine
 
 Tags: v2.2.8-windowsservercore-1809, 2.2.8-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.3.0-rc4](https://github.com/containous/traefik/releases/tag/v2.3.0-rc4).

/cc @ldez @mmatur @SantoDE

Cheers
