### PR TITLE
Fix python installation in CrateDB 3.3.5.

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -18,4 +18,4 @@ GitCommit: 7791cda08fbf054ab2ce7a988f8811074b8c3bf4
 
 Tags: 3.3.5, 3.3
 Architectures: amd64, arm64v8
-GitCommit: f5c527fb12df004e3fc620fd9d91b97686f56ef8
+GitCommit: 896c3f63e8e3d4746019e379a7aefb5225b050e3


### PR DESCRIPTION
The 3.3.5 image was at some point rebuilt with the newer base image
which broke the python installation. Consequently, CrateDB crash CLI
was also not possible to use.