### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.7, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13daa516eb621cb6b43e683c8d5af4516b3ac1e8
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/ubuntu
 
 Tags: 3.8.7-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/ubuntu/management
 
 Tags: 3.8.7-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13daa516eb621cb6b43e683c8d5af4516b3ac1e8
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/alpine
 
 Tags: 3.8.7-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 13d43346f3c0b4de9a15c9589ecdf8b3e22b689c
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/86a695b: Merge pull request https://github.com/docker-library/rabbitmq/pull/422 from infosiftr/prometheus
- https://github.com/docker-library/rabbitmq/commit/8886389: Enable "rabbitmq_prometheus" in RabbitMQ 3.8 by default