### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,20 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-11-jdk-oraclelinux7, 16-ea-11-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-11-jdk-oracle, 16-ea-11-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-12-jdk-oraclelinux7, 16-ea-12-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-12-jdk-oracle, 16-ea-12-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-12-jdk, 16-ea-12, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-11-jdk-buster, 16-ea-11-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-12-jdk-buster, 16-ea-12-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/buster
 
-Tags: 16-ea-11-jdk-slim-buster, 16-ea-11-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-11-jdk-slim, 16-ea-11-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-12-jdk-slim-buster, 16-ea-12-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-12-jdk-slim, 16-ea-12-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -25,24 +25,24 @@ Architectures: amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-11-jdk-windowsservercore-1809, 16-ea-11-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-11-jdk-windowsservercore, 16-ea-11-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-12-jdk-windowsservercore-1809, 16-ea-12-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-12-jdk-windowsservercore, 16-ea-12-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-12-jdk, 16-ea-12, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-11-jdk-windowsservercore-ltsc2016, 16-ea-11-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-11-jdk-windowsservercore, 16-ea-11-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-11-jdk, 16-ea-11, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-12-jdk-windowsservercore-ltsc2016, 16-ea-12-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-12-jdk-windowsservercore, 16-ea-12-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-12-jdk, 16-ea-12, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-11-jdk-nanoserver-1809, 16-ea-11-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-11-jdk-nanoserver, 16-ea-11-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-12-jdk-nanoserver-1809, 16-ea-12-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-12-jdk-nanoserver, 16-ea-12-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 00da66800f522f7aec978e6599ec24ffba31b7c5
+GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -155,12 +155,12 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.8-jre-buster, 11.0-jre-buster, 11-jre-buster
 SharedTags: 11.0.8-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 1f1ff0100fb7d6dad50e71f50f11ce10a1f1dcef
 Directory: 11/jre/buster
 
 Tags: 11.0.8-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.8-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 1f1ff0100fb7d6dad50e71f50f11ce10a1f1dcef
 Directory: 11/jre/slim-buster
 
 Tags: 11.0.8-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/ce18be6: Update to 16-ea+12
- https://github.com/docker-library/openjdk/commit/1f1ff01: Update to 11.0.8
- https://github.com/docker-library/openjdk/commit/4a63352: Update to 11.0.8