### PR TITLE
Update to Flink 1.10.2

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -24,12 +24,12 @@ Architectures: amd64
 GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
 Directory: ./1.11/scala_2.11-java11-debian
 
-Tags: 1.10.1-scala_2.12, 1.10-scala_2.12, 1.10.1, 1.10
+Tags: 1.10.2-scala_2.12, 1.10-scala_2.12, 1.10.2, 1.10
 Architectures: amd64
-GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
+GitCommit: 58a29fca7c6ff05999fad4371638d16335f7e93e
 Directory: ./1.10/scala_2.12-debian
 
-Tags: 1.10.1-scala_2.11, 1.10-scala_2.11
+Tags: 1.10.2-scala_2.11, 1.10-scala_2.11
 Architectures: amd64
-GitCommit: 31794825ad02db8b0eb961372c74a309a4504bcd
+GitCommit: 58a29fca7c6ff05999fad4371638d16335f7e93e
 Directory: ./1.10/scala_2.11-debian


### PR DESCRIPTION
Update to include the latest 1.10.2 release. The Dockerfiles have already been added into flink-docker repo.