### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,11 +1,16 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/83fbf16d99f4094df192b4f07909b473ad1d8392/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/754d834164985ed1852aad4bb6c86ae199683ff8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-12-jdk-oraclelinux7, 16-ea-12-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-12-jdk-oracle, 16-ea-12-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+Tags: 16-ea-12-jdk-oraclelinux8, 16-ea-12-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-12-jdk-oracle, 16-ea-12-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
 SharedTags: 16-ea-12-jdk, 16-ea-12, 16-ea-jdk, 16-ea, 16-jdk, 16
+Architectures: amd64, arm64v8
+GitCommit: 754d834164985ed1852aad4bb6c86ae199683ff8
+Directory: 16/jdk/oraclelinux8
+
+Tags: 16-ea-12-jdk-oraclelinux7, 16-ea-12-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/oraclelinux7
@@ -46,8 +51,13 @@ GitCommit: ce18be6e30d5ca2096c6c87e1d1237e5c83dff09
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-jdk-oraclelinux7, 15-oraclelinux7, 15-jdk-oracle, 15-oracle
+Tags: 15-jdk-oraclelinux8, 15-oraclelinux8, 15-jdk-oracle, 15-oracle
 SharedTags: 15-jdk, 15
+Architectures: amd64, arm64v8
+GitCommit: 754d834164985ed1852aad4bb6c86ae199683ff8
+Directory: 15/jdk/oraclelinux8
+
+Tags: 15-jdk-oraclelinux7, 15-oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: 82d5067061455260f202a00c42ce372d43038be0
 Directory: 15/jdk/oraclelinux7
@@ -83,8 +93,13 @@ GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
+Tags: 14.0.2-jdk-oraclelinux8, 14.0.2-oraclelinux8, 14.0-jdk-oraclelinux8, 14.0-oraclelinux8, 14-jdk-oraclelinux8, 14-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
 SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Architectures: amd64
+GitCommit: 754d834164985ed1852aad4bb6c86ae199683ff8
+Directory: 14/jdk/oraclelinux8
+
+Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 14/jdk/oraclelinux7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/566a953: Merge pull request https://github.com/docker-library/openjdk/pull/425 from infosiftr/oraclelinux8
- https://github.com/docker-library/openjdk/commit/cf6e356: Remove 15-alpine3.12
- https://github.com/docker-library/openjdk/commit/754d834: Update to Oracle Linux 8