### PR TITLE
Update cassandra to 3.0.21, add 4.0-beta1

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,12 +14,17 @@ Architectures: amd64, arm32v7, ppc64le
 GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
 Directory: 2.2
 
-Tags: 3.0.20, 3.0
+Tags: 3.0.21, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
+GitCommit: a39fcee215c6148c3fa4a5c7c66dba7acbc69af7
 Directory: 3.0
 
 Tags: 3.11.7, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 038fd5c0738b5543b2ad2052ceee4f18d7170cae
 Directory: 3.11
+
+Tags: 4.0-beta1, 4.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: d7cb5f108406918d855509f70cebc37ae6dc1131
+Directory: 4.0


### PR DESCRIPTION
(Note that this still does not include 2.2.17 due to https://issues.apache.org/jira/browse/CASSANDRA-16008)