### PR TITLE
Updating Oracle Linux 6/6-slim images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 01f8016e70f354062085a7f3fc156e071ea84943
+amd64-GitCommit: ebe69d3cb52596f308ab2a07e667b2532c8b297d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: c7be2aedfddb50438c203f5ac2201f8853204f8c


### PR DESCRIPTION
Updated `ca-certificates` RPM: https://oss.oracle.com/pipermail/el-errata/2020-August/010249.html

We have also renamed our rootfs tarballs to include the architecture in the file name.

Signed-off-by: Avi Miller <avi.miller@oracle.com>