### PR TITLE
arangodb 3.7.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -9,6 +9,6 @@ Tags: 3.6, 3.6.5
 GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483
 Directory: alpine/3.6.5
 
-Tags: 3.7, 3.7.1, latest
-GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483
-Directory: alpine/3.7.1
+Tags: 3.7, 3.7.2, latest
+GitCommit: 42207325717f11a3a844d8bcc2ca17c93714a2bd
+Directory: alpine/3.7.2


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.2.