### PR TITLE
Update monica to v2.19.0

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -2,17 +2,17 @@
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
-Tags: 2.18.0-apache, 2.18-apache, 2-apache, apache, 2.18.0, 2.18, 2, latest
+Tags: 2.19.0-apache, 2.19-apache, 2-apache, apache, 2.19.0, 2.19, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: 7a83d357006fe1b7947717d75842ea4d6f720ac5
+GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3
 
-Tags: 2.18.0-fpm, 2.18-fpm, 2-fpm, fpm
+Tags: 2.19.0-fpm, 2.19-fpm, 2-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: 7a83d357006fe1b7947717d75842ea4d6f720ac5
+GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3
 
-Tags: 2.18.0-fpm-alpine, 2.18-fpm-alpine, 2-fpm-alpine, fpm-alpine
+Tags: 2.19.0-fpm-alpine, 2.19-fpm-alpine, 2-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: 7a83d357006fe1b7947717d75842ea4d6f720ac5
+GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3


### PR DESCRIPTION
Changes:
https://github.com/monicahq/docker/commit/fd973cc5c4990a023fb8030f4665cd418e672de3 : update to v2.19.0 (https://github.com/monicahq/docker/pull/26) 