### PR TITLE
Adjusted the Kong containers to infer their dependencies from the packages

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -3,19 +3,19 @@ GitRepo: https://github.com/Kong/docker-kong.git
 # needs "Constraints" to match "centos" (which this image is "FROM")
 
 Tags: 2.1.3-alpine, 2.1-alpine, 2.1.3, 2.1, 2, alpine, latest
-GitCommit: 3fc6f864b2f8b34020c5ab0fc6ee694059475cc0
+GitCommit: 4ea6f606bcde98ada72559844e6939ce6ff42efe
 GitFetch: refs/tags/2.1.3
 Directory: alpine
 Architectures: amd64
 
 Tags: 2.1.3-ubuntu, 2.1-ubuntu, ubuntu
-GitCommit: 3fc6f864b2f8b34020c5ab0fc6ee694059475cc0
+GitCommit: 4ea6f606bcde98ada72559844e6939ce6ff42efe
 GitFetch: refs/tags/2.1.3
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 2.1.3-centos, 2.1-centos, centos
-GitCommit: 3fc6f864b2f8b34020c5ab0fc6ee694059475cc0
+GitCommit: 4ea6f606bcde98ada72559844e6939ce6ff42efe
 GitFetch: refs/tags/2.1.3
 Directory: centos
 Architectures: amd64


### PR DESCRIPTION
We'd like to de-dup our dependency list and trust `fpm` to specify the requirements