### PR TITLE
Updates to websphere-liberty for 20.0.0.9 release

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: d2ec62855dc1c7efc1a4294eb84259bc2fbdf5da
+GitCommit: 259400d0cfe000c3741919640983c4e9a4fca3b8
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -16,12 +16,12 @@ Tags: full, latest
 Directory: ga/latest/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.8-kernel-java8-ibmjava
-Directory: ga/20.0.0.8/kernel
+Tags: 20.0.0.9-kernel-java8-ibmjava
+Directory: ga/20.0.0.9/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.8-full-java8-ibmjava
-Directory: ga/20.0.0.8/full
+Tags: 20.0.0.9-full-java8-ibmjava
+Directory: ga/20.0.0.9/full
 File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.6-kernel-java8-ibmjava
@@ -30,12 +30,4 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.6-full-java8-ibmjava
 Directory: ga/20.0.0.6/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.3-kernel-java8-ibmjava
-Directory: ga/20.0.0.3/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.3-full-java8-ibmjava
-Directory: ga/20.0.0.3/full
 File: Dockerfile.ubuntu.ibmjava8


### PR DESCRIPTION
Update available versions for websphere-liberty and release 20.0.0.9.