### PR TITLE
Updates to open-liberty for the 20.0.0.9 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: f298155c3f61532fcf4ed8b4feedfb5ebece793b
+GitCommit: f00edd9cde30ac11d08c0bce4a2de8d435bd8f5d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel, kernel-java8-openj9
@@ -15,13 +15,13 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.8-kernel-java8-openj9
-Directory: releases/20.0.0.8/kernel
+Tags: 20.0.0.9-kernel-java8-openj9
+Directory: releases/20.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.8-full-java8-openj9
-Directory: releases/20.0.0.8/full
+Tags: 20.0.0.9-full-java8-openj9
+Directory: releases/20.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
@@ -32,15 +32,5 @@ File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 20.0.0.6-full-java8-openj9
 Directory: releases/20.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.3-kernel-java8-openj9
-Directory: releases/20.0.0.3/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.3-full-java8-openj9
-Directory: releases/20.0.0.3/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8


### PR DESCRIPTION
Update available versions for open-liberty and release 20.0.0.9.