### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -7,27 +7,27 @@ GitRepo: https://github.com/docker-library/openjdk.git
 Tags: 16-ea-13-jdk-oraclelinux8, 16-ea-13-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-13-jdk-oracle, 16-ea-13-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
 SharedTags: 16-ea-13-jdk, 16-ea-13, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 6d84f8417bf9eb6d25515ab2400c02704bf9b8ea
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/oraclelinux8
 
 Tags: 16-ea-13-jdk-oraclelinux7, 16-ea-13-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 6d84f8417bf9eb6d25515ab2400c02704bf9b8ea
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/oraclelinux7
 
 Tags: 16-ea-13-jdk-buster, 16-ea-13-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 6d84f8417bf9eb6d25515ab2400c02704bf9b8ea
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/buster
 
 Tags: 16-ea-13-jdk-slim-buster, 16-ea-13-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-13-jdk-slim, 16-ea-13-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 6d84f8417bf9eb6d25515ab2400c02704bf9b8ea
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
 Architectures: amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/alpine3.12
 
 Tags: 16-ea-13-jdk-windowsservercore-1809, 16-ea-13-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
@@ -54,22 +54,22 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 15-jdk-oraclelinux8, 15-oraclelinux8, 15-jdk-oracle, 15-oracle
 SharedTags: 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 754d834164985ed1852aad4bb6c86ae199683ff8
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/oraclelinux8
 
 Tags: 15-jdk-oraclelinux7, 15-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 82d5067061455260f202a00c42ce372d43038be0
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/oraclelinux7
 
 Tags: 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
-GitCommit: 82d5067061455260f202a00c42ce372d43038be0
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/buster
 
 Tags: 15-jdk-slim-buster, 15-slim-buster, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
-GitCommit: 82d5067061455260f202a00c42ce372d43038be0
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/slim-buster
 
 Tags: 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
@@ -96,22 +96,22 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 14.0.2-jdk-oraclelinux8, 14.0.2-oraclelinux8, 14.0-jdk-oraclelinux8, 14.0-oraclelinux8, 14-jdk-oraclelinux8, 14-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
 SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
 Architectures: amd64
-GitCommit: 754d834164985ed1852aad4bb6c86ae199683ff8
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/oraclelinux8
 
 Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/oraclelinux7
 
 Tags: 14.0.2-jdk-buster, 14.0.2-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
 Architectures: amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/buster
 
 Tags: 14.0.2-jdk-slim-buster, 14.0.2-slim-buster, 14.0-jdk-slim-buster, 14.0-slim-buster, 14-jdk-slim-buster, 14-slim-buster, jdk-slim-buster, slim-buster, 14.0.2-jdk-slim, 14.0.2-slim, 14.0-jdk-slim, 14.0-slim, 14-jdk-slim, 14-slim, jdk-slim, slim
 Architectures: amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/slim-buster
 
 Tags: 14.0.2-jdk-windowsservercore-1809, 14.0.2-windowsservercore-1809, 14.0-jdk-windowsservercore-1809, 14.0-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
@@ -138,12 +138,12 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.8-jdk-buster, 11.0.8-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 SharedTags: 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 11/jdk/buster
 
 Tags: 11.0.8-jdk-slim-buster, 11.0.8-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.8-jdk-slim, 11.0.8-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 11/jdk/slim-buster
 
 Tags: 11.0.8-jdk-windowsservercore-1809, 11.0.8-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/e47ecbf: Merge pull request https://github.com/docker-library/openjdk/pull/431 from infosiftr/ol8-utf8
- https://github.com/docker-library/openjdk/commit/52cb2ce: Use "C.UTF-8" in Oracle Linux 8 (it doesn't have "en_US.UTF-8" like 7 did)