### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/407a404a9aeb737ebba1d1e5420d9bae6319ccdf/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/5d6a38e81cf7557f6949d633e945cf50d705b45b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 407a404a9aeb737ebba1d1e5420d9bae6319ccdf
+GitCommit: 5d6a38e81cf7557f6949d633e945cf50d705b45b
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5f68e74ab5e43dfae266b6b02172d62108f0f85a
+amd64-GitCommit: 597e1bc3510ea2ba394fd73cd27915a3bd755a36
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: f377e3a13325b9f3de85868c955a222261de2044
+arm32v5-GitCommit: 2de2f9f019c00648ef6f96cf64df24be069946f8
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 6bc27a9c2549745a781c10f153961be11772564a
+arm32v6-GitCommit: e7f611582a8d3d5c154789850c2c30c13a104a67
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7be698bce4526b3a8f6c9e3288cfeaa884786576
+arm32v7-GitCommit: 2677e6c1fef85b3a0de23fbb9822c227f4b7cb75
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2a108bdd465cab558edc9721448e31a0ccad4158
+arm64v8-GitCommit: 4e455f50f85ffe048a2265784d508afd03930561
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 3b7b68f84ff42076e4cb683e9dec3d3863e98a85
+i386-GitCommit: 265a2f6622b5ec2abb16c4f31384cb4671c9776e
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: cd029cb21e5a7dc92d0853fd2d009a1225254695
+mips64le-GitCommit: aa8ea7fb0d4e1e37481b3dc2fc1f207426ed0a6c
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 1fa95bed9df3a5700b9c7d0a43142425c0b06938
+ppc64le-GitCommit: c2b990d6ba482e9ca75b36fed018c2f80a2f3459
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 094f9a1d85289b730f19f5e516125b181ed5f7d2
+s390x-GitCommit: e34c126282d51627131ce4ae9770dd1f1a6f24e8
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/5d6a38e: Update Buildroot to 2020.05.2