### PR TITLE
Update Joomla to 3.9.21

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -1,49 +1,49 @@
-# this file is generated via https://github.com/joomla/docker-joomla/blob/65b178365a9294612ba364adb2e12c02df056430/generate-stackbrew-library.sh
+# this file is generated via https://github.com/joomla-docker/docker-joomla/blob/0c6aa57f33a4ac2f371c35467191424730b23078/generate-stackbrew-library.sh
 
 Maintainers: Michael Babker <michael.babker@joomla.org> (@mbabker)
-GitRepo: https://github.com/joomla/docker-joomla.git
+GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 3.9.20-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.20-php7.2, 3.9-php7.2, 3-php7.2, php7.2
+Tags: 3.9.21-php7.2-apache, 3.9-php7.2-apache, 3-php7.2-apache, php7.2-apache, 3.9.21-php7.2, 3.9-php7.2, 3-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.2/apache
 
-Tags: 3.9.20-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
+Tags: 3.9.21-php7.2-fpm, 3.9-php7.2-fpm, 3-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.2/fpm
 
-Tags: 3.9.20-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 3.9.21-php7.2-fpm-alpine, 3.9-php7.2-fpm-alpine, 3-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.2/fpm-alpine
 
-Tags: 3.9.20-apache, 3.9-apache, 3-apache, apache, 3.9.20, 3.9, 3, latest, 3.9.20-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.20-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Tags: 3.9.21-apache, 3.9-apache, 3-apache, apache, 3.9.21, 3.9, 3, latest, 3.9.21-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.21-php7.3, 3.9-php7.3, 3-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.3/apache
 
-Tags: 3.9.20-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.20-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Tags: 3.9.21-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.21-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.3/fpm
 
-Tags: 3.9.20-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.20-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 3.9.21-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.21-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.3/fpm-alpine
 
-Tags: 3.9.20-php7.4-apache, 3.9-php7.4-apache, 3-php7.4-apache, php7.4-apache, 3.9.20-php7.4, 3.9-php7.4, 3-php7.4, php7.4
+Tags: 3.9.21-php7.4-apache, 3.9-php7.4-apache, 3-php7.4-apache, php7.4-apache, 3.9.21-php7.4, 3.9-php7.4, 3-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.4/apache
 
-Tags: 3.9.20-php7.4-fpm, 3.9-php7.4-fpm, 3-php7.4-fpm, php7.4-fpm
+Tags: 3.9.21-php7.4-fpm, 3.9-php7.4-fpm, 3-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.4/fpm
 
-Tags: 3.9.20-php7.4-fpm-alpine, 3.9-php7.4-fpm-alpine, 3-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 3.9.21-php7.4-fpm-alpine, 3.9-php7.4-fpm-alpine, 3-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 58e9fed6a8257e56dee4fca4a348b52b9ff6b1ab
+GitCommit: 9bbb72ba7eeadca698025d96f78ae441194700b5
 Directory: php7.4/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/joomla-docker/docker-joomla/commit/9deecb9: Merge pull request https://github.com/joomla-docker/docker-joomla/pull/102 from J0WI/update-repo-url
- https://github.com/joomla-docker/docker-joomla/commit/0c6aa57: Update repo url
- https://github.com/joomla-docker/docker-joomla/commit/9bbb72b: Joomla 3.9.21 (https://github.com/joomla-docker/docker-joomla/pull/98)
- https://github.com/joomla-docker/docker-joomla/commit/101afd8: update maintainer to @HLeithner (https://github.com/joomla-docker/docker-joomla/pull/99)
- https://github.com/joomla-docker/docker-joomla/commit/97ec165: Update to 3.9.20
- https://github.com/joomla-docker/docker-joomla/commit/b887639: Added optional environment variable JOOMLA_DB_PASSWORD_FILE (https://github.com/joomla-docker/docker-joomla/pull/100)