### PR TITLE
Add Couchbase Server 6.6.0 Community and 6.0.4 Enterprise.

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,9 +1,14 @@
-# maintainer: Couchbase Docker Team <docker@couchbase.com> (@couchbase)
+Maintainers: Couchbase Docker Team <docker@couchbase.com> (@cb-robot)
+GitRepo: https://github.com/couchbase/docker
 
-latest: https://github.com/couchbase/docker@f0ab8e5c7fc1091465097dc231cd5586f3eb7355 enterprise/couchbase-server/6.6.0
-enterprise: https://github.com/couchbase/docker@f0ab8e5c7fc1091465097dc231cd5586f3eb7355 enterprise/couchbase-server/6.6.0
-6.6.0: https://github.com/couchbase/docker@f0ab8e5c7fc1091465097dc231cd5586f3eb7355 enterprise/couchbase-server/6.6.0
-enterprise-6.6.0: https://github.com/couchbase/docker@f0ab8e5c7fc1091465097dc231cd5586f3eb7355 enterprise/couchbase-server/6.6.0
+Tags: latest, enterprise, 6.6.0, enterprise-6.6.0
+GitCommit: f0ab8e5c7fc1091465097dc231cd5586f3eb7355
+Directory: enterprise/couchbase-server/6.6.0
 
-community: https://github.com/couchbase/docker@f17df7695bbd6efb756b90b683bd5f34d08b5708 community/couchbase-server/6.5.1
-community-6.5.1: https://github.com/couchbase/docker@f17df7695bbd6efb756b90b683bd5f34d08b5708 community/couchbase-server/6.5.1
+Tags: community, community-6.6.0
+GitCommit: 78cbcaa2c90ce4c975299e7cbfdce146a7bab081
+Directory: community/couchbase-server/6.6.0
+
+Tags: 6.0.4, enterprise-6.0.4
+GitCommit: 06229f9e31b76eff7596e76d5894898744fdcb52
+Directory: enterprise/couchbase-server/6.0.4


### PR DESCRIPTION
Also addressed docker-library/bashbrew#16 by converting to new
official-images library format.