### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,76 +5,76 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.15.0-buster, 1.15-buster, 1-buster, buster
-SharedTags: 1.15.0, 1.15, 1, latest
+Tags: 1.15.1-buster, 1.15-buster, 1-buster, buster
+SharedTags: 1.15.1, 1.15, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 27e355e6f1d992c6d274d6023d904ee32526eb4d
 Directory: 1.15/buster
 
-Tags: 1.15.0-alpine3.12, 1.15-alpine3.12, 1-alpine3.12, alpine3.12, 1.15.0-alpine, 1.15-alpine, 1-alpine, alpine
+Tags: 1.15.1-alpine3.12, 1.15-alpine3.12, 1-alpine3.12, alpine3.12, 1.15.1-alpine, 1.15-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 27e355e6f1d992c6d274d6023d904ee32526eb4d
 Directory: 1.15/alpine3.12
 
-Tags: 1.15.0-windowsservercore-1809, 1.15-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.15.0-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.0, 1.15, 1, latest
+Tags: 1.15.1-windowsservercore-1809, 1.15-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.15.1-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.1, 1.15, 1, latest
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 27e355e6f1d992c6d274d6023d904ee32526eb4d
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.15.0-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.15.0-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.0, 1.15, 1, latest
+Tags: 1.15.1-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.15.1-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.1, 1.15, 1, latest
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 27e355e6f1d992c6d274d6023d904ee32526eb4d
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.15.0-nanoserver-1809, 1.15-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.15.0-nanoserver, 1.15-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.15.1-nanoserver-1809, 1.15-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.15.1-nanoserver, 1.15-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 27e355e6f1d992c6d274d6023d904ee32526eb4d
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.14.7-buster, 1.14-buster
-SharedTags: 1.14.7, 1.14
+Tags: 1.14.8-buster, 1.14-buster
+SharedTags: 1.14.8, 1.14
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/buster
 
-Tags: 1.14.7-stretch, 1.14-stretch
+Tags: 1.14.8-stretch, 1.14-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/stretch
 
-Tags: 1.14.7-alpine3.12, 1.14-alpine3.12, 1.14.7-alpine, 1.14-alpine
+Tags: 1.14.8-alpine3.12, 1.14-alpine3.12, 1.14.8-alpine, 1.14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/alpine3.12
 
-Tags: 1.14.7-alpine3.11, 1.14-alpine3.11
+Tags: 1.14.8-alpine3.11, 1.14-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/alpine3.11
 
-Tags: 1.14.7-windowsservercore-1809, 1.14-windowsservercore-1809
-SharedTags: 1.14.7-windowsservercore, 1.14-windowsservercore, 1.14.7, 1.14
+Tags: 1.14.8-windowsservercore-1809, 1.14-windowsservercore-1809
+SharedTags: 1.14.8-windowsservercore, 1.14-windowsservercore, 1.14.8, 1.14
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.14.7-windowsservercore-ltsc2016, 1.14-windowsservercore-ltsc2016
-SharedTags: 1.14.7-windowsservercore, 1.14-windowsservercore, 1.14.7, 1.14
+Tags: 1.14.8-windowsservercore-ltsc2016, 1.14-windowsservercore-ltsc2016
+SharedTags: 1.14.8-windowsservercore, 1.14-windowsservercore, 1.14.8, 1.14
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.14.7-nanoserver-1809, 1.14-nanoserver-1809
-SharedTags: 1.14.7-nanoserver, 1.14-nanoserver
+Tags: 1.14.8-nanoserver-1809, 1.14-nanoserver-1809
+SharedTags: 1.14.8-nanoserver, 1.14-nanoserver
 Architectures: windows-amd64
-GitCommit: 5e970060c3d8916095bc1dadacdd76754305c3c2
+GitCommit: 85066273efa66513af9874c2fc3860f0546e76a2
 Directory: 1.14/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/27e355e: Update 1.15 to 1.15.1
- https://github.com/docker-library/golang/commit/8506627: Update 1.14 to 1.14.8