### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0.6, 6.0, 6, latest, 6.0.6-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.7, 6.0, 6, latest, 6.0.7-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
+GitCommit: 85937fb903e1c0e0f97a79efac8f340e982398ce
 Directory: 6.0
 
-Tags: 6.0.6-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.6-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
+Tags: 6.0.7-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.7-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
+GitCommit: 85937fb903e1c0e0f97a79efac8f340e982398ce
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
+GitCommit: 1b36753550afda4dd1227e883ddb2bb50b30c810
 Directory: 5.0
 
 Tags: 5.0.9-32bit, 5.0-32bit, 5-32bit, 5.0.9-32bit-buster, 5.0-32bit-buster, 5-32bit-buster
 Architectures: amd64
-GitCommit: d3a0f3d95ac768db44dbcb87ecf88cfc436581d5
+GitCommit: 1b36753550afda4dd1227e883ddb2bb50b30c810
 Directory: 5.0/32bit
 
 Tags: 5.0.9-alpine, 5.0-alpine, 5-alpine, 5.0.9-alpine3.12, 5.0-alpine3.12, 5-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfd904a808cf68d4b5ecc267bb4d4a1a0ca5f921
+GitCommit: 1b36753550afda4dd1227e883ddb2bb50b30c810
 Directory: 5.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/85937fb: Update to 6.0.7
- https://github.com/docker-library/redis/commit/1b36753: Update "antirez/redis*" to "redis/redis*"