### PR TITLE
Mediawiki: Add fpm and fpm-alpine variants

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -12,6 +12,7 @@ Tags: 1.34.2-fpm, 1.34-fpm, stable-fpm
 Directory: 1.34/fpm
 
 Tags: 1.34.2-fpm-alpine, 1.34-fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.34/fpm-alpine
 
 Tags: 1.33.4, 1.33, legacy
@@ -21,6 +22,7 @@ Tags: 1.33.4-fpm, 1.33-fpm, legacy-fpm
 Directory: 1.33/fpm
 
 Tags: 1.33.4-fpm-alpine, 1.33-fpm-alpine, legacy-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.33/fpm-alpine
 
 Tags: 1.31.8, 1.31, lts, legacylts
@@ -30,4 +32,5 @@ Tags: 1.31.8-fpm, 1.31-fpm, lts-fpm, legacylts-fpm
 Directory: 1.31/fpm
 
 Tags: 1.31.8-fpm-alpine, 1.31-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.31/fpm-alpine

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,14 +2,32 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: fc6333cecb419c11e84b8c79b547eef6dfc54b17
+GitCommit: 9c1e9bdec7d96abd3a1a497da6f4d684b41dc551
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 Tags: 1.34.2, 1.34, stable, latest
-Directory: 1.34
+Directory: 1.34/apache
+
+Tags: 1.34.2-fpm, 1.34-fpm, stable-fpm, latest-fpm
+Directory: 1.34/fpm
+
+Tags: 1.34.2-fpm-alpine, 1.34-fpm-alpine, stable-fpm-alpine, latest-fpm-alpine
+Directory: 1.34/fpm-alpine
 
 Tags: 1.33.4, 1.33, legacy
-Directory: 1.33
+Directory: 1.33/apache
+
+Tags: 1.33.4-fpm, 1.33-fpm, legacy-fpm
+Directory: 1.33/fpm
+
+Tags: 1.33.4-fpm-alpine, 1.33-fpm-alpine, legacy-fpm-alpine
+Directory: 1.33/fpm-alpine
 
 Tags: 1.31.8, 1.31, lts, legacylts
-Directory: 1.31
+Directory: 1.31/apache
+
+Tags: 1.31.8-fpm, 1.31-fpm, lts-fpm, legacylts-fpm
+Directory: 1.31/fpm
+
+Tags: 1.31.8-fpm-alpine, 1.31-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Directory: 1.31/fpm-alpine

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -8,10 +8,10 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 Tags: 1.34.2, 1.34, stable, latest
 Directory: 1.34/apache
 
-Tags: 1.34.2-fpm, 1.34-fpm, stable-fpm, latest-fpm
+Tags: 1.34.2-fpm, 1.34-fpm, stable-fpm
 Directory: 1.34/fpm
 
-Tags: 1.34.2-fpm-alpine, 1.34-fpm-alpine, stable-fpm-alpine, latest-fpm-alpine
+Tags: 1.34.2-fpm-alpine, 1.34-fpm-alpine, stable-fpm-alpine
 Directory: 1.34/fpm-alpine
 
 Tags: 1.33.4, 1.33, legacy


### PR DESCRIPTION
Relating to https://github.com/wikimedia/mediawiki-docker/pull/81