### PR TITLE
Update Solr to 8.6.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,14 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.6.1, 8.6, 8, latest
+Tags: 8.6.2, 8.6, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: c83769be23088cf543cd268699e8968a1aa1b27e
+GitCommit: e544db9616b5c9a7bf7663c510c90d138bce6ae9
 Directory: 8.6
 
-Tags: 8.6.1-slim, 8.6-slim, 8-slim, slim
+Tags: 8.6.2-slim, 8.6-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: c83769be23088cf543cd268699e8968a1aa1b27e
+GitCommit: e544db9616b5c9a7bf7663c510c90d138bce6ae9
 Directory: 8.6/slim
 
 Tags: 8.5.2, 8.5


### PR DESCRIPTION
See [Announcement](https://lists.apache.org/thread.html/r56e9bc53644a25611ead8a610ec9f41af4b770e3a09c3291f607c580%40%3Csolr-user.lucene.apache.org%3E) which links to the release notes.

Two bug fixes:
* Zookeeper Admin screen not working for old ZK versions.
* Prevent a memory leak during commits