### PR TITLE
[nats] Release v2.1.8

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -3,31 +3,31 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Salinas <wally@synadia.com> (@wallyqs),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 936765ff17c10ab99f0141962897a93914b7e64d
+GitCommit: d10db6bd2f36dbb197173e2120037f4fa269b537
 
-Tags: 2.1.7-alpine3.11, 2.1-alpine3.11, 2-alpine3.11, alpine3.11, 2.1.7-alpine, 2.1-alpine, 2-alpine, alpine
+Tags: 2.1.8-alpine3.11, 2.1-alpine3.11, 2-alpine3.11, alpine3.11, 2.1.8-alpine, 2.1-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.1.7/alpine3.11
+Directory: 2.1.8/alpine3.11
 
-Tags: 2.1.7-scratch, 2.1-scratch, 2-scratch, scratch, 2.1.7-linux, 2.1-linux, 2-linux, linux
-SharedTags: 2.1.7, 2.1, 2, latest
+Tags: 2.1.8-scratch, 2.1-scratch, 2-scratch, scratch, 2.1.8-linux, 2.1-linux, 2-linux, linux
+SharedTags: 2.1.8, 2.1, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.1.7/scratch
+Directory: 2.1.8/scratch
 
-Tags: 2.1.7-windowsservercore-1809, 2.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.1.7-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.1.8-windowsservercore-1809, 2.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.1.8-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.7/windowsservercore-1809
+Directory: 2.1.8/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.1.7-nanoserver-1809, 2.1-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.1.7-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.7, 2.1, 2, latest
+Tags: 2.1.8-nanoserver-1809, 2.1-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.1.8-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.8, 2.1, 2, latest
 Architectures: windows-amd64
-Directory: 2.1.7/nanoserver-1809
+Directory: 2.1.8/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.1.7-windowsservercore-ltsc2016, 2.1-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.1.7-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.1.8-windowsservercore-ltsc2016, 2.1-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.1.8-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.7/windowsservercore-ltsc2016
+Directory: 2.1.8/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.1.8)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>