### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.7, 3.8, 3, latest
+Tags: 3.8.8, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: be3ec8479e17a62efe55d18dd9d5dae37721afba
+GitCommit: bd2d0bc278ed5cf6d203a6cfd46886c886e1d49e
 Directory: 3.8/ubuntu
 
-Tags: 3.8.7-management, 3.8-management, 3-management, management
+Tags: 3.8.8-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.7-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.8-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: be3ec8479e17a62efe55d18dd9d5dae37721afba
+GitCommit: bd2d0bc278ed5cf6d203a6cfd46886c886e1d49e
 Directory: 3.8/alpine
 
-Tags: 3.8.7-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.8-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/bd2d0bc: Update to 3.8.8, Erlang/OTP 23.0.3, OpenSSL 1.1.1g