### PR TITLE
Bump Traefik to v2.2.10

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: 2012b77109a5d9c40c829b3b1471179c490a6472
 Directory: alpine
 
-Tags: v2.2.8-windowsservercore-1809, 2.2.8-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.10-windowsservercore-1809, 2.2.10-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 3a918cb6253b82d01d5423266875617aeda0f1bc
+GitCommit: 5920a9c73cb53b985a535a4b8cfbb98dc2f08ad6
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.8, 2.2.8, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.10, 2.2.10, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 3a918cb6253b82d01d5423266875617aeda0f1bc
+GitCommit: 5920a9c73cb53b985a535a4b8cfbb98dc2f08ad6
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.2.10](https://github.com/containous/traefik/releases/tag/v2.2.10).

/cc @mmatur @SantoDE @jbdoumenjou

Cheers
