### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -53,15 +53,15 @@ Directory: php7.4/fpm-alpine
 
 Tags: cli-2.4.0-php7.2, cli-2.4-php7.2, cli-2-php7.2, cli-php7.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
+GitCommit: c0d11ed412fef07e748a5463041b7be0b5755dd6
 Directory: php7.2/cli
 
 Tags: cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
+GitCommit: c0d11ed412fef07e748a5463041b7be0b5755dd6
 Directory: php7.3/cli
 
 Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 403aefdf9b549d8f3df797e2284889d22a344dd5
+GitCommit: c0d11ed412fef07e748a5463041b7be0b5755dd6
 Directory: php7.4/cli


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/598769a: Merge pull request https://github.com/docker-library/wordpress/pull/387 from terencehonles/remove-cli-entrypoint-path-argument-to-load-plugins
- https://github.com/docker-library/wordpress/commit/c0d11ed: remove --path argument so plugins are loaded