### PR TITLE
Remove Sentry image

### DIFF
--- a/library/sentry
+++ b/library/sentry
@@ -1,12 +1,2 @@
-# this file is generated via https://github.com/getsentry/docker-sentry/blob/f58f91fe5dc31bfe77af277dae7002a5542326a9/generate-stackbrew-library.sh
-
-Maintainers: Matt Robenolt <matt@sentry.io> (@mattrobenolt)
+Maintainers: Sentry Open Source <oss@sentry.io> (@getsentry)
 GitRepo: https://github.com/getsentry/docker-sentry.git
-
-Tags: 9.1.2, 9.1, 9, latest
-GitCommit: 09a7761e841eee7fab758526b14d46ae56134952
-Directory: 9.1
-
-Tags: 9.1.2-onbuild, 9.1-onbuild, 9-onbuild, onbuild
-GitCommit: f58f91fe5dc31bfe77af277dae7002a5542326a9
-Directory: 9.1/onbuild


### PR DESCRIPTION
Sentry now requires multiple services to be set up and having a single official image, especially with the lack of cooperation from the Docker team for updates (see getsentry/docker-sentry#211) does not make sense. This page and image is now dragging us back as we want people to use the newer versions of Sentry.

Ideally, the old page would redirect to https://develop.sentry.dev/self-hosted/ or at least https://hub.docker.com/r/getsentry/sentry but it is okay if this is not possible.

/cc @mattrobenolt @benvinegar @dcramer