### PR TITLE
introduce hitch

### DIFF
--- a/library/hitch
+++ b/library/hitch
@@ -1,0 +1,8 @@
+# this file was generated using https://github.com/varnish/docker-hitch/blob/d2feb9f1a1a3426da633383c2bac4a31559248bd/populate.sh
+Maintainers: Thijs Feryn <thijs@varni.sh> (@thijsferyn),
+             Guillaume Quintard <guillaume@varni.sh> (@gquintard)
+GitRepo: https://github.com/varnish/docker-hitch.git	
+
+Tags: 1, 1.7, 1.7.0, 1.7.0-1, latest
+Architectures: amd64
+GitCommit: d2feb9f1a1a3426da633383c2bac4a31559248bd


### PR DESCRIPTION
Hi,

Here's a new version of https://github.com/docker-library/official-images/pull/7611, hopefully it'll be more aligned with the guidelines. It reuses a lot of the Varnish image experience and tries to fix the problems pointed out by #7611, notably, the command line is much easier to override and we are using a `gpg` fingerprint and the "right" keyservers. Oh, and we are not using the new project-built packages instead of the distro ones, so we can keep up with the releases.

# Checklist for Review
**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
-	[x] associated with or contacted upstream? (yes, I'm part of Varnish Software who maintains `hitch`)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution") (yes, "service")
-	[x] is it reasonably popular, or does it solve a particular use case well? (yes, provides up-to-date versions of the de facto TLS terminator used with Varnish)
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long) (docker-library/docs#1675)
-	[x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?) (no, no relevant base image here)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~ (not `FROM scratch`)
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)