### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,30 +1,30 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/de006e2143c7685102fcc790aec32ebdf1cf7789/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/c191e1ac6c2fe9973c7ac1f106d395d03ed05eba/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 2.1.21, 2.1
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
-Directory: 2.1
+Tags: 4.0-beta2, 4.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: b6554329fe112243d16861b441067227eedcbdf9
+Directory: 4.0
+
+Tags: 3.11.8, 3.11, 3, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 48c0cc4587c8b13dfc8d05d82cf68ee18753ca23
+Directory: 3.11
+
+Tags: 3.0.22, 3.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: d9d67aacb2a9777be83d27b01e85771f64aab577
+Directory: 3.0
 
 Tags: 2.2.16, 2.2, 2
 Architectures: amd64, arm32v7, ppc64le
-GitCommit: 4c146a91f56dc3043284c817f1d61f152199482c
+GitCommit: c191e1ac6c2fe9973c7ac1f106d395d03ed05eba
 Directory: 2.2
 
-Tags: 3.0.21, 3.0
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a39fcee215c6148c3fa4a5c7c66dba7acbc69af7
-Directory: 3.0
-
-Tags: 3.11.7, 3.11, 3, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 038fd5c0738b5543b2ad2052ceee4f18d7170cae
-Directory: 3.11
-
-Tags: 4.0-beta1, 4.0
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: d7cb5f108406918d855509f70cebc37ae6dc1131
-Directory: 4.0
+Tags: 2.1.22, 2.1
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 3c31ef99aca31c459b2cf57ee0596b4ab8024416
+Directory: 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/b655432: Update 4.0 to 4.0-beta2
- https://github.com/docker-library/cassandra/commit/48c0cc4: Update 3.11 to 3.11.8
- https://github.com/docker-library/cassandra/commit/d9d67aa: Update 3.0 to 3.0.22
- https://github.com/docker-library/cassandra/commit/3c31ef9: Update 2.1 to 2.1.22
- https://github.com/docker-library/cassandra/commit/d6edf41: Merge pull request https://github.com/docker-library/cassandra/pull/213 from infosiftr/jq-template
- https://github.com/docker-library/cassandra/commit/c191e1a: Add initial jq-based templating engine