### PR TITLE
Bump Traefik to v2.3.0-rc5 and v2.2.11

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -12,15 +12,15 @@ Architectures: amd64, arm32v6, arm64v8
 GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
 Directory: alpine
 
-Tags: v2.2.10-windowsservercore-1809, 2.2.10-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.2.11-windowsservercore-1809, 2.2.11-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 5920a9c73cb53b985a535a4b8cfbb98dc2f08ad6
+GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.2.10, 2.2.10, v2.2, 2.2, chevrotin, latest
+Tags: v2.2.11, 2.2.11, v2.2, 2.2, chevrotin, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 5920a9c73cb53b985a535a4b8cfbb98dc2f08ad6
+GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,15 +1,15 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
 GitRepo: https://github.com/containous/traefik-library-image.git
 
-Tags: v2.3.0-rc4-windowsservercore-1809, 2.3.0-rc4-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-rc5-windowsservercore-1809, 2.3.0-rc5-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
 Architectures: windows-amd64
-GitCommit: 2012b77109a5d9c40c829b3b1471179c490a6472
+GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc4, 2.3.0-rc4, v2.3, 2.3, picodon
+Tags: v2.3.0-rc5, 2.3.0-rc5, v2.3, 2.3, picodon
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 2012b77109a5d9c40c829b3b1471179c490a6472
+GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
 Directory: alpine
 
 Tags: v2.2.10-windowsservercore-1809, 2.2.10-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.0-rc5](https://github.com/containous/traefik/releases/tag/v2.3.0-rc5) and [v2.2.11](https://github.com/containous/traefik/releases/tag/v2.2.11).

/cc @ldez @mmatur @SantoDE

Cheers
