### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dd549577662cdcae1a57873b2dbb1ad2b682d990
 Directory: 2.3-rc/alpine
 
-Tags: 2.2.2, 2.2, latest, lts
+Tags: 2.2.3, 2.2, latest, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 69c34c84b187066a664ae2bc14600246a586f5f1
+GitCommit: 34fd8405ac1ee97647ec387fd6cd5da77b9b5449
 Directory: 2.2
 
-Tags: 2.2.2-alpine, 2.2-alpine, alpine, lts-alpine
+Tags: 2.2.3-alpine, 2.2-alpine, alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69c34c84b187066a664ae2bc14600246a586f5f1
+GitCommit: 34fd8405ac1ee97647ec387fd6cd5da77b9b5449
 Directory: 2.2/alpine
 
 Tags: 2.1.8, 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/34fd840: Update to 2.2.3