### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/5d6a38e81cf7557f6949d633e945cf50d705b45b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/6dae271348d2d16047c39527fc25f9b06ee67367/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 5d6a38e81cf7557f6949d633e945cf50d705b45b
+GitCommit: 6dae271348d2d16047c39527fc25f9b06ee67367
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 597e1bc3510ea2ba394fd73cd27915a3bd755a36
+amd64-GitCommit: 9f35d71493d683567e30f45b1cda4a0f1f11ae3f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 2de2f9f019c00648ef6f96cf64df24be069946f8
+arm32v5-GitCommit: fa0ab3f4a9198c64f249d45ce2027f077eecf0e4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: e7f611582a8d3d5c154789850c2c30c13a104a67
+arm32v6-GitCommit: 10716777c5b134b42476a3d2108398690b261e83
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 2677e6c1fef85b3a0de23fbb9822c227f4b7cb75
+arm32v7-GitCommit: 7d617c90637444953eca3bc3d3755f392ff7de7d
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4e455f50f85ffe048a2265784d508afd03930561
+arm64v8-GitCommit: 7ad4fc59b8cbbf2758052c0ef960326004d503f2
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 265a2f6622b5ec2abb16c4f31384cb4671c9776e
+i386-GitCommit: 88d369a04164726d329389b68ccc01401aca6d07
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: aa8ea7fb0d4e1e37481b3dc2fc1f207426ed0a6c
+mips64le-GitCommit: ca750041b66692d5704dcecad5abd79829aac1db
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: c2b990d6ba482e9ca75b36fed018c2f80a2f3459
+ppc64le-GitCommit: 93da82c93d7e80ae7402343fc2c01a56f20f0c4b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e34c126282d51627131ce4ae9770dd1f1a6f24e8
+s390x-GitCommit: 83e290048298c38b02d689975caf54978c3de2cb
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/6dae271: Update Buildroot to 2020.08