### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.0.7, 6.0, 6, latest, 6.0.7-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.8, 6.0, 6, latest, 6.0.8-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 85937fb903e1c0e0f97a79efac8f340e982398ce
+GitCommit: b004e0fcf5451a25f0a30f915afc48f69fff75f7
 Directory: 6.0
 
-Tags: 6.0.7-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.7-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
+Tags: 6.0.8-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.8-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 85937fb903e1c0e0f97a79efac8f340e982398ce
+GitCommit: b004e0fcf5451a25f0a30f915afc48f69fff75f7
 Directory: 6.0/alpine
 
 Tags: 5.0.9, 5.0, 5, 5.0.9-buster, 5.0-buster, 5-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/b004e0f: Update to 6.0.8