### PR TITLE
1.10.13 and 2.0.0-RC1

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -3,9 +3,9 @@
 Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
-Tags: 2.0.0-alpha3, 2.0, 2
+Tags: 2.0.0-RC1, 2.0, 2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25c2d0384e6eb770dc027c83643f3ff3942fa994
+GitCommit: a3e0f87f09b387e934bc13ebe7c93a7909fe0438
 Directory: 2.0
 
 Tags: 1.10.13, 1.10, 1, latest

--- a/library/composer
+++ b/library/composer
@@ -8,9 +8,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 25c2d0384e6eb770dc027c83643f3ff3942fa994
 Directory: 2.0
 
-Tags: 1.10.12, 1.10, 1, latest
+Tags: 1.10.13, 1.10, 1, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 349b9ca00c25442df8ec3c69bec8c4e49abf9e1f
+GitCommit: aace87229d5c3f988cb19e1dbac0567c2c503c58
 Directory: 1.10
 
 Tags: 1.9.3, 1.9


### PR DESCRIPTION
Seems I made a mistake with 1.10.13 and forgot to update my PR after we decided to skip the broken 1.10.12 release.