### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.32.1, 3.32, 3, latest
+Tags: 3.32.2, 3.32, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 384850d1f8a089eedc8690ef9801a568816bbee0
+GitCommit: ddc387bf979d3301f9add943156f9451062036dd
 Directory: 3/debian
 
-Tags: 3.32.1-alpine, 3.32-alpine, 3-alpine, alpine
+Tags: 3.32.2-alpine, 3.32-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 384850d1f8a089eedc8690ef9801a568816bbee0
+GitCommit: ddc387bf979d3301f9add943156f9451062036dd
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/ddc387b: Update to 3.32.2, ghost-cli 1.14.1