### PR TITLE
Update monica to v2.19.1

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -2,17 +2,17 @@
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
-Tags: 2.19.0-apache, 2.19-apache, 2-apache, apache, 2.19.0, 2.19, 2, latest
+Tags: 2.19.1-apache, 2.19-apache, 2-apache, apache, 2.19.1, 2.19, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3
+GitCommit: 1c9fd657cfc59067da9b30479ddf5cd04750b392
 
-Tags: 2.19.0-fpm, 2.19-fpm, 2-fpm, fpm
+Tags: 2.19.1-fpm, 2.19-fpm, 2-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3
+GitCommit: 1c9fd657cfc59067da9b30479ddf5cd04750b392
 
-Tags: 2.19.0-fpm-alpine, 2.19-fpm-alpine, 2-fpm-alpine, fpm-alpine
+Tags: 2.19.1-fpm-alpine, 2.19-fpm-alpine, 2-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: fd973cc5c4990a023fb8030f4665cd418e672de3
+GitCommit: 1c9fd657cfc59067da9b30479ddf5cd04750b392


### PR DESCRIPTION
Changes:
- update to v2.19.1 (https://github.com/monicahq/docker/pull/31)
- remove 'schedule:run' output redirect (https://github.com/monicahq/docker/pull/25)