### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/754d834164985ed1852aad4bb6c86ae199683ff8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/47a55000227629745b70a9fbd6cea68848666d0d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -51,85 +51,85 @@ GitCommit: 9bab8e64d6ea6863215d27a23273e8cd32a474be
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-jdk-oraclelinux8, 15-oraclelinux8, 15-jdk-oracle, 15-oracle
-SharedTags: 15-jdk, 15
+Tags: 15-jdk-oraclelinux8, 15-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 15-jdk-oracle, 15-oracle, jdk-oracle, oracle
+SharedTags: 15-jdk, 15, jdk, latest
 Architectures: amd64, arm64v8
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/oraclelinux8
 
-Tags: 15-jdk-oraclelinux7, 15-oraclelinux7
+Tags: 15-jdk-oraclelinux7, 15-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/oraclelinux7
 
-Tags: 15-jdk-buster, 15-buster
+Tags: 15-jdk-buster, 15-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/buster
 
-Tags: 15-jdk-slim-buster, 15-slim-buster, 15-jdk-slim, 15-slim
+Tags: 15-jdk-slim-buster, 15-slim-buster, jdk-slim-buster, slim-buster, 15-jdk-slim, 15-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 15/jdk/slim-buster
 
-Tags: 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, 15-jdk, 15
+Tags: 15-jdk-windowsservercore-1809, 15-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, jdk-windowsservercore, windowsservercore, 15-jdk, 15, jdk, latest
 Architectures: windows-amd64
 GitCommit: 73bb0adbae399094463dec65d1cdec506860c7e2
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, 15-jdk, 15
+Tags: 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 15-jdk-windowsservercore, 15-windowsservercore, jdk-windowsservercore, windowsservercore, 15-jdk, 15, jdk, latest
 Architectures: windows-amd64
 GitCommit: 73bb0adbae399094463dec65d1cdec506860c7e2
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15-jdk-nanoserver, 15-nanoserver
+Tags: 15-jdk-nanoserver-1809, 15-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 15-jdk-nanoserver, 15-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 9338202f5a42dca095a4ec0abb14433458da5cc6
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14.0.2-jdk-oraclelinux8, 14.0.2-oraclelinux8, 14.0-jdk-oraclelinux8, 14.0-oraclelinux8, 14-jdk-oraclelinux8, 14-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
-SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-oraclelinux8, 14.0.2-oraclelinux8, 14.0-jdk-oraclelinux8, 14.0-oraclelinux8, 14-jdk-oraclelinux8, 14-oraclelinux8, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle
+SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14
 Architectures: amd64
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/oraclelinux8
 
-Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7
 Architectures: amd64
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/oraclelinux7
 
-Tags: 14.0.2-jdk-buster, 14.0.2-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
+Tags: 14.0.2-jdk-buster, 14.0.2-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster
 Architectures: amd64
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/buster
 
-Tags: 14.0.2-jdk-slim-buster, 14.0.2-slim-buster, 14.0-jdk-slim-buster, 14.0-slim-buster, 14-jdk-slim-buster, 14-slim-buster, jdk-slim-buster, slim-buster, 14.0.2-jdk-slim, 14.0.2-slim, 14.0-jdk-slim, 14.0-slim, 14-jdk-slim, 14-slim, jdk-slim, slim
+Tags: 14.0.2-jdk-slim-buster, 14.0.2-slim-buster, 14.0-jdk-slim-buster, 14.0-slim-buster, 14-jdk-slim-buster, 14-slim-buster, 14.0.2-jdk-slim, 14.0.2-slim, 14.0-jdk-slim, 14.0-slim, 14-jdk-slim, 14-slim
 Architectures: amd64
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 14/jdk/slim-buster
 
-Tags: 14.0.2-jdk-windowsservercore-1809, 14.0.2-windowsservercore-1809, 14.0-jdk-windowsservercore-1809, 14.0-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-windowsservercore-1809, 14.0.2-windowsservercore-1809, 14.0-jdk-windowsservercore-1809, 14.0-windowsservercore-1809, 14-jdk-windowsservercore-1809, 14-windowsservercore-1809
+SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14
 Architectures: windows-amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 14/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 14.0.2-jdk-windowsservercore-ltsc2016, 14.0.2-windowsservercore-ltsc2016, 14.0-jdk-windowsservercore-ltsc2016, 14.0-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, jdk-windowsservercore, windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
+Tags: 14.0.2-jdk-windowsservercore-ltsc2016, 14.0.2-windowsservercore-ltsc2016, 14.0-jdk-windowsservercore-ltsc2016, 14.0-windowsservercore-ltsc2016, 14-jdk-windowsservercore-ltsc2016, 14-windowsservercore-ltsc2016
+SharedTags: 14.0.2-jdk-windowsservercore, 14.0.2-windowsservercore, 14.0-jdk-windowsservercore, 14.0-windowsservercore, 14-jdk-windowsservercore, 14-windowsservercore, 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14
 Architectures: windows-amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.2-jdk-nanoserver-1809, 14.0.2-nanoserver-1809, 14.0-jdk-nanoserver-1809, 14.0-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 14.0.2-jdk-nanoserver, 14.0.2-nanoserver, 14.0-jdk-nanoserver, 14.0-nanoserver, 14-jdk-nanoserver, 14-nanoserver, jdk-nanoserver, nanoserver
+Tags: 14.0.2-jdk-nanoserver-1809, 14.0.2-nanoserver-1809, 14.0-jdk-nanoserver-1809, 14.0-nanoserver-1809, 14-jdk-nanoserver-1809, 14-nanoserver-1809
+SharedTags: 14.0.2-jdk-nanoserver, 14.0.2-nanoserver, 14.0-jdk-nanoserver, 14.0-nanoserver, 14-jdk-nanoserver, 14-nanoserver
 Architectures: windows-amd64
 GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 14/jdk/windows/nanoserver-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/47a5500: Update latest to 15 (GA)

~This will unfortunately suffer from https://github.com/docker-library/bashbrew/issues/8. :disappointed:~ :smile: https://github.com/docker-library/bashbrew/pull/20