### PR TITLE
Update to Flink 1.11.2

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -4,24 +4,24 @@ Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.11.1-scala_2.12-java8, 1.11-scala_2.12-java8, scala_2.12-java8, 1.11.1-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.1-java8, 1.11-java8, java8, 1.11.1, 1.11, latest
+Tags: 1.11.2-scala_2.12-java8, 1.11-scala_2.12-java8, scala_2.12-java8, 1.11.2-scala_2.12, 1.11-scala_2.12, scala_2.12, 1.11.2-java8, 1.11-java8, java8, 1.11.2, 1.11, latest
 Architectures: amd64
-GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+GitCommit: 149ebb09d9146ec46c6df0ab73d638c4d7549c10
 Directory: ./1.11/scala_2.12-java8-debian
 
-Tags: 1.11.1-scala_2.11-java8, 1.11-scala_2.11-java8, scala_2.11-java8, 1.11.1-scala_2.11, 1.11-scala_2.11, scala_2.11
+Tags: 1.11.2-scala_2.11-java8, 1.11-scala_2.11-java8, scala_2.11-java8, 1.11.2-scala_2.11, 1.11-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+GitCommit: 149ebb09d9146ec46c6df0ab73d638c4d7549c10
 Directory: ./1.11/scala_2.11-java8-debian
 
-Tags: 1.11.1-scala_2.12-java11, 1.11-scala_2.12-java11, scala_2.12-java11, 1.11.1-java11, 1.11-java11, java11
+Tags: 1.11.2-scala_2.12-java11, 1.11-scala_2.12-java11, scala_2.12-java11, 1.11.2-java11, 1.11-java11, java11
 Architectures: amd64
-GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+GitCommit: 149ebb09d9146ec46c6df0ab73d638c4d7549c10
 Directory: ./1.11/scala_2.12-java11-debian
 
-Tags: 1.11.1-scala_2.11-java11, 1.11-scala_2.11-java11, scala_2.11-java11
+Tags: 1.11.2-scala_2.11-java11, 1.11-scala_2.11-java11, scala_2.11-java11
 Architectures: amd64
-GitCommit: 8aafb8413a9675ebbe74fe3e5d22141f26922977
+GitCommit: 149ebb09d9146ec46c6df0ab73d638c4d7549c10
 Directory: ./1.11/scala_2.11-java11-debian
 
 Tags: 1.10.2-scala_2.12, 1.10-scala_2.12, 1.10.2, 1.10


### PR DESCRIPTION
Update to include the latest 1.11.2 release. The Dockerfiles have already been added into flink-docker repo.