### PR TITLE
Release of GeoNetwork 4.0.0-alpha.2

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/7259ce435432fe1814da0e444328f450b8b6654b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/9d7d9cffd5746a263599dd69e84a00e0405e6b9d/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
@@ -24,7 +24,7 @@ Architectures: amd64
 GitCommit: af81a4ff8f592d27b4911ad20d569379864ee85f
 Directory: 3.8.3/postgres
 
-Tags: 4.0.0-alpha.1, 4.0.0-alpha, 4.0-alpha, 4-alpha
+Tags: 4.0.0-alpha.2, 4.0.0-alpha, 4.0-alpha, 4-alpha
 Architectures: amd64
-GitCommit: 4b3fa67a1869eb82609f4117bfe39ccfdd6b2387
-Directory: 4.0.0-alpha.1
+GitCommit: 7e5d8c3c362360b4b62812e5ebe5591c9e22badd
+Directory: 4.0.0-alpha.2


### PR DESCRIPTION
Release of GeoNetwork 4.0.0-alpha.2
https://github.com/geonetwork/docker-geonetwork/pull/53