### PR TITLE
arangodb 3.6.6, 3.7.2.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -5,10 +5,10 @@ Tags: 3.5, 3.5.5
 GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483 
 Directory: alpine/3.5.5.1
 
-Tags: 3.6, 3.6.5
-GitCommit: 64d9cc4ebed741b8098306094e26ee7c09fdf483
-Directory: alpine/3.6.5
+Tags: 3.6, 3.6.6
+GitCommit: 4845b146318913d7ebb71e73db9e04bf9c024348 
+Directory: alpine/3.6.6
 
 Tags: 3.7, 3.7.2, latest
-GitCommit: 42207325717f11a3a844d8bcc2ca17c93714a2bd
-Directory: alpine/3.7.2
+GitCommit: 4845b146318913d7ebb71e73db9e04bf9c024348
+Directory: alpine/3.7.2.1


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.6, 3.7 to 3.7.2.1 (3.7.2 with Hotfix 1).