### PR TITLE
Bump Traefik to v2.3.0-rc6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,40 +1,46 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@containo.us> (@ldez), Julien Salleyron <julien@containo.us> (@juliens), Nicolas Mengin <nicolas@containo.us> (@nmengin), Michael Matur <michael@containo.us> (@mmatur)
-GitRepo: https://github.com/containous/traefik-library-image.git
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.0-rc5-windowsservercore-1809, 2.3.0-rc5-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-rc6-windowsservercore-1809, 2.3.0-rc6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
+GitCommit: 9d823fd7bcc724b09bd9945803f28fc4ae98627f
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc5, 2.3.0-rc5, v2.3, 2.3, picodon
+Tags: v2.3.0-rc6, 2.3.0-rc6, v2.3, 2.3, picodon
+GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
+GitCommit: 9d823fd7bcc724b09bd9945803f28fc4ae98627f
 Directory: alpine
 
 Tags: v2.2.11-windowsservercore-1809, 2.2.11-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
+GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: windows-amd64
 GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.2.11, 2.2.11, v2.2, 2.2, chevrotin, latest
+GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: windows-amd64
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v1.7.26-alpine, 1.7.26-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: alpine
 
 Tags: v1.7.26, 1.7.26, v1.7, 1.7, maroilles
+GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: scratch


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.0-rc6](https://github.com/traefik/traefik/releases/tag/v2.3.0-rc6).

/cc @mmatur @SantoDE @jbdoumenjou

Cheers
