### PR TITLE
Bump Traefik to v2.3.0-rc7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.0-rc6-windowsservercore-1809, 2.3.0-rc6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-rc7-windowsservercore-1809, 2.3.0-rc6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: 9d823fd7bcc724b09bd9945803f28fc4ae98627f
+GitCommit: f26172e964d241b20aec31561a159886d8a9b681
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc6, 2.3.0-rc6, v2.3, 2.3, picodon
+Tags: v2.3.0-rc7, 2.3.0-rc7, v2.3, 2.3, picodon
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 9d823fd7bcc724b09bd9945803f28fc4ae98627f
+GitCommit: f26172e964d241b20aec31561a159886d8a9b681
 Directory: alpine
 
 Tags: v2.2.11-windowsservercore-1809, 2.2.11-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.0-rc7](https://github.com/traefik/traefik/releases/tag/v2.3.0-rc7).

/cc @mmatur @SantoDE @jbdoumenjou

Cheers
