### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.8, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66ddebbb7fc778c481da06856e350ceae3e02113
+GitCommit: d6dfd9c1a3ab39d55acf53e8c42860ff77d4680a
 Directory: 3.8/ubuntu
 
 Tags: 3.8.8-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.8-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66ddebbb7fc778c481da06856e350ceae3e02113
+GitCommit: d6dfd9c1a3ab39d55acf53e8c42860ff77d4680a
 Directory: 3.8/alpine
 
 Tags: 3.8.8-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/f43f4d7: Update to 3.8.8, Erlang/OTP 23.0.4, OpenSSL 1.1.1h