### PR TITLE
Bump Traefik to v2.3.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,29 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.0-rc7-windowsservercore-1809, 2.3.0-rc6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809
+Tags: v2.3.0-windowsservercore-1809, 2.3.0-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: f26172e964d241b20aec31561a159886d8a9b681
+GitCommit: 6827292e34bb173568e72f20281897946d635e4a
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0-rc7, 2.3.0-rc7, v2.3, 2.3, picodon
+Tags: v2.3.0, 2.3.0, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: f26172e964d241b20aec31561a159886d8a9b681
-Directory: alpine
-
-Tags: v2.2.11-windowsservercore-1809, 2.2.11-windowsservercore-1809, v2.2-windowsservercore-1809, 2.2-windowsservercore-1809, chevrotin-windowsservercore-1809, windowsservercore-1809
-GitRepo: https://github.com/containous/traefik-library-image.git
-Architectures: windows-amd64
-GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.2.11, 2.2.11, v2.2, 2.2, chevrotin, latest
-GitRepo: https://github.com/containous/traefik-library-image.git
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: d99fdc97173b0ba01c7da11c70598ac66a51f2db
+GitCommit: 6827292e34bb173568e72f20281897946d635e4a
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.0](https://github.com/traefik/traefik/releases/tag/v2.3.0).

/cc @mmatur @SantoDE @jbdoumenjou @rtribotte

Cheers
