### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.8, 3.8, 3, latest
+Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6dfd9c1a3ab39d55acf53e8c42860ff77d4680a
+GitCommit: 34cc2d72362cb9f73d8439fd7bde7887a2e5fdd3
 Directory: 3.8/ubuntu
 
-Tags: 3.8.8-management, 3.8-management, 3-management, management
+Tags: 3.8.9-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.8-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6dfd9c1a3ab39d55acf53e8c42860ff77d4680a
+GitCommit: 34cc2d72362cb9f73d8439fd7bde7887a2e5fdd3
 Directory: 3.8/alpine
 
-Tags: 3.8.8-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 888638927482f86af6e88bebb67423926cb1112f
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/34cc2d7: Update to 3.8.9, Erlang/OTP 23.1, OpenSSL 1.1.1h