### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-16-jdk-oraclelinux8, 16-ea-16-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-16-jdk-oracle, 16-ea-16-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-16-jdk, 16-ea-16, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-17-jdk-oraclelinux8, 16-ea-17-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-17-jdk-oracle, 16-ea-17-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-17-jdk, 16-ea-17, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-16-jdk-oraclelinux7, 16-ea-16-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-17-jdk-oraclelinux7, 16-ea-17-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-16-jdk-buster, 16-ea-16-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-17-jdk-buster, 16-ea-17-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/buster
 
-Tags: 16-ea-16-jdk-slim-buster, 16-ea-16-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-16-jdk-slim, 16-ea-16-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-17-jdk-slim-buster, 16-ea-17-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-17-jdk-slim, 16-ea-17-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-5-jdk-alpine3.12, 16-ea-5-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-5-jdk-alpine, 16-ea-5-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,24 +30,24 @@ Architectures: amd64
 GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-16-jdk-windowsservercore-1809, 16-ea-16-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-16-jdk-windowsservercore, 16-ea-16-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-16-jdk, 16-ea-16, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-17-jdk-windowsservercore-1809, 16-ea-17-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-17-jdk-windowsservercore, 16-ea-17-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-17-jdk, 16-ea-17, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-16-jdk-windowsservercore-ltsc2016, 16-ea-16-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-16-jdk-windowsservercore, 16-ea-16-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-16-jdk, 16-ea-16, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-17-jdk-windowsservercore-ltsc2016, 16-ea-17-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-17-jdk-windowsservercore, 16-ea-17-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-17-jdk, 16-ea-17, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-16-jdk-nanoserver-1809, 16-ea-16-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-16-jdk-nanoserver, 16-ea-16-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-17-jdk-nanoserver-1809, 16-ea-17-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-17-jdk-nanoserver, 16-ea-17-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 36ef37ea48392c1b6088c2f74cf43bc86701224b
+GitCommit: 858926209579731ec66ac8d71b1d2ea24c4e8483
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8589262: Update to 16-ea+17