### PR TITLE
[ros] add labels with sha of ros packages to invalidate cache

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -59,22 +59,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/debian/stretch/perception
 
 
@@ -86,22 +86,22 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/ubuntu/focal/ros-base
 
 Tags: noetic-robot, noetic-robot-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/ubuntu/focal/robot
 
 Tags: noetic-perception, noetic-perception-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/ubuntu/focal/perception
 
 ########################################
@@ -109,22 +109,22 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/debian/buster/ros-base
 
 Tags: noetic-robot-buster
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/debian/buster/robot
 
 Tags: noetic-perception-buster
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/debian/buster/perception
 
 
@@ -136,17 +136,17 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -158,17 +158,17 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0885dd6fd1a8c465828a76c99b348826a62205be
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 
@@ -180,17 +180,17 @@ Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
 Architectures: amd64, arm64v8
-GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
@@ -202,15 +202,15 @@ Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 Tags: rolling-ros-core, rolling-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/rolling/ubuntu/focal/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-focal, rolling
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/rolling/ubuntu/focal/ros-base
 
 Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/rolling/ubuntu/focal/ros1-bridge

--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -59,22 +59,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ff09c2a75e902bc2bb25a1f1ae748ec4e9c7a4b
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/melodic/debian/stretch/perception
 
 
@@ -86,22 +86,22 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: cc4e832f92bcac995b9a2c9ca8a7b8fcf85c5c28
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/ubuntu/focal/ros-base
 
 Tags: noetic-robot, noetic-robot-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/ubuntu/focal/robot
 
 Tags: noetic-perception, noetic-perception-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/ubuntu/focal/perception
 
 ########################################
@@ -109,22 +109,22 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
 Architectures: amd64, arm64v8
-GitCommit: cc4e832f92bcac995b9a2c9ca8a7b8fcf85c5c28
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/debian/buster/ros-base
 
 Tags: noetic-robot-buster
 Architectures: amd64, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/debian/buster/robot
 
 Tags: noetic-perception-buster
 Architectures: amd64, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/noetic/debian/buster/perception
 
 
@@ -136,17 +136,17 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0eae97e0fa2b34e99d684d88565553b1d67cc590
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0eae97e0fa2b34e99d684d88565553b1d67cc590
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 92b0c6f7753fc2d7bb7697a57f2871cf3895180e
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -158,17 +158,17 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 576e10eb03567a24596c88d515026c84a2ea0dec
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 
@@ -180,17 +180,17 @@ Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 30496b03a10f37d3ee54d5df672a0c27e0ab3952
+GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
 Architectures: amd64, arm64v8
-GitCommit: 30496b03a10f37d3ee54d5df672a0c27e0ab3952
+GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
 Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 947dddf543e6e788fd58dabc38ea4371091787e3
+GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
@@ -202,16 +202,16 @@ Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 Tags: rolling-ros-core, rolling-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/rolling/ubuntu/focal/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-focal, rolling
 Architectures: amd64, arm64v8
-GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/rolling/ubuntu/focal/ros-base
 
 Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: c098e08c9e9a077516dbba9648893e89aecf1d63
+GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
 Directory: ros/rolling/ubuntu/focal/ros1-bridge
 

--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 1c7a5895537e7909774bb8e634d549acd2d71cc9
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -136,17 +136,17 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: e9683113422b4b00ef31c9332c5d1079281644c1
+GitCommit: 04ec552de26d6cc17823ff6e1de0191c136d94f8
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 723da2c26b8aa583fe61d3361d375253c560e7ad
+GitCommit: 0885dd6fd1a8c465828a76c99b348826a62205be
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 
@@ -214,3 +214,4 @@ Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
 GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/rolling/ubuntu/focal/ros1-bridge
+

--- a/library/ros
+++ b/library/ros
@@ -180,17 +180,17 @@ Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
 Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 30b9700f23b1e1e4745919de1eacc93e9543a939
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
@@ -214,4 +214,3 @@ Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
 GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/rolling/ubuntu/focal/ros1-bridge
-

--- a/library/ros
+++ b/library/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -59,22 +59,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/melodic/debian/stretch/perception
 
 
@@ -86,22 +86,22 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/ubuntu/focal/ros-base
 
 Tags: noetic-robot, noetic-robot-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/ubuntu/focal/robot
 
 Tags: noetic-perception, noetic-perception-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/ubuntu/focal/perception
 
 ########################################
@@ -109,22 +109,22 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/debian/buster/ros-base
 
 Tags: noetic-robot-buster
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/debian/buster/robot
 
 Tags: noetic-perception-buster
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/noetic/debian/buster/perception
 
 
@@ -136,17 +136,17 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: e9683113422b4b00ef31c9332c5d1079281644c1
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -158,17 +158,17 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 
@@ -180,17 +180,17 @@ Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
 Architectures: amd64, arm64v8
-GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 9c0e9b350d26a3f0a1b867eedf9cacf133dc2104
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
@@ -202,16 +202,15 @@ Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 Tags: rolling-ros-core, rolling-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/rolling/ubuntu/focal/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-focal, rolling
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/rolling/ubuntu/focal/ros-base
 
 Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 515ebf1870f60a444ef0892a0d2d0bfc883bcdd5
+GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
 Directory: ros/rolling/ubuntu/focal/ros1-bridge
-

--- a/library/ros
+++ b/library/ros
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 421722cdc4b6b3fa5ec3697f851130435454a059
+GitCommit: 723da2c26b8aa583fe61d3361d375253c560e7ad
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
Update all ros images to use the new way of invalidating cache for each new sync of ROS packages.
This adds labels with the sha of the ros packages installed. relates to https://github.com/osrf/docker_images/issues/112 and https://github.com/osrf/docker_images/issues/376