### PR TITLE
arangodb 3.6.7

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -5,9 +5,9 @@ Tags: 3.5, 3.5.6
 GitCommit: 0d0cc55233e8abb08f42e07cd82be9795b75c7c6
 Directory: alpine/3.5.6
 
-Tags: 3.6, 3.6.6
-GitCommit: 4845b146318913d7ebb71e73db9e04bf9c024348 
-Directory: alpine/3.6.6
+Tags: 3.6, 3.6.7
+GitCommit: fd8fbcde85c9d0605bb614a801589c0033049a7a
+Directory: alpine/3.6.7
 
 Tags: 3.7, 3.7.2, latest
 GitCommit: 4845b146318913d7ebb71e73db9e04bf9c024348


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.7.