### PR TITLE
Bump Traefik to v2.3.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,14 +3,14 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vin
 Tags: v2.3.1-windowsservercore-1809, 2.3.1-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
+GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.3.1, 2.3.1, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
+GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.0-windowsservercore-1809, 2.3.0-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.3.1-windowsservercore-1809, 2.3.1-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: 6827292e34bb173568e72f20281897946d635e4a
+GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.0, 2.3.0, v2.3, 2.3, picodon, latest
+Tags: v2.3.1, 2.3.1, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 6827292e34bb173568e72f20281897946d635e4a
+GitCommit: e72df1d91ffa11fd0dc93330dbb61da90f7758a0
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.1](https://github.com/traefik/traefik/releases/tag/v2.3.1).

/cc @mmatur @SantoDE @jbdoumenjou @rtribotte

Cheers
