### PR TITLE
Add versions 7.11.2 & 7.10.6 of Bonita

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -12,13 +12,13 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: b58b05d989055ca3521fc92211d10ff640b4028f
 Directory: 7.9
 
-Tags: 7.10.5, 7.10
+Tags: 7.10.6, 7.10
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 80b6eebd5281c5597e2f38ed4d3a8c4b8449261c
+GitCommit: 6281f82e68a1dab6c53b9191033d05ae43e0f237
 Directory: 7.10
 
-Tags: 7.11.1, 7.11, latest
+Tags: 7.11.2, 7.11, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cefacfd0bf83e68acaeeaddadb7bbbe73293041f
+GitCommit: 9899efb6355ffe6e8edb57385b0cba2941d3ae16
 Directory: 7.11
 


### PR DESCRIPTION
This pull request updates the bonita docker images to the latest versions : 7.11.2 & 7.10.6