### PR TITLE
Update nextcloud

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/nextcloud/docker/blob/323015718be9a2abacf9fb6213ddcf082db435a0/generate-stackbrew-library.sh
+# This file is generated via https://github.com/nextcloud/docker/blob/9c9e8154198131aa283ad478034eb22abe92bdfc/generate-stackbrew-library.sh
 
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
@@ -18,47 +18,47 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 17.0/fpm
 
-Tags: 18.0.9-apache, 18.0-apache, 18-apache, production-apache, 18.0.9, 18.0, 18, production
+Tags: 18.0.9-apache, 18.0-apache, 18-apache, 18.0.9, 18.0, 18
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 18.0/apache
 
-Tags: 18.0.9-fpm-alpine, 18.0-fpm-alpine, 18-fpm-alpine, production-fpm-alpine
+Tags: 18.0.9-fpm-alpine, 18.0-fpm-alpine, 18-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 18.0/fpm-alpine
 
-Tags: 18.0.9-fpm, 18.0-fpm, 18-fpm, production-fpm
+Tags: 18.0.9-fpm, 18.0-fpm, 18-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 18.0/fpm
 
-Tags: 19.0.3-apache, 19.0-apache, 19-apache, apache, stable-apache, 19.0.3, 19.0, 19, latest, stable
+Tags: 19.0.3-apache, 19.0-apache, 19-apache, apache, stable-apache, production-apache, 19.0.3, 19.0, 19, latest, stable, production
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 19.0/apache
 
-Tags: 19.0.3-fpm-alpine, 19.0-fpm-alpine, 19-fpm-alpine, fpm-alpine, stable-fpm-alpine
+Tags: 19.0.3-fpm-alpine, 19.0-fpm-alpine, 19-fpm-alpine, fpm-alpine, stable-fpm-alpine, production-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 19.0/fpm-alpine
 
-Tags: 19.0.3-fpm, 19.0-fpm, 19-fpm, fpm, stable-fpm
+Tags: 19.0.3-fpm, 19.0-fpm, 19-fpm, fpm, stable-fpm, production-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
 Directory: 19.0/fpm
 
-Tags: 20.0.0RC1-apache, 20.0.0-rc-apache, 20.0-rc-apache, 20-rc-apache, 20.0.0RC1, 20.0.0-rc, 20.0-rc, 20-rc
+Tags: 20.0.0RC2-apache, 20.0.0-rc-apache, 20.0-rc-apache, 20-rc-apache, 20.0.0RC2, 20.0.0-rc, 20.0-rc, 20-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
+GitCommit: ae77b5ab9f8b85ecbaf3311b964919cfdafff02b
 Directory: 20.0-rc/apache
 
-Tags: 20.0.0RC1-fpm-alpine, 20.0.0-rc-fpm-alpine, 20.0-rc-fpm-alpine, 20-rc-fpm-alpine
+Tags: 20.0.0RC2-fpm-alpine, 20.0.0-rc-fpm-alpine, 20.0-rc-fpm-alpine, 20-rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
+GitCommit: ae77b5ab9f8b85ecbaf3311b964919cfdafff02b
 Directory: 20.0-rc/fpm-alpine
 
-Tags: 20.0.0RC1-fpm, 20.0.0-rc-fpm, 20.0-rc-fpm, 20-rc-fpm
+Tags: 20.0.0RC2-fpm, 20.0.0-rc-fpm, 20.0-rc-fpm, 20-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1b22e0ceebfec9cc03454809cf36ceb641b82b9
+GitCommit: ae77b5ab9f8b85ecbaf3311b964919cfdafff02b
 Directory: 20.0-rc/fpm


### PR DESCRIPTION
Manually for now since @tilosp-bot is retired.

Is it possible to use doi-janky only for `generate-stackbrew-library.sh` and not `update.sh`?
Since `update.sh ` is now handled by GitHub Actions.