### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,34 +14,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7628980bbcbc5b88ef3f6a2c9aa66a5728dc6e2b
 Directory: 2.3-rc/alpine
 
-Tags: 2.2.3, 2.2, latest, lts
+Tags: 2.2.4, 2.2, latest, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34fd8405ac1ee97647ec387fd6cd5da77b9b5449
+GitCommit: 34f7b69c09fa0f16a0834641aa6556523c67b1ed
 Directory: 2.2
 
-Tags: 2.2.3-alpine, 2.2-alpine, alpine, lts-alpine
+Tags: 2.2.4-alpine, 2.2-alpine, alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34fd8405ac1ee97647ec387fd6cd5da77b9b5449
+GitCommit: 34f7b69c09fa0f16a0834641aa6556523c67b1ed
 Directory: 2.2/alpine
 
-Tags: 2.1.8, 2.1
+Tags: 2.1.9, 2.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a9741204b7df9242954c77fed5fcaf61c81dfce5
+GitCommit: c447fe1188126dd86d04bebbf7f026d18ed18930
 Directory: 2.1
 
-Tags: 2.1.8-alpine, 2.1-alpine
+Tags: 2.1.9-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9741204b7df9242954c77fed5fcaf61c81dfce5
+GitCommit: c447fe1188126dd86d04bebbf7f026d18ed18930
 Directory: 2.1/alpine
 
-Tags: 2.0.17, 2.0
+Tags: 2.0.18, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c8d4c15cee0f5b6ad6b226a61cec408c44f19d6d
+GitCommit: e12ed145d747d8d2cee989d746112bbeb515ac75
 Directory: 2.0
 
-Tags: 2.0.17-alpine, 2.0-alpine
+Tags: 2.0.18-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8d4c15cee0f5b6ad6b226a61cec408c44f19d6d
+GitCommit: e12ed145d747d8d2cee989d746112bbeb515ac75
 Directory: 2.0/alpine
 
 Tags: 1.8.26, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c447fe1: Update to 2.1.9
- https://github.com/docker-library/haproxy/commit/34f7b69: Update to 2.2.4
- https://github.com/docker-library/haproxy/commit/e12ed14: Update to 2.0.18