### PR TITLE
Odoo: Add odoo 14.0

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,15 +1,15 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 1bddcda4b2ef30c7443ebe0cae43d17f92aa43cd
+GitCommit: 0ffdd00409846901e9f877165c143c985ebc4016
 
-Tags: 13.0, 13, latest
+Tags: 14.0, 14, latest
+Architectures: amd64
+Directory: 14.0
+
+Tags: 13.0, 13
 Architectures: amd64
 Directory: 13.0
 
 Tags: 12.0, 12
 Architectures: amd64
 Directory: 12.0
-
-Tags: 11.0, 11
-Architectures: amd64
-Directory: 11.0


### PR DESCRIPTION
* Add the latest Odoo 14.0 release 20201002
* Remove deprecated version 11.0
* Update 12.0 and 13.0 to release 20201002