### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34cc2d72362cb9f73d8439fd7bde7887a2e5fdd3
+GitCommit: 35b41e318d9d9272126f681be74bcbfd9712d71b
 Directory: 3.8/ubuntu
 
 Tags: 3.8.9-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34cc2d72362cb9f73d8439fd7bde7887a2e5fdd3
+GitCommit: 35b41e318d9d9272126f681be74bcbfd9712d71b
 Directory: 3.8/alpine
 
 Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/35b41e3: Update to 3.8.9, Erlang/OTP 23.1.1, OpenSSL 1.1.1h