### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -19,24 +19,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 57a8df4f141840757a74c6caf8d8bae7010cc512
 Directory: 3.0-rc/alpine3.12
 
-Tags: 2.7.1-buster, 2.7-buster, 2-buster, buster, 2.7.1, 2.7, 2, latest
+Tags: 2.7.2-buster, 2.7-buster, 2-buster, buster, 2.7.2, 2.7, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
+GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/buster
 
-Tags: 2.7.1-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.1-slim, 2.7-slim, 2-slim, slim
+Tags: 2.7.2-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.2-slim, 2.7-slim, 2-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
+GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/buster/slim
 
-Tags: 2.7.1-alpine3.12, 2.7-alpine3.12, 2-alpine3.12, alpine3.12, 2.7.1-alpine, 2.7-alpine, 2-alpine, alpine
+Tags: 2.7.2-alpine3.12, 2.7-alpine3.12, 2-alpine3.12, alpine3.12, 2.7.2-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
+GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/alpine3.12
 
-Tags: 2.7.1-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11
+Tags: 2.7.2-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
+GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/alpine3.11
 
 Tags: 2.6.6-buster, 2.6-buster, 2.6.6, 2.6


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/5a4e2d8: Update to 2.7.2
- https://github.com/docker-library/ruby/commit/4deeb55: Simplify update.sh handling of rubygems now that 2.5 is our only remaining instance