### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.35.2, 3.35, 3, latest
+Tags: 3.35.3, 3.35, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e6292b74f795cd5be049bedb690da0243b6108f9
+GitCommit: 40221b93586f79294666378374fedcc0bfff9f89
 Directory: 3/debian
 
-Tags: 3.35.2-alpine, 3.35-alpine, 3-alpine, alpine
+Tags: 3.35.3-alpine, 3.35-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e6292b74f795cd5be049bedb690da0243b6108f9
+GitCommit: 40221b93586f79294666378374fedcc0bfff9f89
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/40221b9: Update to 3.35.3, ghost-cli 1.14.1