### PR TITLE
[mediawiki] move lts to 1.35

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -5,13 +5,13 @@ GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitCommit: 7fb7a88b3dd745fdd1115ad701a1e5f5c6236420
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.35.0, 1.35, stable, latest
+Tags: 1.35.0, 1.35, lts, stable, latest
 Directory: 1.35/apache
 
-Tags: 1.35.0-fpm, 1.35-fpm, stable-fpm
+Tags: 1.35.0-fpm, 1.35-fpm, lts-fpm, stable-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.0-fpm-alpine, 1.35-fpm-alpine, stable-fpm-alpine
+Tags: 1.35.0-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 
@@ -25,12 +25,12 @@ Tags: 1.34.4-fpm-alpine, 1.34-fpm-alpine, legacy-fpm-alpline
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.34/fpm-alpine
 
-Tags: 1.31.10, 1.31, lts, legacylts
+Tags: 1.31.10, 1.31, legacylts
 Directory: 1.31/apache
 
-Tags: 1.31.10-fpm, 1.31-fpm, lts-fpm, legacylts-fpm
+Tags: 1.31.10-fpm, 1.31-fpm, legacylts-fpm
 Directory: 1.31/fpm
 
-Tags: 1.31.10-fpm-alpine, 1.31-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.31.10-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.31/fpm-alpine


### PR DESCRIPTION
currently the latest version is also the lts version. If someone wants
to stick to 1.31 he can still use `legacylts` as a valid tag:
https://www.mediawiki.org/wiki/Version_lifecycle