### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -144,34 +144,3 @@ Tags: 3.6.12-alpine3.11, 3.6-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 554274e3e010fbe89a81d5b7551d44c7d6980414
 Directory: 3.6/alpine3.11
-
-Tags: 3.5.10-buster, 3.5-buster
-SharedTags: 3.5.10, 3.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/buster
-
-Tags: 3.5.10-slim-buster, 3.5-slim-buster, 3.5.10-slim, 3.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/buster/slim
-
-Tags: 3.5.10-stretch, 3.5-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/stretch
-
-Tags: 3.5.10-slim-stretch, 3.5-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/stretch/slim
-
-Tags: 3.5.10-alpine3.12, 3.5-alpine3.12, 3.5.10-alpine, 3.5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/alpine3.12
-
-Tags: 3.5.10-alpine3.11, 3.5-alpine3.11
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c85a8c6d27b6121ae196baae7d7e6353dc934991
-Directory: 3.5/alpine3.11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/93ddb24: Remove Python 3.5 (EOL)