### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 9167d73eea7c65b6ad2c158cb4a67eb559490f9b
+GitCommit: 9d0075db90fd991175b88d58ac608e531f1b8d4e
 Directory: dockerfiles-generated
 
 Tags: 0.19.0-python3.8-buster, 0.19-python3.8-buster, 0-python3.8-buster, python3.8-buster, 0.19.0-buster, 0.19-buster, 0-buster, buster
@@ -73,23 +73,6 @@ File: Dockerfile.python3.6-alpine3.12
 Tags: 0.19.0-python3.6-alpine3.11, 0.19-python3.6-alpine3.11, 0-python3.6-alpine3.11, python3.6-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.11
-
-Tags: 0.19.0-python3.5-buster, 0.19-python3.5-buster, 0-python3.5-buster, python3.5-buster
-SharedTags: 0.19.0-python3.5, 0.19-python3.5, 0-python3.5, python3.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-File: Dockerfile.python3.5-buster
-
-Tags: 0.19.0-python3.5-stretch, 0.19-python3.5-stretch, 0-python3.5-stretch, python3.5-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-File: Dockerfile.python3.5-stretch
-
-Tags: 0.19.0-python3.5-alpine3.12, 0.19-python3.5-alpine3.12, 0-python3.5-alpine3.12, python3.5-alpine3.12, 0.19.0-python3.5-alpine, 0.19-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.5-alpine3.12
-
-Tags: 0.19.0-python3.5-alpine3.11, 0.19-python3.5-alpine3.11, 0-python3.5-alpine3.11, python3.5-alpine3.11
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.5-alpine3.11
 
 Tags: 0.19.0-pypy3.7-buster, 0.19-pypy3.7-buster, 0-pypy3.7-buster, pypy3.7-buster, 0.19.0-pypy-buster, 0.19-pypy-buster, 0-pypy-buster, pypy-buster
 SharedTags: 0.19.0-pypy3.7, 0.19-pypy3.7, 0-pypy3.7, pypy3.7, 0.19.0-pypy, 0.19-pypy, 0-pypy, pypy


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/9d0075d: Remove Python 3.5 (EOL)