### PR TITLE
Updated nginx versions

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,42 +3,42 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.19.2, mainline, 1, 1.19, latest
+Tags: 1.19.3, mainline, 1, 1.19, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9774b522d4661effea57a1fbf64c883e699ac3ec
+GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
 Directory: mainline/buster
 
-Tags: 1.19.2-perl, mainline-perl, 1-perl, 1.19-perl, perl
+Tags: 1.19.3-perl, mainline-perl, 1-perl, 1.19-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9774b522d4661effea57a1fbf64c883e699ac3ec
+GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
 Directory: mainline/buster-perl
 
-Tags: 1.19.2-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
+Tags: 1.19.3-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: aa41ddeef871b7f0ea64a44f26d3f4aa0e6d5e7b
+GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
 Directory: mainline/alpine
 
-Tags: 1.19.2-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
+Tags: 1.19.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: aa41ddeef871b7f0ea64a44f26d3f4aa0e6d5e7b
+GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
 Directory: mainline/alpine-perl
 
 Tags: 1.18.0, stable, 1.18
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 793319d7251c03eccecbf27b60e0cfbbd2d1f400
+GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
 Directory: stable/buster
 
 Tags: 1.18.0-perl, stable-perl, 1.18-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 793319d7251c03eccecbf27b60e0cfbbd2d1f400
+GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
 Directory: stable/buster-perl
 
 Tags: 1.18.0-alpine, stable-alpine, 1.18-alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 793319d7251c03eccecbf27b60e0cfbbd2d1f400
+GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
 Directory: stable/alpine
 
 Tags: 1.18.0-alpine-perl, stable-alpine-perl, 1.18-alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 793319d7251c03eccecbf27b60e0cfbbd2d1f400
+GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
 Directory: stable/alpine-perl


### PR DESCRIPTION
- mainline gets a bump to 1.19.3 with njs 0.4.4
- stable gets njs 0.4.4 and synced entrypoint fixes from mainline