### PR TITLE
Update Python 3.9 images to GA release

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,69 +1,69 @@
-# this file is generated via https://github.com/docker-library/python/blob/ece154e2849e78c383419d0be591cfd332a471d3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/59de995e689414cb7eb3c6cc33354a7f06b29cc8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.9.0rc2-buster, 3.9-rc-buster, rc-buster
-SharedTags: 3.9.0rc2, 3.9-rc, rc
+Tags: 3.9.0-buster, 3.9-buster, 3-buster, buster
+SharedTags: 3.9.0, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 954712327c55e223efd1f601b41bac446743627c
-Directory: 3.9-rc/buster
+GitCommit: 59de995e689414cb7eb3c6cc33354a7f06b29cc8
+Directory: 3.9/buster
 
-Tags: 3.9.0rc2-slim-buster, 3.9-rc-slim-buster, rc-slim-buster, 3.9.0rc2-slim, 3.9-rc-slim, rc-slim
+Tags: 3.9.0-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.0-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 954712327c55e223efd1f601b41bac446743627c
-Directory: 3.9-rc/buster/slim
+GitCommit: 59de995e689414cb7eb3c6cc33354a7f06b29cc8
+Directory: 3.9/buster/slim
 
-Tags: 3.9.0rc2-alpine3.12, 3.9-rc-alpine3.12, rc-alpine3.12, 3.9.0rc2-alpine, 3.9-rc-alpine, rc-alpine
+Tags: 3.9.0-alpine3.12, 3.9-alpine3.12, 3-alpine3.12, alpine3.12, 3.9.0-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 954712327c55e223efd1f601b41bac446743627c
-Directory: 3.9-rc/alpine3.12
+GitCommit: 59de995e689414cb7eb3c6cc33354a7f06b29cc8
+Directory: 3.9/alpine3.12
 
-Tags: 3.9.0rc2-windowsservercore-ltsc2016, 3.9-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.9.0rc2-windowsservercore, 3.9-rc-windowsservercore, rc-windowsservercore, 3.9.0rc2, 3.9-rc, rc
+Tags: 3.9.0-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.9.0-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.0, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 954712327c55e223efd1f601b41bac446743627c
-Directory: 3.9-rc/windows/windowsservercore-ltsc2016
+GitCommit: 59de995e689414cb7eb3c6cc33354a7f06b29cc8
+Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.9.0rc2-windowsservercore-1809, 3.9-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 3.9.0rc2-windowsservercore, 3.9-rc-windowsservercore, rc-windowsservercore, 3.9.0rc2, 3.9-rc, rc
+Tags: 3.9.0-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.9.0-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.0, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 954712327c55e223efd1f601b41bac446743627c
-Directory: 3.9-rc/windows/windowsservercore-1809
+GitCommit: 59de995e689414cb7eb3c6cc33354a7f06b29cc8
+Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.8.6-buster, 3.8-buster, 3-buster, buster
-SharedTags: 3.8.6, 3.8, 3, latest
+Tags: 3.8.6-buster, 3.8-buster
+SharedTags: 3.8.6, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/buster
 
-Tags: 3.8.6-slim-buster, 3.8-slim-buster, 3-slim-buster, slim-buster, 3.8.6-slim, 3.8-slim, 3-slim, slim
+Tags: 3.8.6-slim-buster, 3.8-slim-buster, 3.8.6-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/buster/slim
 
-Tags: 3.8.6-alpine3.12, 3.8-alpine3.12, 3-alpine3.12, alpine3.12, 3.8.6-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.6-alpine3.12, 3.8-alpine3.12, 3.8.6-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/alpine3.12
 
-Tags: 3.8.6-alpine3.11, 3.8-alpine3.11, 3-alpine3.11, alpine3.11
+Tags: 3.8.6-alpine3.11, 3.8-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/alpine3.11
 
-Tags: 3.8.6-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.8.6-windowsservercore, 3.8-windowsservercore, 3-windowsservercore, windowsservercore, 3.8.6, 3.8, 3, latest
+Tags: 3.8.6-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016
+SharedTags: 3.8.6-windowsservercore, 3.8-windowsservercore, 3.8.6, 3.8
 Architectures: windows-amd64
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.8.6-windowsservercore-1809, 3.8-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.8.6-windowsservercore, 3.8-windowsservercore, 3-windowsservercore, windowsservercore, 3.8.6, 3.8, 3, latest
+Tags: 3.8.6-windowsservercore-1809, 3.8-windowsservercore-1809
+SharedTags: 3.8.6-windowsservercore, 3.8-windowsservercore, 3.8.6, 3.8
 Architectures: windows-amd64
 GitCommit: 65492057bd7e8d238e494ded1c478023036864db
 Directory: 3.8/windows/windowsservercore-1809


### PR DESCRIPTION
Changes:
- https://github.com/docker-library/python/commit/a57a40f70a3cc5202c9382d9408a401c250c1f6f: Merge pull request #535 from infosiftr/3.9