### PR TITLE
Fix permissions for license files in alpine image

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -4,7 +4,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Clive Verghese <verghese@amazon.com> (@cliveverghese)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/master
-GitCommit: 45521b3fed98030c45c4a7fb23af52c614b48994
+GitCommit: 231f9cf5b85d04e8b7697b01c018d80ae958bf0d 
 
 Tags: 8, 8u265, 8u265-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
The tar extract command was maintaining owner and group on /licenses.
This was causing an issue with Bitbucket image building.

Changing the tar command to use the current user, which is root.
See: [#32](https://github.com/corretto/corretto-docker/issues/32)