### PR TITLE
Update Clear Linux OS to 33810

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fcecc1534a1bf80e4ee0f73401292bc82a402d58
-GitFetch: refs/tags/clear-linux-33720
+GitCommit: 39aaceb6d07d1df68a6aa5aa19c5dcef83310d04
+GitFetch: refs/tags/clear-linux-33810


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33810

@bryteise @alexjch